### PR TITLE
fix(hub): room-slot interiors were untappable, trapping the player

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -20,7 +20,7 @@ import { getAugmentCard, AUGMENT_SPRITE } from '../../game/augments'
 import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
-import { HubInteractable, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
+import { HubInteractable, HubInterior, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem, GlowSource, PLAYER_OWNER_ID } from './hubAnimals'
 import { getActivePet } from '../../game/hub/pet'
 import { isInteractableGranted, interactableStoreKey } from '../../game/hub/interactables'
@@ -1537,6 +1537,11 @@ export function HubTownCanvas({
     // ── Interior state ─────────────────────────────────────────────────────────
     let interiorActive      = false
     let currentInteriorId: string | null = null
+    // The resolved interior for currentInteriorId — may be a synthesized room-slot
+    // interior (houseRooms.ts) that doesn't exist in the static HUB_INTERIORS map,
+    // so anything needing "the interior currently being stood in" must read this,
+    // not re-derive it via HUB_INTERIORS[currentInteriorId].
+    let currentInteriorObj: HubInterior | null = null
     let interiorCurrentTile: [number, number] = [0, 0]
     let interiorWalkable    = new Set<string>()
     let interiorWalkQueue:  [number, number][] = []
@@ -1620,7 +1625,8 @@ export function HubTownCanvas({
         interiorLayer.visible = false
         interiorLayer.removeChildren()
         interiorAnimals.length = 0
-        currentInteriorId = null
+        currentInteriorId  = null
+        currentInteriorObj = null
         highlightGfx.clear()
         stopInteriorAudio()  // resume town theme + drop ambiance
         onExitInteriorRef.current?.()
@@ -1757,6 +1763,7 @@ export function HubTownCanvas({
       const defaultEntryTile: [number, number] = [entryTx ?? exitTx, entryTy ?? (interior.height - 2)]
       interiorCurrentTile = defaultEntryTile
       currentInteriorId   = buildingId
+      currentInteriorObj  = interior
       interiorExitTile    = isSubRoom ? [-1, -1] : [exitTx, interior.height - 1]
       interiorActive      = true
       interiorIsWalking   = false
@@ -2424,7 +2431,7 @@ export function HubTownCanvas({
 
     app.stage.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
       if (interiorActive) {
-        const interior = HUB_INTERIORS[currentInteriorId!]
+        const interior = currentInteriorObj
         if (!interior) return
         const { x, y } = e.getLocalPosition(interiorLayer)
         const tapTx = Math.max(0, Math.min(interior.width - 1, Math.floor(x / T)))


### PR DESCRIPTION
## Summary

Fixes a bug reported after trying the room-slot feature (#1948): buying the "Upper Floor" (first-floor) slot and walking up worked, but once inside there was no way to walk anywhere — including back onto the "down" exit. The room was a dead end.

**Root cause**: the interior tap handler (`app.stage.on('pointerdown', ...)` in `HubTownCanvas.tsx`) resolved "the interior currently being stood in" via `HUB_INTERIORS[currentInteriorId]` directly. That map only holds statically-authored rooms from `config.json`. A purchased room slot only exists as an object synthesized at runtime inside `doEnterInterior` (`synthesizeSlotInterior`, `houseRooms.ts`) — it's never written into `HUB_INTERIORS`. So the moment a player stepped into a room slot, every subsequent tap hit `if (!interior) return` and silently did nothing, including tapping the tile that would walk them back through the exit.

The walk-*into*-a-slot-room path worked because it uses the already-resolved `interior` object directly (from `processInteriorWalkQueue`'s `exitByTile` lookup, built off `availableExits`) — only the tap-to-walk-*inside* path had the bug, which is why entering felt fine but nothing worked once inside.

**Fix**: cache the resolved interior (static or synthesized) in a new `currentInteriorObj` alongside `currentInteriorId` when entering, and read that in the tap handler instead of re-deriving it from `HUB_INTERIORS`.

## Test plan

- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — 448/448 tests still pass (no existing coverage of `HubTownCanvas.tsx`'s internal interaction logic to extend — it's a large PixiJS component with no existing test harness)
- [ ] In-game: buy a room slot, walk in, confirm you can now tap to walk around and back out through the exit


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_