### PR TITLE
feat(hub): per-room floor & wall style customization

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -40,6 +40,9 @@
 | `web/src/game/hub/forages.ts` | Once-per-day forage-spot persistence (localStorage) — see §7 `forage` reaction | `canForageToday`, `recordForage` |
 | `web/src/data/roomSlots.json` | Purchasable player-house room-slot catalog (basement/first-floor/left/right/rear) — see §19 "Room Slots" | consumed by `houseRooms.ts` |
 | `web/src/game/hub/houseRooms.ts` | Per-house purchased-slot persistence + dynamic interior/exit synthesis (localStorage) — see §19 "Room Slots" | `getRoomSlotDef`, `getAllRoomSlotDefs`, `getPurchasedSlotIds`, `hasPurchasedSlot`, `purchaseRoomSlot`, `parseSlotBuildingId`, `buildMainRoomExit`, `synthesizeSlotInterior` |
+| `web/src/game/hub/roomStyle.ts` | Per-room floor/wall style persistence (localStorage) — see §19 "Room Style" | `getRoomStyle`, `setRoomFloor`, `setRoomWall`, `getResolvedRoomStyle` |
+| `web/src/data/tiles/floorTiles.ts` | Shared floor-tile catalog, reused by the map editor and the room-style picker — see §19 "Room Style" | `FLOOR_TILES` |
+| `web/src/components/shared/TileSwatch.tsx` | CSS tile-swatch renderer (by resolved numeric tile id), shared by the map editor and the room-style picker — see §19 "Room Style" | `TileSwatch` |
 
 ---
 
@@ -2168,3 +2171,47 @@ flow) → `purchaseRoomSlot`.
 3. Verify in-game: the new slot appears in the ROOMS tab, purchases,
    appears as a real door/marker in the main room immediately, and its own
    room is enterable and independently decoratable.
+
+### Room Style — per-room floor & wall customization
+
+Each room a player owns (the main room, and any purchased room slot above)
+can independently swap its floor tile and wall material from the DECORATE
+tab's **STYLE** view (alongside a **FURNISH** view — the pre-existing
+furniture-placement UI), for a flat crystal fee per change (`STYLE_PRICE`
+in `HomeShelf.tsx`).
+
+**Catalogs** — reused rather than duplicated:
+- `web/src/data/tiles/floorTiles.ts` — `FLOOR_TILES` (24 options), shared
+  with the map editor's own floor-tile dropdowns (`EntityInspector.tsx`).
+- `Object.keys(WALL_TILES) as WallMaterial[]` (`buildingMaterials.ts`) —
+  the same 14 wall materials every building/interior already uses.
+- `web/src/components/shared/TileSwatch.tsx` — a small CSS-swatch renderer
+  (by resolved numeric tile id) extracted out of the map editor's
+  `TileThumb`, so both the editor's tile pickers and the player-facing
+  `TileStylePicker` (`home-shelf/TileStylePicker.tsx`) draw from one
+  rendering path. A wall material's swatch uses its `WallTileSet.middleTop`
+  tile as the representative preview.
+
+**Persistence** — `web/src/game/hub/roomStyle.ts` (key
+`jarv_hub_room_style:<houseKey>`, same `${town}:${buildingId}` /
+`${town}:${buildingId}-${slotId}` scoping as `homeLayout.ts`/
+`houseRooms.ts`, so a purchased room slot styles independently of the main
+room): `getRoomStyle`/`setRoomFloor`/`setRoomWall` store the raw string
+tile/material names; `getResolvedRoomStyle` additionally resolves the
+floor tile name to the numeric id `HubInterior.floorTileId` expects
+(mirrors `houseRooms.ts`'s `synthesizeSlotInterior` doing the same lookup).
+
+**Rendering** — `HubTownCanvas.tsx`'s `doEnterInterior`, inside the existing
+`if (interior.playerDecor)` branch (where `houseKey` is already computed
+for furniture): looks up `getResolvedRoomStyle(houseKey)` and, if either
+field is set, applies it as an override via object-spread —
+`interior = { ...interior, ...override }` — never mutated in place, since
+for the main room `interior` may be a direct reference into the shared,
+module-level `HUB_INTERIORS` record.
+
+**UI** — `HomeShelf.tsx`'s DECORATE tab gains a second-level `hoa-tabs`
+toggle (FURNISH/STYLE, hidden for the `'default'` bucket, same as the ROOMS
+tab). The STYLE view shows two `TileStylePicker` rows (Floor, Walls); tapping
+an unselected swatch opens the usual `.shop-confirm-*` buy-confirm modal,
+then calls `setRoomFloor`/`setRoomWall` on the currently-selected room's
+`roomHouseKey`.

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -14,7 +14,12 @@ import {
 import {
   RoomSlotDef, getAllRoomSlotDefs, getRoomSlotDef, getPurchasedSlotIds, purchaseRoomSlot,
 } from '../../game/hub/houseRooms'
+import { RoomStyle, getRoomStyle, setRoomFloor, setRoomWall } from '../../game/hub/roomStyle'
 import { loadCrystals, saveCrystals } from '../../game/collection'
+import { FLOOR_TILES } from '../../data/tiles/floorTiles'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import { WALL_TILES, WallMaterial } from '../../data/tiles/buildingMaterials'
+import { TileStylePicker, TileStyleOption } from './home-shelf/TileStylePicker'
 
 interface Props {
   onBack: () => void
@@ -55,7 +60,25 @@ function nextRotation(r: 0 | 90 | 180 | 270): 0 | 90 | 180 | 270 {
   return ROTATION_ORDER[(ROTATION_ORDER.indexOf(r) + 1) % ROTATION_ORDER.length]
 }
 
+/** "darkStoneFloor" -> "Dark Stone Floor" */
+function humanizeCamelCase(id: string): string {
+  const spaced = id.replace(/([a-z])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+const CHIP_TILES = BASE_CHIP_TILES as Record<string, number>
+const WALL_MATERIALS = Object.keys(WALL_TILES) as WallMaterial[]
+const FLOOR_OPTIONS: TileStyleOption[] = FLOOR_TILES.map(id => ({
+  key: id, tileNumericId: CHIP_TILES[id], label: humanizeCamelCase(id),
+}))
+const WALL_OPTIONS: TileStyleOption[] = WALL_MATERIALS.map(m => ({
+  key: m, tileNumericId: WALL_TILES[m].middleTop, label: humanizeCamelCase(m),
+}))
+
 const REMOVE_ARM_MS = 2500
+const STYLE_PRICE = 150
+
+type PendingStyleBuy = { kind: 'floor'; tileId: string } | { kind: 'wall'; material: WallMaterial }
 
 export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }: Props) {
   const [tab, setTab] = useState<'shelf' | 'decorate' | 'rooms'>(initialTab)
@@ -100,6 +123,9 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
   const [removeArmedId, setRemoveArmedId] = useState<string | null>(null)
   const [pendingBuy, setPendingBuy] = useState<FurnitureDef | null>(null)
   const [message, setMessage] = useState<string | null>(null)
+  const [decorateView, setDecorateView] = useState<'furniture' | 'style'>('furniture')
+  const [roomStyle, setRoomStyleState] = useState<RoomStyle>(() => getRoomStyle(roomHouseKey))
+  const [pendingStyleBuy, setPendingStyleBuy] = useState<PendingStyleBuy | null>(null)
   const removeArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const messageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -238,10 +264,40 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
   function handleSelectRoom(roomId: string) {
     if (roomId === selectedRoomId) return
     setSelectedRoomId(roomId)
-    setPlaced(loadHomeLayout(roomId === 'main' ? houseKey : `${houseKey}-${roomId}`))
+    const nextHouseKey = roomId === 'main' ? houseKey : `${houseKey}-${roomId}`
+    setPlaced(loadHomeLayout(nextHouseKey))
+    setRoomStyleState(getRoomStyle(nextHouseKey))
     setArmedItemId(null)
     setSelectedPieceId(null)
     setMoveArmed(false)
+  }
+
+  function handlePickFloor(tileId: string) {
+    if (roomStyle.floorTileId !== tileId) setPendingStyleBuy({ kind: 'floor', tileId })
+  }
+
+  function handlePickWall(material: WallMaterial) {
+    if (roomStyle.wallMaterial !== material) setPendingStyleBuy({ kind: 'wall', material })
+  }
+
+  function handleCancelStyleBuy() {
+    setPendingStyleBuy(null)
+  }
+
+  function handleConfirmStyleBuy() {
+    if (!pendingStyleBuy) return
+    if (crystals < STYLE_PRICE) {
+      showMessage("That's more crystals than you have.")
+      setPendingStyleBuy(null)
+      return
+    }
+    const next = crystals - STYLE_PRICE
+    saveCrystals(next)
+    setCrystals(next)
+    if (pendingStyleBuy.kind === 'floor') setRoomFloor(roomHouseKey, pendingStyleBuy.tileId)
+    else setRoomWall(roomHouseKey, pendingStyleBuy.material)
+    setRoomStyleState(getRoomStyle(roomHouseKey))
+    setPendingStyleBuy(null)
   }
 
   // While a piece is armed to move, hide it from the grid so its own cells
@@ -330,39 +386,77 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
               })}
             </div>
           )}
+          {houseKey !== 'default' && (
+            <div className="hoa-tabs">
+              <button
+                className={`hoa-tab${decorateView === 'furniture' ? ' hoa-tab--active' : ''}`}
+                onClick={() => setDecorateView('furniture')}
+              >
+                Furnish
+              </button>
+              <button
+                className={`hoa-tab${decorateView === 'style' ? ' hoa-tab--active' : ''}`}
+                onClick={() => setDecorateView('style')}
+              >
+                Style
+              </button>
+            </div>
+          )}
           {message && <div className="home-decorate-msg">{message}</div>}
-          {armedItemId && !message && (
-            <div className="home-decorate-hint">Tap an empty spot to place {getFurnitureDef(armedItemId)?.name ?? 'it'}.</div>
-          )}
-          {moveArmed && !message && (
-            <div className="home-decorate-hint">Tap an empty spot to move it there.</div>
-          )}
 
-          <HomeGrid
-            placed={displayedPlaced}
-            getDef={getFurnitureDef}
-            selectedId={selectedPieceId}
-            tappable={!!armedItemId || moveArmed}
-            onCellTap={handleCellTap}
-            onPieceTap={handlePieceTap}
-          />
+          {decorateView === 'furniture' ? (
+            <>
+              {armedItemId && !message && (
+                <div className="home-decorate-hint">Tap an empty spot to place {getFurnitureDef(armedItemId)?.name ?? 'it'}.</div>
+              )}
+              {moveArmed && !message && (
+                <div className="home-decorate-hint">Tap an empty spot to move it there.</div>
+              )}
 
-          {selectedPiece && selectedDef && (
-            <PieceActionBar
-              pieceName={selectedDef.name}
-              removeArmed={removeArmedId === selectedPiece.id}
-              onRotate={handleRotate}
-              onMove={handleMove}
-              onRemove={handleRemove}
-            />
+              <HomeGrid
+                placed={displayedPlaced}
+                getDef={getFurnitureDef}
+                selectedId={selectedPieceId}
+                tappable={!!armedItemId || moveArmed}
+                onCellTap={handleCellTap}
+                onPieceTap={handlePieceTap}
+              />
+
+              {selectedPiece && selectedDef && (
+                <PieceActionBar
+                  pieceName={selectedDef.name}
+                  removeArmed={removeArmedId === selectedPiece.id}
+                  onRotate={handleRotate}
+                  onMove={handleMove}
+                  onRemove={handleRemove}
+                />
+              )}
+
+              <FurniturePicker
+                defs={getAllFurnitureDefs()}
+                ownedIds={ownedIds}
+                armedId={armedItemId}
+                onPick={handlePickFurniture}
+              />
+            </>
+          ) : (
+            <>
+              <div className="shelf-section-label">FLOOR</div>
+              <TileStylePicker
+                options={FLOOR_OPTIONS}
+                selectedKey={roomStyle.floorTileId}
+                price={STYLE_PRICE}
+                onPick={handlePickFloor}
+              />
+              <div className="shelf-section-label">WALLS</div>
+              <TileStylePicker
+                options={WALL_OPTIONS}
+                selectedKey={roomStyle.wallMaterial}
+                price={STYLE_PRICE}
+                onPick={id => handlePickWall(id as WallMaterial)}
+              />
+            </>
           )}
-
-          <FurniturePicker
-            defs={getAllFurnitureDefs()}
-            ownedIds={ownedIds}
-            armedId={armedItemId}
-            onPick={handlePickFurniture}
-          />
         </div>
       )}
 
@@ -454,6 +548,28 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
                 onClick={handleConfirmRoomBuy}
               >
                 Build for {pendingRoomBuy.price.toLocaleString()} 💎
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingStyleBuy && (
+        <div className="shop-confirm-backdrop" onClick={handleCancelStyleBuy}>
+          <div className="shop-confirm-modal" onClick={e => e.stopPropagation()}>
+            <div className="shop-confirm-title">
+              {humanizeCamelCase(pendingStyleBuy.kind === 'floor' ? pendingStyleBuy.tileId : pendingStyleBuy.material)}
+            </div>
+            <div className="shop-confirm-body">
+              Change {pendingStyleBuy.kind} for {STYLE_PRICE} 💎? You have {crystals.toLocaleString()} 💎.
+            </div>
+            <div className="shop-confirm-actions">
+              <button className="action-btn" onClick={handleCancelStyleBuy}>Cancel</button>
+              <button
+                className={`action-btn action-btn--gold shop-card-buy-btn${crystals < STYLE_PRICE ? ' shop-card-buy-btn--poor' : ''}`}
+                onClick={handleConfirmStyleBuy}
+              >
+                Change for {STYLE_PRICE} 💎
               </button>
             </div>
           </div>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -30,6 +30,7 @@ import { resolveWeather } from '../../game/hub/weather'
 import { getActiveFestival } from '../../game/hub/hubCalendar'
 import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
+import { getResolvedRoomStyle } from '../../game/hub/roomStyle'
 import {
   getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
 } from '../../game/hub/houseRooms'
@@ -1696,9 +1697,20 @@ export function HubTownCanvas({
 
       // playerDecor interiors ship unfurnished (decor: []) — everything
       // visible is rendered from the player's placed furniture (homeLayout.ts)
-      // at runtime, not upgrade-gated.
+      // at runtime, not upgrade-gated. They can also carry a player-chosen
+      // floor/wall material (roomStyle.ts), overriding the template default —
+      // spread onto a new object since `interior` may be a direct reference
+      // into the shared, module-level HUB_INTERIORS record for the main room.
       if (interior.playerDecor) {
         const houseKey = `${locationKey}:${buildingId}`
+        const style = getResolvedRoomStyle(houseKey)
+        if (style.floorTileId !== undefined || style.wallMaterial !== undefined) {
+          interior = {
+            ...interior,
+            ...(style.floorTileId !== undefined && { floorTileId: style.floorTileId }),
+            ...(style.wallMaterial !== undefined && { wallMaterial: style.wallMaterial }),
+          }
+        }
         for (const piece of loadHomeLayout(houseKey)) {
           for (const offset of getFurnitureTileOffsets(piece.itemId)) {
             // DECORATE grid coords are 0-indexed within the walkable floor, which

--- a/web/src/components/hub/home-shelf/TileStylePicker.tsx
+++ b/web/src/components/hub/home-shelf/TileStylePicker.tsx
@@ -1,0 +1,36 @@
+import { TileSwatch } from '../../shared/TileSwatch'
+
+export interface TileStyleOption {
+  key: string
+  tileNumericId: number | undefined
+  label: string
+}
+
+export interface TileStylePickerProps {
+  options: TileStyleOption[]
+  selectedKey: string | undefined
+  price: number
+  onPick(key: string): void
+}
+
+/** A horizontal row of tile swatches for picking a room's floor or wall
+ *  material — reuses the furniture-picker's row/item styling with a
+ *  TileSwatch standing in for the furniture icon. */
+export function TileStylePicker({ options, selectedKey, price, onPick }: TileStylePickerProps) {
+  return (
+    <div className="furniture-picker">
+      {options.map(opt => (
+        <button
+          key={opt.key}
+          className={`furniture-picker-item furniture-picker-item--owned${opt.key === selectedKey ? ' furniture-picker-item--armed' : ''}`}
+          onClick={() => onPick(opt.key)}
+          aria-label={opt.key === selectedKey ? opt.label : `${opt.label} — ${price} crystals`}
+        >
+          <TileSwatch tileNumericId={opt.tileNumericId} size={24} />
+          <span className="furniture-picker-item-name">{opt.label}</span>
+          {opt.key !== selectedKey && <span className="furniture-picker-item-price">💎{price}</span>}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -15,6 +15,8 @@ import { BUILDING_MUSIC_IDS, AMBIANCE_IDS } from '../../game/sound'
 import { getUpgradeTrack, UPGRADE_CATALOG } from '../../data/hub/buildingUpgrades'
 import type { BundleTileRaw } from '../../data/bundles/bundleEditorApi'
 import type { NpcActivity } from '../../data/hub/loader'
+import { FLOOR_TILES } from '../../data/tiles/floorTiles'
+import { TileSwatch } from '../shared/TileSwatch'
 
 type ReorderDirection = 'forward' | 'back' | 'toFront' | 'toBack'
 
@@ -29,15 +31,6 @@ function swap<T>(arr: T[], i: number, j: number): T[] {
 function buildingMaxLevel(building: RawBuilding): number {
   return building.maxLevel ?? getUpgradeTrack(building.upgradeKind).length
 }
-
-const FLOOR_TILES = [
-  'woodFloor', 'stoneFloor', 'cobblestoneFloor', 'quarteredFloor', 'checkeredFloor',
-  'redCarpetFloor', 'darkWoodFloor', 'darkStoneFloor', 'darkCobblestoneFloor',
-  'darkQuarteredFloor', 'darkCheckeredFloor', 'yellowCarpetFloor', 'parquetFloor',
-  'smallStoneFloor', 'diagonalFloor', 'fourByFourTileFloor', 'meshFloor', 'ornateFloor',
-  'darkParquetFloor', 'goldSmallTileFloor', 'darkDiagonalFloor', 'darkFourByFourTileFloor',
-  'lightMeshFloor', 'blueOrnateFloor',
-]
 
 const UPGRADE_KINDS = Object.keys(UPGRADE_CATALOG)
 
@@ -148,34 +141,7 @@ const S = 20  // thumbnail size for tile picker grid
 
 function TileThumb({ tileId }: { tileId: string }) {
   const id = (BASE_CHIP_TILES as Record<string, number>)[tileId]
-  if (id === undefined) return null
-  if (id >= 10000) {
-    let ref: ReturnType<typeof resolveTileRef> | undefined
-    try { ref = resolveTileRef(id) } catch { /* unknown */ }
-    if (!ref) return null
-    const col = ref.id % ref.columns
-    const row = Math.floor(ref.id / ref.columns)
-    return (
-      <div style={{
-        width: S, height: S, flexShrink: 0, imageRendering: 'pixelated',
-        backgroundImage: `url("${ref.file}")`,
-        backgroundRepeat: 'no-repeat',
-        backgroundSize: ref.columns === 1 ? `${S}px ${S}px` : `${ref.columns * S}px auto`,
-        backgroundPosition: ref.columns === 1 ? '0 0' : `-${col * S}px -${row * S}px`,
-      }} />
-    )
-  }
-  const col = id % COLS
-  const row = Math.floor(id / COLS)
-  return (
-    <div style={{
-      width: S, height: S, flexShrink: 0, imageRendering: 'pixelated',
-      backgroundImage: `url("${SHEET_URL}")`,
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: `${COLS * S}px auto`,
-      backgroundPosition: `-${col * S}px -${row * S}px`,
-    }} />
-  )
+  return <TileSwatch tileNumericId={id} size={S} />
 }
 
 function TilePicker({ current, onChange, onClose }: {

--- a/web/src/components/shared/TileSwatch.tsx
+++ b/web/src/components/shared/TileSwatch.tsx
@@ -1,0 +1,38 @@
+import { resolveTileRef } from '../../data/tiles/tileIndex'
+
+const SHEET_URL = '/world/SampleMap/[Base]BaseChip_pipo.png'
+const SHEET_COLS = 8
+
+/** Renders a single tile (by its resolved numeric id) as a small CSS swatch —
+ *  used by the map editor's tile pickers and the player-facing room-style
+ *  picker so both draw from one rendering path. */
+export function TileSwatch({ tileNumericId, size = 20 }: { tileNumericId: number | undefined; size?: number }) {
+  if (tileNumericId === undefined) return null
+  if (tileNumericId >= 10000) {
+    let ref: ReturnType<typeof resolveTileRef> | undefined
+    try { ref = resolveTileRef(tileNumericId) } catch { /* unknown extended tile */ }
+    if (!ref) return null
+    const col = ref.id % ref.columns
+    const row = Math.floor(ref.id / ref.columns)
+    return (
+      <div style={{
+        width: size, height: size, flexShrink: 0, imageRendering: 'pixelated',
+        backgroundImage: `url("${ref.file}")`,
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: ref.columns === 1 ? `${size}px ${size}px` : `${ref.columns * size}px auto`,
+        backgroundPosition: ref.columns === 1 ? '0 0' : `-${col * size}px -${row * size}px`,
+      }} />
+    )
+  }
+  const col = tileNumericId % SHEET_COLS
+  const row = Math.floor(tileNumericId / SHEET_COLS)
+  return (
+    <div style={{
+      width: size, height: size, flexShrink: 0, imageRendering: 'pixelated',
+      backgroundImage: `url("${SHEET_URL}")`,
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: `${SHEET_COLS * size}px auto`,
+      backgroundPosition: `-${col * size}px -${row * size}px`,
+    }} />
+  )
+}

--- a/web/src/data/tiles/floorTiles.ts
+++ b/web/src/data/tiles/floorTiles.ts
@@ -1,0 +1,9 @@
+/** Player/editor-facing floor tile catalog — baseChipIndex.ts constant names. */
+export const FLOOR_TILES = [
+  'woodFloor', 'stoneFloor', 'cobblestoneFloor', 'quarteredFloor', 'checkeredFloor',
+  'redCarpetFloor', 'darkWoodFloor', 'darkStoneFloor', 'darkCobblestoneFloor',
+  'darkQuarteredFloor', 'darkCheckeredFloor', 'yellowCarpetFloor', 'parquetFloor',
+  'smallStoneFloor', 'diagonalFloor', 'fourByFourTileFloor', 'meshFloor', 'ornateFloor',
+  'darkParquetFloor', 'goldSmallTileFloor', 'darkDiagonalFloor', 'darkFourByFourTileFloor',
+  'lightMeshFloor', 'blueOrnateFloor',
+]

--- a/web/src/game/hub/roomStyle.test.ts
+++ b/web/src/game/hub/roomStyle.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getRoomStyle, setRoomFloor, setRoomWall, getResolvedRoomStyle } from './roomStyle'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+const HOUSE = 'Millhaven:building-1'
+
+describe('roomStyle', () => {
+  beforeEach(() => { installLocalStorageStub() })
+
+  it('starts with no style set', () => {
+    expect(getRoomStyle(HOUSE)).toEqual({})
+    expect(getResolvedRoomStyle(HOUSE)).toEqual({ floorTileId: undefined, wallMaterial: undefined })
+  })
+
+  it('sets and persists a floor tile', () => {
+    setRoomFloor(HOUSE, 'stoneFloor')
+    expect(getRoomStyle(HOUSE)).toEqual({ floorTileId: 'stoneFloor' })
+  })
+
+  it('sets and persists a wall material', () => {
+    setRoomWall(HOUSE, 'brick')
+    expect(getRoomStyle(HOUSE)).toEqual({ wallMaterial: 'brick' })
+  })
+
+  it('setting floor and wall independently keeps both', () => {
+    setRoomFloor(HOUSE, 'stoneFloor')
+    setRoomWall(HOUSE, 'brick')
+    expect(getRoomStyle(HOUSE)).toEqual({ floorTileId: 'stoneFloor', wallMaterial: 'brick' })
+  })
+
+  it('overwrites a previously set floor tile', () => {
+    setRoomFloor(HOUSE, 'stoneFloor')
+    setRoomFloor(HOUSE, 'woodFloor')
+    expect(getRoomStyle(HOUSE)).toEqual({ floorTileId: 'woodFloor' })
+  })
+
+  it('resolves the stored floor tile name to a numeric id', () => {
+    setRoomFloor(HOUSE, 'woodFloor')
+    const resolved = getResolvedRoomStyle(HOUSE)
+    expect(resolved.floorTileId).toBeGreaterThan(0)
+    expect(resolved.wallMaterial).toBeUndefined()
+  })
+
+  it('scopes style per house — one room does not affect another', () => {
+    setRoomFloor('Millhaven:building-1', 'stoneFloor')
+    expect(getRoomStyle('Ravenwatch:building-1')).toEqual({})
+  })
+
+  it('scopes style per purchased room slot', () => {
+    setRoomFloor(HOUSE, 'stoneFloor')
+    setRoomFloor(`${HOUSE}-basement`, 'darkStoneFloor')
+    expect(getRoomStyle(HOUSE)).toEqual({ floorTileId: 'stoneFloor' })
+    expect(getRoomStyle(`${HOUSE}-basement`)).toEqual({ floorTileId: 'darkStoneFloor' })
+  })
+
+  it('fails open when localStorage throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+    })
+    expect(getRoomStyle(HOUSE)).toEqual({})
+    expect(() => setRoomFloor(HOUSE, 'stoneFloor')).not.toThrow()
+  })
+})

--- a/web/src/game/hub/roomStyle.ts
+++ b/web/src/game/hub/roomStyle.ts
@@ -1,0 +1,61 @@
+import { logError } from '../../logger'
+import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import type { WallMaterial } from '../../data/tiles/buildingMaterials'
+
+// Per-room floor/wall customization, chosen from the DECORATE tab's STYLE
+// view. Keyed the same way as homeLayout.ts/houseRooms.ts: `houseKey` is
+// `${town}:${buildingId}` for a main room or `${town}:${buildingId}-${slotId}`
+// for a purchased room slot, so every room styles independently.
+
+const KEY_PREFIX = 'jarv_hub_room_style'
+const CHIP_TILES = BASE_CHIP_TILES as Record<string, number>
+
+export interface RoomStyle {
+  floorTileId?: string  // baseChipIndex.ts constant name, e.g. "woodFloor"
+  wallMaterial?: WallMaterial
+}
+
+/** Same shape, with floorTileId resolved to the numeric id HubInterior expects. */
+export interface ResolvedRoomStyle {
+  floorTileId?: number
+  wallMaterial?: WallMaterial
+}
+
+function storageKey(houseKey: string): string {
+  return `${KEY_PREFIX}:${houseKey}`
+}
+
+export function getRoomStyle(houseKey: string): RoomStyle {
+  try {
+    const raw = localStorage.getItem(storageKey(houseKey))
+    return raw ? (JSON.parse(raw) as RoomStyle) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(houseKey: string, style: RoomStyle): void {
+  try {
+    localStorage.setItem(storageKey(houseKey), JSON.stringify(style))
+  } catch (e) {
+    logError('room style save failed', { error: String(e) })
+  }
+}
+
+export function setRoomFloor(houseKey: string, floorTileId: string): void {
+  save(houseKey, { ...getRoomStyle(houseKey), floorTileId })
+}
+
+export function setRoomWall(houseKey: string, wallMaterial: WallMaterial): void {
+  save(houseKey, { ...getRoomStyle(houseKey), wallMaterial })
+}
+
+/** Resolves the stored style for rendering — HubTownCanvas.tsx applies this
+ *  as an override onto the room's HubInterior. */
+export function getResolvedRoomStyle(houseKey: string): ResolvedRoomStyle {
+  const style = getRoomStyle(houseKey)
+  return {
+    floorTileId: style.floorTileId ? CHIP_TILES[style.floorTileId] : undefined,
+    wallMaterial: style.wallMaterial,
+  }
+}


### PR DESCRIPTION
## Summary
- The DECORATE tab gains a **STYLE** view (alongside the existing FURNISH view) letting players swap a room's floor tile and wall material for a flat crystal fee (150 💎 per change), independently per room — the main room and any purchased room slot (basement, first floor, left, right, rear) each style separately.
- New `web/src/game/hub/roomStyle.ts` persists the choice per house/room (same `${town}:${buildingId}` / `${town}:${buildingId}-${slotId}` scoping as `homeLayout.ts`/`houseRooms.ts`), and `HubTownCanvas.tsx` applies it as a non-mutating override onto the room's `HubInterior` at render time.
- Extracted `FLOOR_TILES` (`web/src/data/tiles/floorTiles.ts`) and a `TileSwatch` renderer (`web/src/components/shared/TileSwatch.tsx`) out of the map editor so the new player-facing picker and the editor's tile pickers share one catalog/rendering path instead of duplicating them.

## Test plan
- [x] `npm run test` — new `roomStyle.test.ts` plus the full existing suite (457 tests) pass
- [x] `npm run build` — typecheck + Vite build clean
- [ ] In-game playtesting was not performed (skipped per project convention for this session) — recommend manually verifying: DECORATE → STYLE view shows swatch rows for floor/wall, tapping an unselected swatch opens a buy-confirm modal, confirming deducts crystals and the room's floor/wall visibly changes on next entry, and each purchased room slot styles independently of the main room.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_