### PR TITLE
Hub: Capital City + Royal Palace — activity-aware dialogue for all scheduled NPCs (#1960 batch 2/5)

### DIFF
--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -4980,6 +4980,15 @@
         "Half my guests are here for the coronation. The other half are avoiding it.",
         "If Captain Hale sends you with anything, I'll see it gets where it's going."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Welcome to The Gilded Goose. Rooms are honest, prices less so."
+        ],
+        "sleep": [
+          "...mmh... check the guest book... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... check the guest book... zzz...",
       "questReceive": [
         "crownhaven-gate-key",
         "crownhaven-feast"
@@ -5043,6 +5052,15 @@
         "The old postern gate key went missing on patrol. If it falls into the wrong hands, the palace will have my head.",
         "Keep your nose clean in my city, traveller."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Guardhouse business. Move along unless you've something to report."
+        ],
+        "sleep": [
+          "...mmh... the postern gate... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the postern gate... zzz...",
       "questGive": "crownhaven-gate-key",
       "questReceive": [
         "crownhaven-cutpurse",
@@ -5108,6 +5126,15 @@
         "The couriers dropped them somewhere between here and the gates, I'm certain of it.",
         "History is just paperwork that survived, you know."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Quiet, please — the library keeps its own kind of silence."
+        ],
+        "sleep": [
+          "...mmh... shelve it under... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... shelve it under... zzz...",
       "questGive": "crownhaven-census",
       "questReceive": [
         "crownhaven-census",
@@ -5171,6 +5198,15 @@
         "You want gossip, try the inn. You want a fair price, you talk to me.",
         "Mind the fountain — the pigeons have opinions."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Fresh stalls, fair prices — same as it's been for forty years."
+        ],
+        "sleep": [
+          "...mmh... turnips are forever... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... turnips are forever... zzz...",
       "questGive": "crownhaven-market-day",
       "questReceive": [
         "crownhaven-market-day",
@@ -5234,6 +5270,15 @@
         "Crownhaven looks to Ravenwatch for the old records. We must keep the two cities in step.",
         "Serve the crown well and the crown remembers."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "The senate floor waits for no one, least of all me."
+        ],
+        "sleep": [
+          "...mmh... the charter... needs a seal... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the charter... needs a seal... zzz...",
       "questGive": "crownhaven-charter",
       "questReceive": [
         "crownhaven-charter",
@@ -5297,6 +5342,15 @@
         "The cathedral's relics were scattered in the troubles. We would see them home.",
         "The bell has been silent too long. A city should hear its own heart."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "The cathedral doors are open, child, as they always are."
+        ],
+        "sleep": [
+          "...mmh... the bell... someday... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the bell... someday... zzz...",
       "questGive": "crownhaven-relics",
       "questReceive": [
         "crownhaven-relics",
@@ -5361,6 +5415,15 @@
         "Lose a mint die and you may as well hand a forger the keys to the treasury.",
         "Gold is heavy for a reason — it keeps honest folk grounded."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Strike's clean or it's scrap — the crown doesn't take seconds."
+        ],
+        "sleep": [
+          "...mmh... the die... where'd I leave it... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the die... where'd I leave it... zzz...",
       "questGive": "crownhaven-mint-dies",
       "questReceive": "crownhaven-mint-dies",
       "schedule": [
@@ -5421,6 +5484,15 @@
         "A noble's debt is a delicate thing. Discretion is half my trade.",
         "Vault's sealed tight — only the watch and I hold a key."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Ledgers balance or they don't — there's no third option in banking."
+        ],
+        "sleep": [
+          "...mmh... the vault... locked... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the vault... locked... zzz...",
       "questGive": "crownhaven-stolen-coin",
       "questReceive": [
         "crownhaven-tax-records",
@@ -5488,6 +5560,15 @@
         "A good seam is invisible. Like a good tailor.",
         "Bring me bolts of silk and I'll dress you fit for the throne room."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Pins in the cushion, not in the customer — mind the fitting."
+        ],
+        "sleep": [
+          "...mmh... one more stitch... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... one more stitch... zzz...",
       "questGive": "crownhaven-silk",
       "questReceive": "crownhaven-silk",
       "schedule": [
@@ -5548,6 +5629,15 @@
         "Raw gems are dull little pebbles until I coax the fire out of them.",
         "Careful where you tread; I've dropped stones worth more than your boots."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Steady hands, good light — the rest is patience."
+        ],
+        "sleep": [
+          "...mmh... the setting... just so... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the setting... just so... zzz...",
       "questGive": "crownhaven-gems",
       "questReceive": "crownhaven-gems",
       "schedule": [
@@ -5608,6 +5698,15 @@
         "Half of healing is herbs; the other half is convincing the patient they're healed.",
         "The academy sends me their wildest experiments. I send back the survivors."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Careful with the green bottles — I said MIND them, not taste them."
+        ],
+        "sleep": [
+          "...mmh... the tincture... needs stirring... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the tincture... needs stirring... zzz...",
       "questGive": "crownhaven-remedy",
       "questReceive": [
         "crownhaven-remedy",
@@ -5672,6 +5771,15 @@
         "Coronation feast's coming. I'll be up to my elbows in flour for a week.",
         "Grain's dear this season. Bring me sacks and I'll bake you a king's loaf."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Ovens are hot and the bells haven't even rung yet."
+        ],
+        "sleep": [
+          "...mmh... proving basket... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... proving basket... zzz...",
       "questGive": "crownhaven-bread",
       "questReceive": [
         "crownhaven-bread",
@@ -5735,6 +5843,15 @@
         "A blade's only as honest as the hand that swings it.",
         "Bring me steel and I'll give the watch the edge it needs."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind the sparks — the forge doesn't care whose boots are in the way."
+        ],
+        "sleep": [
+          "...mmh... hammer down... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... hammer down... zzz...",
       "questGive": "crownhaven-armoury",
       "questReceive": [
         "crownhaven-armoury",
@@ -5799,6 +5916,15 @@
         "My family's locket was lost in the gardens. It is all I have of my mother.",
         "Debts and lockets — a noblewoman's life is keeping track of what she's misplaced."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "The manor accounts don't balance themselves, more's the pity."
+        ],
+        "sleep": [
+          "...mmh... the locket... where..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the locket... where...",
       "questGive": "crownhaven-lost-locket",
       "questReceive": "crownhaven-lost-locket",
       "schedule": [
@@ -5860,6 +5986,15 @@
         "My lecture notes have scattered to the four winds. Or four districts, more likely.",
         "Knowledge, like coin, is only useful in circulation."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Quiet in the lecture hall, please — or don't, and learn nothing."
+        ],
+        "sleep": [
+          "...mmh... citation needed... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... citation needed... zzz...",
       "questGive": "crownhaven-lecture",
       "questReceive": "crownhaven-lecture",
       "schedule": [
@@ -5920,6 +6055,15 @@
         "Snapped three lute strings practising for the coronation. Three!",
         "Every great city deserves a great song. I'm still writing Crownhaven's."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Request anything — well, anything I know four chords for."
+        ],
+        "sleep": [
+          "...mmh... one more verse... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... one more verse... zzz...",
       "questGive": "crownhaven-buskers-strings",
       "questReceive": "crownhaven-buskers-strings",
       "schedule": [
@@ -5974,6 +6118,15 @@
         "Lost half my scrolls to the wind. A herald with no words is just a loud nuisance.",
         "Stand for the crown, traveller. The capital is watching."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Hear ye, hear ye! Mind the Chancellor's latest decree."
+        ],
+        "sleep": [
+          "...mmh... hear ye... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... hear ye... zzz...",
       "questGive": "crownhaven-proclamation",
       "questReceive": [
         "crownhaven-proclamation",
@@ -6030,6 +6183,15 @@
         "See anything suspicious, you tell me first, the captain second.",
         "Quiet night. Round here, that's the best kind."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Eyes on the wall. Captain's watching the watchman tonight."
+        ],
+        "sleep": [
+          "...mmh... south wall... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... south wall... zzz...",
       "questGive": "crownhaven-cutpurse",
       "questReceive": "crownhaven-patrol",
       "schedule": [

--- a/web/src/data/hub/npcDialogueCoverage.test.ts
+++ b/web/src/data/hub/npcDialogueCoverage.test.ts
@@ -11,7 +11,7 @@ import { LOCATION_REGISTRY } from './hubWorldFactory'
 // Scoped to towns that have completed their #1960 content batch so far;
 // widen TOWNS_WITH_CONTENT as each subsequent batch lands, and drop the
 // allowlist entirely once every town is covered.
-const TOWNS_WITH_CONTENT = ['millhaven']
+const TOWNS_WITH_CONTENT = ['millhaven', 'capital-city', 'royal-palace']
 
 describe('scheduled-NPC sleep dialogue coverage', () => {
   for (const townKey of TOWNS_WITH_CONTENT) {

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -1866,6 +1866,15 @@
         "Their Majesties are in session. The gardens, however, receive all visitors.",
         "If you've a strong back and a willing heart, the crown has no end of small disasters for you."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Oh dear, oh dear — always something misplaced at this palace."
+        ],
+        "sleep": [
+          "...mmh... the misplaced ledger... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the misplaced ledger... zzz...",
       "questGive": "new-quest-1",
       "questReceive": [
         "palace-lost-regalia",
@@ -1932,6 +1941,16 @@
         "Hear ye, hear ye — the proclamations have gone missing again. A herald with no words is merely a man shouting.",
         "Protocol is the art of standing in the right place while important things happen elsewhere."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Presenting: you. To no one in particular. Still a slow morning.",
+          "Protocol dictates I stand here looking important. It's working, I think."
+        ],
+        "sleep": [
+          "...mmh... presenting... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... presenting... zzz...",
       "questGive": "palace-herald-proclamation",
       "questReceive": "palace-herald-proclamation",
       "schedule": [
@@ -1949,6 +1968,7 @@
         {
           "startHour": 8,
           "endHour": 18,
+          "activity": "idle-chat",
           "location": {
             "type": "exterior",
             "tx": 10,
@@ -1983,6 +2003,15 @@
         "Nobody enters the throne room without an appointment. Or a mop. The mop people go everywhere.",
         "Quietest post in the kingdom, this. I've counted the fence railings twice."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Move along. Or stand there. Either way, I'm watching."
+        ],
+        "sleep": [
+          "...mmh... the railings... counted twice... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the railings... counted twice... zzz...",
       "questGive": "palace-guard-watch",
       "questReceive": "palace-guard-watch",
       "schedule": [
@@ -2000,6 +2029,7 @@
         {
           "startHour": 6,
           "endHour": 14,
+          "activity": "work",
           "location": {
             "type": "exterior",
             "tx": 18,
@@ -2009,6 +2039,7 @@
         {
           "startHour": 14,
           "endHour": 22,
+          "activity": "work",
           "location": {
             "type": "exterior",
             "tx": 20,
@@ -2050,6 +2081,15 @@
         "A crown is heavier than it looks, and most of the weight is other people's problems.",
         "Serve the realm well and the realm remembers. Mostly. When it isn't distracted."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "The court is in session. State your business, or admire the throne from a distance."
+        ],
+        "sleep": [
+          "...mmh... the crown... too heavy... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the crown... too heavy... zzz...",
       "questGive": "palace-court-intrigue-2",
       "questReceive": [
         "palace-court-intrigue-1",
@@ -2070,6 +2110,7 @@
         {
           "startHour": 8,
           "endHour": 18,
+          "activity": "work",
           "location": {
             "type": "interior",
             "buildingId": "palace",
@@ -2112,6 +2153,18 @@
         "The King rules the realm; I rule the garden. We are each terrified of the other's domain.",
         "A kingdom is judged by its kindnesses, not its conquests. Remember that, if you remember nothing else."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Court business, before the garden. The roses can wait a morning."
+        ],
+        "idle-chat": [
+          "Mind the roses — they answer to no one, least of all a queen."
+        ],
+        "sleep": [
+          "...mmh... the roses... need water... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the roses... need water... zzz...",
       "questGive": "palace-queen-roses",
       "questReceive": "palace-queen-roses",
       "favoriteGiftItemId": "silk-ribbon",
@@ -2134,6 +2187,7 @@
         {
           "startHour": 8,
           "endHour": 12,
+          "activity": "work",
           "location": {
             "type": "interior",
             "buildingId": "palace",
@@ -2181,6 +2235,16 @@
         "Everyone says a princess should be content. I should be content the moment my cat is.",
         "The goblin and the ogre by the fountain only wish to meet me. Steward Marigold won't allow it. Isn't that sad?"
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Do you think Kipper misses me as much as I miss him? Say yes.",
+          "The goblin and the ogre wave to me from the fountain. I wave back. Steward Marigold sighs."
+        ],
+        "sleep": [
+          "...mmh... Kipper... come home... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... Kipper... come home... zzz...",
       "questGive": "palace-princess-gift",
       "questReceive": [
         "palace-princess-gift",
@@ -2201,6 +2265,7 @@
         {
           "startHour": 8,
           "endHour": 12,
+          "activity": "idle-chat",
           "location": {
             "type": "interior",
             "buildingId": "palace-1",
@@ -2221,6 +2286,7 @@
         {
           "startHour": 18,
           "endHour": 24,
+          "activity": "idle-chat",
           "location": {
             "type": "interior",
             "buildingId": "palace-1",
@@ -2276,6 +2342,15 @@
         "The audit is overdue and the inner vault stays sealed until the ledgers balance.",
         "Bring me the scattered tallies and I'll open the deep vault myself."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "The vault stays sealed until the ledgers balance. Every coin, every time."
+        ],
+        "sleep": [
+          "...mmh... the tallies... don't add up... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the tallies... don't add up... zzz...",
       "questGive": "palace-vault-audit",
       "questReceive": "palace-vault-audit",
       "schedule": [
@@ -2331,6 +2406,15 @@
         "The crypt below holds kings long past. They keep their counsel well.",
         "Our candles have a way of wandering off. A chapel without light is only a cold stone room."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Peace, traveller. Light a candle if you've a mind to."
+        ],
+        "sleep": [
+          "...mmh... keep their counsel... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... keep their counsel... zzz...",
       "questGive": "palace-chapel-candles",
       "questReceive": "palace-chapel-candles",
       "schedule": [
@@ -2348,6 +2432,7 @@
         {
           "startHour": 6,
           "endHour": 22,
+          "activity": "work",
           "location": {
             "type": "interior",
             "buildingId": "royal-chapel",
@@ -2385,6 +2470,15 @@
         "A royal feast does not cook itself, more's the pity. I've asked the cauldron. It just bubbles at me.",
         "Fetch me what I need and the court eats like kings. Which, conveniently, they are."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Out of my kitchen, unless you're carrying something I asked for!"
+        ],
+        "sleep": [
+          "...mmh... more butter... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... more butter... zzz...",
       "questGive": "palace-kitchen-feast",
       "questReceive": "palace-kitchen-feast",
       "schedule": [
@@ -2444,6 +2538,15 @@
         "The Queen wants roses, the King wants order, and the rabbits want my lettuces. Everyone wants something.",
         "If you've a good eye, there's a rare bloom or two I've lost track of out here."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind the beds! I only just got the begonias straightened out."
+        ],
+        "sleep": [
+          "...mmh... the roses... need pruning... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the roses... need pruning... zzz...",
       "questGive": "palace-royal-bloom",
       "questReceive": [
         "palace-royal-bloom",
@@ -2506,6 +2609,15 @@
         "One of the ponies slipped its tack and bolted half the gear across the grounds. Royal beasts, royal nuisance.",
         "Help me round up the lost harness and there's coin in it for you."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Easy now — mind the stalls, the horses spook easy this morning."
+        ],
+        "sleep": [
+          "...mmh... the tack... put it back... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the tack... put it back... zzz...",
       "questGive": "palace-runaway-pony",
       "questReceive": "palace-runaway-pony",
       "schedule": [


### PR DESCRIPTION
## Summary

Second of 5 batches for issue #1960's content-authoring pass. This batch covers Capital City and Royal Palace — the two largest remaining towns.

- **Authors `dialogueByActivity` (mandatory `sleep` pool + one more activity) and `sleepDialogue`** for all 29 scheduled NPCs: 18 in `capitalcity` (all `[sleep, work, eat]` except `busker-lyle` `[sleep, idle-chat, eat]`) and 11 in `royalpalace`.
- **Tags 6 previously-untagged `royalpalace` schedule blocks** with an activity (`work` or `idle-chat`, matching each NPC's adjacent scheduled activity/flavor) so `dialogueByActivity` pools can actually attach to those hours: `royal-herald` (daytime block), `palace-guard` (both patrol blocks), `king` (court session), `queen` (morning duties), `princess` (both untagged blocks), `chaplain` (long chapel block). Without a tag, `getNpcActivity` returns `null` for that window and the NPC always falls back to flat `dialogue` regardless of any authored pool — these blocks were dead weight for this content pass otherwise.
- Widens the guard test's `TOWNS_WITH_CONTENT` to include `capital-city` and `royal-palace` (`LOCATION_REGISTRY`'s hyphenated keys, which differ from the `config.json` directory names `capitalcity`/`royalpalace` — worth flagging since it's an easy mismatch to hit).

Not closing #1960 — 3 more batches remain (ironholdkeep+gearford, ravenwatch, small towns).

## Test plan

- [x] `npm run build` passes (tsc + vite build clean)
- [x] `npx vitest run src/data/hub/npcDialogueCoverage.test.ts` — 76/76 passing (18 millhaven + 36 capitalcity + 22 royalpalace assertions)
- [x] `npx vitest run src/game/hub/hubNpcSchedule.test.ts src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts src/data/hub/npcDialogueCoverage.test.ts` — 117/117 passing, no regressions
- [x] Scripted an audit confirming all 29 scheduled NPCs across both towns have zero untagged schedule blocks and complete `dialogueByActivity`/`sleepDialogue` coverage
- [x] Verified both `config.json` files stay valid JSON after edits


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_