### PR TITLE
Hub: default NPC dialogue varies by scheduled activity

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -1202,6 +1202,7 @@ schedules and activities are also editable in the in-app map editor
 | `location.tx` / `ty` | `number` | ✓ | Exterior: absolute hub coords. Interior: coords within that building's room grid. |
 | `location.buildingId` | `string` | interior only | Building `id` the NPC waits inside. The exterior sprite hides; if the player enters that building the NPC renders inside (its activity pose shows there too). |
 | `homeBed` | `{ buildingId, tx, ty }` | | Reserved sleeping spot reference (used by night logic). |
+| `dialogueByActivity` | `Partial<Record<NpcActivity, string[]>>` | | Optional activity-specific dialogue pools, e.g. `{ "sleep": ["Zzz..."] }`. When the NPC's current scheduled activity has a non-empty entry here, `getNpcDialoguePool()` cycles those lines instead of the flat `dialogue` array (tap dialogue and ambient speech bubbles both use it). NPCs without a matching entry keep using `dialogue`, so this is fully backward compatible. |
 
 On a game-hour boundary the NPC pathfinds to the new location (emerging at / walking
 to the relevant door for interior transitions). The activity pose only shows while
@@ -1234,8 +1235,12 @@ workflow in `AGENTS.md` (32×32 SVG, create/commit/push one at a time).
 1. Add/extend the NPC's `schedule` in the town `config.json`, setting `activity`
    on the relevant entries (use the activity keys above).
 2. (Optional) Author `{sprite}-{activity}.svg` pose sprites for a richer look.
-3. Run `npm run test` (loader + schedule tests) and `npm run build`.
-4. Verify in-game: at the relevant hours the NPC is at its post in its activity
+3. (Optional) Author `dialogueByActivity` pools so tap dialogue and ambient
+   speech bubbles match what the NPC is currently doing — mandatory in
+   practice for a `sleep` entry, since a sleeping NPC shouldn't say a
+   work-hours line (see field reference above).
+4. Run `npm run test` (loader + schedule tests) and `npm run build`.
+5. Verify in-game: at the relevant hours the NPC is at its post in its activity
    pose; the pose reverts to the base sprite while it walks at an hour boundary.
 
 ---

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -9,7 +9,7 @@ import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, isShopItemSold } from '../../game/shopSchedule'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
-import { isBuildingOpen, getNpcLocation, getNpcActivity } from '../../game/hub/hubNpcSchedule'
+import { isBuildingOpen, getNpcLocation, getNpcActivity, getNpcDialoguePool } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } from '../../game/sound'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
@@ -1148,7 +1148,8 @@ export function HubTownCanvas({
         e.stopPropagation()
         if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive || npc.dialogueTree) {
           const idx = npcDialogueIndex.get(npc.id) ?? 0
-          onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
+          const pool = getNpcDialoguePool(npc, gameHourRef.current)
+          onNpcTapRef.current?.(pool[idx % pool.length] ?? '', npc.id)
           npcDialogueIndex.set(npc.id, idx + 1)
         }
       })
@@ -2032,7 +2033,8 @@ export function HubTownCanvas({
             e.stopPropagation()
             if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive || npc.dialogueTree) {
               const idx = npcDialogueIndex.get(npc.id) ?? 0
-              onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
+              const pool = getNpcDialoguePool(npc, gameHourRef.current)
+              onNpcTapRef.current?.(pool[idx % pool.length] ?? '', npc.id)
               npcDialogueIndex.set(npc.id, idx + 1)
             }
           })
@@ -2060,7 +2062,8 @@ export function HubTownCanvas({
             e.stopPropagation()
             if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive || npc.dialogueTree) {
               const idx = npcDialogueIndex.get(npc.id) ?? 0
-              onNpcTapRef.current?.(npc.dialogue[idx % npc.dialogue.length] ?? '', npc.id)
+              const pool = getNpcDialoguePool(npc, gameHourRef.current)
+              onNpcTapRef.current?.(pool[idx % pool.length] ?? '', npc.id)
               npcDialogueIndex.set(npc.id, idx + 1)
             }
           })
@@ -3087,7 +3090,8 @@ export function HubTownCanvas({
             // whose name tag intro is currently playing
             if (!isNameTagBlockingBubble(npc.id) && namedNpcContainers.get(npc.id)?.visible !== false) {
               const didx = npcDialogueIndex.get(npc.id) ?? 0
-              const line = npc.dialogue[didx % npc.dialogue.length]
+              const pool = getNpcDialoguePool(npc, gameHourRef.current)
+              const line = pool[didx % pool.length]
               const container = createSpeechBubble(line, cx, cy)
               bubbleLayer.addChild(container)
               activeBubbles.push({ container, timer: BUBBLE_SHOW_MS, phase: 'showing', npcId: npc.id })

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -171,6 +171,10 @@ export interface HubNpc {
   levelBuildingId?: string
   schedule?: NpcScheduleEntry[]
   homeBed?: { buildingId: string; tx: number; ty: number }
+  /** Optional activity-specific dialogue pools. When the NPC's current schedule
+   *  activity (getNpcActivity) has a non-empty entry here, those lines are
+   *  cycled instead of the flat `dialogue` array. */
+  dialogueByActivity?: Partial<Record<NpcActivity, string[]>>
   /** Id of a branching dialogue tree (questDefs.json `dialogues`) to run on tap. */
   dialogueTree?: string
   /** Hub-item id (hubItems.json) that grants a bonus friendship/relationship boost when gifted. */

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1632,6 +1632,15 @@
         "I've got fish baskets missing somewhere around the docks.",
         "Fresh catch, get your fresh catch! Don't let the gulls beat you to it."
       ],
+      "dialogueByActivity": {
+        "sleep": [
+          "...mmph... not the nets... five more minutes...",
+          "Zzz... tide's out... zzz..."
+        ],
+        "eat": [
+          "Nothing like a hot stew after a day on the docks."
+        ]
+      },
       "questGive": "millhaven-missing-catch",
       "questReceive": "millhaven-missing-catch",
       "schedule": [
@@ -1684,10 +1693,17 @@
       "tx": 3,
       "ty": 4,
       "dialogue": [
-        "Welcome to The Anchor, best beds on the Millhaven coast.",
         "A merchant from Ravenwatch left a letter here. Meant for someone called Elder Elara.",
         "You look like someone who travels. That letter's been sitting here long enough."
       ],
+      "dialogueByActivity": {
+        "sleep": [
+          "...mmh... last call... zzz..."
+        ],
+        "work": [
+          "Welcome to The Anchor, best beds on the Millhaven coast."
+        ]
+      },
       "building": "inn-millhaven",
       "questGive": "millhaven-message-to-ravenwatch",
       "questReceive": "millhaven-message-to-ravenwatch",
@@ -1878,10 +1894,18 @@
       "tx": 20,
       "ty": 32,
       "dialogue": [
-        "Fresh loaves out of the oven — mind, they're still warm.",
         "Half the town runs on my bread and the other half on Marta's fish.",
         "If you're passing the docks, folk down there are always after a delivery."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Fresh loaves out of the oven — mind, they're still warm."
+        ],
+        "sleep": [
+          "...mmh... the proving basket... five more minutes...",
+          "Zzz... knead... fold... zzz..."
+        ]
+      },
       "questGive": "millhaven-fresh-bread",
       "questReceive": "millhaven-fresh-bread",
       "favoriteGiftItemId": "honey",

--- a/web/src/game/hub/hubNpcSchedule.test.ts
+++ b/web/src/game/hub/hubNpcSchedule.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getNpcActivity, NPC_ACTIVITIES } from './hubNpcSchedule'
+import { getNpcActivity, getNpcDialoguePool, NPC_ACTIVITIES } from './hubNpcSchedule'
 import type { HubNpc } from '../../data/hub/loader'
 
 const npc: HubNpc = {
@@ -30,5 +30,41 @@ describe('NPC_ACTIVITIES', () => {
   it('lists the activity used in the fixture schedule', () => {
     expect(NPC_ACTIVITIES).toContain('work')
     expect(NPC_ACTIVITIES).toContain('fish')
+  })
+})
+
+describe('getNpcDialoguePool', () => {
+  const flatDialogue = ['flat line one', 'flat line two']
+
+  it('returns the flat dialogue array when the NPC has no schedule', () => {
+    const noSchedule: HubNpc = { ...npc, schedule: undefined, dialogue: flatDialogue }
+    expect(getNpcDialoguePool(noSchedule, 12)).toBe(flatDialogue)
+  })
+
+  it('returns the activity pool when the current activity has an authored pool', () => {
+    const withPool: HubNpc = {
+      ...npc,
+      dialogue: flatDialogue,
+      dialogueByActivity: { work: ['fresh loaves!'] },
+    }
+    expect(getNpcDialoguePool(withPool, 12)).toEqual(['fresh loaves!'])
+  })
+
+  it('falls back to the flat dialogue when the current activity has no authored pool', () => {
+    const noMatchingPool: HubNpc = {
+      ...npc,
+      dialogue: flatDialogue,
+      dialogueByActivity: { sleep: ['zzz'] },
+    }
+    expect(getNpcDialoguePool(noMatchingPool, 12)).toBe(flatDialogue)
+  })
+
+  it('falls back to the flat dialogue when the authored pool is empty', () => {
+    const emptyPool: HubNpc = {
+      ...npc,
+      dialogue: flatDialogue,
+      dialogueByActivity: { work: [] },
+    }
+    expect(getNpcDialoguePool(emptyPool, 12)).toBe(flatDialogue)
   })
 })

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -25,6 +25,15 @@ export function getNpcActivity(npc: HubNpc, gameHour: number): NpcActivity | nul
   return null
 }
 
+/** The dialogue pool an NPC should draw from right now: the activity-specific
+ *  pool when one is authored for the current scheduled activity, otherwise
+ *  the flat `dialogue` array. */
+export function getNpcDialoguePool(npc: HubNpc, gameHour: number): string[] {
+  const activity = getNpcActivity(npc, gameHour)
+  const pool = activity ? npc.dialogueByActivity?.[activity] : undefined
+  return pool?.length ? pool : npc.dialogue
+}
+
 export function isNpcInBuilding(npc: HubNpc, buildingId: string, gameHour: number): boolean {
   const loc = getNpcLocation(npc, gameHour)
   return loc?.type === 'interior' && loc.buildingId === buildingId


### PR DESCRIPTION
## Summary

- Adds an optional `dialogueByActivity?: Partial<Record<NpcActivity, string[]>>` field to `HubNpc` (`web/src/data/hub/loader.ts`), purely additive/backward compatible.
- Adds `getNpcDialoguePool(npc, gameHour)` to `web/src/game/hub/hubNpcSchedule.ts`: cycles the activity-specific pool when the NPC's current scheduled activity has a non-empty authored entry, otherwise falls back to the flat `dialogue` array.
- Wires all four dialogue-cycling call sites in `HubTownCanvas.tsx` (exterior tap, two interior tap variants, ambient speech-bubble picker) through `getNpcDialoguePool` instead of indexing `npc.dialogue` directly.
- Content: Baker Pernel's "Fresh loaves out of the oven…" line moves from his flat `dialogue` array into `dialogueByActivity.work`, plus a new `sleep` pool. `fishmonger-marta` and `innkeeper-millhaven` also get `sleep` + one more activity pool each.
- Docs (`docs/hubworld.md`): documents `dialogueByActivity` in the NPC schema field reference and the schedule-activity authoring checklist.

This resolves the reported repro from #1956/#1957: tapping Baker Pernel at 2am (when his schedule has him `sleep`ing) no longer plays his work-hours "fresh loaves" line — he now gets sleep-appropriate lines instead. NPCs without `dialogueByActivity` are unaffected.

Closes #1957

## Test plan

- [x] `npm run build` passes (tsc + vite build clean)
- [x] `npx vitest run src/game/hub/hubNpcSchedule.test.ts` — 8/8 passing, including new `getNpcDialoguePool` cases (no-schedule fallback, matching pool, no-matching-activity fallback, empty-pool fallback)
- [x] `npx vitest run src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts` — 29/29 passing (schema change doesn't break existing loader/content tests)
- [x] Manually traced Baker Pernel's config through `getNpcDialoguePool` at hour 2 (sleep) vs. hour 10 (work) — confirmed distinct, activity-appropriate lines


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_