### PR TITLE
Hub: Millhaven — activity-aware dialogue for all scheduled NPCs (#1960 batch 1/5)

### DIFF
--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1588,6 +1588,17 @@
         "Three grain sacks went missing from the store. Someone's been helping themselves.",
         "If you find those sacks, I'll remember the favour."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind the grindstone, it doesn't stop for anyone.",
+          "Sixty years and this mill's never missed a season."
+        ],
+        "sleep": [
+          "...mmh... turn the wheel... zzz...",
+          "Zzz... sacks... count 'em twice... zzz..."
+        ]
+      },
+      "sleepDialogue": "Zzz... turn the wheel... zzz...",
       "questGive": "millhaven-mill-grain",
       "questReceive": "millhaven-mill-grain",
       "schedule": [
@@ -1641,6 +1652,7 @@
           "Nothing like a hot stew after a day on the docks."
         ]
       },
+      "sleepDialogue": "Zzz... not the nets... five more minutes...",
       "questGive": "millhaven-missing-catch",
       "questReceive": "millhaven-missing-catch",
       "schedule": [
@@ -1704,6 +1716,7 @@
           "Welcome to The Anchor, best beds on the Millhaven coast."
         ]
       },
+      "sleepDialogue": "...mmh... last call... zzz...",
       "building": "inn-millhaven",
       "questGive": "millhaven-message-to-ravenwatch",
       "questReceive": "millhaven-message-to-ravenwatch",
@@ -1753,6 +1766,16 @@
         "The castle to the south needs resupply. We've been meaning to send a courier.",
         "If you're heading to Ironhold Keep, perhaps you could take our supply manifest to Commander Varek?"
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "The council chamber's quiet this time of day. Suits me fine.",
+          "I remember when the harbour was half this size."
+        ],
+        "sleep": [
+          "...mmh... the manifest... in the morning... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the manifest... in the morning... zzz...",
       "building": "town-hall-millhaven",
       "questGive": "millhaven-supplies-for-keep",
       "questReceive": "millhaven-supplies-for-keep",
@@ -1812,6 +1835,12 @@
         "I've seen three ships go dark past the reef. No word from them.",
         "Marta thinks I'm superstitious. Maybe I am."
       ],
+      "dialogueByActivity": {
+        "fish": [
+          "Line's been quiet all morning. That's never a good sign out here.",
+          "Watch the reef line. It's been swallowing more than fish lately."
+        ]
+      },
       "questGive": "millhaven-lost-at-sea",
       "questReceive": "millhaven-missing-catch",
       "schedule": [
@@ -1843,6 +1872,15 @@
         "Trade's been slow. Travellers don't stop here like they used to.",
         "Nice to see a fresh face in Millhaven."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Rope, ribbon, nails — name it and I'll have it under the counter somewhere."
+        ],
+        "sleep": [
+          "...mmh... stock the shelves... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... stock the shelves... zzz...",
       "building": "market-hall",
       "questGive": "millhaven-festival-prep",
       "questReceive": [
@@ -1966,6 +2004,16 @@
         "Net hooks, anchor chain, blades — if it's iron, I've hammered it.",
         "Scrap's been going missing from my yard. A smith can't work without iron."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Hold still or don't stand so close — the anvil doesn't wait for anyone."
+        ],
+        "sleep": [
+          "...mmh... hammer's down... zzz...",
+          "Zzz... quench it... zzz..."
+        ]
+      },
+      "sleepDialogue": "Zzz... hammer's down... zzz...",
       "questGive": "millhaven-scrap-iron",
       "questReceive": "millhaven-scrap-iron",
       "schedule": [
@@ -2024,6 +2072,15 @@
         "Storm last week dragged half our nets out past the moorings.",
         "The boathouse keeps the town's boats — and most of its gossip."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Lantern's lit, boats are in. Good a time as any to swap stories."
+        ],
+        "sleep": [
+          "...mmh... tie it off... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... tie it off... zzz...",
       "questGive": "millhaven-lost-nets",
       "questReceive": "millhaven-lost-nets",
       "schedule": [
@@ -2083,6 +2140,15 @@
         "I lost my late husband's locket somewhere out in the town. It's all I have of him.",
         "You have a kind face. Perhaps you'd keep an eye out for it?"
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "I sit by the window most evenings. It's quiet, but it's mine."
+        ],
+        "sleep": [
+          "...mmh... his voice... I still hear it... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... his voice... I still hear it... zzz...",
       "building": "fisher-cottage",
       "questGive": "millhaven-lost-locket",
       "questReceive": "millhaven-lost-locket",

--- a/web/src/data/hub/npcDialogueCoverage.test.ts
+++ b/web/src/data/hub/npcDialogueCoverage.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { LOCATION_REGISTRY } from './hubWorldFactory'
+
+// Guard for the activity-aware dialogue content pass (#1960): every scheduled
+// NPC whose schedule includes a `sleep` entry must have both a non-empty
+// `dialogueByActivity.sleep` pool (ambient speech bubbles, HubTownCanvas) and
+// a `sleepDialogue` string (the tap-gate narration, HubWorld's `isNpcAsleep`
+// check) — otherwise a sleeping NPC either bubbles nothing or falls back to
+// the generic "fast asleep" default instead of an authored line.
+//
+// Scoped to towns that have completed their #1960 content batch so far;
+// widen TOWNS_WITH_CONTENT as each subsequent batch lands, and drop the
+// allowlist entirely once every town is covered.
+const TOWNS_WITH_CONTENT = ['millhaven']
+
+describe('scheduled-NPC sleep dialogue coverage', () => {
+  for (const townKey of TOWNS_WITH_CONTENT) {
+    const { locationData } = LOCATION_REGISTRY[townKey]
+
+    for (const npc of locationData.HUB_NPCS) {
+      const hasSleepSchedule = npc.schedule?.some(entry => entry.activity === 'sleep')
+      if (!hasSleepSchedule) continue
+
+      it(`${townKey}/${npc.id}: has a non-empty dialogueByActivity.sleep pool`, () => {
+        expect(npc.dialogueByActivity?.sleep?.length, `${npc.id} has a sleep schedule entry but no dialogueByActivity.sleep pool`).toBeTruthy()
+      })
+
+      it(`${townKey}/${npc.id}: has a sleepDialogue line`, () => {
+        expect(npc.sleepDialogue, `${npc.id} has a sleep schedule entry but no sleepDialogue — tapping it while asleep falls back to the generic default`).toBeTruthy()
+      })
+    }
+  }
+})


### PR DESCRIPTION
## Summary

First of 5 batches for issue #1960's content-authoring pass (85–87 scheduled NPCs across 13 towns get `dialogueByActivity` pools). This batch completes Millhaven, the town where the original Baker Pernel repro (#1956) came from and where #1957/#1958 already authored 3 of its 10 scheduled NPCs as proof-of-work.

- **Authors `dialogueByActivity` (mandatory `sleep` pool + one more activity) and `sleepDialogue`** for the 7 remaining scheduled Millhaven NPCs: `mill-owner`, `town-elder-millhaven`, `sailor-finn` (fish-only schedule, no sleep entry — skipped per the authoring rule), `market-trader`, `smith-garrick`, `dockhand-bram`, `widow-tamsin`. All 10 scheduled Millhaven NPCs now have complete coverage.
- **Fixes a small gap in already-merged content**: `fishmonger-marta` and `innkeeper-millhaven` had a `dialogueByActivity.sleep` pool (used by the ambient speech-bubble picker) but no `sleepDialogue` string (used by the tap-interaction sleep gate from #1958) — tapping either while asleep fell back to the generic "fast asleep" default instead of their authored line.
- **Adds a guard test** (`web/src/data/hub/npcDialogueCoverage.test.ts`, net-new) asserting every scheduled NPC whose schedule includes a `sleep` activity has both a non-empty `dialogueByActivity.sleep` pool and a `sleepDialogue` string. Scoped to `millhaven` for this batch via a `TOWNS_WITH_CONTENT` allowlist; will widen town-by-town as the remaining #1960 batches land.

Not closing #1960 — 4 more batches remain (capitalcity+royalpalace, ironholdkeep+gearford, ravenwatch, small towns).

## Test plan

- [x] `npm run build` passes (tsc + vite build clean)
- [x] `npx vitest run src/data/hub/npcDialogueCoverage.test.ts` — 18/18 passing (9 sleep-scheduled Millhaven NPCs × 2 assertions)
- [x] `npx vitest run src/game/hub/hubNpcSchedule.test.ts src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts src/data/hub/npcDialogueCoverage.test.ts` — 59/59 passing, no regressions
- [x] Manually traced `mill-owner` (sleep @ hour 2 vs. work @ hour 10) and `dockhand-bram` (idle-chat @ hour 22 vs. flat fallback @ hour 10, since no `work` pool was authored for him) through the dialogue-pool logic — all activity-appropriate
- [x] Verified `millhaven/config.json` stays valid JSON after edits
- [x] Scripted an audit confirming all 10 scheduled Millhaven NPCs (including the 3 from prior batches) now have consistent `sleep` pool + `sleepDialogue` coverage


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_