### PR TITLE
Hub: time-of-day / activity conditions for branching dialogue trees

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -458,6 +458,8 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `hideIfFlag` | string? | Choice hidden once the flag is set. |
 | `requireFestival` | string? | Choice only shown while that festival is active (§14 festival ids, e.g. `"midsummer"`). |
 | `requireWeather` | string? | Choice only shown while the town's resolved weather (§12) matches (`"clear"`/`"rain"`/`"snow"`/`"fog"`). Weather is date/season-driven — for QA, force `"weather": {"type": "snow"}` in the town config, or use Millhaven (rains year-round). |
+| `requireTimeOfDay` | `"day"` \| `"night"` \| `"dawn"`? | Choice only shown while `hubClock.getTimeOfDay(gameHour)` matches: night 20:00–05:59, dawn 06:00–07:59, day otherwise (§9). |
+| `requireActivity` | `NpcActivity`? | Choice only shown while the speaking NPC's own schedule (§9) currently has this activity (`getNpcActivity`). No effect on NPCs without a `schedule`. |
 
 #### `DialogueEffect` types
 | `type` | Fields | Behaviour |

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -44,8 +44,8 @@ import { resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
-import { formatGameTime, hourInRange, getGameHour } from '../../game/hub/hubClock'
-import { isNpcAsleep } from '../../game/hub/hubNpcSchedule'
+import { formatGameTime, hourInRange, getGameHour, getTimeOfDay } from '../../game/hub/hubClock'
+import { isNpcAsleep, getNpcActivity } from '../../game/hub/hubNpcSchedule'
 import { Festival, getActiveFestival } from '../../game/hub/hubCalendar'
 import { getDailyChallengeNPCDialogue, getMiniGameChallengeNPCDialogue } from '../../game/hub/npcDialogue'
 import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
@@ -1034,7 +1034,10 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireQuest || getQuestState(c.requireQuest).status === 'completed') &&
       (!c.hideIfQuest  || getQuestState(c.hideIfQuest).status !== 'completed') &&
       (!c.requireFestival || c.requireFestival === activeFestival?.id) &&
-      (!c.requireWeather || c.requireWeather === currentWeather)
+      (!c.requireWeather || c.requireWeather === currentWeather) &&
+      (!c.requireTimeOfDay || c.requireTimeOfDay === getTimeOfDay(gameHour)) &&
+      (!c.requireActivity  || (!!npcDef && 'schedule' in npcDef &&
+          getNpcActivity(npcDef as HubNpc, gameHour) === c.requireActivity))
     )
     const speaker = node.speakerName ?? speakerName
 
@@ -1051,7 +1054,7 @@ function hasOfferableQuest(giverId: string): boolean {
       const toChoice = (c: DialogueChoiceDef, primary: boolean) => ({
         label:   c.label,
         primary,
-        onClick: () => applyChoice(tree, c, npcId, speakerName),
+        onClick: () => applyChoice(tree, c, npcId, speakerName, npcDef),
       })
       const nonExitChoices = nonExitDefs.map((c, i) => toChoice(c, i === 0))
       finalChoices = exitDefs.length > 0
@@ -1061,7 +1064,7 @@ function hasOfferableQuest(giverId: string): boolean {
       finalChoices = visible.map((c, i) => ({
         label:   c.label,
         primary: i === 0,
-        onClick: () => applyChoice(tree, c, npcId, speakerName),
+        onClick: () => applyChoice(tree, c, npcId, speakerName, npcDef),
       }))
     }
 
@@ -1072,7 +1075,7 @@ function hasOfferableQuest(giverId: string): boolean {
     })
   }
 
-  function applyChoice(tree: DialogueTree, choice: DialogueChoiceDef, npcId: string, speakerName: string): void {
+  function applyChoice(tree: DialogueTree, choice: DialogueChoiceDef, npcId: string, speakerName: string, npcDef?: NpcTapDef): void {
     let ended = false
     for (const eff of choice.effects ?? []) {
       switch (eff.type) {
@@ -1140,7 +1143,7 @@ function hasOfferableQuest(giverId: string): boolean {
           setDialogueEvent({
             speakerName,
             text: eff.successText,
-            ...(choice.next ? { onClose: () => runDialogueNode(tree, choice.next!, npcId, speakerName) } : {}),
+            ...(choice.next ? { onClose: () => runDialogueNode(tree, choice.next!, npcId, speakerName, npcDef) } : {}),
           })
           return
         }
@@ -1149,7 +1152,7 @@ function hasOfferableQuest(giverId: string): boolean {
           break
       }
     }
-    if (!ended && choice.next) runDialogueNode(tree, choice.next, npcId, speakerName)
+    if (!ended && choice.next) runDialogueNode(tree, choice.next, npcId, speakerName, npcDef)
     else setDialogueEvent(null)
   }
 

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -960,7 +960,25 @@
               ]
             },
             {
+              "label": "You're up late.",
+              "next": "night-chat",
+              "requireTimeOfDay": "night"
+            },
+            {
               "label": "Another time.",
+              "effects": [
+                {
+                  "type": "end"
+                }
+              ]
+            }
+          ]
+        },
+        "night-chat": {
+          "text": "Late crowd's the best crowd — sailors with coin to spend and stories nobody sober would believe. Come sunrise I'm just the fellow who makes the beds.",
+          "choices": [
+            {
+              "label": "Fair enough.",
               "effects": [
                 {
                   "type": "end"

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -1,4 +1,5 @@
 import type { RelationshipTrack } from '../../game/hub/relationships'
+import type { NpcActivity } from './loader'
 
 export interface HubQuestStep {
   key: string
@@ -249,6 +250,8 @@ export interface DialogueChoiceDef {
   requireWeather?: string  // only show this choice while the town's weather matches ('clear'|'rain'|'snow'|'fog')
   requireQuest?: string    // only show this choice once that quest is completed
   hideIfQuest?: string     // hide this choice once that quest is completed
+  requireTimeOfDay?: 'day' | 'night' | 'dawn' // only show this choice during that time bucket (hubClock getTimeOfDay)
+  requireActivity?: NpcActivity               // only show this choice while the speaking NPC's schedule has this activity
 }
 
 export interface DialogueNode {

--- a/web/src/game/hub/hubClock.test.ts
+++ b/web/src/game/hub/hubClock.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { getTimeOfDay } from './hubClock'
+
+describe('getTimeOfDay', () => {
+  it('buckets night hours (20:00–05:59)', () => {
+    expect(getTimeOfDay(20)).toBe('night')
+    expect(getTimeOfDay(23)).toBe('night')
+    expect(getTimeOfDay(0)).toBe('night')
+    expect(getTimeOfDay(5)).toBe('night')
+  })
+
+  it('buckets dawn hours (06:00–07:59)', () => {
+    expect(getTimeOfDay(6)).toBe('dawn')
+    expect(getTimeOfDay(7)).toBe('dawn')
+  })
+
+  it('buckets day hours (08:00–19:59)', () => {
+    expect(getTimeOfDay(8)).toBe('day')
+    expect(getTimeOfDay(12)).toBe('day')
+    expect(getTimeOfDay(19)).toBe('day')
+  })
+
+  it('transitions correctly at the day/night boundary', () => {
+    expect(getTimeOfDay(19)).toBe('day')
+    expect(getTimeOfDay(20)).toBe('night')
+  })
+})

--- a/web/src/game/hub/hubClock.ts
+++ b/web/src/game/hub/hubClock.ts
@@ -46,3 +46,12 @@ export function hourInRange(hour: number, start: number, end: number): boolean {
   // wraps midnight, e.g. start=22 end=6
   return hour >= start || hour < end
 }
+
+export type TimeOfDay = 'night' | 'dawn' | 'day'
+
+/** Bucketed time of day: night 20:00–05:59, dawn 06:00–07:59, else day. */
+export function getTimeOfDay(hour = getGameHour()): TimeOfDay {
+  if (isNight(hour)) return 'night'
+  if (isDawn(hour)) return 'dawn'
+  return 'day'
+}


### PR DESCRIPTION
## Summary

- Adds `getTimeOfDay(hour)` to `web/src/game/hub/hubClock.ts`, bucketing the game hour into `'night'` (20:00–05:59), `'dawn'` (06:00–07:59), or `'day'` (otherwise).
- Adds `requireTimeOfDay?: 'day' | 'night' | 'dawn'` and `requireActivity?: NpcActivity` to `DialogueChoiceDef` (`web/src/data/hub/questDefs.ts`), mirroring the existing `requireFestival`/`requireWeather` conditions.
- Extends the choice-visibility filter in `runDialogueNode` (`web/src/components/hub/HubWorld.tsx`) to check both new conditions against the current `gameHour` and the speaking NPC's own schedule activity.
- Threads `npcDef` through `applyChoice`'s recursive `runDialogueNode` calls (previously dropped past the top-level tap), so `requireActivity` also filters mid-tree nodes, not just the root.
- Content: Innkeeper Cobb's dialogue tree (`millhaven/questDefs.json`) gets a night-only "You're up late." branch as a demonstrated example — reachable only 20:00–24:00 since he sleeps 0:00–7:00 (already gated out by #1958's sleep check).

## Test plan

- [x] `npm run build` passes (tsc + vite build clean — confirms no circular-import issue from `questDefs.ts` importing the `NpcActivity` type from `loader.ts`, which itself imports types from `questDefs.ts`)
- [x] `npx vitest run src/game/hub/hubClock.test.ts src/game/hub/hubNpcSchedule.test.ts` — 16/16 passing, including new `getTimeOfDay` bucket-boundary cases
- [x] `npx vitest run src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts` — 29/29 passing (no content regressions)
- [x] Manually traced the example choice's visibility across hours 2, 6, 10, 19, 20, 22, 23 — confirmed it's only reachable 20:00–24:00 (night + Cobb awake)

Closes #1959


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_