### PR TITLE
Hub: Ironhold Keep + Gearford — activity-aware dialogue for all scheduled NPCs (#1960 batch 3/5)

### DIFF
--- a/web/src/data/hub/gearford/config.json
+++ b/web/src/data/hub/gearford/config.json
@@ -1691,6 +1691,15 @@
         "Somebody's been lifting tools from the yard. A foundry without tools is just a very warm room.",
         "Hear that hammering? That's the sound of nothing being wrong. I like that sound."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Hear that hammering? That's the sound of nothing being wrong."
+        ],
+        "sleep": [
+          "...mmh... coal, iron... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... coal, iron... zzz...",
       "questGive": "gearford-stolen-tools",
       "questReceive": [
         "gearford-stolen-tools",
@@ -1742,6 +1751,15 @@
         "Every machine wants to work. You just have to convince it the work is yours.",
         "The forge eats coal like a dragon eats... well, everything. We're always short."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Every machine wants to work. Convincing it takes patience."
+        ],
+        "sleep": [
+          "...mmh... convince the gears... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... convince the gears... zzz...",
       "questGive": "gearford-coal-run",
       "questReceive": [
         "gearford-coal-run",
@@ -1794,6 +1812,15 @@
         "Between the bandits on the toll road and the mine collapse, half my crew won't travel.",
         "You look sturdy. Ever considered honest work? No? Smart."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Shift's on. Keep up or get out of the way."
+        ],
+        "sleep": [
+          "...mmh... the crew roster... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the crew roster... zzz...",
       "questGive": "gearford-ore-haul",
       "questReceive": [
         "gearford-ore-haul",
@@ -1844,6 +1871,15 @@
         "I dropped a whole tray of parts in the yard yesterday. They went EVERYWHERE.",
         "One day I'll forge a blade so fine they'll sing songs. For now: more carrying."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Brunn says I'll be a real gearwright someday. Someday's taking a while."
+        ],
+        "sleep": [
+          "...mmh... more carrying... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... more carrying... zzz...",
       "questGive": "gearford-scattered-parts",
       "questReceive": [
         "gearford-scattered-parts",
@@ -1894,6 +1930,15 @@
         "Ravenwatch sent word: their gaol lock's jammed and the guard captain wants a new key forged.",
         "Bring me good iron and I'll cut you a key that'd open the gates of dawn."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Miss one tooth and the whole thing seizes. Patience, always patience."
+        ],
+        "sleep": [
+          "...mmh... one more tooth... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... one more tooth... zzz...",
       "questGive": "gearford-forge-the-key",
       "questReceive": "gearford-forge-the-key",
       "schedule": [
@@ -1941,6 +1986,15 @@
         "The old depot south of town's still half-full. Nobody hauls it — too lazy, too scared.",
         "A full barrow and an empty road. That's all a hauler wants out of life."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Coal in, slag out. Mind the barrow, it doesn't slow for anyone."
+        ],
+        "sleep": [
+          "...mmh... one more load... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... one more load... zzz...",
       "schedule": [
         {
           "startHour": 6,
@@ -1996,6 +2050,15 @@
         "Miners drink like the mine's about to close. Some weeks it nearly is.",
         "Rats in my store again. Eating better than my guests, the little tyrants."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Welcome to the Pickaxe Rest. Ale's warm, stew's warmer."
+        ],
+        "sleep": [
+          "...mmh... the rats again... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the rats again... zzz...",
       "questGive": "gearford-rats-in-the-store",
       "questReceive": [
         "gearford-rats-in-the-store",
@@ -2057,6 +2120,15 @@
         "Lost my good lamp in the west drift. Pitch black down there without it.",
         "The ore's rich this season. Pity the road out is so poor."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Down the shaft again. Mind the timbers on your way past."
+        ],
+        "sleep": [
+          "...mmh... the west drift... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the west drift... zzz...",
       "questGive": "gearford-lost-lamp",
       "questReceive": "gearford-lost-lamp",
       "schedule": [
@@ -2115,6 +2187,15 @@
         "Half the stores went walkabout in the last delivery. Slipshod loading, I call it.",
         "Order is the only ore that never runs dry. Remember that."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Every crate gets logged. Lose one and you'll hear about it."
+        ],
+        "sleep": [
+          "...mmh... the ledger... don't lose it... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the ledger... don't lose it... zzz...",
       "questGive": "gearford-missing-stores",
       "questReceive": "gearford-missing-stores",
       "schedule": [
@@ -2157,6 +2238,15 @@
         "A valve's seized and a flywheel's cracked. Vela knows the parts I need.",
         "Keep her turning and Gearford breathes. Let her stop and we drown in the dark."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Keep her turning. The pump doesn't get a day off."
+        ],
+        "sleep": [
+          "...mmh... the flywheel... turning... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the flywheel... turning... zzz...",
       "questReceive": "gearford-broken-pump-3",
       "schedule": [
         {
@@ -2204,6 +2294,15 @@
         "Half of Gearford's collapsed twice over. I keep the plans for what worked.",
         "You don't build a keep in a day. You build it in a thousand right decisions."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Good bones first, everything else after. That's the whole trade."
+        ],
+        "sleep": [
+          "...mmh... check the foundations... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... check the foundations... zzz...",
       "schedule": [
         {
           "startHour": 0,
@@ -2251,6 +2350,15 @@
         "A war's won by whoever counts their troops correctly. I count carefully.",
         "Gear's cheap. The people who wear it into a fight are what costs you."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Counting troops again. It's the only arithmetic that matters out here."
+        ],
+        "sleep": [
+          "...mmh... count 'em again... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... count 'em again... zzz...",
       "schedule": [
         {
           "startHour": 0,

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1874,6 +1874,18 @@
         "The patrol routes have been compromised. We need those reports.",
         "You fight well, traveller. Ravenwatch is lucky to have you."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Three centuries this keep has stood. Not on my watch will it fall."
+        ],
+        "idle-chat": [
+          "Even a commander gets a moment's peace, now and then."
+        ],
+        "sleep": [
+          "...mmh... hold the line... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... hold the line... zzz...",
       "building": "keep",
       "questGive": "castle-missing-patrol",
       "questReceive": "castle-missing-patrol",
@@ -1957,6 +1969,15 @@
         "Every soldier here answers to me before they answer to the Commander.",
         "Stand a watch with us sometime, traveller. You'd learn something."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Drill, drill, and drill again. Discipline wins sieges."
+        ],
+        "sleep": [
+          "...mmh... drill formation... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... drill formation... zzz...",
       "questGive": "castle-watch-rotation",
       "questReceive": "castle-watch-rotation",
       "schedule": [
@@ -2036,6 +2057,15 @@
         "The weapon crates haven't been accounted for since the last resupply.",
         "Iron doesn't lie — only men do."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Every blade matters. Mind the sparks and let me work."
+        ],
+        "sleep": [
+          "...mmh... hammer down... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... hammer down... zzz...",
       "building": "smithy",
       "questGive": "castle-weapon-cache",
       "questReceive": "castle-weapon-cache",
@@ -2107,6 +2137,15 @@
         "Grain, iron, arrows, salt — a castle eats as surely as it fights.",
         "If you're after supplies, mind you sign for them."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Sign the ledger or leave it be — those are your options."
+        ],
+        "sleep": [
+          "...mmh... the ledger... balance... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the ledger... balance... zzz...",
       "building": "quartermasters-store",
       "questGive": "castle-supply-tally",
       "questReceive": "castle-supply-tally",
@@ -2182,6 +2221,18 @@
         "Get out of my kitchen unless you're bringing me something to cook with.",
         "There's stew on the hearth if the guards have left any."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Out of my kitchen, unless you're carrying something useful."
+        ],
+        "sweep": [
+          "A clean hearth makes a hot stew. Mind the ash."
+        ],
+        "sleep": [
+          "...mmh... more stew... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... more stew... zzz...",
       "building": "kitchens",
       "questGive": "castle-feast-preparations",
       "questReceive": "castle-feast-preparations",
@@ -2242,6 +2293,15 @@
         "The crypt below holds the lords of Ironhold, back to the first stone laid.",
         "Light a candle for the fallen. There are always more of them than we'd like."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Peace finds even iron men, in time."
+        ],
+        "sleep": [
+          "...mmh... light a candle... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... light a candle... zzz...",
       "building": "chapel",
       "questGive": "castle-restless-crypt",
       "questReceive": "castle-restless-crypt",
@@ -2313,6 +2373,15 @@
         "A siege chronicle was separated from the archives. It belongs here.",
         "History is the only weapon that never dulls."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Quiet in the scriptorium, please. History doesn't like to be rushed."
+        ],
+        "sleep": [
+          "...mmh... the chronicle... where..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the chronicle... where...",
       "building": "scriptorium",
       "questGive": "castle-siege-memory",
       "questReceive": "castle-siege-memory",
@@ -2373,6 +2442,18 @@
         "Mind where you step — a war horse spooks at less than you'd think.",
         "If you ride out, I'll have a mount saddled before you reach the gate."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind where you step — the destriers spook at less than you'd think."
+        ],
+        "sweep": [
+          "Straw goes out, fresh bedding goes in. Same as every day."
+        ],
+        "sleep": [
+          "...mmh... the destriers... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the destriers... zzz...",
       "building": "stables",
       "questGive": "castle-lost-foal",
       "questReceive": "castle-lost-foal",
@@ -2444,6 +2525,15 @@
         "A knight without a cause is just a man in expensive metal.",
         "The Guard-Master sets the rotation. Take it up with him."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "This wall has held two winters. It'll hold today too."
+        ],
+        "sleep": [
+          "...mmh... hold the wall... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... hold the wall... zzz...",
       "questReceive": "castle-watch-rotation",
       "schedule": [
         {
@@ -2523,6 +2613,15 @@
         "Sir Garrick says I've a good arm. He says it rarely, mind.",
         "I dropped a training sword somewhere out here. Don't tell the Guard-Master."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Polishing armour again. One day it'll be my own."
+        ],
+        "sleep": [
+          "...mmh... one day... a knight... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... one day... a knight... zzz...",
       "questGive": "castle-squires-trial",
       "questReceive": "castle-squires-trial",
       "schedule": [
@@ -2603,6 +2702,11 @@
         "State your business at the gate or state it elsewhere.",
         "Safe roads, traveller. The world beyond these walls is less forgiving."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "State your business at the gate, traveller. Then move along."
+        ]
+      },
       "schedule": [
         {
           "startHour": 0,
@@ -2673,6 +2777,15 @@
         "Three of us dropped our patrol papers during the last drill. Embarrassing.",
         "The south gate is yours to use, traveller."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "South gate's clear. Move along, traveller."
+        ],
+        "sleep": [
+          "...mmh... the patrol route... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the patrol route... zzz...",
       "questReceive": "castle-missing-patrol",
       "schedule": [
         {
@@ -2740,6 +2853,15 @@
         "I lost my patrol report somewhere out in the courtyard. The Commander will have my head.",
         "Ironhold has never fallen. Long may that last."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Eastern wall's quiet. Keeping it that way."
+        ],
+        "sleep": [
+          "...mmh... the eastern wall... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the eastern wall... zzz...",
       "questReceive": "castle-missing-patrol",
       "schedule": [
         {

--- a/web/src/data/hub/npcDialogueCoverage.test.ts
+++ b/web/src/data/hub/npcDialogueCoverage.test.ts
@@ -11,7 +11,7 @@ import { LOCATION_REGISTRY } from './hubWorldFactory'
 // Scoped to towns that have completed their #1960 content batch so far;
 // widen TOWNS_WITH_CONTENT as each subsequent batch lands, and drop the
 // allowlist entirely once every town is covered.
-const TOWNS_WITH_CONTENT = ['millhaven', 'capital-city', 'royal-palace']
+const TOWNS_WITH_CONTENT = ['millhaven', 'capital-city', 'royal-palace', 'ironhold-keep', 'gearford']
 
 describe('scheduled-NPC sleep dialogue coverage', () => {
   for (const townKey of TOWNS_WITH_CONTENT) {


### PR DESCRIPTION
## Summary

Third of 5 batches for issue #1960's content-authoring pass. This batch covers Ironhold Keep and Gearford.

- **Authors `dialogueByActivity` (mandatory `sleep` pool + one more activity) and `sleepDialogue`** for all 25 scheduled NPCs: 13 in `ironholdkeep` (castle/martial voice) and 12 in `gearford` (industrial/mining voice).
- `castle-gatekeeper` has a work-only schedule with no `sleep` entry, so it only gets a `work` pool and no `sleepDialogue` — matching the `sailor-finn` precedent established in batch 1 (Millhaven).
- No untagged schedule blocks in either town (confirmed by audit before starting), so unlike batch 2's `royalpalace` fix, this batch is pure content with no schema/schedule changes needed.
- Widens the guard test's `TOWNS_WITH_CONTENT` to include `ironhold-keep` and `gearford` (`LOCATION_REGISTRY` keys).

Not closing #1960 — 2 more batches remain (ravenwatch, small towns).

## Test plan

- [x] `npm run build` passes (tsc + vite build clean)
- [x] `npx vitest run src/data/hub/npcDialogueCoverage.test.ts` — 124/124 passing (18 millhaven + 36 capitalcity + 22 royalpalace + 24 ironholdkeep + 24 gearford assertions)
- [x] `npx vitest run src/game/hub/hubNpcSchedule.test.ts src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts src/data/hub/npcDialogueCoverage.test.ts` — 165/165 passing, no regressions
- [x] Scripted an audit confirming all 25 scheduled NPCs across both towns have zero untagged schedule blocks and complete `dialogueByActivity`/`sleepDialogue` coverage (except the intentional `castle-gatekeeper` exception)
- [x] Verified both `config.json` files stay valid JSON after edits


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_