### PR TITLE
feat(hub): resize player-house interiors, add second room, fix Decorate button

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1337,32 +1337,37 @@ key/hours checks and calls `onDoorLockedRef.current?.(buildingId,
 'unpurchased')` — `HubWorld.tsx`'s `handleDoorLocked` shows a prompt to visit
 Town Upgrades instead of entering.
 
-The `playerHouse` kind (`buildingUpgrades.json`) is a single-tier track —
-`level 0→1`, "Purchase" — meant for exactly this: pair `"upgradeKind":
+The `playerHouse` kind (`buildingUpgrades.json`) is a two-tier track —
+`level 0→1` "Purchase" (the house itself), `level 1→2` "Expand" (a second
+room, see §19) — meant for exactly this: pair `"upgradeKind":
 "playerHouse"` with `"requiresOwnership": true` on the building, and
 `"playerDecor": true` (§19) with an empty `"decor": []` on its interior.
-Additional tiers can be added later to unlock more rooms the normal way
-(`minLevel` on an interior `exits[]` entry, see the table above) — no new
-code needed, since `playerHouse`-tagged buildings resolve their upgrade
-level through the same `getUpgradeLevel`/`levelKey` machinery as any other
-building. **Id rule**: because `levelKey` resolution requires the
-*building* id to prefix the *interior* id (not the reverse — this bit an
-earlier `home`/`home-building` pairing where the interior id was shorter
-than the building id and never resolved), a player-house building and its
-top-level interior should use the **same id** (e.g. both `"ravenwatch-
-player-house"`), and any sub-room added later should extend that same
-prefix (e.g. `"ravenwatch-player-house-attic"`).
+Further tiers/rooms can be added the same way (`minLevel` on an interior
+`exits[]` entry, see the table above) — no new code needed, since
+`playerHouse`-tagged buildings resolve their upgrade level through the
+same `getUpgradeLevel`/`levelKey` machinery as any other building. **Id
+rule**: because `levelKey` resolution requires the *building* id to prefix
+the *interior* id (not the reverse — this bit an earlier `home`/`home-building`
+pairing where the interior id was shorter than the building id and never
+resolved), a player-house building and its top-level interior should use
+the **same id** (e.g. both `"building-1"`), and any sub-room added later
+should extend that same prefix (e.g. `"building-1-second-room"` — the
+live pattern all three current player houses use).
 
-**Pricing is dynamic, unlike every other kind.** `buildingUpgrades.json`'s
-`playerHouse.cost` (2500) is only the documented baseline — the real price
-is computed in `reputation.ts`'s `nextUpgrade`, which special-cases
-`kind === 'playerHouse'` to charge `price(N) = 7500 × 2^(N-1) − 5000` for
-the Nth player house the player owns **across every town** (not per-town):
-2,500 / 10,000 / 25,000 / 55,000 / ... `countOwnedPlayerHouses()` (also in
+**Pricing is dynamic for tier 1 only, unlike every other kind's static
+per-level cost.** `buildingUpgrades.json`'s `playerHouse[0].cost` (2500) is
+only the documented baseline — the real tier-1 price is computed in
+`reputation.ts`'s `nextUpgrade`, which special-cases `kind === 'playerHouse'
+&& level === 0` to charge `price(N) = 7500 × 2^(N-1) − 5000` for the Nth
+player house the player owns **across every town** (not per-town): 2,500 /
+10,000 / 25,000 / 55,000 / ... `countOwnedPlayerHouses()` (also in
 `reputation.ts`) tallies ownership by scanning every town in
 `LOCATION_REGISTRY` for `upgradeKind === 'playerHouse'` buildings at
 level ≥ 1. `purchaseUpgrade` charges whatever `nextUpgrade` just computed,
-so the displayed and charged prices can't drift apart.
+so the displayed and charged prices can't drift apart. Tier 2 ("Expand")
+and any higher tiers are **not** part of this override — they're priced
+straight from the catalog like any other kind's higher tiers, since
+they're a per-house upgrade rather than a new-house purchase.
 
 ### Services
 
@@ -2011,9 +2016,18 @@ The DECORATE grid (§18) has a real in-world counterpart: any interior
 tagged `playerDecor: true` renders the player's placed furniture as real
 sprites instead of static JSON decor. This is a generic mechanism (§10),
 not tied to one hardcoded interior — every town's player house works the
-same way once its building/interior pair exists (currently: none placed
-yet, pending the map editor "add building" tool).
+same way once its building/interior pair exists. Three are live today:
+Millhaven's `building-1` ("Ocean Heights"), Ravenwatch's `building-1`
+("Lakeside Cottage"), and Capital City's `building-1` ("Meadow View").
 
+- **Room size must match the DECORATE grid.** The walkable floor of an
+  interior is `width-2 × height-2` (`HubTownCanvas.tsx` carves a 1-tile
+  wall border on every side), while the DECORATE grid is a fixed
+  `HOME_GRID_COLS × HOME_GRID_ROWS` = 8×6 (`homeLayout.ts`). A `playerDecor`
+  interior's `width`/`height` should therefore be `HOME_GRID_COLS+2 ×
+  HOME_GRID_ROWS+2` = **10×8** — anything smaller clips placed furniture
+  into (or entirely off) the walkable floor. The three live player houses
+  all use 10×8.
 - **Unfurnished by convention**: a `playerDecor` interior's `decor` array
   is `[]` in `config.json` — everything visible is computed at runtime.
 - **Dynamic decor**: `HubTownCanvas.tsx`'s `doEnterInterior` checks
@@ -2022,11 +2036,29 @@ yet, pending the map editor "add building" tool).
   `loadHomeLayout()` via `web/src/game/hub/furnitureTiles.ts`'s
   `getFurnitureTileOffsets(itemId)`, which maps each catalog id to one or
   more `{dx, dy, tileId}` offsets (numeric tile ids, resolved through
-  `BASE_CHIP_TILES`) relative to the piece's anchor. No other change to the
-  rendering pipeline — the merged list feeds the same `renderDecorItems`
-  every interior uses. The furniture layout itself is global, not
-  per-town — buying houses in two towns furnishes the same shared layout in
-  both (documented limitation, not yet solved).
+  `BASE_CHIP_TILES`) relative to the piece's anchor. DECORATE-grid
+  coordinates are 0-indexed within the walkable floor, so the anchor is
+  offset by `+1` in both axes before being pushed onto the room's decor
+  list, to land inside the wall border rather than on it. No other change
+  to the rendering pipeline — the merged list feeds the same
+  `renderDecorItems` every interior uses.
+- **Furniture layout is scoped per house, not global.** `houseKey =
+  ${locationKey}:${buildingId}` (`HubTownCanvas.tsx`) and the matching
+  `${town}:${activeBuildingId}` string the 🛋 DECORATE button passes
+  through `HubWorld.tsx` — so each town's house (and each of its rooms,
+  see below) has its own independent `jarv_hub_home_layout:<houseKey>`
+  entry in localStorage; buying houses in two towns does **not** share a
+  layout between them.
+- **Buying more rooms**: `playerHouse` (`buildingUpgrades.json`) is a
+  two-tier track — tier 1 "Purchase" (the house itself), tier 2 "Expand"
+  (a second room). A second room is an ordinary `playerDecor: true`
+  sub-room interior, id-prefixed by the main room's id per the rule above
+  (e.g. `building-1-second-room`), connected by a `minLevel: 2`-gated
+  `exits[]` entry on the main room (only appears once "Expand" is bought)
+  plus a plain return `exits[]` entry on the sub-room back to the main
+  room. Because the sub-room has its own id, it automatically gets its own
+  independent DECORATE layout — no extra plumbing needed. All three live
+  player houses follow this pattern today.
 - **Tile art is a stand-in for 7 of 12 items.** oak-bookshelf, four-poster-
   bed, candle-stand, wall-clock, and cozy-rug reuse tiles that are good/exact
   matches. round-table, potted-fern, armchair, framed-portrait, travel-chest,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -250,6 +250,7 @@ type Screen =
   | 'player'
   | 'collection-tabs'
   | 'home-shelf'
+  | 'home-shelf-decorate'
   | 'hubworld'
   | 'hub-minigame'
   | 'hub-fishing'
@@ -3317,8 +3318,12 @@ export default function App() {
         />
       )}
 
-      {screen === 'home-shelf' && (
-        <HomeShelf onBack={() => setScreen('hubworld')} houseKey={shopBuildingId} />
+      {(screen === 'home-shelf' || screen === 'home-shelf-decorate') && (
+        <HomeShelf
+          onBack={() => setScreen('hubworld')}
+          houseKey={shopBuildingId}
+          initialTab={screen === 'home-shelf-decorate' ? 'decorate' : 'shelf'}
+        />
       )}
 
       {screen === 'heroCards' && (

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -18,6 +18,9 @@ interface Props {
   /** Which owned house's furniture layout to edit — opaque key (e.g. `${town}:${buildingId}`).
    *  Falls back to a shared 'default' bucket when no specific house is known. */
   houseKey?: string
+  /** Which tab to open on — defaults to 'shelf' (e.g. Ravenwatch's Steward Maren).
+   *  The in-house 🛋 DECORATE button passes 'decorate' to skip straight past SHELF. */
+  initialTab?: 'shelf' | 'decorate'
 }
 
 type ShelfEntry =
@@ -46,8 +49,8 @@ function nextRotation(r: 0 | 90 | 180 | 270): 0 | 90 | 180 | 270 {
 
 const REMOVE_ARM_MS = 2500
 
-export function HomeShelf({ onBack, houseKey = 'default' }: Props) {
-  const [tab, setTab] = useState<'shelf' | 'decorate'>('shelf')
+export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }: Props) {
+  const [tab, setTab] = useState<'shelf' | 'decorate'>(initialTab)
 
   // ── Shelf tab (existing, unchanged) ──
   const items  = loadInventory()

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1669,7 +1669,9 @@ export function HubTownCanvas({
         const houseKey = `${locationKey}:${buildingId}`
         for (const piece of loadHomeLayout(houseKey)) {
           for (const offset of getFurnitureTileOffsets(piece.itemId)) {
-            visibleDecor.push({ tx: piece.x + offset.dx, ty: piece.y + offset.dy, tileId: offset.tileId })
+            // DECORATE grid coords are 0-indexed within the walkable floor, which
+            // itself starts at (1,1) inside the room's 1-tile wall border.
+            visibleDecor.push({ tx: piece.x + 1 + offset.dx, ty: piece.y + 1 + offset.dy, tileId: offset.tileId })
           }
         }
       }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -2081,7 +2081,7 @@ function hasOfferableQuest(giverId: string): boolean {
           <button
             className="action-btn"
             style={{ position: 'absolute', top: 16, right: 96, zIndex: 10 }}
-            onClick={() => handleNodeInteract('home-shelf', `${town}:${activeBuildingId}`)}
+            onClick={() => handleNodeInteract('home-shelf-decorate', `${town}:${activeBuildingId}`)}
           >
             🛋 DECORATE
           </button>

--- a/web/src/data/hub/buildingUpgrades.json
+++ b/web/src/data/hub/buildingUpgrades.json
@@ -111,6 +111,14 @@
       "repRequired": 0,
       "benefit": "A house of your own — unfurnished, ready to decorate.",
       "service": "player-house-purchase"
+    },
+    {
+      "label": "Expand",
+      "cost": 5000,
+      "repReward": 50,
+      "repRequired": 0,
+      "benefit": "A second room, ready to decorate.",
+      "service": "player-house-expand"
     }
   ],
   "workshop": [

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -4524,10 +4524,41 @@
     "building-1": {
       "name": "Meadow View",
       "width": 10,
-      "height": 7,
+      "height": 8,
       "floorTileId": "woodFloor",
       "decor": [],
-      "playerDecor": true
+      "playerDecor": true,
+      "exits": [
+        {
+          "tx": 9,
+          "ty": 4,
+          "toInteriorId": "building-1-second-room",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "minLevel": 2,
+          "label": "Second Room"
+        }
+      ]
+    },
+    "building-1-second-room": {
+      "name": "Meadow View — Parlour",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "decor": [],
+      "playerDecor": true,
+      "exits": [
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "building-1",
+          "entryTx": 8,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "Back"
+        }
+      ]
     },
     "building-2": {
       "name": "building-2",

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -3098,11 +3098,42 @@
     },
     "building-1": {
       "name": "Ocean Heights",
-      "width": 5,
-      "height": 5,
+      "width": 10,
+      "height": 8,
       "floorTileId": "woodFloor",
       "decor": [],
-      "playerDecor": true
+      "playerDecor": true,
+      "exits": [
+        {
+          "tx": 9,
+          "ty": 4,
+          "toInteriorId": "building-1-second-room",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "minLevel": 2,
+          "label": "Second Room"
+        }
+      ]
+    },
+    "building-1-second-room": {
+      "name": "Ocean Heights — Guest Room",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "decor": [],
+      "playerDecor": true,
+      "exits": [
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "building-1",
+          "entryTx": 8,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "Back"
+        }
+      ]
     }
   },
   "treasures": [

--- a/web/src/data/hub/playerHouseConsistency.test.ts
+++ b/web/src/data/hub/playerHouseConsistency.test.ts
@@ -28,5 +28,16 @@ describe('player-house tag consistency (all towns)', () => {
         })
       }
     }
+
+    // Every minLevel-gated exit (e.g. a purchasable second room) must point at
+    // an interior that actually exists — otherwise the door opens onto nothing.
+    for (const [interiorId, interior] of Object.entries(locationData.HUB_INTERIORS)) {
+      for (const exit of interior.exits ?? []) {
+        if (exit.minLevel === undefined) continue
+        it(`${townKey}/${interiorId}: minLevel-gated exit "${exit.label ?? exit.toInteriorId}" targets a real interior`, () => {
+          expect(locationData.HUB_INTERIORS[exit.toInteriorId], `${townKey}/${interiorId}'s exit to "${exit.toInteriorId}" has no matching interior`).toBeTruthy()
+        })
+      }
+    }
   }
 })

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8595,11 +8595,42 @@
     },
     "building-1": {
       "name": "Lakeside Cottage",
-      "width": 6,
-      "height": 6,
+      "width": 10,
+      "height": 8,
       "floorTileId": "woodFloor",
       "decor": [],
-      "playerDecor": true
+      "playerDecor": true,
+      "exits": [
+        {
+          "tx": 9,
+          "ty": 4,
+          "toInteriorId": "building-1-second-room",
+          "entryTx": 1,
+          "entryTy": 4,
+          "direction": "right",
+          "minLevel": 2,
+          "label": "Second Room"
+        }
+      ]
+    },
+    "building-1-second-room": {
+      "name": "Lakeside Cottage — Loft",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "woodFloor",
+      "decor": [],
+      "playerDecor": true,
+      "exits": [
+        {
+          "tx": 0,
+          "ty": 4,
+          "toInteriorId": "building-1",
+          "entryTx": 8,
+          "entryTy": 4,
+          "direction": "left",
+          "label": "Back"
+        }
+      ]
     }
   },
   "npcs": [

--- a/web/src/game/hub/reputation.test.ts
+++ b/web/src/game/hub/reputation.test.ts
@@ -136,17 +136,29 @@ describe('unlocked services', () => {
 describe('playerHouse building track', () => {
   const playerHouse = getUpgradeTrack('playerHouse')
 
-  it('is a single-tier, unlocked-from-the-start purchase', () => {
-    expect(playerHouse.length).toBe(1)
+  it('is a two-tier track (Purchase + Expand), unlocked-from-the-start', () => {
+    expect(playerHouse.length).toBe(2)
     expect(playerHouse[0].repRequired).toBe(0)
+    expect(playerHouse[1].repRequired).toBe(0)
   })
 
-  it('purchasing it raises the level to 1 and maxes the track', () => {
+  it('purchasing tier 1 raises the level to 1 without maxing the track', () => {
     saveCrystals(playerHouse[0].cost)
     const res = purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
     expect(res.ok).toBe(true)
     expect(getUpgradeLevel(TOWN, 'player-house')).toBe(1)
     expect(loadCrystals()).toBe(0)
+    expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').maxed).toBe(false)
+  })
+
+  it('tier 2 ("Expand") is priced statically from the catalog, not the dynamic per-house formula', () => {
+    saveCrystals(playerHouse[0].cost)
+    purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
+    expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').cost).toBe(playerHouse[1].cost)
+    saveCrystals(playerHouse[1].cost)
+    const res = purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
+    expect(res.ok).toBe(true)
+    expect(getUpgradeLevel(TOWN, 'player-house')).toBe(2)
     expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').maxed).toBe(true)
   })
 

--- a/web/src/game/hub/reputation.ts
+++ b/web/src/game/hub/reputation.ts
@@ -130,7 +130,10 @@ export function nextUpgrade(town: string, buildingId: string, kind: string | und
   }
 
   const def = track[level]
-  const cost = kind === 'playerHouse' ? playerHousePrice(countOwnedPlayerHouses()) : def.cost
+  // Dynamic pricing only applies to the first tier (buying the house itself) —
+  // higher tiers (e.g. "Expand") are per-house upgrades, priced statically
+  // from the catalog like every other kind's higher tiers.
+  const cost = kind === 'playerHouse' && level === 0 ? playerHousePrice(countOwnedPlayerHouses()) : def.cost
   return {
     def: { ...def, cost },
     level,


### PR DESCRIPTION
## Summary

Three fixes for the player-house feature (follow-up to #1944/#1945/#1946):

- **Room size matches the DECORATE grid.** Interiors were smaller than the DECORATE tab's 8×6 placement grid — Millhaven's walkable floor was literally 3×3 (`width-2 × height-2` after the 1-tile wall border `HubTownCanvas.tsx` carves on every side). Resized all three player houses (Millhaven, Ravenwatch, Capital City) to `10×8`, giving exactly an 8×6 walkable floor. Also fixed a latent bug alongside it: `HubTownCanvas.tsx`'s `playerDecor` rendering branch was missing the same `+1` wall-border offset every other tile group in that file already applies, so placed furniture would have rendered clipped into the wall instead of on the floor even in a correctly-sized room.

- **Buying more rooms.** Extended the `playerHouse` upgrade track to two tiers ("Purchase" + "Expand") and authored a real second room (`<building>-second-room`) per town, connected by a `minLevel: 2`-gated exit plus a return exit. The underlying mechanism (`minLevel`-gated exits, per-interior `playerDecor` scoping via `houseKey = ${town}:${buildingId}`) was already fully generic — this activates it with real content, no new runtime code needed. Also caught and fixed a bug in `reputation.ts`'s dynamic pricing: the cross-town doubling formula was incorrectly applying to *every* tier instead of just the first house purchase (`level === 0`) — tier 2 ("Expand") now correctly reads its static cost from the catalog like every other kind's higher tiers.

- **Decorate button skips straight to DECORATE.** Routes through a new `'home-shelf-decorate'` screen id so the 🛋 DECORATE button opens directly on the DECORATE tab instead of SHELF, without touching Ravenwatch's Steward Maren NPC — which uses the same `HomeShelf` component via the existing `'home-shelf'` route and must keep defaulting to SHELF.

## Test plan

- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — 435/435 tests pass, including new/updated coverage for the two-tier `playerHouse` track, tier-2 static pricing, and `minLevel`-gated exit consistency
- [x] Confirmed via a real browser that the dev server boots cleanly with these changes (no runtime errors) and reaches the hub world
- [ ] Full interactive playtest (buy a house, walk into the resized room, place furniture in all four corners, buy "Expand" and confirm the second room, confirm the Decorate button behavior) — not completed in this session due to canvas-navigation constraints in the sandbox; recommended before merging


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_