### PR TITLE
Hub: small towns — activity-aware dialogue for all remaining scheduled NPCs (#1960 batch 5/5, final)

### DIFF
--- a/web/src/data/hub/appleford/config.json
+++ b/web/src/data/hub/appleford/config.json
@@ -1220,6 +1220,15 @@
         "Raiders hit the east rows last week. Took apples, baskets, and my best ladder.",
         "An orchard is patience you can eat. Remember that."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind the east rows. Every tree here has a name and I know them all."
+        ],
+        "sleep": [
+          "...mmh... the east rows... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the east rows... zzz...",
       "questGive": "appleford-scattered-harvest",
       "questReceive": [
         "appleford-scattered-harvest",
@@ -1402,6 +1411,15 @@
         "Best apples are always the ones just out of reach. Orchard's little joke.",
         "Fill a crate, haul it to Posy, start again. It's honest work, if you like apples. I'm sick of apples."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Up the ladder again. My arms have opinions, but the apples don't care."
+        ],
+        "sleep": [
+          "...mmh... one more basket... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... one more basket... zzz...",
       "questGive": "appleford-orchard-pickers",
       "questReceive": [
         "appleford-orchard-pickers"

--- a/web/src/data/hub/dreadspirecitadel/config.json
+++ b/web/src/data/hub/dreadspirecitadel/config.json
@@ -590,6 +590,18 @@
         "Four centuries of research and I have proven, conclusively, that the dead make poor conversationalists.",
         "If Ordrin asks, I did NOT borrow his shadow-oil. I liberated it. There is a difference."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind the sigils while I work. The floor ones bite, remember."
+        ],
+        "idle-chat": [
+          "Even a warlock needs a moment away from the sigils. Don't tell Ordrin I said that."
+        ],
+        "sleep": [
+          "...mmh... the sigils... unfinished... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the sigils... unfinished... zzz...",
       "questGive": "dreadspire-intrigue-1",
       "questReceive": [
         "dreadspire-intrigue-1",
@@ -793,6 +805,15 @@
         "I dropped the master's old keys somewhere on my rounds. Four centuries of rounds. They could be anywhere.",
         "Mind the crypt door. It sticks. Everything down here sticks, including time."
       ],
+      "dialogueByActivity": {
+        "sweep": [
+          "Dust to sweep, dust to dust. Four centuries in and the work still isn't done."
+        ],
+        "sleep": [
+          "...zzz... the work is eternal... so am I... zzz..."
+        ]
+      },
+      "sleepDialogue": "...zzz... the work is eternal... so am I... zzz...",
       "questGive": "dreadspire-lost-keys",
       "questReceive": "dreadspire-lost-keys",
       "schedule": [

--- a/web/src/data/hub/gravemoor/config.json
+++ b/web/src/data/hub/gravemoor/config.json
@@ -1134,6 +1134,15 @@
         "I was mayor when I died and nobody's run against me since. Democracy at its finest.",
         "We're dead, not rude. Wipe your feet and you're welcome anywhere in town."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Welcome to Gravemoor! Population: technically zero. Spiritually: thriving."
+        ],
+        "sleep": [
+          "...zzz... nobody's run against me... zzz..."
+        ]
+      },
+      "sleepDialogue": "...zzz... nobody's run against me... zzz...",
       "favoriteGiftItemId": "grave-moss",
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
@@ -1153,6 +1162,7 @@
         {
           "startHour": 20,
           "endHour": 7,
+          "activity": "sleep",
           "location": {
             "type": "interior",
             "buildingId": "ruined-town-hall",
@@ -1221,6 +1231,15 @@
         "The dead are good company. Quiet. Never complain about the digging.",
         "Mind the soft ground by the new plots. You'd not be the first to fall in."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Mind the soft ground. Somebody's got to keep these holes tidy."
+        ],
+        "sleep": [
+          "...mmh... the new plots... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the new plots... zzz...",
       "questGive": "gravemoor-six-feet-under",
       "questReceive": [
         "gravemoor-six-feet-under",

--- a/web/src/data/hub/harrowfield/config.json
+++ b/web/src/data/hub/harrowfield/config.json
@@ -1570,6 +1570,15 @@
         "Three seed-grain sacks have gone missing. Maeve will have my ears if they're not found.",
         "The scarecrow moved again last night. I'm not paid enough to ask it why."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Sowing, hoeing, mowing. The fields don't care what day it is."
+        ],
+        "sleep": [
+          "...mmh... the scarecrow... moved... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the scarecrow... moved... zzz...",
       "questGive": "harrowfield-seed-grain",
       "questReceive": [
         "harrowfield-seed-grain",
@@ -1644,6 +1653,15 @@
         "Floss keeps the flock, but she can't mend a fence. The ewes are through the gap again.",
         "Wool to the market, mutton never if I can help it. I get attached, see."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Floss has the flock in hand. Mostly. The ewes have other ideas some days."
+        ],
+        "sleep": [
+          "...mmh... mend the fence... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... mend the fence... zzz...",
       "questGive": "harrowfield-mend-pasture",
       "questReceive": [
         "harrowfield-mend-pasture",

--- a/web/src/data/hub/hollowmere/config.json
+++ b/web/src/data/hub/hollowmere/config.json
@@ -1300,6 +1300,15 @@
         "Folk think monsters can't be kind. Folk never met Mott, or Mott's pens.",
         "You want to learn beast-taming? Start small. Start with the ones that bite least."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Easy now, easy. These beasts just want to be asked nicely."
+        ],
+        "sleep": [
+          "...mmh... gentle as lambs... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... gentle as lambs... zzz...",
       "questGive": "beast-taming-1",
       "questReceive": [
         "beast-taming-1",

--- a/web/src/data/hub/npcDialogueCoverage.test.ts
+++ b/web/src/data/hub/npcDialogueCoverage.test.ts
@@ -8,14 +8,11 @@ import { LOCATION_REGISTRY } from './hubWorldFactory'
 // check) — otherwise a sleeping NPC either bubbles nothing or falls back to
 // the generic "fast asleep" default instead of an authored line.
 //
-// Scoped to towns that have completed their #1960 content batch so far;
-// widen TOWNS_WITH_CONTENT as each subsequent batch lands, and drop the
-// allowlist entirely once every town is covered.
-const TOWNS_WITH_CONTENT = ['millhaven', 'capital-city', 'royal-palace', 'ironhold-keep', 'gearford', 'ravenwatch']
-
+// Runs against every town in LOCATION_REGISTRY — #1960's content pass now
+// covers every town with scheduled NPCs, so any new sleep-scheduled NPC
+// added later (in any town) is covered by this guard automatically.
 describe('scheduled-NPC sleep dialogue coverage', () => {
-  for (const townKey of TOWNS_WITH_CONTENT) {
-    const { locationData } = LOCATION_REGISTRY[townKey]
+  for (const [townKey, { locationData }] of Object.entries(LOCATION_REGISTRY)) {
 
     for (const npc of locationData.HUB_NPCS) {
       const hasSleepSchedule = npc.schedule?.some(entry => entry.activity === 'sleep')

--- a/web/src/data/hub/saltmereport/config.json
+++ b/web/src/data/hub/saltmereport/config.json
@@ -1569,6 +1569,15 @@
         "Cargo's been going missing off the quay. The manifest doesn't lie — people do.",
         "Pirates to the north, smugglers to the south, and paperwork in every direction."
       ],
+      "dialogueByActivity": {
+        "work": [
+          "Every crate on this dock answers to me. Mind you sign for what you take."
+        ],
+        "sleep": [
+          "...mmh... the manifest... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... the manifest... zzz...",
       "building": "harbourmaster",
       "questGive": "saltmere-lost-cargo",
       "questReceive": "saltmere-rum-run",
@@ -1712,6 +1721,15 @@
         "Oil runs low faster than it should. Someone's skimming, or the wick's thirstier than it used to be.",
         "I watch so the rest of you can sleep. Mind you remember that, next time the bell rings."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "The lamp's burning steady tonight. That's one less thing to worry about."
+        ],
+        "sleep": [
+          "...mmh... mind the lamp... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... mind the lamp... zzz...",
       "schedule": [
         {
           "startHour": 6,
@@ -1817,6 +1835,15 @@
         "The Brined Anchor pours the only rum on this coast worth drinking. Present company excepted, obviously.",
         "Sleep below deck, drink above it. That's balance, that is."
       ],
+      "dialogueByActivity": {
+        "idle-chat": [
+          "Pull up a stool. I've a story about the Horn that gets taller every telling."
+        ],
+        "sleep": [
+          "...mmh... below deck... zzz..."
+        ]
+      },
+      "sleepDialogue": "...mmh... below deck... zzz...",
       "building": "sailors-inn",
       "schedule": [
         {


### PR DESCRIPTION
## Summary

Fifth and final batch for issue #1960's content-authoring pass. This batch covers all remaining small towns and **closes #1960**.

- **Authors `dialogueByActivity` (mandatory `sleep` pool + one more activity) and `sleepDialogue`** for all 12 remaining scheduled NPCs: saltmereport (3), appleford (2), dreadspirecitadel (2), gravemoor (2), harrowfield (2), hollowmere (1). `thornwoodcamp` has no scheduled NPCs, so there was nothing to author there.
- **Fixes an untagged schedule block**: `gravemoor`'s `ghost-mayor-aldous` had an overnight block (20:00–07:00, interior `ruined-town-hall`) with no `activity` tag. Tagged it `sleep` — a ghost "resting" overnight in the town hall fits the established pattern — so a `dialogueByActivity.sleep` pool and `sleepDialogue` could actually attach to those hours. Same fix pattern as batch 2's `royalpalace`.
- **Ghost NPC voice**: `ghost-servant-isolde` (dreadspirecitadel) and `ghost-mayor-aldous` (gravemoor) get sleep lines in a spectral/eternal register, consistent with their existing flat dialogue and #1960's own "ghost NPCs stay ghostly" authoring note.
- **Simplifies the guard test**: `npcDialogueCoverage.test.ts` now iterates every town in `LOCATION_REGISTRY` directly instead of an explicit `TOWNS_WITH_CONTENT` allowlist, now that every town with scheduled NPCs has complete coverage — any future sleep-scheduled NPC added to any town is covered automatically, no allowlist maintenance needed.

## Epic resolution

This closes #1960, and since #1960 was the last of #1956's four sub-issues (#1957, #1958, #1959, #1960 — all now merged), it also resolves the parent epic #1956. The originally reported repro — tapping Baker Pernel in Millhaven at 2am playing his "fresh loaves" work-hours line while he's actually asleep — has been fixed end-to-end since batch 1 (#1957's `dialogueByActivity` content) + #1958's sleep gate, and was re-verified in this PR's test plan.

Closes #1960

## Test plan

- [x] `npm run build` passes (tsc + vite build clean)
- [x] `npx vitest run src/data/hub/npcDialogueCoverage.test.ts` — 170/170 passing across all 13 towns (previously an allowlist-scoped 146; now runs unconditionally)
- [x] `npx vitest run src/game/hub/hubNpcSchedule.test.ts src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts src/data/hub/npcDialogueCoverage.test.ts` — 211/211 passing, no regressions
- [x] Scripted an audit confirming all 12 scheduled NPCs across the 6 remaining towns have complete `dialogueByActivity`/`sleepDialogue` coverage and zero untagged schedule blocks
- [x] Verified all 6 `config.json` files stay valid JSON after edits
- [x] Re-traced the original Baker Pernel repro end-to-end: at hour 2 he's flagged asleep (`isNpcAsleep` true) and shows a sleep-appropriate line via the tap gate; at hour 10 he's awake and shows "Fresh loaves out of the oven..." — confirmed fixed


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_