### PR TITLE
Auto-dismiss hub dialogue after 5 avatar steps

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -78,6 +78,8 @@ interface Props {
   onAreaEnter:      (areaName: string | null) => void
   onNodeInteract:   (screen: string) => void
   onAvatarMove:     (px: number, py: number) => void
+  /** Fires once per tile the avatar walks onto (a discrete "step"). */
+  onAvatarStep?:    () => void
   returnRef?:       React.MutableRefObject<(() => void) | null>
   unitCards?:       string[]
   commander?:       CommanderState
@@ -125,7 +127,7 @@ interface Props {
 }
 
 export function HubTownCanvas({
-  onAreaEnter, onNodeInteract, onAvatarMove,
+  onAreaEnter, onNodeInteract, onAvatarMove, onAvatarStep,
   returnRef, unitCards, commander, onNpcTap, onAnimalTap, onAnimalSeen, onAmbientAnimalTap,
   interiorEnterRef, interiorExitRef, petActionRef, onEnterInterior, onExitInterior, onTileTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
@@ -161,6 +163,8 @@ export function HubTownCanvas({
   onNodeInteractRef.current = onNodeInteract
   const onAvatarMoveRef   = useRef(onAvatarMove)
   onAvatarMoveRef.current = onAvatarMove
+  const onAvatarStepRef   = useRef(onAvatarStep)
+  onAvatarStepRef.current = onAvatarStep
   const onNpcTapRef       = useRef(onNpcTap)
   onNpcTapRef.current     = onNpcTap
   const onAnimalTapRef    = useRef(onAnimalTap)
@@ -2384,6 +2388,7 @@ export function HubTownCanvas({
         currentTile = [tx, ty]
         _savedTiles.set(locationKey, [tx, ty])
         emitSound('hubFootstep')  // throttled internally
+        onAvatarStepRef.current?.()
 
         // Touch-pickup: collect requireTouch items when avatar walks onto their tile
         for (const [pid, sprite] of pickupSprites) {

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -571,6 +571,26 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     return () => clearTimeout(id)
   }, [dialogueEvent, dialogueLine])
 
+  // Auto-dismiss dialogue after the avatar takes 5 steps — skip if it has choices
+  // (quest offers need manual input). Counter resets whenever the dialogue changes.
+  const dialogueStepsRef = useRef(0)
+  useEffect(() => {
+    dialogueStepsRef.current = 0
+  }, [dialogueEvent, dialogueLine])
+
+  const handleAvatarStep = useCallback(() => {
+    const hasContent = !!(dialogueEvent?.text ?? dialogueLine)
+    const hasChoices  = !!(dialogueEvent?.choices?.length)
+    if (!hasContent || hasChoices) return
+    dialogueStepsRef.current += 1
+    if (dialogueStepsRef.current >= 5) {
+      const after = dialogueEvent?.onClose
+      setDialogueEvent(null)
+      setDialogueLine(null)
+      after?.()
+    }
+  }, [dialogueEvent, dialogueLine])
+
   // Live player world-pixel position, read imperatively by the minimap's rAF loop.
   const playerPixelRef = useRef({
     x: locationData.AVATAR_START.tx * T + T / 2,
@@ -2026,6 +2046,7 @@ function hasOfferableQuest(giverId: string): boolean {
             onAreaEnter={handleAreaEnter}
             onNodeInteract={handleNodeInteract}
             onAvatarMove={handleAvatarMove}
+            onAvatarStep={handleAvatarStep}
             returnRef={returnRef}
             unitCards={unitCards}
             commander={commander}


### PR DESCRIPTION
## Summary
- Hub NPC/quest/info dialogue (`HubDialogue`, driven by `dialogueEvent`/`dialogueLine` in `HubWorld.tsx`) now also auto-dismisses once the avatar takes 5 steps while it's open, in addition to the existing 15s timer.
- `HubTownCanvas` gains a new `onAvatarStep` callback prop, fired once per tile the avatar walks onto (inside `processWalkQueue`), which `HubWorld` uses to count steps and dismiss.
- Dismissal is skipped when the dialogue has choices (quest offers requiring manual input), matching the existing timer behavior. The step counter resets whenever the dialogue content changes.

## Test plan
- [x] `tsc --noEmit` passes with no new errors
- [ ] Manually verify in-browser: open an NPC/quest dialogue, walk 5 tiles, confirm it auto-closes; confirm choice-based dialogues (quest offers) are unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pq8bjZvkyCaLM6yNAuMcWu)_