### PR TITLE
Hub: sleeping NPCs don't hold normal conversations

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -616,6 +616,14 @@ rivalry (no chains).
 
 ## §7d — Generic Talk / Give (every named NPC)
 
+Before any of this: if the tapped NPC's schedule (§9) currently has them
+`sleep`ing, `handleNpcTap` short-circuits with a plain sleep line
+(`sleepDialogue`, or a generic "fast asleep" default) and returns — no
+bounty report, quest offer/turn-in, dialogue tree, or Talk/Give. Sleep
+windows are short in real time (30 real minutes = a full game day), so
+nothing becomes unreachable; the player just has to come back later or wait
+a few minutes.
+
 Every named NPC gets two always-available dialogue choices — no authoring
 required — so the Town Directory's 💗 Relationship button has a real way to
 move even for the ~5 in 6 NPCs with no `dialogueTree` (§7b) and no active
@@ -1203,6 +1211,7 @@ schedules and activities are also editable in the in-app map editor
 | `location.buildingId` | `string` | interior only | Building `id` the NPC waits inside. The exterior sprite hides; if the player enters that building the NPC renders inside (its activity pose shows there too). |
 | `homeBed` | `{ buildingId, tx, ty }` | | Reserved sleeping spot reference (used by night logic). |
 | `dialogueByActivity` | `Partial<Record<NpcActivity, string[]>>` | | Optional activity-specific dialogue pools, e.g. `{ "sleep": ["Zzz..."] }`. When the NPC's current scheduled activity has a non-empty entry here, `getNpcDialoguePool()` cycles those lines instead of the flat `dialogue` array (tap dialogue and ambient speech bubbles both use it). NPCs without a matching entry keep using `dialogue`, so this is fully backward compatible. |
+| `sleepDialogue` | `string` | | Line shown (as plain narration, no Talk/Give/quest options) when the NPC is tapped while `sleep`ing per its schedule (§7d). Defaults to a generic "💤 {name} is fast asleep." when omitted. |
 
 On a game-hour boundary the NPC pathfinds to the new location (emerging at / walking
 to the relevant door for interior transitions). The activity pose only shows while

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -44,7 +44,8 @@ import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
-import { formatGameTime, hourInRange } from '../../game/hub/hubClock'
+import { formatGameTime, hourInRange, getGameHour } from '../../game/hub/hubClock'
+import { isNpcAsleep } from '../../game/hub/hubNpcSchedule'
 import { Festival, getActiveFestival } from '../../game/hub/hubCalendar'
 import { getDailyChallengeNPCDialogue, getMiniGameChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
@@ -1162,6 +1163,17 @@ function hasOfferableQuest(giverId: string): boolean {
       locationData.HUB_ANIMALS.find(a => a.id === npcId)
     const speakerName = npcDef?.name ?? ''
     if (namedNpc) recordNpcMet(npcId)
+
+    // Sleeping NPCs don't chat, trade, or take quest hand-ins — the whole
+    // cascade below assumes an awake NPC. Sleep windows are short in real
+    // time (a full game day is 30 real minutes), so nothing is soft-locked.
+    if (namedNpc?.schedule && isNpcAsleep(namedNpc, getGameHour())) {
+      setDialogueEvent({
+        speakerName,
+        text: namedNpc.sleepDialogue ?? `💤 ${speakerName} is fast asleep.`,
+      })
+      return
+    }
 
     // ── Bounty report (takes priority — a bounty's report step is satisfied
     // by talking to the named NPC, independent of any quest dialogue). ──────

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -175,6 +175,9 @@ export interface HubNpc {
    *  activity (getNpcActivity) has a non-empty entry here, those lines are
    *  cycled instead of the flat `dialogue` array. */
   dialogueByActivity?: Partial<Record<NpcActivity, string[]>>
+  /** Line shown when tapped while the schedule has this NPC sleeping.
+   *  Defaults to a generic "fast asleep" narration. */
+  sleepDialogue?: string
   /** Id of a branching dialogue tree (questDefs.json `dialogues`) to run on tap. */
   dialogueTree?: string
   /** Hub-item id (hubItems.json) that grants a bonus friendship/relationship boost when gifted. */

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1906,6 +1906,7 @@
           "Zzz... knead... fold... zzz..."
         ]
       },
+      "sleepDialogue": "Zzz... knead... fold... zzz...",
       "questGive": "millhaven-fresh-bread",
       "questReceive": "millhaven-fresh-bread",
       "favoriteGiftItemId": "honey",

--- a/web/src/game/hub/hubNpcSchedule.test.ts
+++ b/web/src/game/hub/hubNpcSchedule.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getNpcActivity, getNpcDialoguePool, NPC_ACTIVITIES } from './hubNpcSchedule'
+import { getNpcActivity, getNpcDialoguePool, isNpcAsleep, NPC_ACTIVITIES } from './hubNpcSchedule'
 import type { HubNpc } from '../../data/hub/loader'
 
 const npc: HubNpc = {
@@ -66,5 +66,45 @@ describe('getNpcDialoguePool', () => {
       dialogueByActivity: { work: [] },
     }
     expect(getNpcDialoguePool(emptyPool, 12)).toBe(flatDialogue)
+  })
+})
+
+describe('isNpcAsleep', () => {
+  const sleeper: HubNpc = {
+    id: 'baker-pernel', name: 'Baker Pernel', sprite: 'hub-npc-merchant', tx: 5, ty: 5, dialogue: [],
+    schedule: [
+      { startHour: 0, endHour: 6, activity: 'sleep', location: { type: 'interior', buildingId: 'inn', tx: 9, ty: 2 } },
+      { startHour: 6, endHour: 18, activity: 'work', location: { type: 'interior', buildingId: 'bakery', tx: 3, ty: 4 } },
+      { startHour: 18, endHour: 24, activity: 'work', location: { type: 'exterior', tx: 8, ty: 7 } },
+    ],
+  }
+
+  it('is true inside the sleep window', () => {
+    expect(isNpcAsleep(sleeper, 0)).toBe(true)
+    expect(isNpcAsleep(sleeper, 2)).toBe(true)
+    expect(isNpcAsleep(sleeper, 5)).toBe(true)
+  })
+
+  it('is false once the sleep window ends', () => {
+    expect(isNpcAsleep(sleeper, 6)).toBe(false)
+    expect(isNpcAsleep(sleeper, 12)).toBe(false)
+  })
+
+  it('is false for NPCs without a schedule', () => {
+    expect(isNpcAsleep({ ...sleeper, schedule: undefined }, 2)).toBe(false)
+  })
+
+  it('handles a midnight-wrapping sleep window', () => {
+    const wrapsMidnight: HubNpc = {
+      ...sleeper,
+      schedule: [
+        { startHour: 22, endHour: 6, activity: 'sleep', location: { type: 'interior', buildingId: 'inn', tx: 1, ty: 1 } },
+        { startHour: 6, endHour: 22, activity: 'work', location: { type: 'exterior', tx: 5, ty: 5 } },
+      ],
+    }
+    expect(isNpcAsleep(wrapsMidnight, 23)).toBe(true)
+    expect(isNpcAsleep(wrapsMidnight, 3)).toBe(true)
+    expect(isNpcAsleep(wrapsMidnight, 6)).toBe(false)
+    expect(isNpcAsleep(wrapsMidnight, 21)).toBe(false)
   })
 })

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -34,6 +34,11 @@ export function getNpcDialoguePool(npc: HubNpc, gameHour: number): string[] {
   return pool?.length ? pool : npc.dialogue
 }
 
+/** True while the NPC's schedule has them sleeping. */
+export function isNpcAsleep(npc: HubNpc, gameHour: number): boolean {
+  return getNpcActivity(npc, gameHour) === 'sleep'
+}
+
 export function isNpcInBuilding(npc: HubNpc, buildingId: string, gameHour: number): boolean {
   const loc = getNpcLocation(npc, gameHour)
   return loc?.type === 'interior' && loc.buildingId === buildingId


### PR DESCRIPTION
## Summary

- Adds `isNpcAsleep(npc, gameHour)` to `web/src/game/hub/hubNpcSchedule.ts` — a reusable predicate that's true while the NPC's schedule has them in the `sleep` activity.
- Adds an optional `sleepDialogue?: string` field to `HubNpc` (`web/src/data/hub/loader.ts`) for a custom interrupted-sleep line; defaults to a generic "💤 {name} is fast asleep." narration.
- Gates `handleNpcTap` in `web/src/components/hub/HubWorld.tsx`: right after `recordNpcMet(npcId)` and before the bounty-report branch, a sleeping scheduled NPC now short-circuits with the sleep line and `return`s — skipping bounty reports, quest offers/turn-ins, dialogue trees, and Talk/Give entirely.
- Content: Baker Pernel gets a `sleepDialogue` line matching his existing sleep `dialogueByActivity` pool from #1957.
- Docs (`docs/hubworld.md`): documents the sleep gate as the first step in the NPC-tap dispatch order (§7d) and adds `sleepDialogue` to the NPC schema field reference (§9).

Combined with #1957 (merged), this resolves the reported repro end-to-end: tapping Baker Pernel at 2am now shows a sleep-appropriate line and doesn't open any quest/dialogue flow. Sleep windows are short in real time (30 real minutes = a full game day), so nothing becomes permanently unreachable — the player just has to come back later.

Closes #1958

## Test plan

- [x] `npm run build` passes (tsc + vite build clean)
- [x] `npx vitest run src/game/hub/hubNpcSchedule.test.ts` — 12/12 passing, including new `isNpcAsleep` cases (inside/outside sleep window, no-schedule NPC, midnight-wrapping sleep window)
- [x] Manually traced Baker Pernel's config through the tap-gate logic at hour 2 (sleep, cascade skipped, sleep line shown) vs. hour 10 (work, cascade proceeds normally)


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_