### PR TITLE
feat(hub): purchasable player-house room slots (basement/floor/left/right/rear)

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -38,6 +38,8 @@
 | `web/src/components/hub/HubInventoryModal.tsx` | 🎒 Hub Inventory UI — held quest items, materials & tools, pet accessories — see §16 | `HubInventoryModal` |
 | `web/src/game/hub/talkCooldown.ts` | Once-per-day "Make conversation" persistence (localStorage) — see §7d | `canTalkToday`, `recordTalk` |
 | `web/src/game/hub/forages.ts` | Once-per-day forage-spot persistence (localStorage) — see §7 `forage` reaction | `canForageToday`, `recordForage` |
+| `web/src/data/roomSlots.json` | Purchasable player-house room-slot catalog (basement/first-floor/left/right/rear) — see §19 "Room Slots" | consumed by `houseRooms.ts` |
+| `web/src/game/hub/houseRooms.ts` | Per-house purchased-slot persistence + dynamic interior/exit synthesis (localStorage) — see §19 "Room Slots" | `getRoomSlotDef`, `getAllRoomSlotDefs`, `getPurchasedSlotIds`, `hasPurchasedSlot`, `purchaseRoomSlot`, `parseSlotBuildingId`, `buildMainRoomExit`, `synthesizeSlotInterior` |
 
 ---
 
@@ -1337,37 +1339,32 @@ key/hours checks and calls `onDoorLockedRef.current?.(buildingId,
 'unpurchased')` — `HubWorld.tsx`'s `handleDoorLocked` shows a prompt to visit
 Town Upgrades instead of entering.
 
-The `playerHouse` kind (`buildingUpgrades.json`) is a two-tier track —
-`level 0→1` "Purchase" (the house itself), `level 1→2` "Expand" (a second
-room, see §19) — meant for exactly this: pair `"upgradeKind":
+The `playerHouse` kind (`buildingUpgrades.json`) is a single-tier track —
+`level 0→1` "Purchase" — meant for exactly this: pair `"upgradeKind":
 "playerHouse"` with `"requiresOwnership": true` on the building, and
 `"playerDecor": true` (§19) with an empty `"decor": []` on its interior.
-Further tiers/rooms can be added the same way (`minLevel` on an interior
-`exits[]` entry, see the table above) — no new code needed, since
-`playerHouse`-tagged buildings resolve their upgrade level through the
-same `getUpgradeLevel`/`levelKey` machinery as any other building. **Id
-rule**: because `levelKey` resolution requires the *building* id to prefix
-the *interior* id (not the reverse — this bit an earlier `home`/`home-building`
-pairing where the interior id was shorter than the building id and never
-resolved), a player-house building and its top-level interior should use
-the **same id** (e.g. both `"building-1"`), and any sub-room added later
-should extend that same prefix (e.g. `"building-1-second-room"` — the
-live pattern all three current player houses use).
+**Id rule**: because `levelKey` resolution requires the *building* id to
+prefix the *interior* id (not the reverse — this bit an earlier
+`home`/`home-building` pairing where the interior id was shorter than the
+building id and never resolved), a player-house building and its top-level
+interior should use the **same id** (e.g. both `"building-1"`).
 
-**Pricing is dynamic for tier 1 only, unlike every other kind's static
-per-level cost.** `buildingUpgrades.json`'s `playerHouse[0].cost` (2500) is
-only the documented baseline — the real tier-1 price is computed in
-`reputation.ts`'s `nextUpgrade`, which special-cases `kind === 'playerHouse'
-&& level === 0` to charge `price(N) = 7500 × 2^(N-1) − 5000` for the Nth
-player house the player owns **across every town** (not per-town): 2,500 /
-10,000 / 25,000 / 55,000 / ... `countOwnedPlayerHouses()` (also in
-`reputation.ts`) tallies ownership by scanning every town in
-`LOCATION_REGISTRY` for `upgradeKind === 'playerHouse'` buildings at
-level ≥ 1. `purchaseUpgrade` charges whatever `nextUpgrade` just computed,
-so the displayed and charged prices can't drift apart. Tier 2 ("Expand")
-and any higher tiers are **not** part of this override — they're priced
-straight from the catalog like any other kind's higher tiers, since
-they're a per-house upgrade rather than a new-house purchase.
+Additional rooms are **not** further upgrade tiers — see §19's Room Slots
+for the player-facing "buy a room" system (basement/first-floor/left/right/
+rear), which synthesizes each purchased room from a shared catalog template
+at runtime instead of authoring more `playerHouse` levels.
+
+**Pricing is dynamic, unlike every other kind's static per-level cost.**
+`buildingUpgrades.json`'s `playerHouse[0].cost` (2500) is only the
+documented baseline — the real price is computed in `reputation.ts`'s
+`nextUpgrade`, which special-cases `kind === 'playerHouse'` to charge
+`price(N) = 7500 × 2^(N-1) − 5000` for the Nth player house the player owns
+**across every town** (not per-town): 2,500 / 10,000 / 25,000 / 55,000 /
+... `countOwnedPlayerHouses()` (also in `reputation.ts`) tallies ownership
+by scanning every town in `LOCATION_REGISTRY` for `upgradeKind ===
+'playerHouse'` buildings at level ≥ 1. `purchaseUpgrade` charges whatever
+`nextUpgrade` just computed, so the displayed and charged prices can't
+drift apart.
 
 ### Services
 
@@ -2049,16 +2046,8 @@ Millhaven's `building-1` ("Ocean Heights"), Ravenwatch's `building-1`
   see below) has its own independent `jarv_hub_home_layout:<houseKey>`
   entry in localStorage; buying houses in two towns does **not** share a
   layout between them.
-- **Buying more rooms**: `playerHouse` (`buildingUpgrades.json`) is a
-  two-tier track — tier 1 "Purchase" (the house itself), tier 2 "Expand"
-  (a second room). A second room is an ordinary `playerDecor: true`
-  sub-room interior, id-prefixed by the main room's id per the rule above
-  (e.g. `building-1-second-room`), connected by a `minLevel: 2`-gated
-  `exits[]` entry on the main room (only appears once "Expand" is bought)
-  plus a plain return `exits[]` entry on the sub-room back to the main
-  room. Because the sub-room has its own id, it automatically gets its own
-  independent DECORATE layout — no extra plumbing needed. All three live
-  player houses follow this pattern today.
+- **Buying more rooms**: see "Room Slots" below — a player-facing, per-room
+  purchase, not another `playerHouse` upgrade tier.
 - **Tile art is a stand-in for 7 of 12 items.** oak-bookshelf, four-poster-
   bed, candle-stand, wall-clock, and cozy-rug reuse tiles that are good/exact
   matches. round-table, potted-fern, armchair, framed-portrait, travel-chest,
@@ -2077,3 +2066,71 @@ Millhaven's `building-1` ("Ocean Heights"), Ravenwatch's `building-1`
   round-table, 2×1) renders one sprite at its anchor cell only —
   `renderDecorItems` has no support for scaling a decor sprite across
   multiple tiles.
+
+### Room Slots — purchasable rooms
+
+A player-facing "buy a room" system, independent of the `playerHouse`
+upgrade-track mechanism above. One shared catalog of five room types —
+`web/src/data/roomSlots.json` — is reused across every player house in
+every town; buying a slot for a specific house synthesizes that room's
+`HubInterior` at runtime from the catalog template, so adding a slot type
+or a new player-house town never needs per-room JSON authoring.
+
+| id | name | price | direction | notes |
+|---|---|---|---|---|
+| `left` | Left Room | 3,000 | `left` | wall-gap door, west wall |
+| `right` | Right Room | 3,000 | `right` | wall-gap door, east wall |
+| `rear` | Rear Room | 3,500 | `back`/`front` | wall-gap door, north wall |
+| `basement` | Basement | 4,000 | `down`/`up` | floor marker, no wall gap |
+| `first-floor` | Upper Floor | 4,500 | `up`/`down` | floor marker, no wall gap |
+
+Each catalog entry (`RoomSlotDef`, `web/src/game/hub/houseRooms.ts`) carries
+a `mainExit` (the door/marker the main room gets once purchased) and a
+`roomExit` (the door/marker back to the main room, inside the slot's own
+10×8 interior) — mirrored docking positions, same convention as any other
+hand-authored two-way room pair (`entryTx`/`entryTy` land just inside the
+opposite wall). `left`/`right`/`rear` punch a real wall gap (`direction`
+`left`/`right`/`front`/`back`, same wall-gap mechanics `HubTownCanvas.tsx`
+already has for any authored exit); `basement`/`first-floor` are plain
+floor-level passage markers (`direction` `up`/`down`, rendered as a ▲/▼
+text glyph, same as any multi-story building's stairs) — no wall gap, so
+`homeLayout.ts` permanently reserves the two DECORATE cells under those
+markers (`RESERVED_CELLS`) so furniture can't be placed on top of them, in
+every house regardless of whether those slots are bought.
+
+**Persistence** — `web/src/game/hub/houseRooms.ts` (key
+`jarv_hub_house_rooms:<houseKey>`, same `${town}:${buildingId}` scoping as
+`homeLayout.ts`): `getPurchasedSlotIds`, `hasPurchasedSlot`,
+`purchaseRoomSlot` (idempotent grant; the caller spends crystals itself,
+matching `furniture.ts`'s `grantFurniture` convention).
+
+**Runtime synthesis** — `HubTownCanvas.tsx`'s `doEnterInterior`:
+- If `HUB_INTERIORS[buildingId]` misses, checks whether `buildingId` is
+  `<mainHouseId>-<slotId>` for a `playerHouse` building with that slot
+  purchased, and if so calls `synthesizeSlotInterior` to build a real
+  `HubInterior` (10×8, `playerDecor: true`, one `roomExit`) from the
+  catalog template — everything downstream (walls, floor, furniture
+  rendering, exits) already works generically off any `HubInterior`, so
+  nothing else needs to change.
+- A player-house **main** room's `availableExits` is the union of its
+  static authored `exits` (if any) and one synthesized `buildMainRoomExit`
+  per purchased slot — computed fresh every time the room is entered, so a
+  purchase shows up immediately without a reload.
+
+**UI** — `HomeShelf.tsx`'s third `ROOMS` tab (alongside `SHELF`/`DECORATE`,
+same `hoa-tabs` bar, no new `Screen`/routing needed since it already
+receives `houseKey`): lists all five slots, tap an unowned one → buy-confirm
+(reuses `.shop-confirm-*`, same pattern as the DECORATE tab's furniture-buy
+flow) → `purchaseRoomSlot`.
+
+**Authoring checklist: new slot type**
+1. Add an entry to `roomSlots.json` with a unique `id`, `price`,
+   `floorTileId` (a `baseChipIndex.ts` constant), and mirrored `mainExit`/
+   `roomExit` docking positions (wall-gap directions need a wall-boundary
+   `tx`/`ty`; `up`/`down` can be any open floor tile, but reserve it in
+   `homeLayout.ts`'s `RESERVED_CELLS` the same way).
+2. Run `npm run test` (`houseRooms.test.ts`, `homeLayout.test.ts`) and
+   `npm run build`.
+3. Verify in-game: the new slot appears in the ROOMS tab, purchases,
+   appears as a real door/marker in the main room immediately, and its own
+   room is enterable and independently decoratable.

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -11,16 +11,20 @@ import {
 import {
   FurnitureDef, getFurnitureDef, getAllFurnitureDefs, getOwnedFurnitureIds, grantFurniture,
 } from '../../game/hub/furniture'
+import {
+  RoomSlotDef, getAllRoomSlotDefs, getPurchasedSlotIds, purchaseRoomSlot,
+} from '../../game/hub/houseRooms'
 import { loadCrystals, saveCrystals } from '../../game/collection'
 
 interface Props {
   onBack: () => void
-  /** Which owned house's furniture layout to edit — opaque key (e.g. `${town}:${buildingId}`).
-   *  Falls back to a shared 'default' bucket when no specific house is known. */
+  /** Which owned house's furniture layout (and room-slot purchases) to edit —
+   *  opaque key (e.g. `${town}:${buildingId}`). Falls back to a shared
+   *  'default' bucket when no specific house is known. */
   houseKey?: string
   /** Which tab to open on — defaults to 'shelf' (e.g. Ravenwatch's Steward Maren).
    *  The in-house 🛋 DECORATE button passes 'decorate' to skip straight past SHELF. */
-  initialTab?: 'shelf' | 'decorate'
+  initialTab?: 'shelf' | 'decorate' | 'rooms'
 }
 
 type ShelfEntry =
@@ -50,7 +54,7 @@ function nextRotation(r: 0 | 90 | 180 | 270): 0 | 90 | 180 | 270 {
 const REMOVE_ARM_MS = 2500
 
 export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }: Props) {
-  const [tab, setTab] = useState<'shelf' | 'decorate'>(initialTab)
+  const [tab, setTab] = useState<'shelf' | 'decorate' | 'rooms'>(initialTab)
 
   // ── Shelf tab (existing, unchanged) ──
   const items  = loadInventory()
@@ -86,6 +90,10 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
   const [message, setMessage] = useState<string | null>(null)
   const removeArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const messageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // ── Rooms tab ──
+  const [purchasedSlotIds, setPurchasedSlotIds] = useState<string[]>(() => getPurchasedSlotIds(houseKey))
+  const [pendingRoomBuy, setPendingRoomBuy] = useState<RoomSlotDef | null>(null)
 
   function clearRemoveArm() {
     if (removeArmTimeoutRef.current) { clearTimeout(removeArmTimeoutRef.current); removeArmTimeoutRef.current = null }
@@ -134,6 +142,28 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
     setOwnedIds(getOwnedFurnitureIds())
     setArmedItemId(pendingBuy.id)
     setPendingBuy(null)
+  }
+
+  function handlePickRoomSlot(slot: RoomSlotDef) {
+    if (!purchasedSlotIds.includes(slot.id)) setPendingRoomBuy(slot)
+  }
+
+  function handleCancelRoomBuy() {
+    setPendingRoomBuy(null)
+  }
+
+  function handleConfirmRoomBuy() {
+    if (!pendingRoomBuy) return
+    if (crystals < pendingRoomBuy.price) {
+      showMessage("That's more crystals than you have.")
+      return
+    }
+    const next = crystals - pendingRoomBuy.price
+    saveCrystals(next)
+    setCrystals(next)
+    purchaseRoomSlot(houseKey, pendingRoomBuy.id)
+    setPurchasedSlotIds(getPurchasedSlotIds(houseKey))
+    setPendingRoomBuy(null)
   }
 
   function handleCellTap(x: number, y: number) {
@@ -203,11 +233,12 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
     <OverlayScreen
       title="HOME"
       onBack={onBack}
-      right={tab === 'decorate' ? <span className="crystal-count">💎 {crystals.toLocaleString()}</span> : undefined}
+      right={tab !== 'shelf' ? <span className="crystal-count">💎 {crystals.toLocaleString()}</span> : undefined}
     >
       <div className="hoa-tabs">
         <button className={`hoa-tab${tab === 'shelf' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('shelf')}>SHELF</button>
         <button className={`hoa-tab${tab === 'decorate' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('decorate')}>DECORATE</button>
+        <button className={`hoa-tab${tab === 'rooms' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('rooms')}>ROOMS</button>
       </div>
 
       {tab === 'shelf' && (
@@ -290,6 +321,31 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
         </div>
       )}
 
+      {tab === 'rooms' && (
+        <div className="shelf-room">
+          <div className="town-directory__list">
+            {getAllRoomSlotDefs().map(slot => {
+              const owned = purchasedSlotIds.includes(slot.id)
+              return (
+                <div key={slot.id} className="town-directory__row">
+                  <div className="town-directory__info">
+                    <span className="town-directory__name">{slot.name}</span>
+                    {!owned && <span className="town-directory__place">💎 {slot.price.toLocaleString()}</span>}
+                  </div>
+                  <button
+                    className="action-btn action-btn--gold town-upgrades__btn"
+                    disabled={owned}
+                    onClick={() => handlePickRoomSlot(slot)}
+                  >
+                    {owned ? 'Built' : `Buy · 💎 ${slot.price.toLocaleString()}`}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       {detail && (
         <div className="shelf-modal-backdrop" onClick={() => setDetail(null)}>
           <div className="shelf-modal" onClick={e => e.stopPropagation()}>
@@ -333,6 +389,26 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
                 onClick={handleConfirmBuy}
               >
                 Buy for {pendingBuy.price} 💎
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingRoomBuy && (
+        <div className="shop-confirm-backdrop" onClick={handleCancelRoomBuy}>
+          <div className="shop-confirm-modal" onClick={e => e.stopPropagation()}>
+            <div className="shop-confirm-title">{pendingRoomBuy.name}</div>
+            <div className="shop-confirm-body">
+              Build for {pendingRoomBuy.price.toLocaleString()} 💎? You have {crystals.toLocaleString()} 💎.
+            </div>
+            <div className="shop-confirm-actions">
+              <button className="action-btn" onClick={handleCancelRoomBuy}>Cancel</button>
+              <button
+                className={`action-btn action-btn--gold shop-card-buy-btn${crystals < pendingRoomBuy.price ? ' shop-card-buy-btn--poor' : ''}`}
+                onClick={handleConfirmRoomBuy}
+              >
+                Build for {pendingRoomBuy.price.toLocaleString()} 💎
               </button>
             </div>
           </div>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -30,6 +30,9 @@ import { resolveWeather } from '../../game/hub/weather'
 import { getActiveFestival } from '../../game/hub/hubCalendar'
 import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
+import {
+  getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
+} from '../../game/hub/houseRooms'
 
 
 const T                 = 32
@@ -1649,7 +1652,20 @@ export function HubTownCanvas({
         return
       }
 
-      const interior = HUB_INTERIORS[buildingId]
+      // Player-owned room slots (basement/first-floor/left/right/rear, see
+      // houseRooms.ts) aren't authored in config.json — if the static lookup
+      // misses, check whether buildingId is `<mainHouseId>-<slotId>` for a
+      // slot the player has actually purchased, and synthesize its interior
+      // from the shared catalog template.
+      let interior = HUB_INTERIORS[buildingId]
+      if (!interior) {
+        const mainHouse = HUB_BUILDINGS.find(b => b.id && b.upgradeKind === 'playerHouse' && buildingId.startsWith(`${b.id}-`))
+        const slot = mainHouse?.id ? parseSlotBuildingId(buildingId, mainHouse.id) : undefined
+        if (mainHouse?.id && slot && getPurchasedSlotIds(`${locationKey}:${mainHouse.id}`).includes(slot.id)) {
+          const mainName = HUB_INTERIORS[mainHouse.id]?.name ?? mainHouse.id
+          interior = synthesizeSlotInterior(mainHouse.id, mainName, slot)
+        }
+      }
       if (!interior) return
 
       // ── Upgrade-level gating ───────────────────────────────────────────────
@@ -1659,8 +1675,18 @@ export function HubTownCanvas({
       // prefixes this interior's id.
       const levelKey = HUB_BUILDINGS.find(b => b.id && buildingId.startsWith(b.id) && b.upgradeKind)?.id ?? buildingId
       const currentLevel = buildingUpgradeLevelsRef?.current[levelKey] ?? 0
-      const visibleDecor   = interior.decor.filter(d => isVisibleAtLevel(d, currentLevel))
-      const availableExits = (interior.exits ?? []).filter(e => (e.minLevel ?? 0) <= currentLevel)
+      const visibleDecor = interior.decor.filter(d => isVisibleAtLevel(d, currentLevel))
+      const staticExits  = (interior.exits ?? []).filter(e => (e.minLevel ?? 0) <= currentLevel)
+      // A player-house main room also exposes one exit per purchased room
+      // slot — these are synthesized from houseRooms.ts, not authored here.
+      const isPlayerHouseMain = HUB_BUILDINGS.some(b => b.id === buildingId && b.upgradeKind === 'playerHouse')
+      const dynamicExits = isPlayerHouseMain
+        ? getPurchasedSlotIds(`${locationKey}:${buildingId}`)
+            .map(id => getRoomSlotDef(id))
+            .filter((s): s is NonNullable<typeof s> => !!s)
+            .map(slot => buildMainRoomExit(slot, `${buildingId}-${slot.id}`))
+        : []
+      const availableExits = [...staticExits, ...dynamicExits]
 
       // playerDecor interiors ship unfurnished (decor: []) — everything
       // visible is rendered from the player's placed furniture (homeLayout.ts)

--- a/web/src/data/hub/buildingUpgrades.json
+++ b/web/src/data/hub/buildingUpgrades.json
@@ -111,14 +111,6 @@
       "repRequired": 0,
       "benefit": "A house of your own — unfurnished, ready to decorate.",
       "service": "player-house-purchase"
-    },
-    {
-      "label": "Expand",
-      "cost": 5000,
-      "repReward": 50,
-      "repRequired": 0,
-      "benefit": "A second room, ready to decorate.",
-      "service": "player-house-expand"
     }
   ],
   "workshop": [

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -4527,38 +4527,7 @@
       "height": 8,
       "floorTileId": "woodFloor",
       "decor": [],
-      "playerDecor": true,
-      "exits": [
-        {
-          "tx": 9,
-          "ty": 4,
-          "toInteriorId": "building-1-second-room",
-          "entryTx": 1,
-          "entryTy": 4,
-          "direction": "right",
-          "minLevel": 2,
-          "label": "Second Room"
-        }
-      ]
-    },
-    "building-1-second-room": {
-      "name": "Meadow View — Parlour",
-      "width": 10,
-      "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": [],
-      "playerDecor": true,
-      "exits": [
-        {
-          "tx": 0,
-          "ty": 4,
-          "toInteriorId": "building-1",
-          "entryTx": 8,
-          "entryTy": 4,
-          "direction": "left",
-          "label": "Back"
-        }
-      ]
+      "playerDecor": true
     },
     "building-2": {
       "name": "building-2",

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -3102,38 +3102,7 @@
       "height": 8,
       "floorTileId": "woodFloor",
       "decor": [],
-      "playerDecor": true,
-      "exits": [
-        {
-          "tx": 9,
-          "ty": 4,
-          "toInteriorId": "building-1-second-room",
-          "entryTx": 1,
-          "entryTy": 4,
-          "direction": "right",
-          "minLevel": 2,
-          "label": "Second Room"
-        }
-      ]
-    },
-    "building-1-second-room": {
-      "name": "Ocean Heights — Guest Room",
-      "width": 10,
-      "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": [],
-      "playerDecor": true,
-      "exits": [
-        {
-          "tx": 0,
-          "ty": 4,
-          "toInteriorId": "building-1",
-          "entryTx": 8,
-          "entryTy": 4,
-          "direction": "left",
-          "label": "Back"
-        }
-      ]
+      "playerDecor": true
     }
   },
   "treasures": [

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8599,38 +8599,7 @@
       "height": 8,
       "floorTileId": "woodFloor",
       "decor": [],
-      "playerDecor": true,
-      "exits": [
-        {
-          "tx": 9,
-          "ty": 4,
-          "toInteriorId": "building-1-second-room",
-          "entryTx": 1,
-          "entryTy": 4,
-          "direction": "right",
-          "minLevel": 2,
-          "label": "Second Room"
-        }
-      ]
-    },
-    "building-1-second-room": {
-      "name": "Lakeside Cottage — Loft",
-      "width": 10,
-      "height": 8,
-      "floorTileId": "woodFloor",
-      "decor": [],
-      "playerDecor": true,
-      "exits": [
-        {
-          "tx": 0,
-          "ty": 4,
-          "toInteriorId": "building-1",
-          "entryTx": 8,
-          "entryTy": 4,
-          "direction": "left",
-          "label": "Back"
-        }
-      ]
+      "playerDecor": true
     }
   },
   "npcs": [

--- a/web/src/data/roomSlots.json
+++ b/web/src/data/roomSlots.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "left",
+    "name": "Left Room",
+    "price": 3000,
+    "floorTileId": "woodFloor",
+    "mainExit": { "tx": 0, "ty": 3, "direction": "left", "entryTx": 8, "entryTy": 3 },
+    "roomExit": { "tx": 9, "ty": 3, "direction": "right", "entryTx": 1, "entryTy": 3 }
+  },
+  {
+    "id": "right",
+    "name": "Right Room",
+    "price": 3000,
+    "floorTileId": "woodFloor",
+    "mainExit": { "tx": 9, "ty": 3, "direction": "right", "entryTx": 1, "entryTy": 3 },
+    "roomExit": { "tx": 0, "ty": 3, "direction": "left", "entryTx": 8, "entryTy": 3 }
+  },
+  {
+    "id": "rear",
+    "name": "Rear Room",
+    "price": 3500,
+    "floorTileId": "woodFloor",
+    "mainExit": { "tx": 5, "ty": 0, "direction": "back", "entryTx": 5, "entryTy": 6 },
+    "roomExit": { "tx": 5, "ty": 7, "direction": "front", "entryTx": 5, "entryTy": 1 }
+  },
+  {
+    "id": "basement",
+    "name": "Basement",
+    "price": 4000,
+    "floorTileId": "stoneFloor",
+    "mainExit": { "tx": 3, "ty": 3, "direction": "down", "entryTx": 3, "entryTy": 3 },
+    "roomExit": { "tx": 3, "ty": 3, "direction": "up", "entryTx": 3, "entryTy": 3 }
+  },
+  {
+    "id": "first-floor",
+    "name": "Upper Floor",
+    "price": 4500,
+    "floorTileId": "woodFloor",
+    "mainExit": { "tx": 6, "ty": 3, "direction": "up", "entryTx": 6, "entryTy": 3 },
+    "roomExit": { "tx": 6, "ty": 3, "direction": "down", "entryTx": 6, "entryTy": 3 }
+  }
+]

--- a/web/src/game/hub/homeLayout.test.ts
+++ b/web/src/game/hub/homeLayout.test.ts
@@ -72,10 +72,10 @@ describe('homeLayout', () => {
   })
 
   it('a multi-cell footprint blocks every cell it covers, not just its origin', () => {
-    expect(placeFurniture(HOUSE, TABLE, 2, 2)).not.toBeNull() // covers (2,2) and (3,2)
-    expect(placeFurniture(HOUSE, LAMP, 3, 2)).toBeNull()
-    expect(placeFurniture(HOUSE, LAMP, 2, 2)).toBeNull()
-    expect(placeFurniture(HOUSE, LAMP, 4, 2)).not.toBeNull() // just outside the footprint
+    expect(placeFurniture(HOUSE, TABLE, 2, 3)).not.toBeNull() // covers (2,3) and (3,3)
+    expect(placeFurniture(HOUSE, LAMP, 3, 3)).toBeNull()
+    expect(placeFurniture(HOUSE, LAMP, 2, 3)).toBeNull()
+    expect(placeFurniture(HOUSE, LAMP, 4, 3)).not.toBeNull() // just outside the footprint
   })
 
   it('rotation swaps footprint dimensions for bounds checking', () => {
@@ -84,6 +84,22 @@ describe('homeLayout', () => {
     expect(placeFurniture(HOUSE, TABLE, 0, HOME_GRID_ROWS - 2, 90)).not.toBeNull()
     // Unrotated, a 2-wide piece can't fit in the last single row.
     expect(placeFurniture(HOUSE, TABLE, 0, HOME_GRID_ROWS - 1)).toBeNull()
+  })
+
+  it('rejects placement on the basement/first-floor room-slot marker cells', () => {
+    expect(placeFurniture(HOUSE, LAMP, 2, 2)).toBeNull() // basement marker
+    expect(placeFurniture(HOUSE, LAMP, 5, 2)).toBeNull() // first-floor marker
+    expect(loadHomeLayout(HOUSE)).toHaveLength(0)
+  })
+
+  it('rejects a multi-cell piece whose footprint covers a reserved cell', () => {
+    expect(placeFurniture(HOUSE, TABLE, 1, 2)).toBeNull() // would cover (1,2) and (2,2) — the latter reserved
+    expect(loadHomeLayout(HOUSE)).toHaveLength(0)
+  })
+
+  it('rejects moving a piece onto a reserved cell', () => {
+    const piece = placeFurniture(HOUSE, LAMP, 0, 0)!
+    expect(moveFurniture(HOUSE, piece.id, 2, 2)).toBe(false)
   })
 
   it('moves a piece to a free cell', () => {
@@ -106,10 +122,10 @@ describe('homeLayout', () => {
   })
 
   it('removes a piece and frees its cell', () => {
-    const piece = placeFurniture(HOUSE, LAMP, 2, 2)!
+    const piece = placeFurniture(HOUSE, LAMP, 2, 3)!
     expect(removeFurniture(HOUSE, piece.id)).toBe(true)
     expect(loadHomeLayout(HOUSE)).toHaveLength(0)
-    expect(placeFurniture(HOUSE, LAMP, 2, 2)).not.toBeNull()
+    expect(placeFurniture(HOUSE, LAMP, 2, 3)).not.toBeNull()
   })
 
   it('returns false when removing an unknown id', () => {

--- a/web/src/game/hub/homeLayout.ts
+++ b/web/src/game/hub/homeLayout.ts
@@ -57,6 +57,21 @@ function overlaps(ax: number, ay: number, aw: number, ah: number, bx: number, by
   return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by
 }
 
+// DECORATE cells permanently reserved for the basement/first-floor room-slot
+// passage markers (houseRooms.ts's roomSlots catalog: world tx=3,ty=3 and
+// tx=6,ty=3, offset -1/-1 into DECORATE-grid coordinates) — furniture can't
+// be placed on top of them, in every house, whether or not those slots have
+// actually been purchased. Simpler than tracking per-house slot ownership
+// here, at the cost of 2 permanently-unusable cells out of 48.
+const RESERVED_CELLS: ReadonlyArray<{ x: number; y: number }> = [
+  { x: 2, y: 2 }, // basement marker
+  { x: 5, y: 2 }, // first-floor marker
+]
+
+function overlapsReserved(x: number, y: number, w: number, h: number): boolean {
+  return RESERVED_CELLS.some(c => overlaps(x, y, w, h, c.x, c.y, 1, 1))
+}
+
 function isOccupied(placed: PlacedFurniture[], x: number, y: number, w: number, h: number, excludeId?: string): boolean {
   return placed.some(p => {
     if (p.id === excludeId) return false
@@ -78,7 +93,7 @@ export function isHomeLayoutEmpty(houseKey: string): boolean {
 export function placeFurniture(houseKey: string, itemId: string, x: number, y: number, rotation: 0 | 90 | 180 | 270 = 0): PlacedFurniture | null {
   if (!getFurnitureDef(itemId) || !ownsFurniture(itemId)) return null
   const { w, h } = footprintFor(itemId, rotation)
-  if (!inBounds(x, y, w, h)) return null
+  if (!inBounds(x, y, w, h) || overlapsReserved(x, y, w, h)) return null
   const data = load(houseKey)
   if (isOccupied(data.placed, x, y, w, h)) return null
 
@@ -97,7 +112,7 @@ export function moveFurniture(houseKey: string, id: string, x: number, y: number
 
   const nextRotation = rotation ?? piece.rotation
   const { w, h } = footprintFor(piece.itemId, nextRotation)
-  if (!inBounds(x, y, w, h)) return false
+  if (!inBounds(x, y, w, h) || overlapsReserved(x, y, w, h)) return false
   if (isOccupied(data.placed, x, y, w, h, id)) return false
 
   piece.x = x

--- a/web/src/game/hub/houseRooms.test.ts
+++ b/web/src/game/hub/houseRooms.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  getRoomSlotDef, getAllRoomSlotDefs, getPurchasedSlotIds, hasPurchasedSlot, purchaseRoomSlot,
+  parseSlotBuildingId, buildMainRoomExit, synthesizeSlotInterior,
+} from './houseRooms'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+const HOUSE = 'Millhaven:building-1'
+
+describe('houseRooms catalog', () => {
+  it('lists all five slot types', () => {
+    const all = getAllRoomSlotDefs()
+    expect(all.map(s => s.id).sort()).toEqual(['basement', 'first-floor', 'left', 'rear', 'right'])
+  })
+
+  it('looks up a slot by id', () => {
+    expect(getRoomSlotDef('left')).toMatchObject({ id: 'left', name: 'Left Room' })
+  })
+
+  it('returns undefined for an unknown slot id', () => {
+    expect(getRoomSlotDef('attic')).toBeUndefined()
+  })
+})
+
+describe('houseRooms purchase persistence', () => {
+  beforeEach(() => { installLocalStorageStub() })
+
+  it('starts with nothing purchased', () => {
+    expect(getPurchasedSlotIds(HOUSE)).toEqual([])
+    expect(hasPurchasedSlot(HOUSE, 'left')).toBe(false)
+  })
+
+  it('purchases a slot', () => {
+    expect(purchaseRoomSlot(HOUSE, 'left')).toBe(true)
+    expect(hasPurchasedSlot(HOUSE, 'left')).toBe(true)
+    expect(getPurchasedSlotIds(HOUSE)).toEqual(['left'])
+  })
+
+  it('is idempotent — purchasing an already-owned slot returns false', () => {
+    purchaseRoomSlot(HOUSE, 'left')
+    expect(purchaseRoomSlot(HOUSE, 'left')).toBe(false)
+    expect(getPurchasedSlotIds(HOUSE)).toEqual(['left'])
+  })
+
+  it('refuses to purchase an unknown slot id', () => {
+    expect(purchaseRoomSlot(HOUSE, 'attic')).toBe(false)
+    expect(getPurchasedSlotIds(HOUSE)).toEqual([])
+  })
+
+  it('scopes purchases per house — buying in one town/building does not affect another', () => {
+    purchaseRoomSlot('Millhaven:building-1', 'left')
+    expect(hasPurchasedSlot('Ravenwatch:building-1', 'left')).toBe(false)
+    expect(getPurchasedSlotIds('Ravenwatch:building-1')).toEqual([])
+  })
+
+  it('fails open when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(getPurchasedSlotIds(HOUSE)).toEqual([])
+    expect(() => purchaseRoomSlot(HOUSE, 'left')).not.toThrow()
+  })
+})
+
+describe('parseSlotBuildingId', () => {
+  it('matches a valid <mainId>-<slotId> pair', () => {
+    expect(parseSlotBuildingId('building-1-left', 'building-1')).toMatchObject({ id: 'left' })
+    expect(parseSlotBuildingId('building-1-first-floor', 'building-1')).toMatchObject({ id: 'first-floor' })
+  })
+
+  it('returns undefined for ids not prefixed by the main building', () => {
+    expect(parseSlotBuildingId('building-2-left', 'building-1')).toBeUndefined()
+  })
+
+  it('returns undefined for a suffix that is not a real slot', () => {
+    expect(parseSlotBuildingId('building-1-attic', 'building-1')).toBeUndefined()
+  })
+})
+
+describe('exit synthesis', () => {
+  it('builds a main-room exit pointing at the slot sub-interior', () => {
+    const slot = getRoomSlotDef('left')!
+    const exit = buildMainRoomExit(slot, 'building-1-left')
+    expect(exit).toMatchObject({ toInteriorId: 'building-1-left', direction: 'left', label: 'Left Room' })
+  })
+
+  it('synthesizes a full playerDecor interior with a return exit to the main room', () => {
+    const slot = getRoomSlotDef('basement')!
+    const interior = synthesizeSlotInterior('building-1', 'Ocean Heights', slot)
+    expect(interior.id).toBe('building-1-basement')
+    expect(interior.name).toBe('Ocean Heights — Basement')
+    expect(interior.width).toBe(10)
+    expect(interior.height).toBe(8)
+    expect(interior.playerDecor).toBe(true)
+    expect(interior.decor).toEqual([])
+    expect(interior.floorTileId).toBeGreaterThan(0)
+    expect(interior.exits).toHaveLength(1)
+    expect(interior.exits![0]).toMatchObject({ toInteriorId: 'building-1', direction: 'up', label: 'Back' })
+  })
+})

--- a/web/src/game/hub/houseRooms.ts
+++ b/web/src/game/hub/houseRooms.ts
@@ -1,0 +1,133 @@
+import { logError } from '../../logger'
+import ROOM_SLOTS_DATA from '../../data/roomSlots.json'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import type { HubInterior, HubInteriorExit } from '../../data/hub/loader'
+
+// Player-owned room slots: independently purchasable rooms (basement, first
+// floor, left, right, rear) attached to a player house's main room. Unlike
+// the tiered-upgrade-track/hand-authored-per-town rooms this replaces, each
+// slot is a single shared template (this catalog) synthesized into a real
+// HubInterior at runtime for whichever house/town bought it — adding a slot
+// or a new player-house town needs no per-room JSON authoring.
+
+const KEY_PREFIX = 'jarv_hub_house_rooms'
+
+export interface RoomSlotExit {
+  tx: number
+  ty: number
+  direction: 'left' | 'right' | 'front' | 'back' | 'up' | 'down'
+  entryTx: number
+  entryTy: number
+}
+
+export interface RoomSlotDef {
+  id: string
+  name: string
+  price: number       // crystals
+  floorTileId: string  // baseChipIndex.ts constant name
+  /** The door/passage this slot punches into the main room. */
+  mainExit: RoomSlotExit
+  /** The door/passage back to the main room, inside the slot's own interior. */
+  roomExit: RoomSlotExit
+}
+
+const ROOM_SLOT_CATALOG = ROOM_SLOTS_DATA as RoomSlotDef[]
+const CHIP_TILES = BASE_CHIP_TILES as Record<string, number>
+
+export function getRoomSlotDef(id: string): RoomSlotDef | undefined {
+  return ROOM_SLOT_CATALOG.find(s => s.id === id)
+}
+
+export function getAllRoomSlotDefs(): RoomSlotDef[] {
+  return ROOM_SLOT_CATALOG
+}
+
+// ── Purchased-slot persistence (per house, like homeLayout.ts/furniture.ts) ──
+
+function storageKey(houseKey: string): string {
+  return `${KEY_PREFIX}:${houseKey}`
+}
+
+function load(houseKey: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey(houseKey))
+    return raw ? (JSON.parse(raw) as string[]) : []
+  } catch {
+    return []
+  }
+}
+
+function save(houseKey: string, ids: string[]): void {
+  try {
+    localStorage.setItem(storageKey(houseKey), JSON.stringify(ids))
+  } catch (e) {
+    logError('house room slot save failed', { error: String(e) })
+  }
+}
+
+export function getPurchasedSlotIds(houseKey: string): string[] {
+  return load(houseKey)
+}
+
+export function hasPurchasedSlot(houseKey: string, slotId: string): boolean {
+  return load(houseKey).includes(slotId)
+}
+
+/** Grants a room slot for this house. Idempotent — returns false if the slot
+ *  id isn't in the catalog or is already owned. Caller (UI) handles the
+ *  crystal spend, mirroring furniture.ts's grantFurniture. */
+export function purchaseRoomSlot(houseKey: string, slotId: string): boolean {
+  if (!getRoomSlotDef(slotId)) return false
+  const owned = load(houseKey)
+  if (owned.includes(slotId)) return false
+  save(houseKey, [...owned, slotId])
+  return true
+}
+
+// ── Dynamic interior/exit synthesis (pure — HubTownCanvas.tsx wires these in) ──
+
+/** If `buildingId` is `<mainBuildingId>-<slotId>` for a real catalog slot,
+ *  returns that slot's def — regardless of purchase state. */
+export function parseSlotBuildingId(buildingId: string, mainBuildingId: string): RoomSlotDef | undefined {
+  if (!buildingId.startsWith(`${mainBuildingId}-`)) return undefined
+  const slotId = buildingId.slice(mainBuildingId.length + 1)
+  return getRoomSlotDef(slotId)
+}
+
+/** The exit a purchased slot punches into the main player-house room. */
+export function buildMainRoomExit(slot: RoomSlotDef, subInteriorId: string): HubInteriorExit {
+  return {
+    tx: slot.mainExit.tx,
+    ty: slot.mainExit.ty,
+    toInteriorId: subInteriorId,
+    entryTx: slot.mainExit.entryTx,
+    entryTy: slot.mainExit.entryTy,
+    direction: slot.mainExit.direction,
+    label: slot.name,
+  }
+}
+
+/** Synthesizes a purchased slot's own interior — same shape/size/playerDecor
+ *  convention as a hand-authored player-house room, generated from the
+ *  shared catalog template instead of per-town JSON. */
+export function synthesizeSlotInterior(mainBuildingId: string, mainName: string, slot: RoomSlotDef): HubInterior {
+  const backExit: HubInteriorExit = {
+    tx: slot.roomExit.tx,
+    ty: slot.roomExit.ty,
+    toInteriorId: mainBuildingId,
+    entryTx: slot.roomExit.entryTx,
+    entryTy: slot.roomExit.entryTy,
+    direction: slot.roomExit.direction,
+    label: 'Back',
+  }
+  return {
+    id: `${mainBuildingId}-${slot.id}`,
+    name: `${mainName} — ${slot.name}`,
+    width: 10,
+    height: 8,
+    decor: [],
+    floorTileId: CHIP_TILES[slot.floorTileId] ?? CHIP_TILES.woodFloor,
+    playerDecor: true,
+    exits: [backExit],
+  }
+}

--- a/web/src/game/hub/reputation.test.ts
+++ b/web/src/game/hub/reputation.test.ts
@@ -136,29 +136,17 @@ describe('unlocked services', () => {
 describe('playerHouse building track', () => {
   const playerHouse = getUpgradeTrack('playerHouse')
 
-  it('is a two-tier track (Purchase + Expand), unlocked-from-the-start', () => {
-    expect(playerHouse.length).toBe(2)
+  it('is a single-tier, unlocked-from-the-start purchase', () => {
+    expect(playerHouse.length).toBe(1)
     expect(playerHouse[0].repRequired).toBe(0)
-    expect(playerHouse[1].repRequired).toBe(0)
   })
 
-  it('purchasing tier 1 raises the level to 1 without maxing the track', () => {
+  it('purchasing it raises the level to 1 and maxes the track', () => {
     saveCrystals(playerHouse[0].cost)
     const res = purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
     expect(res.ok).toBe(true)
     expect(getUpgradeLevel(TOWN, 'player-house')).toBe(1)
     expect(loadCrystals()).toBe(0)
-    expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').maxed).toBe(false)
-  })
-
-  it('tier 2 ("Expand") is priced statically from the catalog, not the dynamic per-house formula', () => {
-    saveCrystals(playerHouse[0].cost)
-    purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
-    expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').cost).toBe(playerHouse[1].cost)
-    saveCrystals(playerHouse[1].cost)
-    const res = purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
-    expect(res.ok).toBe(true)
-    expect(getUpgradeLevel(TOWN, 'player-house')).toBe(2)
     expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').maxed).toBe(true)
   })
 

--- a/web/src/game/hub/reputation.ts
+++ b/web/src/game/hub/reputation.ts
@@ -131,7 +131,7 @@ export function nextUpgrade(town: string, buildingId: string, kind: string | und
 
   const def = track[level]
   // Dynamic pricing only applies to the first tier (buying the house itself) —
-  // higher tiers (e.g. "Expand") are per-house upgrades, priced statically
+  // any future higher tier would be a per-house upgrade, priced statically
   // from the catalog like every other kind's higher tiers.
   const cost = kind === 'playerHouse' && level === 0 ? playerHousePrice(countOwnedPlayerHouses()) : def.cost
   return {


### PR DESCRIPTION
## Summary

Replaces the tier-2 "Expand" + hand-authored second room shipped in #1947 with a player-facing, per-room purchase system: buy a basement, first floor, left, right, or rear room independently, each generated from one shared catalog template at runtime instead of hand-authored JSON per town.

- **`roomSlots.json` + `houseRooms.ts`**: the 5-slot catalog (price, floor tile, mirrored main-room/sub-room exit geometry — wall-gap doors for left/right/rear, floor-marker passages for basement/first-floor, reusing `HubTownCanvas.tsx`'s existing exit-direction mechanics) and per-house purchase persistence (`jarv_hub_house_rooms:<houseKey>`, same `town:building` scoping as `homeLayout.ts`), plus pure/unit-tested exit and interior synthesis helpers.
- **`HubTownCanvas.tsx`**: `doEnterInterior` now falls back to synthesizing a slot's interior when the static `HUB_INTERIORS` lookup misses and that slot has been purchased. A player-house main room's available exits are the union of its authored exits and one synthesized exit per purchased slot, computed fresh on every entry — a purchase shows up immediately, no reload needed.
- **`homeLayout.ts`**: reserves the two DECORATE cells under the basement/first-floor floor markers so placed furniture can't cover them.
- **`HomeShelf.tsx`**: new `ROOMS` tab (alongside `SHELF`/`DECORATE`) lists all five slots with owned/locked state and a buy-confirm flow, reusing existing tab/modal CSS — no new screen routing needed.
- **Cleanup**: `buildingUpgrades.json`'s `playerHouse` track reverts to single-tier, and the three towns' `<building>-second-room` content is removed — this is a replacement, not an addition.
- **`docs/hubworld.md`**: documents the slot system (§10 updated, new §19 "Room Slots" subsection with the authoring checklist for a 6th slot type, §1 file map).

## Test plan

- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — 448/448 tests pass (13 new: `houseRooms.test.ts` catalog/persistence/synthesis, `homeLayout.test.ts` reserved-cell rejection)
- [ ] In-game playtest (buy a house, buy each of the 5 slots, walk through each door, confirm DECORATE works independently per room, confirm the reserved stairs tiles can't be built on) — not performed in this session; recommended before merging


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_