### PR TITLE
fix(hub): DECORATE grid CSS was still hardcoded to the old 8x6 size

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1949,7 +1949,11 @@ pure-visual pieces under `web/src/components/hub/home-shelf/` (each with a
 `.stories.tsx`):
 
 - `HomeGrid.tsx` — the `HOME_GRID_COLS × HOME_GRID_ROWS` grid; placed pieces
-  span their (rotation-aware) footprint via `gridColumn`/`gridRow`.
+  span their (rotation-aware) footprint via `gridColumn`/`gridRow`. The
+  container's `grid-template-columns`/`-rows`/`aspect-ratio` are set inline
+  from those same constants (not in `styles.css`'s `.home-grid` rule, which
+  only holds non-dimension styling) — resizing the grid is a two-constant
+  change in `homeLayout.ts`, not also a CSS edit.
 - `FurniturePicker.tsx` — a horizontal strip over the full catalog; owned
   pieces are plain, unowned ones show a price tag.
 - `PieceActionBar.tsx` — Rotate / Move / Remove for the selected piece.

--- a/web/src/components/hub/home-shelf/HomeGrid.tsx
+++ b/web/src/components/hub/home-shelf/HomeGrid.tsx
@@ -41,7 +41,14 @@ export function HomeGrid({ placed, getDef, selectedId, tappable, onCellTap, onPi
   }
 
   return (
-    <div className="home-grid">
+    <div
+      className="home-grid"
+      style={{
+        gridTemplateColumns: `repeat(${HOME_GRID_COLS}, 1fr)`,
+        gridTemplateRows: `repeat(${HOME_GRID_ROWS}, 1fr)`,
+        aspectRatio: `${HOME_GRID_COLS} / ${HOME_GRID_ROWS}`,
+      }}
+    >
       {cells}
       {placed.map(p => {
         const def = getDef(p.itemId)

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7928,11 +7928,10 @@ body {
 }
 
 .home-grid {
+  /* grid-template-columns/rows and aspect-ratio are set inline from
+     HOME_GRID_COLS/HOME_GRID_ROWS (homeLayout.ts) — see HomeGrid.tsx */
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  grid-template-rows: repeat(6, 1fr);
   gap: 3px;
-  aspect-ratio: 8 / 6;
   background: rgba(20,30,20,0.4);
   border: 1px solid #2a3a2a;
   border-radius: 3px;


### PR DESCRIPTION
## Summary

Fixes a bug reported after the room resize (#1950): the DECORATE modal didn't visually match the new 11×9 room / 9×7 grid.

**Root cause**: `HomeGrid.tsx` already derived the number of rendered cells from `HOME_GRID_COLS`/`HOME_GRID_ROWS`, but `styles.css`'s `.home-grid` rule had `grid-template-columns: repeat(8, 1fr)`, `grid-template-rows: repeat(6, 1fr)`, and `aspect-ratio: 8 / 6` hardcoded — stale from before the grid moved to 9×7. The 9th column and 7th row had no explicit CSS grid track, so the container didn't actually match the JS-side cell count.

**Fix**: moved `grid-template-columns`/`grid-template-rows`/`aspect-ratio` into an inline style on the `.home-grid` div, computed directly from `HOME_GRID_COLS`/`HOME_GRID_ROWS`. `styles.css` keeps only the non-dimension styling (background, border, padding, gap). This makes a future grid resize the two-constant change the previous PR's docs already claimed it was, instead of also silently requiring a CSS edit.

## Test plan

- [x] `npm run build` — TypeScript check + Vite build pass clean
- [x] `npm run test` — 448/448 tests pass (no dimension-specific test coverage for this CSS rule to update)
- [ ] In-game: open DECORATE, confirm the grid visually shows a full 9×7 layout matching the room


---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_