### PR TITLE
Hub: sleep pose art + interior pose-swap fix (Millhaven proof-of-work)

### DIFF
--- a/web/public/sprites/hub-npc-elder-sleep.svg
+++ b/web/public/sprites/hub-npc-elder-sleep.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- robe -->
+  <rect x="10" y="14" width="12" height="14" rx="3" fill="#8b5e3c"/>
+  <!-- arms, folded and resting -->
+  <rect x="8"  y="18" width="3" height="6" rx="1" fill="#8b5e3c"/>
+  <rect x="21" y="18" width="3" height="6" rx="1" fill="#8b5e3c"/>
+  <!-- staff, set aside and leaning -->
+  <rect x="24" y="12" width="2" height="16" rx="1" fill="#6b4020" transform="rotate(8 25 20)"/>
+  <circle cx="24.5" cy="11.5" r="2" fill="#d4a847"/>
+  <!-- beard -->
+  <rect x="12" y="13" width="8" height="5" rx="2" fill="#c8c0b0"/>
+  <!-- head, drooped forward -->
+  <circle cx="16" cy="11" r="5" fill="#d4b090"/>
+  <!-- white hair -->
+  <rect x="11" y="6" width="10" height="4" rx="2" fill="#e8e0d8"/>
+  <!-- closed eyes -->
+  <path d="M13 11 q1.5 1 3 0" stroke="#2a1a0a" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <path d="M17 11 q1.5 1 3 0" stroke="#2a1a0a" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <!-- zzz -->
+  <text x="20" y="7" font-family="monospace" font-size="5" fill="#9a9aa6">z</text>
+  <text x="24" y="4" font-family="monospace" font-size="4" fill="#9a9aa6">z</text>
+</svg>

--- a/web/public/sprites/hub-npc-fisherman-eat.svg
+++ b/web/public/sprites/hub-npc-fisherman-eat.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Body -->
+  <rect x="11" y="14" width="10" height="11" rx="2" fill="#4a6a3a"/>
+  <!-- Head -->
+  <circle cx="16" cy="10" r="5" fill="#c8a07a"/>
+  <!-- Wide-brim fishing hat -->
+  <ellipse cx="16" cy="6" rx="8" ry="2.5" fill="#6a5a2a"/>
+  <rect x="13" y="4" width="6" height="4" rx="1.5" fill="#7a6a30"/>
+  <!-- Eyes -->
+  <circle cx="14" cy="10" r="1" fill="#3a2a1a"/>
+  <circle cx="18" cy="10" r="1" fill="#3a2a1a"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="14" rx="3.5" ry="2" fill="#c8c8b0"/>
+  <!-- Arm raising a spoon to the mouth -->
+  <rect x="20" y="12" width="3" height="6" rx="1.2" fill="#c8a07a"/>
+  <rect x="22" y="9" width="1.4" height="4" rx="0.6" fill="#9a9aa6"/>
+  <!-- Other arm resting on the bowl -->
+  <rect x="9" y="16" width="3" height="6" rx="1" fill="#c8a07a"/>
+  <!-- Bowl of stew on the table -->
+  <ellipse cx="12" cy="25" rx="4" ry="1.6" fill="#7a5a3a"/>
+  <ellipse cx="12" cy="24.2" rx="3.4" ry="1.2" fill="#c86a3a"/>
+  <!-- steam -->
+  <path d="M10 21 q1 -2 0 -4" stroke="#cccccc" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <path d="M13 21 q1 -2 0 -4" stroke="#cccccc" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <!-- Legs -->
+  <rect x="12" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <rect x="17" y="24" width="4" height="6" rx="1" fill="#3a4a2a"/>
+  <!-- Boots -->
+  <rect x="11" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+  <rect x="16" y="28" width="5" height="3" rx="1" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/hub-npc-fisherman-sleep.svg
+++ b/web/public/sprites/hub-npc-fisherman-sleep.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="30" rx="6" ry="1.6" fill="rgba(0,0,0,0.2)"/>
+  <!-- Body, slumped -->
+  <rect x="11" y="16" width="10" height="10" rx="2" fill="#4a6a3a"/>
+  <!-- Head, drooped forward -->
+  <circle cx="16" cy="13" r="5" fill="#c8a07a"/>
+  <!-- Wide-brim fishing hat, tipped down over the eyes -->
+  <ellipse cx="16" cy="10" rx="8" ry="2.5" fill="#6a5a2a"/>
+  <rect x="13" y="8" width="6" height="4" rx="1.5" fill="#7a6a30"/>
+  <!-- Closed eyes -->
+  <path d="M13 13 q1.5 1 3 0" stroke="#3a2a1a" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <path d="M17 13 q1.5 1 3 0" stroke="#3a2a1a" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <!-- Beard -->
+  <ellipse cx="16" cy="17" rx="3.5" ry="2" fill="#c8c8b0"/>
+  <!-- Arms folded, rod set aside -->
+  <rect x="9"  y="18" width="4" height="6" rx="1.5" fill="#c8a07a"/>
+  <rect x="19" y="18" width="4" height="6" rx="1.5" fill="#c8a07a"/>
+  <!-- Legs -->
+  <rect x="12" y="26" width="4" height="4" rx="1" fill="#3a4a2a"/>
+  <rect x="17" y="26" width="4" height="4" rx="1" fill="#3a4a2a"/>
+  <!-- Boots -->
+  <rect x="11" y="29" width="5" height="2" rx="1" fill="#2a1a0a"/>
+  <rect x="16" y="29" width="5" height="2" rx="1" fill="#2a1a0a"/>
+  <!-- zzz -->
+  <text x="22" y="9" font-family="monospace" font-size="5" fill="#9a9aa6">z</text>
+  <text x="26" y="6" font-family="monospace" font-size="4" fill="#9a9aa6">z</text>
+</svg>

--- a/web/public/sprites/hub-npc-merchant-sleep.svg
+++ b/web/public/sprites/hub-npc-merchant-sleep.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.2)"/>
+  <!-- boots -->
+  <rect x="11" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <rect x="17" y="26" width="4" height="2" rx="1" fill="#1a0a00"/>
+  <!-- legs -->
+  <rect x="12" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <rect x="17" y="21" width="3" height="6" rx="1" fill="#4a2a10"/>
+  <!-- tunic -->
+  <rect x="10" y="12" width="12" height="10" rx="2" fill="#aa2a2a"/>
+  <!-- gold trim -->
+  <rect x="10" y="12" width="12" height="2" rx="1" fill="#d4a020"/>
+  <rect x="10" y="20" width="12" height="2" rx="1" fill="#d4a020"/>
+  <!-- arms, relaxed at sides -->
+  <rect x="8"  y="16" width="3" height="5" rx="1" fill="#c8a070"/>
+  <rect x="21" y="16" width="3" height="5" rx="1" fill="#c8a070"/>
+  <!-- coin pouch -->
+  <circle cx="9" cy="22" r="3" fill="#d4a020"/>
+  <!-- head, tilted and drooped -->
+  <circle cx="15" cy="10" r="5" fill="#c8a070"/>
+  <!-- merchant hat, tilted with the head -->
+  <rect x="10" y="5" width="10" height="4" rx="2" fill="#2a1a00" transform="rotate(-8 15 7)"/>
+  <rect x="8"  y="7" width="14" height="2" rx="1" fill="#2a1a00" transform="rotate(-8 15 8)"/>
+  <!-- closed eyes -->
+  <path d="M12 10 q1.5 1 3 0" stroke="#1a0a00" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <path d="M16 10 q1.5 1 3 0" stroke="#1a0a00" stroke-width="0.9" fill="none" stroke-linecap="round"/>
+  <!-- zzz -->
+  <text x="21" y="6" font-family="monospace" font-size="5" fill="#9a9aa6">z</text>
+  <text x="25" y="3" font-family="monospace" font-size="4" fill="#9a9aa6">z</text>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2035,7 +2035,15 @@ export function HubTownCanvas({
       // Interior NPCs — rendered inside the room, tappable
       const interiorNpcList: HubNpc[] = (INTERIOR_NPCS[buildingId] ?? []).filter(n => isVisibleAtLevel(n, currentLevel))
       for (const npc of interiorNpcList) {
-        loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
+        // Activity pose swap, mirroring the exterior ticker logic — resolved once
+        // here since this block only reruns when the player re-enters the room.
+        const interiorSpriteSlug = resolveNpcSprite(npc.sprite)
+        const interiorBaseTexUrl = `${base}sprites/${interiorSpriteSlug}.svg`
+        const interiorActivity = npc.schedule ? getNpcActivity(npc, gameHourRef.current) : null
+        const interiorTexLoader = interiorActivity
+          ? loadTextureUrl(`${base}sprites/${interiorSpriteSlug}-${interiorActivity}.svg`).catch(() => loadTextureUrl(interiorBaseTexUrl))
+          : loadTextureUrl(interiorBaseTexUrl)
+        interiorTexLoader.then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
           const s = new PIXI.Sprite(tex)
           s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
@@ -2064,7 +2072,15 @@ export function HubTownCanvas({
       })
       for (const npc of scheduledVisitors) {
         const loc = getNpcLocation(npc, gameHourRef.current) as { type: 'interior'; buildingId: string; tx: number; ty: number }
-        loadTextureUrl(`${base}sprites/${resolveNpcSprite(npc.sprite)}.svg`).then(tex => {
+        // Activity pose swap, mirroring the exterior ticker logic — resolved once
+        // here since this block only reruns when the player re-enters the room.
+        const visitorSpriteSlug = resolveNpcSprite(npc.sprite)
+        const visitorBaseTexUrl = `${base}sprites/${visitorSpriteSlug}.svg`
+        const visitorActivity = getNpcActivity(npc, gameHourRef.current)
+        const visitorTexLoader = visitorActivity
+          ? loadTextureUrl(`${base}sprites/${visitorSpriteSlug}-${visitorActivity}.svg`).catch(() => loadTextureUrl(visitorBaseTexUrl))
+          : loadTextureUrl(visitorBaseTexUrl)
+        visitorTexLoader.then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
           const s = new PIXI.Sprite(tex)
           s.width = SPRITE_SIZE; s.height = SPRITE_SIZE


### PR DESCRIPTION
## Summary

Second and final sub-issue under #1971. Fixes a gap surfaced by #1972's investigation: **neither** interior-render code path in `HubTownCanvas.tsx` applied activity-based pose-swap, so sleep pose art would never actually render for the NPCs players most commonly see it on — those shown inside a building.

- **Fix** (`web/src/components/hub/HubTownCanvas.tsx`): both `interiorNpcList` (building-tagged NPCs like Fishmonger Marta and Elder Bramwell, statically rendered via `INTERIOR_NPCS`) and `scheduledVisitors` (schedule-driven `EXTERIOR_NPCS` like Baker Pernel, currently located inside a building) now resolve `getNpcActivity(npc, gameHourRef.current)` and try `{sprite}-{activity}.svg` before falling back to the base texture — mirroring the exterior ticker's pose-swap logic. Resolved once at sprite-creation time since these blocks only rerun when the player re-enters the room.
- **Content**: authors `sleep` pose art for the three proof-of-work sprites from #1972 (`hub-npc-merchant`, `hub-npc-fisherman`, `hub-npc-elder`) plus an `eat` pose for `hub-npc-fisherman`, demonstrating Fishmonger Marta's dinner-hour activity — directly answering the "other things they can do like eating" part of the original request.

## Verification

- `npm run build` passes.
- `npx vitest run src/game/hub/hubNpcSchedule.test.ts src/data/hub/loader.test.ts src/data/hub/playerHouseConsistency.test.ts src/data/hub/npcDialogueCoverage.test.ts` — 211/211 passing, no regressions.
- **End-to-end verified live** via Storybook's `HubTownCanvas` Millhaven story with a temporary debug harness (not committed) that forced specific game hours and jumped directly into buildings via `interiorEnterRef`:
  - All 4 new pose SVGs load with `200` status across the full test sequence (entering each NPC's building at their sleep/eat hour), with **zero 404s** for any of them.
  - Isolated, cache-disabled network captures gave clean, unambiguous fresh `200` responses for `hub-npc-fisherman-eat.svg` (Marta, hour 21) and `hub-npc-elder-sleep.svg` (Elder, hour 2) at the exact moment of building entry.
  - A control test (same building, work hour instead of sleep hour) confirmed the sleep pose is *not* requested outside the sleep window — the activity-conditional logic is genuinely gating on the computed activity, not just always loading every variant.
  - Traced why the merchant-sleep/fisherman-sleep requests didn't show as "fresh" in the isolated capture: both are already preloaded at mount by other schedule-driven `EXTERIOR_NPCS` sharing those base sprites (Baker Pernel himself for `merchant-sleep`; `dockhand-bram`, who also uses `hub-npc-fisherman`, for `fisherman-sleep`) — confirming the interior fix resolves to the same correctly-cached pose texture via the shared per-URL cache in `pixiHelpers.ts`, not a new/redundant request.

## Wrap-up

This completes #1971 (the NPC sprite animation follow-up to the dialogue epic). I'll post a summary comment and close #1971 once this merges, same pattern as #1956 at the end of the dialogue epic.

Closes #1973


---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oCC5AJCpQnY4P3hXZM7)_