### PR TITLE
feat(mapEditor): one-click "Make Player House" + consistency test

### DIFF
--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -77,6 +77,7 @@ interface Props {
   activeLevel:      number
   onSetActiveLevel:      (level: number) => void
   onUpdateBuilding:      (index: number, patch: Partial<RawBuilding>) => void
+  onMakePlayerHouse:     (index: number) => void
   onResizeBuilding?:     (index: number, dir: 'top' | 'bottom' | 'left' | 'right', grow?: boolean) => void
   onUpdateBuildingLevelVisual: (buildingIndex: number, minLevel: number, patch: Partial<{ rect: [number, number, number, number]; wall: WallMaterial; roof: RoofMaterial }>) => void
   onUpdateDecorMinLevel: (entity: SelectedEntity, minLevel: number | undefined) => void
@@ -1023,6 +1024,7 @@ function StreetInspector({
 function BuildingInspector({
   building, buildingIndex, activeLevel, onSetActiveLevel, onUpdateBuilding, onUpdateBuildingLevelVisual,
   onOpenInterior, onOpenBuildingEditor, interiorIds, existingInteriorIds, onAddInterior, onResizeBuilding,
+  onMakePlayerHouse, hasMatchingInterior, isPlayerHouse,
 }: {
   building: RawBuilding
   buildingIndex: number
@@ -1036,6 +1038,9 @@ function BuildingInspector({
   existingInteriorIds: string[]
   onAddInterior: (id: string, interior: RawInterior) => void
   onResizeBuilding?: (index: number, dir: 'top' | 'bottom' | 'left' | 'right', grow?: boolean) => void
+  onMakePlayerHouse: (index: number) => void
+  hasMatchingInterior: boolean
+  isPlayerHouse: boolean
 }) {
   const [tx1, ty1, tx2, ty2] = building.rect ?? [0, 0, 0, 0]
   const [showForm, setShowForm] = useState(false)
@@ -1210,6 +1215,25 @@ function BuildingInspector({
             title="Door stays locked until purchased via Town Upgrades — e.g. a player house"
           />
         </Field>
+        <button
+          onClick={() => onMakePlayerHouse(buildingIndex)}
+          disabled={!hasMatchingInterior || isPlayerHouse}
+          title={
+            !hasMatchingInterior
+              ? 'Add a matching interior first (use + New room below)'
+              : 'Sets Upgrade Kind: playerHouse + Requires Ownership on this building, and Player Decor on its interior — all at once'
+          }
+          style={{
+            width: '100%', padding: '5px 0', borderRadius: 3, fontSize: 11, marginTop: 6,
+            cursor: (!hasMatchingInterior || isPlayerHouse) ? 'default' : 'pointer',
+            background: isPlayerHouse ? '#16241a' : '#1a2e1a',
+            border: `1px solid ${isPlayerHouse ? '#2a4a2a' : '#3a6a3a'}`,
+            color: isPlayerHouse ? '#6a8a6a' : '#8adb8a',
+            opacity: (!hasMatchingInterior && !isPlayerHouse) ? 0.5 : 1,
+          }}
+        >
+          {isPlayerHouse ? '✓ Player House' : '🏠 Make Player House'}
+        </button>
 
         {/* Per-level look — base (level 0) edits the building; higher levels write
             a levelVisuals override that kicks in once the building is upgraded. */}
@@ -2631,7 +2655,7 @@ function SpawnTileInspector({
 
 export function EntityInspector({
   selectedEntities, mapId, configData, activeInteriorId, activeBuildingIndex, activeLevel, viewMode,
-  onSetActiveLevel, onUpdateBuilding, onResizeBuilding, onUpdateBuildingLevelVisual, onUpdateDecorMinLevel, onUpdateDecorHideAtLevel,
+  onSetActiveLevel, onUpdateBuilding, onMakePlayerHouse, onResizeBuilding, onUpdateBuildingLevelVisual, onUpdateDecorMinLevel, onUpdateDecorHideAtLevel,
   onDelete, onMoveEntity, onZlayerChange, onUpdateGlow, onUpdatePickupGlow, onUpdatePickupExtraTiles, onDialogueChange,
   onOpenInterior, onCloseInterior, onOpenBuildingEditor, onCloseBuildingEditor, onUpdateStreetEntry,
   onResizeInterior, onAddInterior, onAddInteriorExit, onUpdateInteriorProps, onUpdateInteriorExit,
@@ -3252,6 +3276,9 @@ export function EntityInspector({
         })
       : []
     const existingLock = buildingId ? (configData.lockedDoors ?? []).find(d => d.buildingId === buildingId) : undefined
+    const matchedInterior = buildingId ? configData.interiors?.[buildingId] : undefined
+    const isPlayerHouse = building.upgradeKind === 'playerHouse'
+      && !!building.requiresOwnership && !!matchedInterior?.playerDecor
 
     return (
       <div style={panelStyle}>
@@ -3270,6 +3297,9 @@ export function EntityInspector({
             existingInteriorIds={Object.keys(configData.interiors ?? {})}
             onAddInterior={onAddInterior}
             onResizeBuilding={onResizeBuilding}
+            onMakePlayerHouse={onMakePlayerHouse}
+            hasMatchingInterior={!!matchedInterior}
+            isPlayerHouse={isPlayerHouse}
           />
           {buildingId && !existingLock && (
             <div style={{ borderTop: '1px solid #333', marginTop: 10, paddingTop: 10 }}>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -51,7 +51,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
     addPondTile, addBridgeTile, updatePondEntry, updateBridgeEntry, addNpcSpawnTile, addChickenZone, addArea, addBuilding,
     convertStreetToPond, convertPondToStreet,
     batchUpdateZlayer, batchUpdateStreetPathType,
-    updateDecorZlayer, updateDecorTileId, reorderDecor, updateGlow, updateDecorMinLevel, updateDecorHideAtLevel, updateBuildingLevelVisual, updateBuilding, resizeBuilding, addNpc, updateNpcDialogue, updateNpc,
+    updateDecorZlayer, updateDecorTileId, reorderDecor, updateGlow, updateDecorMinLevel, updateDecorHideAtLevel, updateBuildingLevelVisual, updateBuilding, makeBuildingPlayerHouse, resizeBuilding, addNpc, updateNpcDialogue, updateNpc,
     addAnimal, updateAnimal,
     updateTreasure, updateConfig,
     updateArea, updateMapProps, resizeMap,
@@ -410,6 +410,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
               viewMode={state.viewMode}
               onSetActiveLevel={setActiveLevel}
               onUpdateBuilding={updateBuilding}
+              onMakePlayerHouse={makeBuildingPlayerHouse}
               onResizeBuilding={resizeBuilding}
               onUpdateBuildingLevelVisual={updateBuildingLevelVisual}
               onUpdateDecorMinLevel={updateDecorMinLevel}

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -991,6 +991,29 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     })
   }, [])
 
+  // Atomically tags a building + its matching interior as a purchasable,
+  // player-decorated house — the 3-field pattern from docs/hubworld.md §10/§13
+  // that's easy to half-apply since the fields live in two separate panels.
+  const makeBuildingPlayerHouse = useCallback((index: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const buildings = [...(prevConfig.buildings ?? [])]
+      const building = buildings[index]
+      const id = building?.id
+      const interior = id ? prevConfig.interiors?.[id] : undefined
+      if (!building || !id || !interior) return s
+      buildings[index] = { ...building, upgradeKind: 'playerHouse', requiresOwnership: true }
+      const interiors = { ...prevConfig.interiors, [id]: { ...interior, playerDecor: true } }
+      return {
+        ...s,
+        configData: { ...prevConfig, buildings, interiors },
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
   // Grows/shrinks a single-rect building's footprint by one tile on the given
   // edge. Doors/windows/decor are stored relative to the building's (ox, oy)
   // origin (ox = min x1, oy = max y2) — growing/shrinking on the left or
@@ -1655,6 +1678,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     updateDecorHideAtLevel,
     updateBuildingLevelVisual,
     updateBuilding,
+    makeBuildingPlayerHouse,
     resizeBuilding,
     addNpc,
     updateNpcDialogue,

--- a/web/src/data/hub/playerHouseConsistency.test.ts
+++ b/web/src/data/hub/playerHouseConsistency.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { LOCATION_REGISTRY } from './hubWorldFactory'
+
+// Regression sentinel for the player-house authoring trap (see docs/hubworld.md
+// §10/§13): a building can be tagged `requiresOwnership`/`upgradeKind` without
+// its matching interior ever getting `playerDecor`, which purchases fine but
+// never renders placed furniture — or `requiresOwnership` without an
+// `upgradeKind` track, which can never be purchased at all. Runs against every
+// real town's parsed data (not synthetic fixtures), so it would have caught
+// the original Millhaven/Ravenwatch/Capital City bug and catches recurrences,
+// including ones introduced by hand-editing config.json outside the map editor.
+describe('player-house tag consistency (all towns)', () => {
+  for (const [townKey, { locationData }] of Object.entries(LOCATION_REGISTRY)) {
+    for (const building of locationData.HUB_BUILDINGS) {
+      const label = `${townKey}/${building.id ?? '(no id)'}`
+
+      if (building.requiresOwnership) {
+        it(`${label}: requiresOwnership implies a purchase track (upgradeKind)`, () => {
+          expect(building.upgradeKind, `${label} has requiresOwnership but no upgradeKind — its door can never be purchased/unlocked`).toBeTruthy()
+        })
+      }
+
+      if (building.upgradeKind === 'playerHouse') {
+        it(`${label}: playerHouse building has a matching interior with playerDecor`, () => {
+          const interior = building.id ? locationData.HUB_INTERIORS[building.id] : undefined
+          expect(interior, `${label} has no matching interior keyed by its own id`).toBeTruthy()
+          expect(interior?.playerDecor, `${label}'s interior is missing playerDecor — placed furniture will never render`).toBe(true)
+        })
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Follow-up to #1944, which fixed the *data* for Millhaven/Ravenwatch/Capital City's player houses. This PR fixes the underlying map-editor gap that caused all three to ship half-tagged in the first place, plus adds a regression sentinel.

- The player-house purchase/decorate fields (`upgradeKind`, `requiresOwnership`, `playerDecor`) live in two separate inspector panels (Building inspector vs. Interior properties) with nothing tying them together or warning when they're inconsistent — exactly the trap that produced the same mistake in all three towns.
- `useMapEditorState.ts`: new `makeBuildingPlayerHouse(index)` action sets all three fields atomically as one undo step, reusing `addBuilding`'s existing building+matching-interior pattern.
- `MapEditor.tsx` / `EntityInspector.tsx`: wires the action to a new **"🏠 Make Player House"** button on the Building inspector, right after the "Requires Ownership" checkbox. Disabled (with a tooltip) until a matching interior exists; shows a disabled **"✓ Player House"** once all three fields are already set.
- `playerHouseConsistency.test.ts`: new test scanning every real town's parsed data (`LOCATION_REGISTRY`) for the two failure modes — `requiresOwnership` with no `upgradeKind` (door can never be purchased), and `upgradeKind: playerHouse` with no matching interior `playerDecor` (furniture never renders). Runs against real town data, not synthetic fixtures, so it would have caught the original bug and catches any recurrence — including hand-edited JSON that bypasses the editor entirely.

No changes to `loader.ts`/`config.ts`/`buildingUpgrades.json` — the underlying mechanism was already correct; this is purely an editor-workflow + test-coverage fix.

## Test plan

- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — 426/426 tests pass (6 new from the consistency test, covering the now-fixed Millhaven/Ravenwatch/Capital City buildings)
- [ ] In-editor: open a fresh "Draw Building" shell + matching room, confirm the "Make Player House" button is disabled until a room exists, then enabled, then click it and confirm Upgrade Kind/Requires Ownership/Player Decor are all set and the button flips to "✓ Player House"


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_