### PR TITLE
Add richer Rollbar diagnostics for WebGL context recovery and tab-resume

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect, useRef, useMemo, useReducer } 
 import { resolvedNodeOpts, loadHandicap, HANDICAP_KEY, buildQuickBattleOpts, loadCurrentDeckInfo } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
+import { getGlStats } from './utils/pixiTelemetry'
 import { useStartupData } from './hooks/useStartupData'
 import { useCloudSync } from './hooks/useCloudSync'
 import { useRegisterSW } from 'virtual:pwa-register/react'
@@ -261,6 +262,10 @@ type Screen =
   | 'sceneryPreview'
 
 
+// Below this, a tab switch/app-switcher glance isn't worth a Rollbar breadcrumb —
+// only log genuine "away for a while" returns.
+const VISIBILITY_BREADCRUMB_THRESHOLD_MS = 15_000
+
 const STANCE_RULES_BY_NODE_TYPE: Partial<Record<string, StanceRules>> = {
   // Normal battles: no restrictions (current behaviour)
   battle: undefined,
@@ -508,6 +513,9 @@ export default function App() {
   const [pendingBattleIsCampaign, setPendingBattleIsCampaign] = useState(false)
   const campaignPlayCountsRef = useRef<Record<string, number>>({})  // per-battle play tracking
   const gameStateRef = useRef<GameState | null>(null)  // always-current snapshot for callbacks
+  const screenRef = useRef<Screen>(screen)  // always-current snapshot for the visibility handler below
+  const currentLocationKeyRef = useRef<string>(currentLocationKey)
+  const hiddenAtRef = useRef<number | null>(null)  // timestamp the tab was last hidden, for the visibility breadcrumb
 
   // Unit death tracking
   const prevPlayerUnitsRef   = useRef<Map<string, string>>(new Map())
@@ -567,6 +575,8 @@ export default function App() {
   // Keep gameStateRef in sync so callbacks can read current state without stale closures
   gameStateRef.current = gameState
   runRef.current = run
+  screenRef.current = screen
+  currentLocationKeyRef.current = currentLocationKey
 
   // ── Crash sentinel: record screen transitions so unclean exits (iOS page
   // kills) report where the player was when the page died ──
@@ -577,7 +587,28 @@ export default function App() {
   // ── Page visibility: pause game loop when tab is hidden ──
   const [isTabHidden, setIsTabHidden] = useState(() => document.hidden)
   useEffect(() => {
-    function handleVisibility() { setIsTabHidden(document.hidden) }
+    function handleVisibility() {
+      const hidden = document.hidden
+      setIsTabHidden(hidden)
+      if (hidden) {
+        hiddenAtRef.current = Date.now()
+        return
+      }
+      // Breadcrumb for any "blank screen after being away" report — logged on
+      // every meaningful return from background, not just when something goes
+      // wrong, so a later crash/error report can be correlated against how
+      // long the tab sat backgrounded and what screen it resumed on.
+      const hiddenMs = hiddenAtRef.current != null ? Date.now() - hiddenAtRef.current : null
+      hiddenAtRef.current = null
+      if (hiddenMs != null && hiddenMs >= VISIBILITY_BREADCRUMB_THRESHOLD_MS) {
+        rollbar?.info('[visibility] tab resumed after background', {
+          hiddenMs,
+          screen: screenRef.current,
+          location: currentLocationKeyRef.current,
+          ...getGlStats(),
+        })
+      }
+    }
     document.addEventListener('visibilitychange', handleVisibility)
     return () => document.removeEventListener('visibilitychange', handleVisibility)
   }, [])

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -111,10 +111,13 @@ export function usePixiApp(
     }
 
     // Creates and initialises a fresh Application, appending its canvas and
-    // calling onReady once ready. Called on mount, and again to rebuild the
-    // scene from scratch after an unrecoverable webglcontextlost.
-    const buildApp = () => {
+    // calling onReady once ready. Called on mount (isRebuild=false), and
+    // again to rebuild the scene from scratch after an unrecoverable
+    // webglcontextlost (isRebuild=true) — logged distinctly from the initial
+    // mount so Rollbar shows whether recovery actually completed.
+    const buildApp = (isRebuild: boolean) => {
       initialized = false
+      const buildStartedAt = Date.now()
       const app = new PIXI.Application()
       appRef.current = app
 
@@ -131,9 +134,14 @@ export function usePixiApp(
         noteContextCreated(contextInfo)
         if (destroyed) {
           // Cleanup ran before init resolved — destroy properly to release the WebGL context.
-          rollbar?.warn('[usePixiApp] init resolved after unmount — destroying orphan app')
+          rollbar?.warn('[usePixiApp] init resolved after unmount — destroying orphan app', { isRebuild, rebuildAttempts })
           teardown(app)
           return
+        }
+        if (isRebuild) {
+          rollbar?.info('[usePixiApp] webgl context recovered — rebuild succeeded', {
+            ...contextInfo, ...getGlStats(), rebuildAttempts, rebuildMs: Date.now() - buildStartedAt,
+          })
         }
         const canvas = app.canvas as HTMLCanvasElement
         // Intentional loss during our own teardown never reaches this listener:
@@ -143,20 +151,26 @@ export function usePixiApp(
           e.preventDefault()  // signal we intend to recover, not abandon the canvas
           rebuildAttempts++
           if (rebuildAttempts > MAX_CONTEXT_REBUILD_ATTEMPTS) {
-            rollbar?.error('[usePixiApp] webglcontextlost — giving up after repeated rebuild failures', { ...contextInfo, ...getGlStats(), rebuildAttempts })
+            rollbar?.error('[usePixiApp] webglcontextlost — giving up after repeated rebuild failures', {
+              ...contextInfo, ...getGlStats(), rebuildAttempts, visibility: document.visibilityState,
+            })
             teardown(app)
             return
           }
-          rollbar?.warn('[usePixiApp] webglcontextlost — rebuilding app', { ...contextInfo, ...getGlStats(), rebuildAttempts })
+          rollbar?.warn('[usePixiApp] webglcontextlost — rebuilding app', {
+            ...contextInfo, ...getGlStats(), rebuildAttempts, visibility: document.visibilityState,
+          })
           teardown(app)
-          if (!destroyed) buildApp()
+          if (!destroyed) buildApp(true)
         }
         canvas.addEventListener('webglcontextlost', contextLostHandler)
         container.appendChild(canvas)
         onReady(app)
       }).catch(e => {
         console.error('[usePixiApp] app.init failed', e)
-        rollbar?.error('[usePixiApp] app.init failed', { message: (e as Error)?.message, ...contextInfo, ...getGlStats() })
+        rollbar?.error(isRebuild ? '[usePixiApp] rebuild after context loss failed' : '[usePixiApp] app.init failed', {
+          message: (e as Error)?.message, ...contextInfo, ...getGlStats(), isRebuild, rebuildAttempts,
+        })
         // Release any partial WebGL context created before the failure to prevent
         // context accumulation that crashes the browser after repeated navigations.
         try {
@@ -168,7 +182,7 @@ export function usePixiApp(
       })
     }
 
-    buildApp()
+    buildApp(false)
 
     return () => {
       destroyed = true


### PR DESCRIPTION
## Summary

Follow-up to #1954 (`usePixiApp` WebGL-context-lost recovery). The user reported the blank-screen-after-being-away issue still occurred once after that fix shipped, so this adds diagnostics to pin down exactly what's happening next time:

- `web/src/hooks/usePixiApp.ts`: each `webglcontextlost` rebuild attempt is now tagged (`rebuildAttempts`), and the rebuild path logs distinctly from the initial mount — an explicit `info`-level "webgl context recovered — rebuild succeeded" log when a post-loss rebuild's `init()` resolves, and a distinct "rebuild after context loss failed" error if a rebuild's `init()` itself throws (vs. the original mount failing). Previously we only knew a context was lost and a rebuild was attempted, never whether it actually worked.
- `web/src/App.tsx`: the existing `visibilitychange` listener now tracks how long the tab was hidden and logs an `info`-level Rollbar breadcrumb (`[visibility] tab resumed after background`) whenever the tab returns from being hidden 15s+, including hidden duration, current screen/location, and live WebGL context stats (`getGlStats()`). This covers the case where a recurrence isn't the WebGL-context path at all — Rollbar already auto-captures uncaught errors/unhandled rejections, so this breadcrumb gives a fixed point to correlate whatever fires right after a long background return against how long the player was away and where they were.

No behavior change — this is diagnostics-only.

## Test plan

- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 469/469 unit tests pass (only failure in the full run is a pre-existing, unrelated Storybook browser-test project that can't launch its headless Chromium binary in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xfmi2PJ9QNRPja79HH1zMU)_