### PR TITLE
feat(hub): display SHELF items (relics, keepsakes, odds & ends) in the house

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -43,6 +43,7 @@
 | `web/src/game/hub/roomStyle.ts` | Per-room floor/wall style persistence (localStorage) — see §19 "Room Style" | `getRoomStyle`, `setRoomFloor`, `setRoomWall`, `getResolvedRoomStyle` |
 | `web/src/data/tiles/floorTiles.ts` | Shared floor-tile catalog, reused by the map editor and the room-style picker — see §19 "Room Style" | `FLOOR_TILES` |
 | `web/src/components/shared/TileSwatch.tsx` | CSS tile-swatch renderer (by resolved numeric tile id), shared by the map editor and the room-style picker — see §19 "Room Style" | `TileSwatch` |
+| `web/src/game/hub/shelfDecor.ts` | Bridges SHELF-tab items (relics, keepsakes, odds & ends) into homeLayout.ts's placement system — see §19 "Shelf Decor" | `shelfItemDisplayId`, `shelfRelicDisplayId`, `isShelfDecorId`, `getShelfDecorDef`, `ownsShelfDecor` |
 
 ---
 
@@ -2215,3 +2216,53 @@ tab). The STYLE view shows two `TileStylePicker` rows (Floor, Walls); tapping
 an unselected swatch opens the usual `.shop-confirm-*` buy-confirm modal,
 then calls `setRoomFloor`/`setRoomWall` on the currently-selected room's
 `roomHouseKey`.
+
+### Shelf Decor — displaying quest/shelf items in the house
+
+Anything visible on the SHELF tab (relics, keepsakes, odds & ends) can also
+be placed in the DECORATE grid as a plain 1x1 display piece, free (it's
+already owned) — reusing the exact same `homeLayout.ts` placement grid,
+collision rules, and `FurniturePicker`/`PieceActionBar` UI as real
+furniture, rather than building a parallel placement system.
+
+**Bridging module** — `web/src/game/hub/shelfDecor.ts` gives a shelf item or
+relic an opaque placement id that homeLayout.ts can treat like any other
+`itemId`, without homeLayout.ts needing to know two separate item universes
+exist:
+- `shelfItemDisplayId(itemId)` / `shelfRelicDisplayId(relicName)` — prefix
+  a real `dailyLogin.ts` item id / relic name (`shelf-item:<id>` /
+  `shelf-relic:<name>`) so it can never collide with a `furniture.json` id.
+- `isShelfDecorId(id)` — cheap prefix check.
+- `getShelfDecorDef(id)` / `ownsShelfDecor(id)` — resolve a placement id back
+  to `{ name, icon }` by looking the underlying id/name up in
+  `loadInventory()` / `loadEarnedRelics()` + `getRelicDef()` live (not a
+  snapshot) — so an item sold/traded away after being placed stops
+  resolving, same graceful-degradation-to-`❓` fallback pattern used
+  elsewhere for unknown ids.
+
+**`homeLayout.ts` integration** — three small hooks, no parallel grid/store:
+- `footprintFor()` returns a fixed `{w:1,h:1}` for any `isShelfDecorId(itemId)`
+  (never in `furniture.json`, so `getFurnitureDef` would miss).
+- `placeFurniture`'s ownership gate (`isPlaceable()`) checks
+  `ownsShelfDecor(itemId)` instead of the furniture catalog when the id is a
+  shelf-decor id.
+- Placed shelf-decor pieces live in the exact same per-house
+  `jarv_hub_home_layout:<houseKey>` array as furniture — no new storage key.
+
+**In-world rendering** — `furnitureTiles.ts`'s `getFurnitureTileOffsets`
+(the map from a placed piece's `itemId` to the real tile(s) rendered in the
+walkable room, see "Walkable room" above) special-cases `isShelfDecorId`
+ids to a single generic stand-in tile (`smallChest`) — the DECORATE grid
+still shows each piece's real icon/name (so players can tell their relics
+apart while arranging them), but in-world they're indistinguishable from
+each other, same "not worth the complexity" tradeoff already accepted for
+furniture's own imperfect stand-in tiles.
+
+**UI** — `HomeShelf.tsx`'s DECORATE → FURNISH view gets a second
+`FurniturePicker` row below the furniture one, labeled "FROM THE SHELF",
+built from synthetic `FurnitureDef`-shaped objects (`shelfPlaceableDef`) so
+it drops into the existing `FurniturePicker`/`HomeGrid`/`PieceActionBar`
+components unmodified. `getPlaceableDef()` is the one place that resolves
+either a real furniture id or a shelf-decor id, used everywhere `HomeShelf.tsx`
+previously called `getFurnitureDef` directly for a placed/armed piece's
+display info.

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -15,6 +15,7 @@ import {
   RoomSlotDef, getAllRoomSlotDefs, getRoomSlotDef, getPurchasedSlotIds, purchaseRoomSlot,
 } from '../../game/hub/houseRooms'
 import { RoomStyle, getRoomStyle, setRoomFloor, setRoomWall } from '../../game/hub/roomStyle'
+import { isShelfDecorId, shelfItemDisplayId, shelfRelicDisplayId } from '../../game/hub/shelfDecor'
 import { loadCrystals, saveCrystals } from '../../game/collection'
 import { FLOOR_TILES } from '../../data/tiles/floorTiles'
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
@@ -66,6 +67,13 @@ function humanizeCamelCase(id: string): string {
   return spaced.charAt(0).toUpperCase() + spaced.slice(1)
 }
 
+/** A shelf item/relic reused as a placeable — always "owned" (it's already on
+ *  the shelf) and always a plain 1x1, so it fits FurnitureDef/FurniturePicker
+ *  as-is without any special-casing in the picker or grid components. */
+function shelfPlaceableDef(id: string, name: string, icon: string): FurnitureDef {
+  return { id, name, icon, desc: '', footprint: { w: 1, h: 1 }, price: 0 }
+}
+
 const CHIP_TILES = BASE_CHIP_TILES as Record<string, number>
 const WALL_MATERIALS = Object.keys(WALL_TILES) as WallMaterial[]
 const FLOOR_OPTIONS: TileStyleOption[] = FLOOR_TILES.map(id => ({
@@ -92,6 +100,14 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
   const relicEntries:    ShelfEntry[] = relics.map(r => ({ kind: 'relic' as const, relic: r }))
   const keepsakeEntries: ShelfEntry[] = items.filter(i => i.isKeepsake).map(i => ({ kind: 'item' as const, item: i }))
   const junkEntries:     ShelfEntry[] = items.filter(i => !i.isKeepsake).map(i => ({ kind: 'item' as const, item: i }))
+
+  // Anything on the shelf (relics, keepsakes, odds & ends) can also be placed
+  // in the DECORATE grid as a 1x1 display piece — already owned, nothing to buy.
+  const shelfDecorDefs: FurnitureDef[] = [
+    ...relics.map(r => shelfPlaceableDef(shelfRelicDisplayId(r.name), r.name, r.icon)),
+    ...items.map(i => shelfPlaceableDef(shelfItemDisplayId(i.id), i.name, i.icon)),
+  ]
+  const shelfDecorIds = shelfDecorDefs.map(d => d.id)
 
   const isEmpty = relicEntries.length === 0 && keepsakeEntries.length === 0 && junkEntries.length === 0
 
@@ -149,13 +165,18 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
     messageTimeoutRef.current = setTimeout(() => { messageTimeoutRef.current = null; setMessage(null) }, 2200)
   }
 
+  /** Resolves either a furniture.json catalog id or a shelf-decor id (see shelfDecor.ts). */
+  function getPlaceableDef(itemId: string): FurnitureDef | undefined {
+    return getFurnitureDef(itemId) ?? shelfDecorDefs.find(d => d.id === itemId)
+  }
+
   const selectedPiece = selectedPieceId ? placed.find(p => p.id === selectedPieceId) ?? null : null
-  const selectedDef = selectedPiece ? getFurnitureDef(selectedPiece.itemId) : null
+  const selectedDef = selectedPiece ? getPlaceableDef(selectedPiece.itemId) : null
 
   function handlePickFurniture(itemId: string) {
     setSelectedPieceId(null)
     setMoveArmed(false)
-    if (ownedIds.includes(itemId)) {
+    if (isShelfDecorId(itemId) || ownedIds.includes(itemId)) {
       setArmedItemId(prev => (prev === itemId ? null : itemId))
       return
     }
@@ -407,7 +428,7 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
           {decorateView === 'furniture' ? (
             <>
               {armedItemId && !message && (
-                <div className="home-decorate-hint">Tap an empty spot to place {getFurnitureDef(armedItemId)?.name ?? 'it'}.</div>
+                <div className="home-decorate-hint">Tap an empty spot to place {getPlaceableDef(armedItemId)?.name ?? 'it'}.</div>
               )}
               {moveArmed && !message && (
                 <div className="home-decorate-hint">Tap an empty spot to move it there.</div>
@@ -415,7 +436,7 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
 
               <HomeGrid
                 placed={displayedPlaced}
-                getDef={getFurnitureDef}
+                getDef={getPlaceableDef}
                 selectedId={selectedPieceId}
                 tappable={!!armedItemId || moveArmed}
                 onCellTap={handleCellTap}
@@ -438,6 +459,18 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
                 armedId={armedItemId}
                 onPick={handlePickFurniture}
               />
+
+              {shelfDecorDefs.length > 0 && (
+                <>
+                  <div className="shelf-section-label">FROM THE SHELF</div>
+                  <FurniturePicker
+                    defs={shelfDecorDefs}
+                    ownedIds={shelfDecorIds}
+                    armedId={armedItemId}
+                    onPick={handlePickFurniture}
+                  />
+                </>
+              )}
             </>
           ) : (
             <>

--- a/web/src/game/hub/furnitureTiles.test.ts
+++ b/web/src/game/hub/furnitureTiles.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { getFurnitureTileOffsets } from './furnitureTiles'
+import { shelfItemDisplayId, shelfRelicDisplayId } from './shelfDecor'
+
+describe('getFurnitureTileOffsets', () => {
+  it('resolves a known furniture id to its authored offsets', () => {
+    expect(getFurnitureTileOffsets('reading-lamp')).toEqual([{ dx: 0, dy: 0, tileId: expect.any(Number) }])
+    expect(getFurnitureTileOffsets('cozy-rug')).toHaveLength(4)
+  })
+
+  it('returns nothing for an unknown, non-shelf-decor id', () => {
+    expect(getFurnitureTileOffsets('not-a-real-item')).toEqual([])
+  })
+
+  it('resolves any shelf-decor id to a single generic display tile', () => {
+    const itemOffsets = getFurnitureTileOffsets(shelfItemDisplayId('trinket-1'))
+    const relicOffsets = getFurnitureTileOffsets(shelfRelicDisplayId('Bark Shield'))
+    expect(itemOffsets).toEqual([{ dx: 0, dy: 0, tileId: expect.any(Number) }])
+    expect(relicOffsets).toEqual(itemOffsets)
+  })
+})

--- a/web/src/game/hub/furnitureTiles.ts
+++ b/web/src/game/hub/furnitureTiles.ts
@@ -17,6 +17,7 @@
 // tiles that aren't a perfect visual match for their catalog item).
 
 import { BASE_CHIP_TILES } from '../../data/tiles/baseChipIndex'
+import { isShelfDecorId } from './shelfDecor'
 
 export interface FurnitureTileOffset {
   dx: number
@@ -57,7 +58,13 @@ const FURNITURE_TILES_RAW: Record<string, RawOffset[]> = {
 
 const CHIP_TILES = BASE_CHIP_TILES as Record<string, number>
 
+// Shelf-decor pieces (keepsakes, relics, odds & ends — see shelfDecor.ts) aren't
+// in FURNITURE_TILES_RAW above; they render as one generic display stand-in
+// tile in-world (the DECORATE grid still shows their real icon/name).
+const SHELF_DECOR_TILE_ID = 'smallChest'
+
 export function getFurnitureTileOffsets(itemId: string): FurnitureTileOffset[] {
+  if (isShelfDecorId(itemId)) return [{ dx: 0, dy: 0, tileId: CHIP_TILES[SHELF_DECOR_TILE_ID] ?? 0 }]
   const raw = FURNITURE_TILES_RAW[itemId] ?? []
   return raw.map(o => ({ dx: o.dx, dy: o.dy, tileId: CHIP_TILES[o.tileId] ?? 0 }))
 }

--- a/web/src/game/hub/homeLayout.test.ts
+++ b/web/src/game/hub/homeLayout.test.ts
@@ -4,6 +4,8 @@ import {
   HOME_GRID_COLS, HOME_GRID_ROWS,
 } from './homeLayout'
 import { grantFurniture } from './furniture'
+import { shelfItemDisplayId } from './shelfDecor'
+import { addToInventory } from '../dailyLogin'
 
 function installLocalStorageStub(): Map<string, string> {
   const store = new Map<string, string>()
@@ -175,6 +177,29 @@ describe('homeLayout', () => {
       placeFurniture('default', LAMP, 1, 1)
       expect(store.has('jarv_hub_home_layout:default')).toBe(true)
       expect(store.has('jarv_hub_home_layout')).toBe(false)
+    })
+  })
+
+  describe('shelf-decor placement', () => {
+    it('places a shelf item (keepsake/junk) the player owns', () => {
+      addToInventory({ id: 'trinket-1', name: 'Old Trinket', icon: '🔮', desc: '', lore: '' })
+      const itemId = shelfItemDisplayId('trinket-1')
+      const piece = placeFurniture(HOUSE, itemId, 2, 5)
+      expect(piece).toMatchObject({ itemId, x: 2, y: 5, rotation: 0 })
+      expect(loadHomeLayout(HOUSE)).toHaveLength(1)
+    })
+
+    it('rejects a shelf-item id the player does not own', () => {
+      expect(placeFurniture(HOUSE, shelfItemDisplayId('never-owned'), 0, 0)).toBeNull()
+      expect(loadHomeLayout(HOUSE)).toHaveLength(0)
+    })
+
+    it('shelf-decor pieces are always a 1x1 footprint, occupying just their own cell', () => {
+      addToInventory({ id: 'trinket-1', name: 'Old Trinket', icon: '🔮', desc: '', lore: '' })
+      const itemId = shelfItemDisplayId('trinket-1')
+      expect(placeFurniture(HOUSE, itemId, 2, 5)).not.toBeNull()
+      expect(placeFurniture(HOUSE, LAMP, 2, 5)).toBeNull() // occupied
+      expect(placeFurniture(HOUSE, LAMP, 3, 5)).not.toBeNull() // adjacent cell is free
     })
   })
 })

--- a/web/src/game/hub/homeLayout.ts
+++ b/web/src/game/hub/homeLayout.ts
@@ -1,5 +1,6 @@
 import { logError } from '../../logger'
 import { getFurnitureDef, ownsFurniture } from './furniture'
+import { isShelfDecorId, ownsShelfDecor } from './shelfDecor'
 
 const KEY_PREFIX = 'jarv_hub_home_layout'
 
@@ -47,11 +48,21 @@ function save(houseKey: string, data: Store): void {
   }
 }
 
-/** The footprint a piece occupies, accounting for rotation swapping width/height. */
+/** The footprint a piece occupies, accounting for rotation swapping width/height.
+ *  Shelf-decor pieces (keepsakes, relics, odds & ends off the SHELF tab) are
+ *  always a plain 1x1 — they're not in furniture.json, just placed as-is. */
 function footprintFor(itemId: string, rotation: 0 | 90 | 180 | 270): { w: number; h: number } {
+  if (isShelfDecorId(itemId)) return { w: 1, h: 1 }
   const def = getFurnitureDef(itemId)
   const { w, h } = def?.footprint ?? { w: 1, h: 1 }
   return rotation === 90 || rotation === 270 ? { w: h, h: w } : { w, h }
+}
+
+/** Whether itemId can be placed at all — either an owned furniture.json catalog
+ *  piece, or a shelf-decor id the player currently still owns (see shelfDecor.ts). */
+function isPlaceable(itemId: string): boolean {
+  if (isShelfDecorId(itemId)) return ownsShelfDecor(itemId)
+  return !!getFurnitureDef(itemId) && ownsFurniture(itemId)
 }
 
 function inBounds(x: number, y: number, w: number, h: number): boolean {
@@ -96,7 +107,7 @@ export function isHomeLayoutEmpty(houseKey: string): boolean {
 /** Places a new piece of furniture at (x, y). Returns null if the item isn't in the catalog or
  *  isn't owned, the placement is out of bounds, or its footprint overlaps an existing piece. */
 export function placeFurniture(houseKey: string, itemId: string, x: number, y: number, rotation: 0 | 90 | 180 | 270 = 0): PlacedFurniture | null {
-  if (!getFurnitureDef(itemId) || !ownsFurniture(itemId)) return null
+  if (!isPlaceable(itemId)) return null
   const { w, h } = footprintFor(itemId, rotation)
   if (!inBounds(x, y, w, h) || overlapsReserved(x, y, w, h)) return null
   const data = load(houseKey)

--- a/web/src/game/hub/shelfDecor.test.ts
+++ b/web/src/game/hub/shelfDecor.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  shelfItemDisplayId, shelfRelicDisplayId, isShelfDecorId, getShelfDecorDef, ownsShelfDecor,
+} from './shelfDecor'
+import { addToInventory } from '../dailyLogin'
+import { addEarnedRelic } from '../relics'
+
+function installLocalStorageStub(): void {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+  })
+}
+
+describe('shelfDecor', () => {
+  beforeEach(() => { installLocalStorageStub() })
+
+  it('recognizes shelf-item and shelf-relic ids', () => {
+    expect(isShelfDecorId(shelfItemDisplayId('foo'))).toBe(true)
+    expect(isShelfDecorId(shelfRelicDisplayId('Foo Relic'))).toBe(true)
+    expect(isShelfDecorId('reading-lamp')).toBe(false)
+  })
+
+  it('resolves a keepsake/junk item that is in the inventory', () => {
+    addToInventory({ id: 'trinket-1', name: 'Old Trinket', icon: '🔮', desc: '', lore: '', isKeepsake: true })
+    const id = shelfItemDisplayId('trinket-1')
+    expect(getShelfDecorDef(id)).toEqual({ id, name: 'Old Trinket', icon: '🔮' })
+    expect(ownsShelfDecor(id)).toBe(true)
+  })
+
+  it('returns undefined for an item id no longer in the inventory', () => {
+    const id = shelfItemDisplayId('never-owned')
+    expect(getShelfDecorDef(id)).toBeUndefined()
+    expect(ownsShelfDecor(id)).toBe(false)
+  })
+
+  it('resolves an earned relic', () => {
+    addEarnedRelic('Bark Shield')
+    const id = shelfRelicDisplayId('Bark Shield')
+    const def = getShelfDecorDef(id)
+    expect(def?.id).toBe(id)
+    expect(def?.name).toBe('Bark Shield')
+    expect(def?.icon).toBe('🛡️')
+    expect(ownsShelfDecor(id)).toBe(true)
+  })
+
+  it('returns undefined for a relic name not earned', () => {
+    const id = shelfRelicDisplayId('Never Earned')
+    expect(getShelfDecorDef(id)).toBeUndefined()
+    expect(ownsShelfDecor(id)).toBe(false)
+  })
+
+  it('returns undefined for a non-shelf-decor id', () => {
+    expect(getShelfDecorDef('reading-lamp')).toBeUndefined()
+  })
+})

--- a/web/src/game/hub/shelfDecor.ts
+++ b/web/src/game/hub/shelfDecor.ts
@@ -1,0 +1,52 @@
+import { loadInventory } from '../dailyLogin'
+import { getRelicDef, loadEarnedRelics } from '../relics'
+
+// Lets shelf items (relics, keepsakes, odds & ends — anything SHELF-tab-visible)
+// be placed in the DECORATE grid as 1x1 display pieces alongside purchased
+// furniture. They're already owned by virtue of being on the shelf, so there's
+// nothing to buy here — homeLayout.ts just needs a way to resolve and validate
+// these ids alongside real furniture.json ids.
+
+const ITEM_PREFIX  = 'shelf-item:'
+const RELIC_PREFIX = 'shelf-relic:'
+
+export function shelfItemDisplayId(itemId: string): string {
+  return `${ITEM_PREFIX}${itemId}`
+}
+
+export function shelfRelicDisplayId(relicName: string): string {
+  return `${RELIC_PREFIX}${relicName}`
+}
+
+export function isShelfDecorId(id: string): boolean {
+  return id.startsWith(ITEM_PREFIX) || id.startsWith(RELIC_PREFIX)
+}
+
+export interface ShelfDecorDef {
+  id: string
+  name: string
+  icon: string
+}
+
+/** Resolves a shelf-decor placement id back to its display info — undefined if
+ *  it's not a shelf-decor id, or the underlying item/relic is no longer owned
+ *  (e.g. sold or traded away since it was placed). */
+export function getShelfDecorDef(id: string): ShelfDecorDef | undefined {
+  if (id.startsWith(ITEM_PREFIX)) {
+    const itemId = id.slice(ITEM_PREFIX.length)
+    const item = loadInventory().find(i => i.id === itemId)
+    return item ? { id, name: item.name, icon: item.icon } : undefined
+  }
+  if (id.startsWith(RELIC_PREFIX)) {
+    const name = id.slice(RELIC_PREFIX.length)
+    if (!loadEarnedRelics().includes(name)) return undefined
+    const def = getRelicDef(name)
+    return def ? { id, name: def.name, icon: def.icon } : undefined
+  }
+  return undefined
+}
+
+/** True if this shelf-decor id currently resolves to something the player still owns. */
+export function ownsShelfDecor(id: string): boolean {
+  return getShelfDecorDef(id) !== undefined
+}


### PR DESCRIPTION
## Summary
- Requested feature: let players place quest-reward items (anything shown on the SHELF tab — relics, keepsakes, odds & ends) into the house as decor.
- DECORATE's FURNISH view gets a second picker row, "FROM THE SHELF", listing every relic/keepsake/junk item the player currently owns. They're always free to place (already earned) and always a plain 1x1 footprint.
- New `web/src/game/hub/shelfDecor.ts` gives each shelf item/relic an opaque placement id (`shelf-item:<id>` / `shelf-relic:<name>`) that `homeLayout.ts` treats like any other furniture id — no parallel grid, storage, or placement logic; footprint/ownership checks just special-case the id prefix.
- `furnitureTiles.ts` (which maps a placed piece's id to its real in-world tile) special-cases shelf-decor ids to a single generic display tile (`smallChest`), so placed items actually render when standing in the room — the DECORATE grid still shows each item's real icon/name so players can tell them apart while arranging.

## Test plan
- [x] `npm run test` — new `shelfDecor.test.ts`, `furnitureTiles.test.ts`, and extended `homeLayout.test.ts` cases, plus the full existing suite (469 tests) pass
- [x] `npm run build` — typecheck + Vite build clean
- [ ] In-game playtesting was not performed (skipped per project convention for this session) — recommend manually verifying: earn/hold a keepsake or relic, open DECORATE → FURNISH, confirm a "FROM THE SHELF" row appears, place one, and confirm it renders in the room (as a generic small-chest-style prop) and can be moved/removed like furniture.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBgnFNvjDAqJDenVTdEamV)_