### PR TITLE
fix(hub): wire up player-house purchase/decorate for 3 towns

### DIFF
--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -1409,6 +1409,7 @@
         }
       ],
       "requiresOwnership": true,
+      "upgradeKind": "playerHouse",
       "decor": [
         {
           "tx": 5,
@@ -4521,11 +4522,12 @@
       ]
     },
     "building-1": {
-      "name": "building-1",
+      "name": "Meadow View",
       "width": 10,
       "height": 7,
       "floorTileId": "woodFloor",
-      "decor": []
+      "decor": [],
+      "playerDecor": true
     },
     "building-2": {
       "name": "building-2",

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -797,6 +797,8 @@
       ],
       "wall": "whiteStone",
       "roof": "redSlateRoof",
+      "upgradeKind": "playerHouse",
+      "requiresOwnership": true,
       "doors": [
         {
           "tx": 3,
@@ -3095,11 +3097,12 @@
       ]
     },
     "building-1": {
-      "name": "building-1",
+      "name": "Ocean Heights",
       "width": 5,
       "height": 5,
       "floorTileId": "woodFloor",
-      "decor": []
+      "decor": [],
+      "playerDecor": true
     }
   },
   "treasures": [

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -2704,6 +2704,7 @@
         }
       ],
       "requiresOwnership": true,
+      "upgradeKind": "playerHouse",
       "comment": "Lakeside Cottage"
     }
   ],
@@ -8593,11 +8594,12 @@
       ]
     },
     "building-1": {
-      "name": "building-1",
+      "name": "Lakeside Cottage",
       "width": 6,
       "height": 6,
       "floorTileId": "woodFloor",
-      "decor": []
+      "decor": [],
+      "playerDecor": true
     }
   },
   "npcs": [


### PR DESCRIPTION
## Summary

Millhaven's `building-1` ("Ocean Heights") was checked for a correct player-purchasable/decoratable house setup and found broken: it was drawn via the map editor's "Draw Building" tool but never tagged with the fields the player-house mechanism needs (`docs/hubworld.md` §10/§13). The same incomplete setup was found on the two other existing player-house stubs — Ravenwatch's "Lakeside Cottage" and Capital City's "Meadow View" — so this PR fixes all three.

- Added `"upgradeKind": "playerHouse"` to all three buildings — without it they were excluded from the 🏗️ Town Upgrades purchase panel (`HubWorld.tsx` filters on this field), so there was no way to buy them in-game.
- Added `"requiresOwnership": true` to Millhaven's building (Ravenwatch/Capital City already had it) — without it, Millhaven's door was unlocked and enterable for free, with no ownership gate.
- Added `"playerDecor": true` to all three interiors — without it, `HubTownCanvas` never renders placed DECORATE furniture, so the room would stay empty forever even after purchase.
- Replaced the placeholder interior `"name": "building-1"` with the human-readable name already recorded in each building's `comment` (Ocean Heights / Lakeside Cottage / Meadow View), since the Town Upgrades panel displays the interior name directly.

No code changes — the `playerHouse` mechanism (upgrade track, ownership gate, DECORATE rendering) was already fully implemented; this is purely a data-tagging fix in each town's `config.json`.

## Test plan

- [x] `python3 -m json.tool` on all three edited `config.json` files — valid JSON
- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — all 420 tests pass (40 test files), including `loader.test.ts`'s player-house-field coverage
- [ ] In-game: open Town Upgrades in Millhaven/Ravenwatch/Capital City, confirm "Ocean Heights"/"Lakeside Cottage"/"Meadow View" now list a purchasable "Purchase" tier, buy it, walk in, place furniture via DECORATE, and confirm it renders in the room


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_