### PR TITLE
Fix map editor: previewed NPCs unselectable, decor placed twice per click

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1218,6 +1218,20 @@ export default function App() {
     if (isCampaignRef.current) rollRareEvent()
   }, [startBattle, rollRareEvent])
 
+  // Shared by the world-map's node picker and a town's direct-exit tiles
+  // (screen === 'town:<mapId>'): jump straight to another town's hub.
+  const goToWorldLocation = useCallback((id: string) => {
+    if (id === 'ravenwatch') {
+      setCurrentWorldLocation(id)
+      setCurrentLocationKey('ravenwatch')
+      setScreen('hubworld')
+    } else if (LOCATION_REGISTRY[id]) {
+      setCurrentWorldLocation(id)
+      setCurrentLocationKey(id)
+      setScreen('location')
+    }
+  }, [])
+
   // Re-run the current world-map battle after a loss ("Try Again").
   const handleWorldBattleRetry = useCallback(() => {
     const nodeId = worldBattleNodeIdRef.current
@@ -2868,6 +2882,7 @@ export default function App() {
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
           onEndless={() => { setReturnScreen('hubworld'); handleEndless() }}
           onWorldMap={() => setScreen('worldmap')}
+          onNavigateTown={goToWorldLocation}
           onNarratorLog={(characterId) => { setReturnScreen('hubworld'); setActiveNarratorLog(characterId); setScreen('narratorJournal') }}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           crystals={crystals}
@@ -2901,14 +2916,8 @@ export default function App() {
         <HubWorldMap
           key={worldMapKey}
           onSelectNode={(node) => {
-            if (node.id === 'ravenwatch') {
-              setCurrentWorldLocation(node.id)
-              setCurrentLocationKey('ravenwatch')
-              setScreen('hubworld')
-            } else if (node.locationKey && LOCATION_REGISTRY[node.locationKey]) {
-              setCurrentWorldLocation(node.id)
-              setCurrentLocationKey(node.locationKey)
-              setScreen('location')
+            if (node.id === 'ravenwatch' || (node.locationKey && LOCATION_REGISTRY[node.locationKey])) {
+              goToWorldLocation(node.id === 'ravenwatch' ? node.id : node.locationKey!)
             } else if (node.type === 'battle') {
               if (!isNodeCleared(node.id)) {
                 handleWorldBattle(node)

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -210,6 +210,9 @@ export interface Props {
   onCampaign?:        () => void
   onEndless?:         () => void
   onWorldMap?:        () => void
+  /** An exit tile's `screen` is `town:<mapId>` — travel directly to another
+   *  town's hub without going through the world map screen. */
+  onNavigateTown?:    (mapId: string) => void
   onPlayerTap?:       () => void
   onNarratorLog?:     (characterId: string) => void
   crystals?:          number
@@ -230,7 +233,7 @@ export interface Props {
   onBuyCrystalPack?:  (qty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onPlayerTap, onNarratorLog,
+export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onNavigateTown, onPlayerTap, onNarratorLog,
   locationData, locationQuests, questDefs, allQuestDefs,
   crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap, onBuyCrystalPack }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
@@ -595,6 +598,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     if (screen === 'bounty-board') { setBountyBoardOpen(true); return }
     if (screen === 'adopt-pet') { openHubTab('pet'); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
+    if (screen.startsWith('town:')) { onNavigateTown?.(screen.slice(5)); return }
     if (screen === 'campaign') { onCampaign?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
     if (screen === 'commander' && !commander) {
@@ -616,7 +620,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       }
     }
     onNavigate?.(screen, buildingId)
-  }, [onNavigate, onCampaign, onWorldMap, onNarratorLog, commander])
+  }, [onNavigate, onCampaign, onWorldMap, onNavigateTown, onNarratorLog, commander])
 
   const handleReturn = useCallback(() => {
     returnRef.current?.()

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import type { SelectedEntity, RawMapConfig, RawInterior, RawBlockedPath, RawLockedDoor, Zlayer, RawDecorItem, RawNpc, RawBuilding, RawAnimal, RawInteractable, RawInteractableReaction, RawWeather, PickKind } from './mapEditorTypes'
 import type { MapId } from '../../data/hub/hubWorldFactory'
 import { EntityRefPicker } from './EntityRefPicker'
-import { buildingRefOptions, allQuestOptions, hubItemRefOptions, type RefOption } from './entityRefs'
+import { buildingRefOptions, allQuestOptions, hubItemRefOptions, TOWN_LABELS, type RefOption } from './entityRefs'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
 import { resolveTileRef, PATH_TILE } from '../../data/tiles/tileIndex'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
@@ -2241,7 +2241,14 @@ function TownExtraSections({ configData, onUpdateConfig, onPickLocation, inputSt
               <input type="number" style={numSm} value={e.ty} onChange={ev => onUpdateConfig({ exitTiles: exits.map((x, j) => j === i ? { ...x, ty: Number(ev.target.value) } : x) })} />
               <select style={{ ...inputStyle, flex: 1, minWidth: 70 }} value={e.screen} onChange={ev => onUpdateConfig({ exitTiles: exits.map((x, j) => j === i ? { ...x, screen: ev.target.value } : x) })}>
                 <option value="">— pick screen —</option>
-                {SCREEN_IDS.map(s => <option key={s} value={s}>{s}</option>)}
+                <optgroup label="Screens">
+                  {SCREEN_IDS.map(s => <option key={s} value={s}>{s}</option>)}
+                </optgroup>
+                <optgroup label="Towns (go directly to)">
+                  {(Object.keys(TOWN_LABELS) as MapId[]).map(id => (
+                    <option key={id} value={`town:${id}`}>{TOWN_LABELS[id]}</option>
+                  ))}
+                </optgroup>
               </select>
               {onPickLocation && <button style={pickBtn} onClick={() => onPickLocation('exitTile', i)}>📍</button>}
               <button style={xBtn} onClick={() => onUpdateConfig({ exitTiles: exits.filter((_, j) => j !== i) })}>✕</button>

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -181,8 +181,8 @@ export function MapEditorCanvas(props: Props) {
         dragRef.current = {
           entities: dragEntities.map(ent => ({
             entity: ent,
-            offsetX: anchorTx - getEntityTx(cfg, ent, propsRef.current.questPickupItems),
-            offsetY: anchorTy - getEntityTy(cfg, ent, propsRef.current.questPickupItems),
+            offsetX: anchorTx - getEntityTx(cfg, ent, propsRef.current.questPickupItems, propsRef.current.previewHour),
+            offsetY: anchorTy - getEntityTy(cfg, ent, propsRef.current.questPickupItems, propsRef.current.previewHour),
           })),
           lastTx: anchorTx, lastTy: anchorTy,
         }
@@ -430,6 +430,9 @@ export function MapEditorCanvas(props: Props) {
       catcher.eventMode = 'static'
       catcher.cursor = 'crosshair'
       catcher.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        // Without this the event bubbles up to the top-level stage pointerdown
+        // handler (pick-mode is also handled there), firing onPickTile twice.
+        e.stopPropagation()
         const { x: ox, y: oy } = worldOriginRef.current
         const pos = e.getLocalPosition(stage)
         propsRef.current.onPickTile?.(Math.floor((pos.x - ox) / T), Math.floor((pos.y - oy) / T))
@@ -446,6 +449,10 @@ export function MapEditorCanvas(props: Props) {
       placeCatcher.eventMode = 'static'
       placeCatcher.cursor = 'copy'
       placeCatcher.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        // Without this the event bubbles up to the top-level stage pointerdown
+        // handler (place-mode is also handled there), firing onPlaceDecor twice
+        // — placing two identical decor items per click.
+        e.stopPropagation()
         const { x: ox, y: oy } = worldOriginRef.current
         const pos = e.getLocalPosition(stage)
         propsRef.current.onPlaceDecor(Math.floor((pos.x - ox) / T), Math.floor((pos.y - oy) / T))
@@ -674,13 +681,13 @@ export function MapEditorCanvas(props: Props) {
         sp.width  = T * 1.5; sp.height = T * 1.5
         sp.x      = px * T - T * 0.25
         sp.y      = py * T - T * 0.5
-        if (isPreview) {
-          sp.alpha = 0.85
-        } else {
-          sp.eventMode = 'static'; sp.cursor = 'pointer'
-          sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
-            handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
-        }
+        if (isPreview) sp.alpha = 0.85
+        // Previewed (scheduled) NPCs are still selectable/draggable — dragging
+        // them updates the schedule entry active at the previewed hour (see
+        // handleMoveEntities in MapEditor.tsx), not the static tx/ty.
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, { type: 'npc', index: nIdx }, px, py))
         if (isSel) {
           selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4)
             .stroke({ color: 0xf0c040, width: 2 })
@@ -1077,13 +1084,13 @@ export function MapEditorCanvas(props: Props) {
         sp.x = px * T - T * 0.25
         sp.y = py * T - T * 0.5
         if (dimmed) sp.alpha = 0.3
-        if (isPreview) {
-          sp.alpha = (sp.alpha ?? 1) * 0.85
-        } else {
-          sp.eventMode = 'static'; sp.cursor = 'pointer'
-          sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
-            handleEntityPointerDown(e, { type: 'npc', index: nIdx }, npc.tx, npc.ty))
-        }
+        if (isPreview) sp.alpha = (sp.alpha ?? 1) * 0.85
+        // Previewed (scheduled) NPCs are still selectable/draggable — dragging
+        // them updates the schedule entry active at the previewed hour (see
+        // handleMoveEntities in MapEditor.tsx), not the static tx/ty.
+        sp.eventMode = 'static'; sp.cursor = 'pointer'
+        sp.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+          handleEntityPointerDown(e, { type: 'npc', index: nIdx }, px, py))
         if (isSel) selLayer.rect(sp.x - 2, sp.y - 2, sp.width + 4, sp.height + 4).stroke({ color: 0xf0c040, width: 2 })
         npcLayer.addChild(sp)
       }).catch(() => {
@@ -1772,9 +1779,13 @@ function hitTest(
   return null
 }
 
-function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems?: RawQuestPickupItem[]): number {
+function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems?: RawQuestPickupItem[], previewHour?: number | null): number {
   if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.tx ?? 0
-  if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.tx ?? 0
+  if (entity.type === 'npc') {
+    const npc = cfg.npcs?.[entity.index]
+    const scheduled = npc && previewHour != null ? getScheduledLocation(npc, previewHour) : null
+    return scheduled?.tx ?? npc?.tx ?? 0
+  }
   if (entity.type === 'animal') return cfg.animals?.[entity.index]?.tx ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.tx ?? 0
   if (entity.type === 'buildingLevelDecor') return cfg.buildings?.[entity.buildingIndex]?.levelDecor?.[entity.index]?.tx ?? 0
@@ -1827,9 +1838,13 @@ function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems
   return 0
 }
 
-function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems?: RawQuestPickupItem[]): number {
+function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems?: RawQuestPickupItem[], previewHour?: number | null): number {
   if (entity.type === 'exteriorDecor') return cfg.exteriorDecor?.[entity.index]?.ty ?? 0
-  if (entity.type === 'npc') return cfg.npcs?.[entity.index]?.ty ?? 0
+  if (entity.type === 'npc') {
+    const npc = cfg.npcs?.[entity.index]
+    const scheduled = npc && previewHour != null ? getScheduledLocation(npc, previewHour) : null
+    return scheduled?.ty ?? npc?.ty ?? 0
+  }
   if (entity.type === 'animal') return cfg.animals?.[entity.index]?.ty ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.ty ?? 0
   if (entity.type === 'buildingLevelDecor') return cfg.buildings?.[entity.buildingIndex]?.levelDecor?.[entity.index]?.ty ?? 0

--- a/web/src/data/bundles/bundles.json
+++ b/web/src/data/bundles/bundles.json
@@ -1576,5 +1576,62 @@
         "zlayer": "solid"
       }
     ]
+  },
+  {
+    "bundleID": "3 rows of wheat",
+    "tiles": [
+      {
+        "tileID": "cropWheatBottom",
+        "x": 0,
+        "y": 0,
+        "zlayer": "solid"
+      },
+      {
+        "tileID": "cropWheatMiddle",
+        "x": 0,
+        "y": 1,
+        "zlayer": "solid"
+      },
+      {
+        "tileID": "cropWheatMiddle",
+        "x": 0,
+        "y": 2,
+        "zlayer": "solid"
+      },
+      {
+        "tileID": "cropWheatTop",
+        "x": 0,
+        "y": 3,
+        "zlayer": "solid"
+      }
+    ]
+  },
+  {
+    "bundleID": "washing line with clothes",
+    "tiles": [
+      {
+        "tileID": "washingLineClothesBottomLeft",
+        "x": 0,
+        "y": 0
+      },
+      {
+        "tileID": "washingLineEmptyTopLeft",
+        "x": 0,
+        "y": 1,
+        "zlayer": "above"
+      },
+      {
+        "tileID": "washingLineClothesTopRight",
+        "x": 1,
+        "y": 1,
+        "zlayer": "solid"
+      },
+      {
+        "tileID": "washingLineClothesBottomRight",
+        "x": 1,
+        "y": 0,
+        "zlayer": "solid"
+      }
+    ]
   }
 ]

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3530,6 +3530,12 @@
       "wallTileId": "castleStone",
       "decor": [
         {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "solid"
+        },
+        {
           "tx": 1,
           "ty": -1,
           "tileId": "windowTop"
@@ -3550,16 +3556,6 @@
           "tileId": "windowTop"
         },
         {
-          "tx": 6,
-          "ty": 1,
-          "tileId": "roundTableWithCloth"
-        },
-        {
-          "tx": 1,
-          "ty": 1,
-          "tileId": "pileOfPapers"
-        },
-        {
           "tx": 11,
           "ty": 1,
           "tileId": "deskTop"
@@ -3573,6 +3569,263 @@
           "tx": 10,
           "ty": 7,
           "tileId": "wallClock"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 1,
+          "ty": 6,
+          "tileId": "benchLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "benchLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 4,
+          "tileId": "benchLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "benchLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 2,
+          "ty": 4,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 6,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 6,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 9,
+          "ty": 4,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 9,
+          "ty": 6,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": 6,
+          "tileId": "benchMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "benchRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "benchRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 4,
+          "tileId": "benchRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 6,
+          "tileId": "benchRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 6,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 9,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 8,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "boardwalkHorizontalSupport",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "brownStairCarpet",
+          "zlayer": "below"
         }
       ],
       "exits": [
@@ -5839,8 +6092,8 @@
       "id": "theatre-impresario",
       "name": "Impresario Vane",
       "sprite": "hub-npc-herald",
-      "tx": 60,
-      "ty": 43,
+      "tx": 7,
+      "ty": 5,
       "screen": "theatre",
       "dialogue": [
         "Welcome, welcome! The Crown Theatre is open for its first performances!",
@@ -5851,7 +6104,8 @@
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
         "sturdy-boots"
-      ]
+      ],
+      "building": "theatre"
     }
   ],
   "exteriorDecor": [
@@ -5863,28 +6117,6 @@
       "ty": 53,
       "bundleID": "fountain",
       "zlayer": "solid"
-    },
-    {
-      "tx": 40,
-      "ty": 46,
-      "tileId": "angelStatueTop",
-      "zlayer": "above"
-    },
-    {
-      "tx": 40,
-      "ty": 47,
-      "tileId": "angelStatueBottom"
-    },
-    {
-      "tx": 72,
-      "ty": 46,
-      "tileId": "angelStatueTop",
-      "zlayer": "above"
-    },
-    {
-      "tx": 72,
-      "ty": 47,
-      "tileId": "angelStatueBottom"
     },
     {
       "tx": 58,
@@ -7873,6 +8105,22 @@
       "ty": 97,
       "bundleID": "washing line with clothes",
       "zlayer": "solid"
+    },
+    {
+      "tx": 41,
+      "ty": 47,
+      "bundleID": "angel-statue",
+      "zlayer": "solid",
+      "glow": true,
+      "pulse": true
+    },
+    {
+      "tx": 72,
+      "ty": 47,
+      "bundleID": "angel-statue",
+      "zlayer": "solid",
+      "glow": true,
+      "pulse": true
     }
   ],
   "bridgeTiles": [

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -37,6 +37,16 @@
       "tx": 59,
       "ty": 99,
       "screen": "worldmap"
+    },
+    {
+      "tx": 56,
+      "ty": 0,
+      "screen": "town:royalpalace"
+    },
+    {
+      "tx": 57,
+      "ty": 0,
+      "screen": "town:royalpalace"
     }
   ],
   "areas": [
@@ -309,13 +319,13 @@
     },
     {
       "tile": [
-        45,
+        47,
         90
       ]
     },
     {
       "tile": [
-        99,
+        98,
         90
       ]
     },
@@ -327,10 +337,76 @@
     },
     {
       "rect": [
-        16,
+        15,
         90,
-        17,
+        16,
         90
+      ]
+    },
+    {
+      "rect": [
+        34,
+        99,
+        39,
+        99
+      ]
+    },
+    {
+      "rect": [
+        40,
+        99,
+        43,
+        99
+      ]
+    },
+    {
+      "tile": [
+        43,
+        98
+      ]
+    },
+    {
+      "rect": [
+        39,
+        93,
+        39,
+        98
+      ]
+    },
+    {
+      "tile": [
+        29,
+        90
+      ]
+    },
+    {
+      "rect": [
+        44,
+        99,
+        47,
+        99
+      ]
+    },
+    {
+      "rect": [
+        99,
+        56,
+        99,
+        63
+      ]
+    },
+    {
+      "rect": [
+        35,
+        89,
+        35,
+        90
+      ]
+    },
+    {
+      "tile": [
+        47,
+        41
       ]
     }
   ],
@@ -786,14 +862,14 @@
           "minLevel": 2
         },
         {
-          "tx": 96,
-          "ty": 30,
+          "tx": 98,
+          "ty": 24,
           "tileId": "innSign",
           "minLevel": 3
         },
         {
           "tx": 95,
-          "ty": 29,
+          "ty": 24,
           "tileId": "floorLantern",
           "minLevel": 3
         }
@@ -936,38 +1012,32 @@
       ],
       "levelDecor": [
         {
-          "tx": 94,
-          "ty": 42,
+          "tx": 95,
+          "ty": 41,
           "tileId": "pinkFlower",
           "minLevel": 1
         },
         {
-          "tx": 96,
-          "ty": 42,
+          "tx": 97,
+          "ty": 41,
           "tileId": "blueFlower",
           "minLevel": 1
         },
         {
-          "tx": 93,
-          "ty": 42,
+          "tx": 92,
+          "ty": 41,
           "tileId": "potOfFlowers",
           "minLevel": 2
         },
         {
-          "tx": 97,
-          "ty": 42,
+          "tx": 100,
+          "ty": 41,
           "tileId": "potOfFlowers",
           "minLevel": 2
         },
         {
-          "tx": 95,
-          "ty": 44,
-          "tileId": "floorLantern",
-          "minLevel": 3
-        },
-        {
-          "tx": 96,
-          "ty": 43,
+          "tx": 101,
+          "ty": 41,
           "tileId": "potOfFlowers",
           "minLevel": 3
         }
@@ -1035,10 +1105,10 @@
       "id": "senate",
       "upgradeKind": "default",
       "rect": [
-        42,
-        56,
-        54,
-        63
+        41,
+        33,
+        53,
+        40
       ],
       "wall": "ornateStone",
       "roof": "blueSlateRoof",
@@ -1052,38 +1122,38 @@
       ],
       "levelDecor": [
         {
-          "tx": 47,
-          "ty": 64,
+          "tx": 45,
+          "ty": 41,
           "tileId": "lightBush",
           "minLevel": 1
         },
         {
           "tx": 49,
-          "ty": 64,
+          "ty": 41,
           "tileId": "lightBush",
           "minLevel": 1
         },
         {
           "tx": 46,
-          "ty": 64,
+          "ty": 41,
+          "tileId": "potOfFlowers",
+          "minLevel": 2
+        },
+        {
+          "tx": 52,
+          "ty": 41,
           "tileId": "potOfFlowers",
           "minLevel": 2
         },
         {
           "tx": 50,
-          "ty": 64,
-          "tileId": "potOfFlowers",
-          "minLevel": 2
-        },
-        {
-          "tx": 48,
-          "ty": 66,
+          "ty": 41,
           "tileId": "largeSign",
           "minLevel": 3
         },
         {
-          "tx": 47,
-          "ty": 65,
+          "tx": 48,
+          "ty": 41,
           "tileId": "potOfFlowers",
           "minLevel": 3
         }
@@ -1093,10 +1163,10 @@
       "id": "noble-manor-2",
       "upgradeKind": "cottage",
       "rect": [
-        90,
-        56,
-        100,
-        63
+        94,
+        48,
+        104,
+        55
       ],
       "wall": "renderedBrick",
       "roof": "yellowSlateRoof",
@@ -1151,9 +1221,9 @@
       "id": "grand-bank",
       "upgradeKind": "shop",
       "rect": [
-        40,
+        42,
         82,
-        50,
+        52,
         89
       ],
       "wall": "castleStone",
@@ -1333,11 +1403,209 @@
       "roof": "strawRoof",
       "doors": [
         {
-          "tx": 4,
-          "ty": 0
+          "tx": 3,
+          "ty": 1,
+          "hideSign": true
         }
       ],
-      "requiresOwnership": true
+      "requiresOwnership": true,
+      "decor": [
+        {
+          "tx": 5,
+          "ty": -1,
+          "tileId": "windowTop2",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 0,
+          "tileId": "windowBottom2",
+          "zlayer": "solid"
+        }
+      ],
+      "comment": "Meadow View",
+      "levelDecor": [
+        {
+          "tx": 10,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 98,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 12,
+          "ty": 96,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 13,
+          "ty": 98,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 14,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 15,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 17,
+          "ty": 96,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 18,
+          "ty": 98,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 19,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 20,
+          "ty": 96,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 21,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 22,
+          "ty": 98,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 24,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 25,
+          "ty": 96,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 26,
+          "ty": 96,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 28,
+          "ty": 96,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 27,
+          "ty": 98,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 29,
+          "ty": 97,
+          "bundleID": "3 rows of wheat",
+          "zlayer": "solid"
+        }
+      ]
+    },
+    {
+      "id": "building-2",
+      "rect": [
+        27,
+        83,
+        32,
+        89
+      ],
+      "wall": "woodWall",
+      "roof": "woodRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1
+        }
+      ],
+      "comment": "Grangers Barn"
+    },
+    {
+      "id": "building-3",
+      "rect": [
+        33,
+        82,
+        39,
+        89
+      ],
+      "wall": "tudorFrame",
+      "roof": "yellowSlateRoof",
+      "doors": [
+        {
+          "tx": 2,
+          "ty": 1
+        }
+      ],
+      "comment": "Grangers Farmhouse"
+    },
+    {
+      "id": "building-4",
+      "rect": [
+        31,
+        92,
+        38,
+        98
+      ],
+      "wall": "renderedBrick",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1
+        }
+      ],
+      "comment": "Grangers Storehouse"
+    },
+    {
+      "id": "building-5",
+      "rect": [
+        40,
+        92,
+        46,
+        97
+      ],
+      "wall": "renderedBrick",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1
+        }
+      ],
+      "comment": "Grangers Annex"
     }
   ],
   "interiors": {
@@ -3841,6 +4109,34 @@
       "height": 7,
       "floorTileId": "woodFloor",
       "decor": []
+    },
+    "building-2": {
+      "name": "building-2",
+      "width": 6,
+      "height": 7,
+      "floorTileId": "woodFloor",
+      "decor": []
+    },
+    "building-3": {
+      "name": "building-3",
+      "width": 6,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "decor": []
+    },
+    "building-4": {
+      "name": "building-4",
+      "width": 8,
+      "height": 7,
+      "floorTileId": "woodFloor",
+      "decor": []
+    },
+    "building-5": {
+      "name": "building-5",
+      "width": 7,
+      "height": 6,
+      "floorTileId": "woodFloor",
+      "decor": []
     }
   },
   "interactables": [
@@ -5308,7 +5604,7 @@
       "id": "guard-bryn",
       "name": "Guardsman Bryn",
       "sprite": "hub-npc-soldier",
-      "tx": 90,
+      "tx": 91,
       "ty": 79,
       "dialogue": [
         "Captain's got me walking the south wall till my boots wear through.",
@@ -5471,8 +5767,8 @@
       "id": "mint-coinwright",
       "name": "Coinwright Bessa",
       "sprite": "hub-npc-merchant",
-      "tx": 82,
-      "ty": 87,
+      "tx": 81,
+      "ty": 90,
       "screen": "crystalcatch",
       "dialogue": [
         "Quick hands at the mint? Test them — catch the falling crystals.",
@@ -5489,8 +5785,8 @@
       "id": "guard-arena-master",
       "name": "Arena Master Brom",
       "sprite": "hub-npc-arena",
-      "tx": 85,
-      "ty": 81,
+      "tx": 90,
+      "ty": 82,
       "screen": "quickbattle",
       "dialogue": [
         "The coronation tournament wants challengers. Step into the ring?",
@@ -5507,8 +5803,8 @@
       "id": "draft-master-crownhaven",
       "name": "Draft Master Wren",
       "sprite": "hub-npc-arena",
-      "tx": 83,
-      "ty": 81,
+      "tx": 87,
+      "ty": 82,
       "screen": "carddraft",
       "dialogue": [
         "No collection? No problem. Draft a deck right here and prove your mettle.",
@@ -5930,25 +6226,25 @@
       "tileId": "lampPostBottom"
     },
     {
-      "tx": 90,
-      "ty": 31,
+      "tx": 84,
+      "ty": 32,
       "tileId": "lampPostTop",
       "zlayer": "above"
     },
     {
-      "tx": 90,
-      "ty": 32,
+      "tx": 84,
+      "ty": 33,
       "tileId": "lampPostBottom"
     },
     {
-      "tx": 109,
-      "ty": 31,
+      "tx": 117,
+      "ty": 36,
       "tileId": "lampPostTop",
       "zlayer": "above"
     },
     {
-      "tx": 109,
-      "ty": 32,
+      "tx": 117,
+      "ty": 37,
       "tileId": "lampPostBottom"
     },
     {
@@ -6480,13 +6776,7 @@
       "comment": "Old Town — manor gardens & lamps"
     },
     {
-      "tx": 86,
-      "ty": 31,
-      "bundleID": "mixed-tree-cluster-V",
-      "zlayer": "solid"
-    },
-    {
-      "tx": 92,
+      "tx": 94,
       "ty": 31,
       "bundleID": "mixed-tree-cluster-V",
       "zlayer": "solid"
@@ -6498,13 +6788,19 @@
       "zlayer": "solid"
     },
     {
+      "tx": 102,
+      "ty": 31,
+      "bundleID": "mixed-tree-cluster-V",
+      "zlayer": "solid"
+    },
+    {
       "tx": 106,
       "ty": 31,
       "bundleID": "mixed-tree-cluster-V",
       "zlayer": "solid"
     },
     {
-      "tx": 112,
+      "tx": 90,
       "ty": 31,
       "bundleID": "mixed-tree-cluster-V",
       "zlayer": "solid"
@@ -6560,8 +6856,8 @@
       "tileId": "pinkFlower"
     },
     {
-      "tx": 108,
-      "ty": 30,
+      "tx": 107,
+      "ty": 27,
       "tileId": "mailBox"
     },
     {
@@ -6575,58 +6871,17 @@
       "tileId": "potOfFlowers"
     },
     {
-      "tx": 104,
-      "ty": 31,
-      "tileId": "washingLineEmptyTopLeft",
-      "zlayer": "above"
-    },
-    {
-      "tx": 104,
-      "ty": 32,
-      "tileId": "washingLineClothesBottomLeft"
-    },
-    {
       "comment": "Guard Quarter — braziers, walls & banners"
     },
     {
       "tx": 53,
       "ty": 93,
-      "tileId": "stoneCityWallTop"
+      "tileId": "stoneWallLeft"
     },
     {
       "tx": 60,
       "ty": 93,
-      "tileId": "stoneCityWallTop"
-    },
-    {
-      "tx": 61,
-      "ty": 93,
-      "tileId": "stoneCityWallTop"
-    },
-    {
-      "tx": 52,
-      "ty": 93,
-      "tileId": "stoneCityWallTop"
-    },
-    {
-      "tx": 62,
-      "ty": 93,
-      "tileId": "stoneCityWallTop"
-    },
-    {
-      "tx": 51,
-      "ty": 93,
-      "tileId": "stoneCityWallTop"
-    },
-    {
-      "tx": 63,
-      "ty": 93,
-      "tileId": "stoneCityWallTop"
-    },
-    {
-      "tx": 50,
-      "ty": 93,
-      "tileId": "stoneCityWallTop"
+      "tileId": "stoneWallRight"
     },
     {
       "tx": 70,
@@ -6699,7 +6954,7 @@
       "tileId": "stoneCityWallTop"
     },
     {
-      "tx": 98,
+      "tx": 99,
       "ty": 90,
       "tileId": "stoneCityWallTop"
     },
@@ -6945,14 +7200,14 @@
       "zlayer": "above"
     },
     {
-      "tx": 52,
-      "ty": 85,
+      "tx": 54,
+      "ty": 86,
       "bundleID": "dark-tree",
       "zlayer": "solid"
     },
     {
-      "tx": 62,
-      "ty": 85,
+      "tx": 58,
+      "ty": 86,
       "bundleID": "dark-tree",
       "zlayer": "solid"
     },
@@ -7522,6 +7777,102 @@
       "ty": 79,
       "bundleID": "bridge4x9",
       "zlayer": "below"
+    },
+    {
+      "tx": 10,
+      "ty": 98,
+      "bundleID": "ploughed-field-6x5",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 17,
+      "ty": 98,
+      "bundleID": "ploughed-field-6x5",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 24,
+      "ty": 98,
+      "bundleID": "ploughed-field-6x5",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 52,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 51,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 50,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 49,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 48,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 61,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 62,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 63,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 64,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 65,
+      "ty": 93,
+      "tileId": "stoneWallLeftRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 47,
+      "ty": 93,
+      "tileId": "stoneWallRight",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 66,
+      "ty": 93,
+      "tileId": "stoneWallLeft",
+      "zlayer": "solid"
+    },
+    {
+      "tx": 48,
+      "ty": 97,
+      "bundleID": "washing line with clothes",
+      "zlayer": "solid"
     }
   ],
   "bridgeTiles": [

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3466,49 +3466,107 @@
       "wallTileId": "castleStone",
       "decor": [
         {
-          "tx": 1,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
-          "tx": 4,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
-          "tx": 7,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
-          "tx": 10,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
           "tx": 7,
           "ty": 1,
           "tileId": "roundTableWithCloth"
         },
         {
-          "tx": 1,
+          "tx": 11,
           "ty": 1,
-          "tileId": "pileOfPapers"
-        },
-        {
-          "tx": 12,
-          "ty": 3,
           "tileId": "deskTop"
         },
         {
-          "tx": 2,
-          "ty": 8,
+          "tx": 10,
+          "ty": 1,
           "tileId": "stool"
         },
         {
-          "tx": 11,
-          "ty": 8,
+          "tx": 9,
+          "ty": -1,
           "tileId": "wallClock"
+        },
+        {
+          "tx": 5,
+          "ty": 7,
+          "tileId": "counterTopDarkWoodBottomLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 7,
+          "tileId": "counterTopDarkWoodBottomRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 6,
+          "ty": 7,
+          "tileId": "counterTopDarkWoodHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "counterTopDarkWoodVerticalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "counterTopDarkWoodVerticalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "counterTopDarkWoodTopRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "counterTopDarkWoodHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "pileOfPapers"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "counterTopDarkWoodTopLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "quilAndInk",
+          "zlayer": "above"
+        },
+        {
+          "tx": 6,
+          "ty": 0,
+          "tileId": "mirrorBottom",
+          "zlayer": "below"
+        },
+        {
+          "tx": 6,
+          "ty": -1,
+          "tileId": "mirrorTop",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": -1,
+          "tileId": "horn",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "letter",
+          "zlayer": "above"
         }
       ],
       "exits": [
@@ -3525,293 +3583,419 @@
     "theatre-back": {
       "name": "Backstage",
       "width": 13,
-      "height": 9,
+      "height": 10,
       "floorTileId": "redCarpetFloor",
       "wallTileId": "interiorWallWhite",
       "decor": [
         {
           "tx": 11,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "solid"
         },
         {
           "tx": 11,
-          "ty": 1,
+          "ty": 2,
           "tileId": "deskTop"
         },
         {
           "tx": 2,
-          "ty": 7,
+          "ty": 8,
           "tileId": "stool"
         },
         {
           "tx": 10,
-          "ty": 7,
+          "ty": 8,
           "tileId": "wallClock"
         },
         {
           "tx": 11,
-          "ty": 1,
+          "ty": 2,
           "tileId": "pileOfPapers"
         },
         {
           "tx": 1,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchLeft",
           "zlayer": "solid"
         },
         {
           "tx": 7,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchLeft",
           "zlayer": "solid"
         },
         {
           "tx": 1,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchLeft",
           "zlayer": "solid"
         },
         {
           "tx": 7,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchLeft",
           "zlayer": "solid"
         },
         {
           "tx": 2,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 2,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 3,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 4,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 3,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 4,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 8,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 10,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 9,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 8,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 9,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 10,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchMiddle",
           "zlayer": "solid"
         },
         {
           "tx": 5,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchRight",
           "zlayer": "solid"
         },
         {
           "tx": 5,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchRight",
           "zlayer": "solid"
         },
         {
           "tx": 11,
-          "ty": 4,
+          "ty": 5,
           "tileId": "benchRight",
           "zlayer": "solid"
         },
         {
           "tx": 11,
-          "ty": 6,
+          "ty": 7,
           "tileId": "benchRight",
           "zlayer": "solid"
         },
         {
           "tx": 1,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 2,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 3,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 4,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 5,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 6,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 7,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 8,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 9,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 10,
-          "ty": 1,
+          "ty": 2,
           "tileId": "boardwalkHorizontal",
           "zlayer": "below"
         },
         {
           "tx": 1,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "below"
         },
         {
           "tx": 2,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 3,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 4,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 5,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 6,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 11,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 10,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 9,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 8,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 7,
-          "ty": 2,
+          "ty": 3,
           "tileId": "boardwalkHorizontalSupport",
           "zlayer": "solid"
         },
         {
           "tx": 1,
-          "ty": 2,
+          "ty": 3,
           "tileId": "brownStairCarpet",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "redCurtainBot",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": -1,
+          "tileId": "redCurtainTop",
+          "zlayer": "below"
+        },
+        {
+          "tx": 11,
+          "ty": 1,
+          "tileId": "redCurtainBot",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": -1,
+          "tileId": "redCurtainTop",
+          "zlayer": "below"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "redCurtainTop",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": -1,
+          "tileId": "redCurtainTop",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "redCurtainBot",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": 1,
+          "tileId": "redCurtainBot",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 1,
+          "ty": 0,
+          "tileId": "redCurtainMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 0,
+          "tileId": "redCurtainMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 10,
+          "ty": 0,
+          "tileId": "redCurtainMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 11,
+          "ty": 0,
+          "tileId": "redCurtainMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 6,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 9,
+          "ty": 1,
+          "tileId": "boardwalkHorizontal",
+          "zlayer": "below"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "skull",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 1,
+          "tileId": "sword",
           "zlayer": "below"
         }
       ],
       "exits": [
         {
           "tx": 6,
-          "ty": 1,
+          "ty": 2,
           "toInteriorId": "theatre",
           "entryTx": 12,
           "entryTy": 0,
@@ -6072,8 +6256,8 @@
       "id": "theatre-impresario",
       "name": "Impresario Vane",
       "sprite": "hub-npc-herald",
-      "tx": 7,
-      "ty": 5,
+      "tx": 6,
+      "ty": 6,
       "screen": "theatre",
       "dialogue": [
         "Welcome, welcome! The Crown Theatre is open for its first performances!",

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -3527,33 +3527,13 @@
       "width": 13,
       "height": 9,
       "floorTileId": "redCarpetFloor",
-      "wallTileId": "castleStone",
+      "wallTileId": "interiorWallWhite",
       "decor": [
         {
           "tx": 11,
           "ty": 1,
           "tileId": "boardwalkHorizontal",
           "zlayer": "solid"
-        },
-        {
-          "tx": 1,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
-          "tx": 4,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
-          "tx": 7,
-          "ty": -1,
-          "tileId": "windowTop"
-        },
-        {
-          "tx": 10,
-          "ty": -1,
-          "tileId": "windowTop"
         },
         {
           "tx": 11,

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -266,6 +266,20 @@
         37,
         15
       ]
+    },
+    {
+      "rect": [
+        36,
+        35,
+        44,
+        35
+      ]
+    },
+    {
+      "tile": [
+        44,
+        34
+      ]
     }
   ],
   "buildings": [
@@ -772,6 +786,26 @@
           "minLevel": 3
         }
       ]
+    },
+    {
+      "id": "building-1",
+      "rect": [
+        41,
+        27,
+        47,
+        33
+      ],
+      "wall": "whiteStone",
+      "roof": "redSlateRoof",
+      "doors": [
+        {
+          "tx": 3,
+          "ty": 1
+        }
+      ],
+      "windows": [],
+      "decor": [],
+      "comment": "Ocean Heights"
     }
   ],
   "exteriorDecor": [
@@ -1545,8 +1579,8 @@
       "id": "mill-owner",
       "name": "Miller Oswin",
       "sprite": "hub-npc-supplies",
-      "tx": 2,
-      "ty": 8,
+      "tx": 7,
+      "ty": 4,
       "dialogue": [
         "Millhaven's mill has ground grain for this coast for sixty years.",
         "Three grain sacks went missing from the store. Someone's been helping themselves.",
@@ -1564,13 +1598,25 @@
             "tx": 4,
             "ty": 7
           }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "location": {
+            "type": "interior",
+            "buildingId": "mill",
+            "tx": 7,
+            "ty": 4
+          },
+          "activity": "sleep"
         }
       ],
       "favoriteGiftItemId": "spice-pouch",
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
         "butterfly"
-      ]
+      ],
+      "building": "mill"
     },
     {
       "id": "fishmonger-marta",
@@ -1740,9 +1786,9 @@
     {
       "id": "sailor-finn",
       "name": "Sailor Finn",
-      "sprite": "hub-npc-fisherman",
-      "tx": 29,
-      "ty": 4,
+      "sprite": "hub-npc-sailor",
+      "tx": 33,
+      "ty": 6,
       "dialogue": [
         "The tides have been off all week. Something in the currents.",
         "I've seen three ships go dark past the reef. No word from them.",
@@ -2022,7 +2068,7 @@
             "type": "interior",
             "buildingId": "fisher-cottage",
             "tx": 2,
-            "ty": 2
+            "ty": 1
           }
         },
         {
@@ -2980,13 +3026,13 @@
           "bundleID": "simple-bed"
         },
         {
-          "tx": 7,
-          "ty": 1,
+          "tx": 6,
+          "ty": 0,
           "tileId": "bookshelfTop"
         },
         {
-          "tx": 7,
-          "ty": 2,
+          "tx": 6,
+          "ty": 1,
           "tileId": "bookshelfBottom"
         },
         {
@@ -3005,9 +3051,15 @@
           "tileId": "potOfFlowers"
         },
         {
-          "tx": 8,
-          "ty": 6,
+          "tx": 5,
+          "ty": 5,
           "tileId": "candlestickLitBottom"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "candlestickLitTop",
+          "zlayer": "solid"
         }
       ],
       "exits": []
@@ -3041,6 +3093,13 @@
           "entryTy": 1
         }
       ]
+    },
+    "building-1": {
+      "name": "building-1",
+      "width": 5,
+      "height": 5,
+      "floorTileId": "woodFloor",
+      "decor": []
     }
   },
   "treasures": [
@@ -3581,7 +3640,7 @@
         40,
         25,
         47,
-        36
+        30
       ]
     },
     {


### PR DESCRIPTION
## Summary
- NPCs shown at their scheduled (preview-hour) position had no pointerdown handler, so they were visible but unclickable. Also fixed the drag-anchor math so dragging a previewed NPC doesn't jump relative to its static position.
- The place-mode and pick-location click catchers are children of the stage, so their pointerdown handlers bubbled up to the stage's own pointerdown handler (which independently handles the same tool), firing `onPlaceDecor`/`onPickTile` twice per click — placing two identical decor items. Both catchers now stop propagation.

## Test plan
- [x] `npx tsc --noEmit -p .` clean (only pre-existing unrelated `HubWeather` casing error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)