### PR TITLE
Mobile resume blank screen: recover from silent WebGL context loss + persist resume telemetry

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { resolvedNodeOpts, loadHandicap, HANDICAP_KEY, buildQuickBattleOpts, loa
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
 import { getGlStats } from './utils/pixiTelemetry'
+import { journal, flushResumeJournal } from './utils/resumeJournal'
 import { useStartupData } from './hooks/useStartupData'
 import { useCloudSync } from './hooks/useCloudSync'
 import { useRegisterSW } from 'virtual:pwa-register/react'
@@ -299,6 +300,8 @@ export default function App() {
       }
     },
     onNeedRefresh() {
+      journal('sw-need-refresh')
+      rollbar?.info('[sw] update available — applying skipWaiting')
       updateServiceWorker(true)
     },
   })
@@ -308,7 +311,15 @@ export default function App() {
   useEffect(() => {
     if (!navigator.serviceWorker) return
     let reloading = false
-    const handler = () => { if (!reloading) { reloading = true; window.location.reload() } }
+    const handler = () => {
+      if (reloading) return
+      reloading = true
+      // Journaled (not just logged live) because this reload typically fires
+      // right at foreground resume, when a live Rollbar event has no time to
+      // send — the journal entry survives the reload and is flushed at boot.
+      journal('sw-controllerchange-reload', { visibility: document.visibilityState })
+      window.location.reload()
+    }
     navigator.serviceWorker.addEventListener('controllerchange', handler)
     return () => navigator.serviceWorker.removeEventListener('controllerchange', handler)
   }, [])
@@ -592,6 +603,7 @@ export default function App() {
       setIsTabHidden(hidden)
       if (hidden) {
         hiddenAtRef.current = Date.now()
+        journal('hidden', { screen: screenRef.current }, { coalesce: true })
         return
       }
       // Breadcrumb for any "blank screen after being away" report — logged on
@@ -607,6 +619,10 @@ export default function App() {
           location: currentLocationKeyRef.current,
           ...getGlStats(),
         })
+        journal('visible', { hiddenMs, screen: screenRef.current })
+        // Deliver anything journaled while backgrounded (context losses,
+        // deferred rebuilds) now that the network is reliable again.
+        flushResumeJournal('resume')
       }
     }
     document.addEventListener('visibilitychange', handleVisibility)

--- a/web/src/hooks/pixiContextLossController.test.ts
+++ b/web/src/hooks/pixiContextLossController.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createContextLossController, type ContextLossEvent } from './pixiContextLossController'
+
+describe('pixiContextLossController', () => {
+  let hidden = false
+  const teardown = vi.fn()
+  const rebuild = vi.fn()
+  const notify = vi.fn()
+  const events = () => notify.mock.calls.map(call => call[0] as ContextLossEvent)
+
+  const makeController = () => createContextLossController({
+    maxAttempts: 3,
+    isHidden: () => hidden,
+    teardown,
+    rebuild,
+    notify,
+  })
+
+  beforeEach(() => {
+    hidden = false
+    teardown.mockClear()
+    rebuild.mockClear()
+    notify.mockClear()
+  })
+
+  it('rebuilds immediately when the context is lost while visible', () => {
+    const c = makeController()
+    c.onContextLost()
+    expect(teardown).toHaveBeenCalledTimes(1)
+    expect(rebuild).toHaveBeenCalledTimes(1)
+    expect(c.attempts()).toBe(1)
+    expect(events()).toEqual(['contextlost', 'rebuild-started'])
+  })
+
+  it('defers the rebuild when the context is lost while hidden', () => {
+    hidden = true
+    const c = makeController()
+    c.onContextLost()
+    expect(teardown).toHaveBeenCalledTimes(1)  // GPU memory is still freed immediately
+    expect(rebuild).not.toHaveBeenCalled()
+    expect(c.hasPendingRebuild()).toBe(true)
+    expect(c.attempts()).toBe(0)
+    expect(events()).toEqual(['contextlost', 'rebuild-deferred'])
+  })
+
+  it('does not burn attempts on repeated losses while hidden', () => {
+    hidden = true
+    const c = makeController()
+    for (let i = 0; i < 10; i++) c.onContextLost()
+    expect(c.attempts()).toBe(0)
+    expect(rebuild).not.toHaveBeenCalled()
+  })
+
+  it('runs a deferred rebuild exactly once on becoming visible', () => {
+    hidden = true
+    const c = makeController()
+    c.onContextLost()
+    hidden = false
+    c.onVisible(() => true)
+    expect(rebuild).toHaveBeenCalledTimes(1)
+    expect(c.hasPendingRebuild()).toBe(false)
+    expect(c.attempts()).toBe(1)
+    c.onVisible(() => false)
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+
+  it('detects a silent context loss on resume and rebuilds', () => {
+    const c = makeController()
+    c.onVisible(() => true)
+    expect(events()).toEqual(['silent-context-loss', 'rebuild-started'])
+    expect(teardown).toHaveBeenCalledTimes(1)
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing on resume when the context is healthy', () => {
+    const c = makeController()
+    c.onVisible(() => false)
+    expect(notify).not.toHaveBeenCalled()
+    expect(teardown).not.toHaveBeenCalled()
+    expect(rebuild).not.toHaveBeenCalled()
+  })
+
+  it('re-arms the attempt budget after each successful rebuild', () => {
+    const c = makeController()
+    for (let i = 0; i < 5; i++) {
+      c.onContextLost()
+      c.onRebuildSucceeded()
+    }
+    expect(c.attempts()).toBe(0)
+    expect(events()).not.toContain('rebuild-given-up')
+    expect(rebuild).toHaveBeenCalledTimes(5)
+  })
+
+  it('gives up after exceeding the cap without an intervening success', () => {
+    const c = makeController()
+    c.onContextLost()
+    c.onContextLost()
+    c.onContextLost()
+    expect(rebuild).toHaveBeenCalledTimes(3)
+    c.onContextLost()
+    expect(rebuild).toHaveBeenCalledTimes(3)
+    expect(events().filter(e => e === 'rebuild-given-up')).toEqual(['rebuild-given-up'])
+    expect(teardown).toHaveBeenCalledTimes(4)
+  })
+
+  it('gives up on a silent-loss loop too', () => {
+    const c = makeController()
+    for (let i = 0; i < 4; i++) c.onVisible(() => true)
+    expect(rebuild).toHaveBeenCalledTimes(3)
+    expect(events()).toContain('rebuild-given-up')
+  })
+})

--- a/web/src/hooks/pixiContextLossController.ts
+++ b/web/src/hooks/pixiContextLossController.ts
@@ -1,0 +1,89 @@
+// ── WebGL context-loss recovery state machine ─────────────────────────────────
+// Extracted from usePixiApp so the defer/attempt logic is unit-testable without
+// Pixi or a DOM. Two mobile-specific rules drive the design:
+//
+// 1. Never rebuild while the page is hidden. Creating a WebGL context on a
+//    backgrounded page routinely fails or is immediately re-lost, which would
+//    burn the whole attempt budget before the player even returns. A loss while
+//    hidden tears down immediately (freeing GPU memory) but defers the rebuild
+//    to the next foreground resume.
+// 2. The attempt cap only guards against tight failure loops. Attempts reset
+//    after every successful rebuild, so occasional context losses over a long
+//    session never accumulate into a permanent give-up.
+//
+// onVisible also handles the loss iOS never announces: a backgrounded tab's
+// context can be reclaimed without webglcontextlost ever firing, so the caller
+// supplies an isContextLost() probe to detect it on resume.
+
+export type ContextLossEvent =
+  | 'contextlost'
+  | 'rebuild-deferred'
+  | 'rebuild-started'
+  | 'silent-context-loss'
+  | 'rebuild-given-up'
+
+export interface ContextLossControllerOpts {
+  maxAttempts: number
+  isHidden: () => boolean
+  teardown: () => void
+  rebuild: () => void
+  notify: (event: ContextLossEvent, data: { attempts: number; hidden: boolean }) => void
+}
+
+export function createContextLossController(opts: ContextLossControllerOpts) {
+  let attempts = 0
+  let pendingRebuild = false
+
+  const state = () => ({ attempts, hidden: opts.isHidden() })
+
+  // Counts an attempt and either rebuilds or gives up at the cap. The app is
+  // expected to be torn down already (or torn down here for the silent-loss path
+  // via tearDownFirst).
+  const tryRebuild = (tearDownFirst: boolean) => {
+    attempts++
+    if (attempts > opts.maxAttempts) {
+      opts.notify('rebuild-given-up', state())
+      if (tearDownFirst) opts.teardown()
+      return
+    }
+    opts.notify('rebuild-started', state())
+    if (tearDownFirst) opts.teardown()
+    opts.rebuild()
+  }
+
+  return {
+    /** Call from the canvas webglcontextlost handler (after preventDefault). */
+    onContextLost(): void {
+      opts.notify('contextlost', state())
+      if (opts.isHidden()) {
+        opts.teardown()
+        pendingRebuild = true
+        opts.notify('rebuild-deferred', state())
+        return
+      }
+      opts.teardown()
+      tryRebuild(false)
+    },
+
+    /** Call on every visibilitychange → visible. */
+    onVisible(isContextLost: () => boolean): void {
+      if (pendingRebuild) {
+        pendingRebuild = false
+        tryRebuild(false)
+        return
+      }
+      if (isContextLost()) {
+        opts.notify('silent-context-loss', state())
+        tryRebuild(true)
+      }
+    },
+
+    /** Call when a rebuild's init resolves successfully. */
+    onRebuildSucceeded(): void {
+      attempts = 0
+    },
+
+    hasPendingRebuild: () => pendingRebuild,
+    attempts: () => attempts,
+  }
+}

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 import * as PIXI from 'pixi.js'
 import rollbar from '../rollbar'
 import { noteContextCreated, noteContextDestroyed, getGlStats } from '../utils/pixiTelemetry'
+import { createContextLossController, type ContextLossEvent } from './pixiContextLossController'
+import { journal } from '../utils/resumeJournal'
 
 /**
  * Initialises a PixiJS v8 Application and mounts its canvas into the given container.
@@ -64,9 +66,10 @@ function releaseCanvasBackingStore(canvas: HTMLCanvasElement) {
 
 // A browser that backgrounds a tab long enough to reclaim its GPU context often
 // never fires webglcontextrestored on the old context — recovery instead relies
-// on requesting a brand-new context on a brand-new canvas. Cap rebuild attempts
-// so a hard GPU failure (context lost immediately on every new context too)
-// logs and gives up instead of spinning forever.
+// on requesting a brand-new context on a brand-new canvas. Cap consecutive
+// rebuild attempts (the counter re-arms after each success) so a hard GPU
+// failure (context lost immediately on every new context too) logs and gives
+// up instead of spinning forever.
 const MAX_CONTEXT_REBUILD_ATTEMPTS = 3
 
 export function usePixiApp(
@@ -84,7 +87,6 @@ export function usePixiApp(
     let destroyed = false
     let initialized = false
     let contextLostHandler: ((e: Event) => void) | null = null
-    let rebuildAttempts = 0
 
     const resizeEl = opts?.resizeTo?.current ?? undefined
     const initW = resizeEl?.clientWidth  || width
@@ -110,6 +112,53 @@ export function usePixiApp(
       noteContextDestroyed(contextInfo)
     }
 
+    // Tears down the current app (if any) and clears the hook's live-app state,
+    // so a rebuild always starts from a clean slate and the unmount cleanup
+    // never double-destroys.
+    const teardownCurrent = () => {
+      const app = appRef.current
+      if (app && initialized) teardown(app)
+      appRef.current = null
+      initialized = false
+    }
+
+    // Maps recovery state transitions to Rollbar + the persisted resume journal.
+    // Live Rollbar events fired while the tab is hidden are often never
+    // delivered on mobile — the journal entries are the reliable record and are
+    // flushed as one event at the next boot or foreground resume.
+    const notify = (event: ContextLossEvent, data: { attempts: number; hidden: boolean }) => {
+      const payload = { ...contextInfo, ...getGlStats(), rebuildAttempts: data.attempts, visibility: document.visibilityState }
+      switch (event) {
+        case 'contextlost':
+          journal('webglcontextlost', { hidden: data.hidden, attempts: data.attempts })
+          break
+        case 'rebuild-deferred':
+          rollbar?.warn('[usePixiApp] webglcontextlost while hidden — deferring rebuild to resume', payload)
+          journal('rebuild-deferred', { attempts: data.attempts })
+          break
+        case 'rebuild-started':
+          rollbar?.warn('[usePixiApp] webglcontextlost — rebuilding app', payload)
+          journal('rebuild-started', { attempts: data.attempts })
+          break
+        case 'silent-context-loss':
+          rollbar?.warn('[usePixiApp] context silently lost while backgrounded — rebuilding on resume', payload)
+          journal('silent-context-loss', { attempts: data.attempts })
+          break
+        case 'rebuild-given-up':
+          rollbar?.error('[usePixiApp] webglcontextlost — giving up after repeated rebuild failures', payload)
+          journal('rebuild-given-up', { attempts: data.attempts })
+          break
+      }
+    }
+
+    const controller = createContextLossController({
+      maxAttempts: MAX_CONTEXT_REBUILD_ATTEMPTS,
+      isHidden: () => document.hidden,
+      teardown: teardownCurrent,
+      rebuild: () => { if (!destroyed) buildApp(true) },
+      notify,
+    })
+
     // Creates and initialises a fresh Application, appending its canvas and
     // calling onReady once ready. Called on mount (isRebuild=false), and
     // again to rebuild the scene from scratch after an unrecoverable
@@ -134,14 +183,17 @@ export function usePixiApp(
         noteContextCreated(contextInfo)
         if (destroyed) {
           // Cleanup ran before init resolved — destroy properly to release the WebGL context.
-          rollbar?.warn('[usePixiApp] init resolved after unmount — destroying orphan app', { isRebuild, rebuildAttempts })
+          rollbar?.warn('[usePixiApp] init resolved after unmount — destroying orphan app', { isRebuild, rebuildAttempts: controller.attempts() })
           teardown(app)
           return
         }
         if (isRebuild) {
+          const rebuildMs = Date.now() - buildStartedAt
           rollbar?.info('[usePixiApp] webgl context recovered — rebuild succeeded', {
-            ...contextInfo, ...getGlStats(), rebuildAttempts, rebuildMs: Date.now() - buildStartedAt,
+            ...contextInfo, ...getGlStats(), rebuildAttempts: controller.attempts(), rebuildMs,
           })
+          journal('rebuild-succeeded', { rebuildMs })
+          controller.onRebuildSucceeded()
         }
         const canvas = app.canvas as HTMLCanvasElement
         // Intentional loss during our own teardown never reaches this listener:
@@ -149,19 +201,7 @@ export function usePixiApp(
         // stops immediate propagation before this handler would fire.
         contextLostHandler = (e: Event) => {
           e.preventDefault()  // signal we intend to recover, not abandon the canvas
-          rebuildAttempts++
-          if (rebuildAttempts > MAX_CONTEXT_REBUILD_ATTEMPTS) {
-            rollbar?.error('[usePixiApp] webglcontextlost — giving up after repeated rebuild failures', {
-              ...contextInfo, ...getGlStats(), rebuildAttempts, visibility: document.visibilityState,
-            })
-            teardown(app)
-            return
-          }
-          rollbar?.warn('[usePixiApp] webglcontextlost — rebuilding app', {
-            ...contextInfo, ...getGlStats(), rebuildAttempts, visibility: document.visibilityState,
-          })
-          teardown(app)
-          if (!destroyed) buildApp(true)
+          controller.onContextLost()
         }
         canvas.addEventListener('webglcontextlost', contextLostHandler)
         container.appendChild(canvas)
@@ -169,8 +209,9 @@ export function usePixiApp(
       }).catch(e => {
         console.error('[usePixiApp] app.init failed', e)
         rollbar?.error(isRebuild ? '[usePixiApp] rebuild after context loss failed' : '[usePixiApp] app.init failed', {
-          message: (e as Error)?.message, ...contextInfo, ...getGlStats(), isRebuild, rebuildAttempts,
+          message: (e as Error)?.message, ...contextInfo, ...getGlStats(), isRebuild, rebuildAttempts: controller.attempts(),
         })
+        if (isRebuild) journal('rebuild-failed', { message: (e as Error)?.message })
         // Release any partial WebGL context created before the failure to prevent
         // context accumulation that crashes the browser after repeated navigations.
         try {
@@ -184,7 +225,25 @@ export function usePixiApp(
 
     buildApp(false)
 
+    // iOS can reclaim a backgrounded tab's WebGL context without ever firing
+    // webglcontextlost on it. Probe the context on every return to foreground
+    // and rebuild if it died silently; this is also where a rebuild deferred
+    // during a hidden-tab context loss actually runs.
+    const isContextLost = (): boolean => {
+      const app = appRef.current
+      if (!initialized || !app || !app.renderer) return false
+      if (app.renderer.name !== 'webgl') return false  // WebGPU/canvas renderers need different handling; not used today
+      const gl = (app.renderer as PIXI.WebGLRenderer).gl
+      return !gl || gl.isContextLost()
+    }
+    const visibilityHandler = () => {
+      if (document.visibilityState !== 'visible' || destroyed) return
+      controller.onVisible(isContextLost)
+    }
+    document.addEventListener('visibilitychange', visibilityHandler)
+
     return () => {
+      document.removeEventListener('visibilitychange', visibilityHandler)
       destroyed = true
       if (initialized && appRef.current) {
         teardown(appRef.current)

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import rollbar from './rollbar'
 import { setErrorLogger } from './logger'
 import { initCrashSentinel } from './utils/crashSentinel'
+import { initResumeJournal } from './utils/resumeJournal'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import App from './App'
 
@@ -12,6 +13,11 @@ setErrorLogger((msg, ctx) => rollbar.error(msg, ctx as object))
 // killing the page under memory pressure) — before React renders, so crash
 // loops are reported even when rendering itself dies.
 initCrashSentinel()
+
+// Flush lifecycle breadcrumbs stranded by the previous session (background
+// page kill, service-worker reload) and start journaling this session's
+// resume behaviour — also before React renders, for the same reason.
+initResumeJournal()
 
 // Unlock any achievements whose progress target was already met before the
 // achievement was added (e.g. after a game update adds new achievements).

--- a/web/src/utils/resumeJournal.test.ts
+++ b/web/src/utils/resumeJournal.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// resumeJournal needs window/document/localStorage at module load (via
+// rollbar.ts) and call time — stub them before importing the module under test.
+const rollbarSpy = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), configure: vi.fn() }
+
+let store = new Map<string, string>()
+let storageThrows = false
+const localStorageStub = {
+  getItem: (k: string) => { if (storageThrows) throw new Error('quota'); return store.get(k) ?? null },
+  setItem: (k: string, v: string) => { if (storageThrows) throw new Error('quota'); store.set(k, v) },
+  removeItem: (k: string) => { if (storageThrows) throw new Error('quota'); store.delete(k) },
+}
+
+const windowListeners = new Map<string, (e: { persisted?: boolean }) => void>()
+const documentListeners = new Map<string, () => void>()
+vi.stubGlobal('window', {
+  Rollbar: rollbarSpy,
+  addEventListener: (type: string, fn: (e: { persisted?: boolean }) => void) => windowListeners.set(type, fn),
+})
+vi.stubGlobal('document', {
+  visibilityState: 'visible',
+  addEventListener: (type: string, fn: () => void) => documentListeners.set(type, fn),
+})
+vi.stubGlobal('localStorage', localStorageStub)
+vi.stubGlobal('performance', {
+  getEntriesByType: (type: string) => type === 'navigation' ? [{ type: 'reload' }] : [],
+})
+
+const { journal, flushResumeJournal, initResumeJournal, _resetResumeJournalForTest } = await import('./resumeJournal')
+
+const KEY = 'jarv_resume_journal'
+const readEntries = () => JSON.parse(store.get(KEY) ?? '[]')
+
+describe('resumeJournal', () => {
+  beforeEach(() => {
+    store = new Map()
+    storageThrows = false
+    windowListeners.clear()
+    documentListeners.clear()
+    rollbarSpy.info.mockClear()
+    _resetResumeJournalForTest()
+  })
+
+  it('appends entries with timestamp, event, data and unsent flag', () => {
+    journal('hidden', { screen: 'hubworld' })
+    expect(readEntries()).toEqual([
+      { ts: expect.any(Number), event: 'hidden', data: { screen: 'hubworld' }, sent: false },
+    ])
+  })
+
+  it('keeps only the most recent entries when the ring buffer overflows', () => {
+    for (let i = 0; i < 25; i++) journal('tick', { i })
+    const entries = readEntries()
+    expect(entries).toHaveLength(20)
+    expect(entries[0].data.i).toBe(5)
+    expect(entries[19].data.i).toBe(24)
+  })
+
+  it('coalesces consecutive unsent entries of the same event', () => {
+    journal('hidden', { screen: 'title' }, { coalesce: true })
+    journal('hidden', { screen: 'hubworld' }, { coalesce: true })
+    expect(readEntries()).toHaveLength(1)
+    expect(readEntries()[0].data.screen).toBe('hubworld')
+  })
+
+  it('does not coalesce across a different intervening event', () => {
+    journal('hidden', undefined, { coalesce: true })
+    journal('visible')
+    journal('hidden', undefined, { coalesce: true })
+    expect(readEntries().map((e: { event: string }) => e.event)).toEqual(['hidden', 'visible', 'hidden'])
+  })
+
+  it('does not coalesce into an already-sent entry', () => {
+    journal('hidden', undefined, { coalesce: true })
+    flushResumeJournal('resume')
+    journal('hidden', undefined, { coalesce: true })
+    expect(readEntries()).toHaveLength(2)
+  })
+
+  it('flushes all unsent entries as a single rollbar.info and marks them sent', () => {
+    journal('webglcontextlost', { hidden: true })
+    journal('rebuild-deferred')
+    flushResumeJournal('resume', { hiddenMs: 60_000 })
+    expect(rollbarSpy.info).toHaveBeenCalledTimes(1)
+    expect(rollbarSpy.info).toHaveBeenCalledWith('[resumeJournal] flush', expect.objectContaining({
+      trigger: 'resume',
+      count: 2,
+      hiddenMs: 60_000,
+      entries: [
+        expect.objectContaining({ event: 'webglcontextlost' }),
+        expect.objectContaining({ event: 'rebuild-deferred' }),
+      ],
+    }))
+    expect(readEntries().every((e: { sent: boolean }) => e.sent)).toBe(true)
+  })
+
+  it('sends nothing when there are no unsent entries', () => {
+    journal('hidden')
+    flushResumeJournal('resume')
+    rollbarSpy.info.mockClear()
+    flushResumeJournal('boot')
+    expect(rollbarSpy.info).not.toHaveBeenCalled()
+  })
+
+  it('only includes entries journaled since the previous flush', () => {
+    journal('hidden')
+    flushResumeJournal('resume')
+    journal('visible')
+    rollbarSpy.info.mockClear()
+    flushResumeJournal('resume')
+    expect(rollbarSpy.info).toHaveBeenCalledWith('[resumeJournal] flush', expect.objectContaining({
+      count: 1,
+      entries: [expect.objectContaining({ event: 'visible' })],
+    }))
+  })
+
+  it('boot flush reports the navigation type of the new page load', () => {
+    journal('sw-controllerchange-reload')
+    initResumeJournal()
+    expect(rollbarSpy.info).toHaveBeenCalledWith('[resumeJournal] flush', expect.objectContaining({
+      trigger: 'boot',
+      navigationType: 'reload',
+      entries: [expect.objectContaining({ event: 'sw-controllerchange-reload' })],
+    }))
+  })
+
+  it('journals bfcache pageshow restores but not normal loads', () => {
+    initResumeJournal()
+    windowListeners.get('pageshow')!({ persisted: false })
+    expect(readEntries()).toHaveLength(0)
+    windowListeners.get('pageshow')!({ persisted: true })
+    expect(readEntries()).toEqual([expect.objectContaining({ event: 'pageshow', data: { persisted: true } })])
+  })
+
+  it('journals Page Lifecycle freeze/resume events', () => {
+    initResumeJournal()
+    documentListeners.get('freeze')!()
+    documentListeners.get('resume')!()
+    expect(readEntries().map((e: { event: string }) => e.event)).toEqual(['freeze', 'resume'])
+  })
+
+  it('survives a throwing localStorage', () => {
+    storageThrows = true
+    expect(() => {
+      journal('hidden')
+      flushResumeJournal('resume')
+      initResumeJournal()
+    }).not.toThrow()
+    expect(rollbarSpy.info).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/utils/resumeJournal.ts
+++ b/web/src/utils/resumeJournal.ts
@@ -1,0 +1,99 @@
+import rollbar from '../rollbar'
+
+// ── Resume journal ─────────────────────────────────────────────────────────────
+// Rollbar events emitted while a mobile tab is backgrounded are frequently never
+// delivered: iOS suspends timers/network for hidden pages, and a jetsam kill
+// discards Rollbar's in-memory send queue. That makes the exact scenario we most
+// need to trace — "backgrounded for a while, came back to a blank screen" —
+// invisible in Rollbar. This journal persists lifecycle breadcrumbs (visibility
+// changes, WebGL context loss/rebuilds, service-worker reloads) to localStorage
+// as they happen, then flushes any unsent entries as a single Rollbar event at
+// the next boot or foreground resume, when the network is reliable again.
+
+const JOURNAL_KEY = 'jarv_resume_journal'
+const MAX_ENTRIES = 20
+
+export interface JournalEntry {
+  ts: number
+  event: string
+  data?: Record<string, unknown>
+  sent?: boolean
+}
+
+function readEntries(): JournalEntry[] {
+  try {
+    const raw = localStorage.getItem(JOURNAL_KEY)
+    const parsed = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed) ? parsed as JournalEntry[] : []
+  } catch {
+    return []
+  }
+}
+
+function writeEntries(entries: JournalEntry[]): void {
+  try {
+    localStorage.setItem(JOURNAL_KEY, JSON.stringify(entries))
+  } catch {
+    // localStorage unavailable/full — the journal is diagnostics-only, and this
+    // runs in hot lifecycle paths, so fail silently (no Rollbar call here).
+  }
+}
+
+/** Append a lifecycle breadcrumb to the persisted journal. Never sends to
+ *  Rollbar itself — entries are delivered later by flushResumeJournal().
+ *  With coalesce, a repeat of the same still-unsent event replaces the previous
+ *  entry instead of appending, so e.g. rapid tab-switching uses one slot. */
+export function journal(event: string, data?: Record<string, unknown>, opts?: { coalesce?: boolean }): void {
+  const entries = readEntries()
+  const entry: JournalEntry = { ts: Date.now(), event, ...(data && { data }), sent: false }
+  const last = entries[entries.length - 1]
+  if (opts?.coalesce && last && last.event === event && last.sent !== true) {
+    entries[entries.length - 1] = entry
+  } else {
+    entries.push(entry)
+  }
+  writeEntries(entries.slice(-MAX_ENTRIES))
+}
+
+/** Send all not-yet-sent journal entries to Rollbar as one event, then mark
+ *  them sent (they age out of the ring buffer naturally, so recent context
+ *  stays inspectable in localStorage). No unsent entries → no Rollbar event. */
+export function flushResumeJournal(trigger: 'boot' | 'resume', extra?: Record<string, unknown>): void {
+  const entries = readEntries()
+  const unsent = entries.filter(e => e.sent !== true)
+  if (unsent.length === 0) return
+  rollbar?.info('[resumeJournal] flush', { trigger, count: unsent.length, entries: unsent, ...extra })
+  writeEntries(entries.map(e => e.sent === true ? e : { ...e, sent: true }))
+}
+
+let _initialized = false
+
+/** Call once at boot, before React renders: flushes entries stranded by the
+ *  previous session (page kill / SW reload) and installs the page-lifecycle
+ *  listeners that visibilitychange alone doesn't cover. */
+export function initResumeJournal(): void {
+  if (_initialized) return
+  _initialized = true
+
+  // bfcache restore — the page resumes without reloading or firing boot code.
+  window.addEventListener('pageshow', (e: PageTransitionEvent) => {
+    if (e.persisted) journal('pageshow', { persisted: true })
+  })
+  // Page Lifecycle API (Chrome on Android): the browser is about to freeze the
+  // page / has just resumed it. No-ops on browsers without these events.
+  document.addEventListener('freeze', () => journal('freeze'))
+  document.addEventListener('resume', () => journal('resume'))
+
+  let navigationType: string | undefined
+  try {
+    navigationType = (performance.getEntriesByType?.('navigation')?.[0] as PerformanceNavigationTiming | undefined)?.type
+  } catch {
+    // performance API unavailable — navigationType stays undefined
+  }
+  flushResumeJournal('boot', { navigationType })
+}
+
+/** Test-only: reset module state between cases. */
+export function _resetResumeJournalForTest(): void {
+  _initialized = false
+}


### PR DESCRIPTION
## Summary

Third follow-up to the "blank screen after being away" investigation (#1941, #1954, #1961, #1966). The user report driving this: on mobile, backgrounding the game for a while and returning shows a blank black screen **with no Rollbar events at all**. Root-causing against the current code found three recovery gaps and one telemetry gap that together match that signature exactly:

1. **Silent context loss (the big one).** iOS Safari can reclaim a backgrounded tab's WebGL context *without ever firing `webglcontextlost`* — acknowledged in `usePixiApp.ts`'s own comments — yet the event was the only recovery trigger. `usePixiApp` now probes `gl.isContextLost()` on every `visibilitychange → visible` and tears down + rebuilds the Pixi app if the context died silently, logged distinctly as `[usePixiApp] context silently lost while backgrounded — rebuilding on resume`.
2. **Rebuilds while hidden burned the retry budget.** A `webglcontextlost` during background triggered an immediate rebuild on the hidden page, where context creation typically fails or is instantly re-lost — exhausting `MAX_CONTEXT_REBUILD_ATTEMPTS` before the player returned, then giving up permanently. Losses while hidden now tear down immediately (still freeing GPU memory) but defer the rebuild to the next foreground resume, without burning attempts. The attempt counter also re-arms after every successful rebuild, so the cap only guards tight failure loops. This logic is extracted into `pixiContextLossController.ts` so it's unit-testable.
3. **Telemetry died with the page.** Rollbar events emitted while hidden are frequently never delivered (iOS suspends network/timers; a jetsam kill drops Rollbar's in-memory queue) — which is why the blank screens produced *no* events. New `resumeJournal.ts` (modeled on `crashSentinel.ts`) persists lifecycle breadcrumbs to a localStorage ring buffer as they happen — hidden/visible transitions, context losses, deferred/started/succeeded/failed rebuilds, SW updates, bfcache `pageshow`, Page Lifecycle `freeze`/`resume` — and flushes unsent entries as **one** `rollbar.info('[resumeJournal] flush', …)` at the next boot or ≥15s foreground resume, including the boot's `navigationType`. Even when a session is killed mid-background, the next boot reports the full timeline.
4. **The SW reload at resume was invisible.** With multiple production deploys per day, returning after hours away almost always coincides with a service-worker update → `controllerchange` → `window.location.reload()` right at resume. That path is now journaled synchronously before the reload (plus a live `[sw] update available` log on `onNeedRefresh`), so Rollbar can distinguish "blank after SW reload" from "blank after context loss".

## Test plan

- [x] `npm run build` (tsc + vite) clean
- [x] `npm test` — 1295/1295 passing (226 files), including 12 new `resumeJournal` tests and 9 new `pixiContextLossController` tests
- [x] **Verified end-to-end in headless Chromium against the running game** (quick battle screen, Rollbar stubbed to capture calls, visibility emulated, `WEBGL_lose_context` to force losses):
  - visible loss → immediate rebuild, battlefield re-renders, `webglcontextlost`/`rebuild-started`/`rebuild-succeeded` journaled
  - loss while hidden → canvas torn down, `rebuild-deferred`, rebuild on resume, canvas healthy, resume flush delivered all 7 pending entries as one Rollbar event
  - **silent loss** (event suppressed with a capture-phase listener, mimicking iOS) → detected on resume, rebuilt, distinct Rollbar warn fired
  - reload with a stranded unsent entry → boot flush delivered it with `navigationType: 'reload'`
  - 5 consecutive losses with successful rebuilds → never hits the give-up cap

## What to watch in Rollbar after deploy

`[resumeJournal] flush` events now give a per-session timeline of every resume. For a reported blank screen, check the flush for that player: `silent-context-loss`/`rebuild-*` entries point at GPU eviction (and whether recovery worked), `sw-controllerchange-reload` points at the update-reload path, and an unclean-exit sentinel event with no rebuild entries points at a full page kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01287fJDAJ3fRV6Dkhj2qHj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01287fJDAJ3fRV6Dkhj2qHj5)_