### PR TITLE
feat(hub): tiered global pricing for player-house purchases

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1353,6 +1353,17 @@ top-level interior should use the **same id** (e.g. both `"ravenwatch-
 player-house"`), and any sub-room added later should extend that same
 prefix (e.g. `"ravenwatch-player-house-attic"`).
 
+**Pricing is dynamic, unlike every other kind.** `buildingUpgrades.json`'s
+`playerHouse.cost` (2500) is only the documented baseline — the real price
+is computed in `reputation.ts`'s `nextUpgrade`, which special-cases
+`kind === 'playerHouse'` to charge `price(N) = 7500 × 2^(N-1) − 5000` for
+the Nth player house the player owns **across every town** (not per-town):
+2,500 / 10,000 / 25,000 / 55,000 / ... `countOwnedPlayerHouses()` (also in
+`reputation.ts`) tallies ownership by scanning every town in
+`LOCATION_REGISTRY` for `upgradeKind === 'playerHouse'` buildings at
+level ≥ 1. `purchaseUpgrade` charges whatever `nextUpgrade` just computed,
+so the displayed and charged prices can't drift apart.
+
 ### Services
 
 Each unlocked `service` id is readable via `getUnlockedServices(town)` /

--- a/web/src/data/hub/buildingUpgrades.json
+++ b/web/src/data/hub/buildingUpgrades.json
@@ -106,7 +106,7 @@
   "playerHouse": [
     {
       "label": "Purchase",
-      "cost": 500,
+      "cost": 2500,
       "repReward": 50,
       "repRequired": 0,
       "benefit": "A house of your own — unfurnished, ready to decorate.",

--- a/web/src/game/hub/reputation.test.ts
+++ b/web/src/game/hub/reputation.test.ts
@@ -11,6 +11,7 @@ import {
   tributeAmount,
   tributeAvailable,
   collectTribute,
+  countOwnedPlayerHouses,
 } from './reputation'
 import { saveCrystals, loadCrystals } from '../collection'
 import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
@@ -147,6 +148,28 @@ describe('playerHouse building track', () => {
     expect(getUpgradeLevel(TOWN, 'player-house')).toBe(1)
     expect(loadCrystals()).toBe(0)
     expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').maxed).toBe(true)
+  })
+
+  it('prices scale with how many player houses are already owned across all towns', () => {
+    expect(nextUpgrade('Millhaven', 'building-1', 'playerHouse').cost).toBe(2500)
+    saveCrystals(2500)
+    expect(purchaseUpgrade('Millhaven', 'building-1', 'playerHouse').ok).toBe(true)
+
+    expect(nextUpgrade('Ravenwatch', 'building-1', 'playerHouse').cost).toBe(10000)
+    saveCrystals(10000)
+    expect(purchaseUpgrade('Ravenwatch', 'building-1', 'playerHouse').ok).toBe(true)
+
+    expect(nextUpgrade('Crownhaven', 'building-1', 'playerHouse').cost).toBe(25000)
+  })
+
+  it('formula extrapolates past the third house by continuing to double', () => {
+    expect(countOwnedPlayerHouses()).toBe(0) // sanity: fresh store
+    for (const t of ['Millhaven', 'Ravenwatch', 'Crownhaven']) {
+      saveCrystals(nextUpgrade(t, 'building-1', 'playerHouse').cost)
+      purchaseUpgrade(t, 'building-1', 'playerHouse')
+    }
+    expect(countOwnedPlayerHouses()).toBe(3)
+    expect(nextUpgrade('SomeFourthTown', 'building-1', 'playerHouse').cost).toBe(55000)
   })
 })
 

--- a/web/src/game/hub/reputation.ts
+++ b/web/src/game/hub/reputation.ts
@@ -15,6 +15,7 @@ import {
   getReputationTier,
   type BuildingUpgradeLevel,
 } from '../../data/hub/buildingUpgrades'
+import { LOCATION_REGISTRY } from '../../data/hub/hubWorldFactory'
 
 const KEY = 'jarv_hub_reputation'
 
@@ -70,6 +71,34 @@ export function getUpgradeLevel(town: string, buildingId: string): number {
   return townState(load(), town).levels[buildingId] ?? 0
 }
 
+// ── Player-house dynamic pricing ─────────────────────────────────────────────
+//
+// Unlike every other upgrade kind, `playerHouse` cost isn't a static
+// per-level number from buildingUpgrades.json — it scales with how many
+// player houses the player already owns *across every town*, not just the
+// one they're buying in. This is a real-estate-style "each house costs more
+// than the last" curve, so it lives here rather than in the generic catalog.
+
+/** Crystal cost of the player's *next* player-house purchase, based on how
+ *  many they already own across every town. Doubles the running cost each
+ *  additional house: 2500, 10000, 25000, 55000, 115000, ... */
+function playerHousePrice(ownedCount: number): number {
+  const n = ownedCount + 1 // 1-indexed: the house about to be purchased
+  return 7500 * 2 ** (n - 1) - 5000
+}
+
+/** Count of player-house buildings currently owned (purchased) across every town. */
+export function countOwnedPlayerHouses(): number {
+  let count = 0
+  for (const { locationData } of Object.values(LOCATION_REGISTRY)) {
+    const t = locationData.HUB_TOWN_NAME
+    for (const b of locationData.HUB_BUILDINGS) {
+      if (b.id && b.upgradeKind === 'playerHouse' && getUpgradeLevel(t, b.id) >= 1) count++
+    }
+  }
+  return count
+}
+
 // ── Next-upgrade query ───────────────────────────────────────────────────────
 
 export interface NextUpgrade {
@@ -101,11 +130,12 @@ export function nextUpgrade(town: string, buildingId: string, kind: string | und
   }
 
   const def = track[level]
+  const cost = kind === 'playerHouse' ? playerHousePrice(countOwnedPlayerHouses()) : def.cost
   return {
-    def,
+    def: { ...def, cost },
     level,
     total,
-    cost: def.cost,
+    cost,
     repRequired: def.repRequired,
     repLocked: state.rep < def.repRequired,
     maxed: false,


### PR DESCRIPTION
## Summary

Player houses (Millhaven "Ocean Heights", Ravenwatch "Lakeside Cottage", Crownhaven "Meadow View" — #1944/#1945) currently all cost a flat 500 crystals. This replaces that with a real-estate-style escalation: the price of a player's *next* house purchase depends on how many player houses they already own **across every town**, not on which town they're buying in — 2,500 / 10,000 / 25,000 / 55,000 / ..., doubling the running cost each additional house (`price(N) = 7500 × 2^(N-1) − 5000`).

- `reputation.ts`: `nextUpgrade()` special-cases `upgradeKind === 'playerHouse'` to price off a new `countOwnedPlayerHouses()` (scans every town in `LOCATION_REGISTRY` for purchased `playerHouse` buildings) instead of the flat catalog cost. `purchaseUpgrade()` needed no change — it already charges whatever `nextUpgrade()` returns, so the displayed and charged prices can never drift apart, and a building being purchased (level 0) is never double-counted as already owned.
- `buildingUpgrades.json`: `playerHouse` baseline `cost` 500 → 2500 — documents the first-house price; the real price is always computed dynamically at purchase time.
- `reputation.test.ts`: new tests cover the 2,500 → 10,000 → 25,000 sequence across the three real towns (Millhaven, Ravenwatch, Crownhaven) in purchase order, and that the formula keeps doubling correctly past the third house.
- `docs/hubworld.md` §10: documents that `playerHouse` pricing is dynamic and globally-scoped, unlike every other upgrade kind's static per-level cost, so the catalog's generic "cost" field description isn't misread for this kind.

No changes needed to `HubTownUpgrades.tsx`/`HubWorld.tsx` — they already display/charge whatever `nextUpgrade`/`purchaseUpgrade` return.

## Test plan

- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — 428/428 tests pass (2 new, covering the pricing sequence and formula extrapolation)
- [ ] In-game: buy player houses in Millhaven, then Ravenwatch, then Crownhaven in sequence and confirm the Town Upgrades panel shows 2,500 → 10,000 → 25,000


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_