### PR TITLE
Stop silently swallowing corrupt-save parse failures in loadRun/loadBattleState

### DIFF
--- a/web/src/game/battleState.ts
+++ b/web/src/game/battleState.ts
@@ -45,7 +45,10 @@ export function loadBattleState(): GameState | null {
     // counter restarts at 0 after a reload — bump it so new spawns can't collide.
     syncUnitIdCounter(parsed.field)
     return parsed
-  } catch { return null }
+  } catch (e) {
+    logError('loadBattleState: corrupt saved battle state — discarding', { error: String(e) })
+    return null
+  }
 }
 
 /** Remove the persisted battle state (call on battle end or game reset). */

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -628,8 +628,9 @@ export function loadRun(): RunState | null {
     }
 
     return parsed
-  } catch {
+  } catch (e) {
     // Corrupt JSON — clear and start fresh
+    logError('loadRun: corrupt saved run — clearing and starting fresh', { error: String(e) })
     try { localStorage.removeItem(RUN_KEY) } catch { /* ignore */ }
     return null
   }


### PR DESCRIPTION
## Summary

Second follow-up to the "blank screen after being away for a while" investigation (#1954, #1961). A Rollbar crash-sentinel event showed a real occurrence: the player was on `hubworld`/`millhaven`, the tab went `hidden`, and ~59 minutes later the game rebooted having found the previous session's heartbeat unclean — the signature of iOS Safari killing a long-backgrounded tab and reloading it fresh. That's a different mechanism from the WebGL-context-loss case already fixed: the whole page was killed and reloaded, not just the GPU context evicted under a live page.

Digging into the fresh-boot path (`App.tsx`'s synchronous `_startup` computation, which calls `loadRun()` and `loadBattleState()`), both had a bare `catch` around `JSON.parse` that silently discarded the error and fell back to a clean/null state:

- `web/src/game/questline.ts` — `loadRun()`'s outer `catch` (corrupt saved run)
- `web/src/game/battleState.ts` — `loadBattleState()`'s outer `catch` (corrupt saved battle state)

This violates the project's own logging standard ("silent swallowing is banned for anything user-impacting" — every other catch in these two files already calls `logError`/`rollbar`). An abrupt OS-level page kill is exactly the kind of event that could leave `localStorage` in a partially-written state, and there was no visibility into whether that's actually contributing to the blank-screen reports.

Both catches now call `logError` (which forwards to Rollbar via `logger.ts`) before falling back to their existing clean/null behavior — no behavior change otherwise.

## Test plan

- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 499/499 unit tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xfmi2PJ9QNRPja79HH1zMU)_