### PR TITLE
fix(hub): LEAVE from a purchased room slot teleported the avatar off-map

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1614,7 +1614,11 @@ export function HubTownCanvas({
           interiorLayer.removeChild(avatar)
           avatarLayer.addChild(avatar)
           avatarInInterior = false
+          // A purchased room slot (or any hand-authored sub-room) has no
+          // exterior door of its own — its id is `<mainBuildingId>-<slotId>`,
+          // so fall back to the door of the building whose id prefixes it.
           const door = HUB_DOORS.find(d => d.buildingId === currentInteriorId)
+            ?? HUB_DOORS.find(d => !!currentInteriorId && currentInteriorId.startsWith(`${d.buildingId}-`))
           if (door) {
             avatar.x = door.tx * T + T / 2
             avatar.y = door.ty * T + T


### PR DESCRIPTION
## Summary
- Reported bug: standing inside a purchased room slot (e.g. an "upstairs"/first-floor room) and tapping LEAVE placed the avatar at the top-left corner of the hub canvas, which then walked all the way to the building's exit before responding to the next tap.
- Root cause: `HubTownCanvas.tsx`'s `doExitInterior` resolves the exterior door via `HUB_DOORS.find(d => d.buildingId === currentInteriorId)`. A room slot's interior id is `<mainBuildingId>-<slotId>` (e.g. `building-1-first-floor`), which has no door entry of its own, so the lookup missed, the `if (door)` correction was skipped, and the avatar kept whatever interior-space pixel coordinates it last had — reused verbatim as exterior world coordinates, landing near the map origin.
- Fix: fall back to the door of the building whose id prefixes `currentInteriorId` when there's no exact match, mirroring the same "resolve the owning main building" pattern already used elsewhere in this file (e.g. upgrade-level gating).

## Test plan
- [x] `npm run test` — full suite (457 tests) passes
- [x] `npm run build` — typecheck + Vite build clean
- [ ] In-game playtesting was not performed (skipped per project convention for this session) — recommend manually verifying: buy a room slot (e.g. first floor), enter it, tap LEAVE, and confirm the avatar reappears at the house's front door instead of the map's top-left corner.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_