### PR TITLE
Hub: NPC walk-cycle animation (engine + Millhaven proof-of-work)

### DIFF
--- a/web/public/sprites/hub-npc-elder-1.svg
+++ b/web/public/sprites/hub-npc-elder-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 — stride A: arms swing, robe hides legs -->
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robe -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#8b5e3c"/>
+  <!-- arms -->
+  <rect x="8"  y="15" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <rect x="21" y="13" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <!-- staff -->
+  <rect x="22" y="8" width="2" height="18" rx="1" fill="#6b4020"/>
+  <circle cx="23" cy="7" r="2" fill="#d4a847"/>
+  <!-- beard -->
+  <rect x="12" y="11" width="8" height="5" rx="2" fill="#c8c0b0"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#d4b090"/>
+  <!-- white hair -->
+  <rect x="11" y="4" width="10" height="4" rx="2" fill="#e8e0d8"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-elder-2.svg
+++ b/web/public/sprites/hub-npc-elder-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robe -->
+  <rect x="10" y="12" width="12" height="15" rx="3" fill="#8b5e3c"/>
+  <!-- arms -->
+  <rect x="8"  y="13" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <rect x="21" y="13" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <!-- staff -->
+  <rect x="22" y="7" width="2" height="18" rx="1" fill="#6b4020"/>
+  <circle cx="23" cy="6" r="2" fill="#d4a847"/>
+  <!-- beard -->
+  <rect x="12" y="10" width="8" height="5" rx="2" fill="#c8c0b0"/>
+  <!-- head -->
+  <circle cx="16" cy="8" r="5" fill="#d4b090"/>
+  <!-- white hair -->
+  <rect x="11" y="3" width="10" height="4" rx="2" fill="#e8e0d8"/>
+  <!-- eyes -->
+  <rect x="13" y="7" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="7" width="2" height="2" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-elder-3.svg
+++ b/web/public/sprites/hub-npc-elder-3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B (opposite arm swing of frame 1) -->
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robe -->
+  <rect x="10" y="13" width="12" height="15" rx="3" fill="#8b5e3c"/>
+  <!-- arms -->
+  <rect x="8"  y="13" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <rect x="21" y="15" width="3" height="8" rx="1" fill="#8b5e3c"/>
+  <!-- staff -->
+  <rect x="22" y="8" width="2" height="18" rx="1" fill="#6b4020"/>
+  <circle cx="23" cy="7" r="2" fill="#d4a847"/>
+  <!-- beard -->
+  <rect x="12" y="11" width="8" height="5" rx="2" fill="#c8c0b0"/>
+  <!-- head -->
+  <circle cx="16" cy="9" r="5" fill="#d4b090"/>
+  <!-- white hair -->
+  <rect x="11" y="4" width="10" height="4" rx="2" fill="#e8e0d8"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-fisherman-1.svg
+++ b/web/public/sprites/hub-npc-fisherman-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- walk frame 1 — stride A: left leg forward, right leg back -->
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#4a6a3a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a07a"/>
+  <!-- Wide-brim fishing hat -->
+  <ellipse cx="16" cy="6" rx="8" ry="2.5" fill="#6a5a2a"/>
+  <rect x="13" y="4" width="6" height="4" rx="1.5" fill="#7a6a30"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="10" r="1" fill="#3a2a1a"/>
+  <circle cx="18" cy="10" r="1" fill="#3a2a1a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="14" rx="3.5" ry="2" fill="#c8c8b0"/>
+  <!-- Fishing rod (right hand) -->
+  <line x1="21" y1="15" x2="30" y2="4" stroke="#8a6a3a" stroke-width="1.5"/>
+  <line x1="30" y1="4" x2="30" y2="10" stroke="#88bbdd" stroke-width="1"/>
+  <circle cx="30" cy="10" r="1.5" fill="#88bbdd"/>
+  <!-- Legs -->
+  <rect x="11" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <rect x="18" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <!-- Boots -->
+  <rect x="10" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+  <rect x="17" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-fisherman-2.svg
+++ b/web/public/sprites/hub-npc-fisherman-2.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <!-- Body -->
+  <rect x="11" y="13" width="10" height="11" rx="2" fill="#4a6a3a"/>
+  <!-- Head -->
+  <circle cx="16" cy="9" r="5" fill="#c8a07a"/>
+  <!-- Wide-brim fishing hat -->
+  <ellipse cx="16" cy="5" rx="8" ry="2.5" fill="#6a5a2a"/>
+  <rect x="13" y="3" width="6" height="4" rx="1.5" fill="#7a6a30"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="9" r="1" fill="#3a2a1a"/>
+  <circle cx="18" cy="9" r="1" fill="#3a2a1a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="13" rx="3.5" ry="2" fill="#c8c8b0"/>
+  <!-- Fishing rod (right hand) -->
+  <line x1="21" y1="14" x2="30" y2="3" stroke="#8a6a3a" stroke-width="1.5"/>
+  <line x1="30" y1="3" x2="30" y2="9" stroke="#88bbdd" stroke-width="1"/>
+  <circle cx="30" cy="9" r="1.5" fill="#88bbdd"/>
+  <!-- Legs -->
+  <rect x="12" y="23" width="4" height="7" rx="1" fill="#3a4a2a"/>
+  <rect x="17" y="23" width="4" height="7" rx="1" fill="#3a4a2a"/>
+  <!-- Boots -->
+  <rect x="11" y="27" width="5" height="3" rx="1" fill="#2a1a0a"/>
+  <rect x="16" y="27" width="5" height="3" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-fisherman-3.svg
+++ b/web/public/sprites/hub-npc-fisherman-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- walk frame 3 — stride B (opposite of frame 1) -->
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#4a6a3a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a07a"/>
+  <!-- Wide-brim fishing hat -->
+  <ellipse cx="16" cy="6" rx="8" ry="2.5" fill="#6a5a2a"/>
+  <rect x="13" y="4" width="6" height="4" rx="1.5" fill="#7a6a30"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="10" r="1" fill="#3a2a1a"/>
+  <circle cx="18" cy="10" r="1" fill="#3a2a1a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="14" rx="3.5" ry="2" fill="#c8c8b0"/>
+  <!-- Fishing rod (right hand) -->
+  <line x1="21" y1="15" x2="30" y2="4" stroke="#8a6a3a" stroke-width="1.5"/>
+  <line x1="30" y1="4" x2="30" y2="10" stroke="#88bbdd" stroke-width="1"/>
+  <circle cx="30" cy="10" r="1.5" fill="#88bbdd"/>
+  <!-- Legs -->
+  <rect x="13" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <rect x="16" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <!-- Boots -->
+  <rect x="12" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+  <rect x="15" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-merchant-1.svg
+++ b/web/public/sprites/hub-npc-merchant-1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 1 — stride A: left leg forward, right leg back -->
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- boots -->
+  <rect x="10" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="18" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <!-- legs -->
+  <rect x="11" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <rect x="18" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <!-- tunic -->
+  <rect x="10" y="12" width="12" height="10" rx="2" fill="#aa2a2a"/>
+  <!-- gold trim -->
+  <rect x="10" y="12" width="12" height="2" rx="1" fill="#d4a020"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#d4a020"/>
+  <!-- arms -->
+  <rect x="8"  y="13" width="3" height="7" rx="1" fill="#c8a070"/>
+  <rect x="21" y="13" width="3" height="7" rx="1" fill="#c8a070"/>
+  <!-- coin pouch -->
+  <circle cx="9" cy="22" r="3" fill="#d4a020"/>
+  <!-- head -->
+  <circle cx="16" cy="8" r="5" fill="#c8a070"/>
+  <!-- merchant hat -->
+  <rect x="11" y="3" width="10" height="4" rx="2" fill="#2a1a00"/>
+  <rect x="9"  y="5" width="14" height="2" rx="1" fill="#2a1a00"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#1a0a00"/>
+</svg>

--- a/web/public/sprites/hub-npc-merchant-2.svg
+++ b/web/public/sprites/hub-npc-merchant-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 2 — mid stride, body 1px higher -->
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- boots -->
+  <rect x="11" y="25" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="25" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <!-- legs -->
+  <rect x="12" y="20" width="3" height="7" rx="1" fill="#4a2a10"/>
+  <rect x="17" y="20" width="3" height="7" rx="1" fill="#4a2a10"/>
+  <!-- tunic -->
+  <rect x="10" y="11" width="12" height="10" rx="2" fill="#aa2a2a"/>
+  <!-- gold trim -->
+  <rect x="10" y="11" width="12" height="2" rx="1" fill="#d4a020"/>
+  <rect x="10" y="19" width="12" height="2" rx="1" fill="#d4a020"/>
+  <!-- arms -->
+  <rect x="8"  y="12" width="3" height="7" rx="1" fill="#c8a070"/>
+  <rect x="21" y="12" width="3" height="7" rx="1" fill="#c8a070"/>
+  <!-- coin pouch -->
+  <circle cx="9" cy="21" r="3" fill="#d4a020"/>
+  <!-- head -->
+  <circle cx="16" cy="7" r="5" fill="#c8a070"/>
+  <!-- merchant hat -->
+  <rect x="11" y="2" width="10" height="4" rx="2" fill="#2a1a00"/>
+  <rect x="9"  y="4" width="14" height="2" rx="1" fill="#2a1a00"/>
+  <!-- eyes -->
+  <rect x="13" y="7" width="2" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="7" width="2" height="2" rx="1" fill="#1a0a00"/>
+</svg>

--- a/web/public/sprites/hub-npc-merchant-3.svg
+++ b/web/public/sprites/hub-npc-merchant-3.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- walk frame 3 — stride B (opposite of frame 1) -->
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- boots -->
+  <rect x="12" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="16" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <!-- legs -->
+  <rect x="13" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <rect x="16" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <!-- tunic -->
+  <rect x="10" y="12" width="12" height="10" rx="2" fill="#aa2a2a"/>
+  <!-- gold trim -->
+  <rect x="10" y="12" width="12" height="2" rx="1" fill="#d4a020"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#d4a020"/>
+  <!-- arms -->
+  <rect x="8"  y="13" width="3" height="7" rx="1" fill="#c8a070"/>
+  <rect x="21" y="13" width="3" height="7" rx="1" fill="#c8a070"/>
+  <!-- coin pouch -->
+  <circle cx="9" cy="22" r="3" fill="#d4a020"/>
+  <!-- head -->
+  <circle cx="16" cy="8" r="5" fill="#c8a070"/>
+  <!-- merchant hat -->
+  <rect x="11" y="3" width="10" height="4" rx="2" fill="#2a1a00"/>
+  <rect x="9"  y="5" width="14" height="2" rx="1" fill="#2a1a00"/>
+  <!-- eyes -->
+  <rect x="13" y="8" width="2" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="8" width="2" height="2" rx="1" fill="#1a0a00"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1108,6 +1108,8 @@ export function HubTownCanvas({
       isWalking: boolean
       isInside: boolean
       currentBuildingId: string | null
+      animFrame: number
+      animTimer: number
     }
     const namedNpcWalkStates = new Map<string, NamedNpcWalkState>()
     // Proximity bubbles for named NPCs driven by npcProximityDialogue ref
@@ -1116,6 +1118,7 @@ export function HubTownCanvas({
     const namedNpcActivity       = new Map<string, ReturnType<typeof getNpcActivity>>()
     const namedNpcBaseTex        = new Map<string, PIXI.Texture>()
     const namedNpcPoseTex        = new Map<string, PIXI.Texture>()  // keyed `${npcId}:${activity}`
+    const namedNpcAnimFrames     = new Map<string, PIXI.Texture[]>()  // 3-frame walk cycle, if authored
     // Interior quest indicators: rebuilt each time we enter a building
     const interiorQuestIndicators     = new Map<string, PIXI.Text>()
     const interiorIndicatorBaseY      = new Map<string, number>()
@@ -1135,6 +1138,8 @@ export function HubTownCanvas({
         isWalking: false,
         isInside: initLoc?.type === 'interior',
         currentBuildingId: initLoc?.type === 'interior' ? initLoc.buildingId : null,
+        animFrame: 0,
+        animTimer: 0,
       }
       namedNpcWalkStates.set(npc.id, walkState)
       if (npc.schedule) namedNpcActivity.set(npc.id, getNpcActivity(npc, gameHourRef.current))
@@ -1204,6 +1209,15 @@ export function HubTownCanvas({
               .then(poseTex => { namedNpcPoseTex.set(`${npc.id}:${activity}`, poseTex) })
               .catch(() => { /* no pose art — keep base sprite */ })
           }
+        }
+
+        // Load a 3-frame walk cycle (`{sprite}-1/2/3.svg`), if authored — cycled
+        // in the ticker below while the NPC is walking. Missing frames just
+        // mean no walk animation, same fallback discipline as pose art.
+        if (!isCommanderNpc) {
+          loadAnimFrames(npcSpriteSlug, 3)
+            .then(frames => { namedNpcAnimFrames.set(npc.id, frames) })
+            .catch(() => {})
         }
 
         if (isCommanderNpc) {
@@ -2754,12 +2768,24 @@ export function HubTownCanvas({
         }
 
         // Activity pose swap — use the activity pose sprite while the NPC is at its
-        // post (not walking/indoors), the base sprite otherwise.
+        // post (not walking/indoors), the base sprite otherwise. While walking,
+        // cycle the 3-frame walk animation instead, if one was authored.
         for (const [npcId, baseTex] of namedNpcBaseTex) {
           const ws = namedNpcWalkStates.get(npcId)
           const container = namedNpcContainers.get(npcId)
           const s = container?.children[0] as PIXI.Sprite | undefined
           if (!s) continue
+          const animFrames = namedNpcAnimFrames.get(npcId)
+          if (ws && ws.isWalking && animFrames && animFrames.length > 0) {
+            ws.animTimer -= ticker.deltaMS
+            if (ws.animTimer <= 0) {
+              ws.animTimer = 200
+              ws.animFrame = (ws.animFrame + 1) % animFrames.length
+              s.texture = animFrames[ws.animFrame]
+            }
+            continue
+          }
+          if (ws) { ws.animFrame = 0; ws.animTimer = 0 }
           const activity = (ws && !ws.isWalking && !ws.isInside) ? namedNpcActivity.get(npcId) ?? null : null
           const poseTex = activity ? namedNpcPoseTex.get(`${npcId}:${activity}`) : undefined
           const wantTex = poseTex ?? baseTex


### PR DESCRIPTION
## Summary

First of 2 sub-issues under #1971 (NPC sprite animation follow-up to the dialogue epic). Wires up the existing walk-cycle infrastructure for named schedule-driven NPCs, which were previously static `PIXI.Sprite`s the entire time they moved between scheduled locations.

- **Code** (`web/src/components/hub/HubTownCanvas.tsx`): loads a 3-frame `{sprite}-1/2/3.svg` walk cycle per NPC alongside the existing base/pose texture load (`loadAnimFrames`, already used by the player avatar and ambient wandering NPCs), falling back silently to no animation if the files don't exist — same discipline as activity pose art. The ticker cycles frames every 200ms while an NPC's walk state is `isWalking`, mutually exclusive by construction with the existing activity pose-swap logic (which only applies while not walking).
- **Content**: authors 9 walk-cycle SVGs (3 frames × 3 base sprites) for Millhaven's flagship cast — `hub-npc-merchant` (Baker Pernel, Innkeeper Cobb), `hub-npc-fisherman` (Fishmonger Marta), `hub-npc-elder` (Elder Bramwell) — following the `animal-cat-1/2/3.svg` convention already used elsewhere: legs/feet alternate ~1-2px per stride, whole silhouette raises 1px on the middle frame. The elder's robe hides separate legs, so its walk cue is an alternating arm swing instead.

## Verification

- `npm run build` passes.
- `npx vitest run src/game/hub/hubNpcSchedule.test.ts src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts src/data/hub/npcDialogueCoverage.test.ts` — 211/211 passing, no regressions.
- **End-to-end verified live** via Storybook's `HubTownCanvas` Millhaven story with a temporary fast-cycling `gameHour` test harness (not committed) plus a temporary debug log (removed before commit): confirmed Baker Pernel's `isWalking` state transitions to `true` during his scheduled walk, `namedNpcAnimFrames` successfully loads all 3 new textures, and the ticker correctly cycles frame `0→1→2→0→1→2→0` every 200ms with each texture assignment succeeding.
- Confirmed via network trace that all 9 new SVGs load with `200` status when Millhaven renders.

## Important finding for #1973

`fishmonger-marta` and `town-elder-millhaven` are both `building`-tagged NPCs (`HubNpc.building` set), which means they're rendered through the static `INTERIOR_NPCS` path rather than `EXTERIOR_NPCS` — so **they never appear on the exterior map and never walk**, even though this PR's engine change and art now support it. Only Baker Pernel (no `building` field) is a true exterior wanderer today, and he's the one verified walking end-to-end above. The walk-cycle art for `hub-npc-fisherman`/`hub-npc-elder` is still correct and reusable — it'll animate for any future exterior wanderer using those sprites — but doesn't currently render for Marta/Elder specifically. This is exactly the kind of interior-rendering gap #1973 (sleep pose + interior pose-swap fix) is scoped to address, so I've noted it there for that work.

Closes #1972


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_