### PR TITLE
Fix interactable aura: gate on reaction type, make it visible

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -54,10 +54,16 @@ const NIGHT_NPC_LIGHT_R  = 2 * T   // small glow radius around each NPC
 const INTERACTABLE_AURA_ENABLED      = true
 const INTERACTABLE_AURA_COLOR        = 0x7ec8ff  // faint sky-blue
 const INTERACTABLE_AURA_RADIUS_PAD   = 6         // px the aura extends past the object's footprint
-const INTERACTABLE_AURA_LAYER_ALPHA  = 0.10      // alpha of each stacked ring (rings compound for a soft falloff)
-const INTERACTABLE_AURA_PULSE_MIN    = 0.6       // aura alpha multiplier at the dimmest point of the pulse
+const INTERACTABLE_AURA_FILL_ALPHA   = 0.12      // soft inner glow fill
+const INTERACTABLE_AURA_RING_ALPHA   = 0.55      // crisp outline ring — the main visibility driver
+const INTERACTABLE_AURA_RING_WIDTH   = 1.5       // px
+const INTERACTABLE_AURA_PULSE_MIN    = 0.7       // aura alpha multiplier at the dimmest point of the pulse
 const INTERACTABLE_AURA_PULSE_MAX    = 1.0       // ...and the brightest
-const INTERACTABLE_AURA_PULSE_PERIOD = 2200      // ms per full pulse cycle
+const INTERACTABLE_AURA_PULSE_PERIOD = 1800      // ms per full pulse cycle
+// Reaction types that mean "the player is meant to find and use this" — gates the aura.
+// Deliberately excludes dialogue/giveItem-only secrets and dig/forage spots, which are
+// authored to stay non-obvious (docs/hubworld.md §7), regardless of whether they own decor.
+const AURA_REACTION_TYPES = new Set(['buy', 'buyPack', 'buyHubItem', 'screen', 'quest', 'move'])
 
 const _savedTiles = new Map<string, [number, number]>()
 export function getSavedHubTile(locationKey?: string): [number, number] | null {
@@ -601,14 +607,19 @@ export function HubTownCanvas({
       return { x: tx * T + (def.hitRect.w * T) / 2 + ind.dx * T, y: ty * T - 6 + ind.dy * T }
     }
 
+    function interactableWantsAura(def: HubInteractable): boolean {
+      return def.reactions.some(r => AURA_REACTION_TYPES.has(r.type))
+    }
+
     function buildInteractableAura(footprintW: number, footprintH: number): PIXI.Graphics {
       const cx = (footprintW * T) / 2
       const cy = (footprintH * T) / 2
       const baseR = (Math.max(footprintW, footprintH) * T) / 2 + INTERACTABLE_AURA_RADIUS_PAD
       const aura = new PIXI.Graphics()
-      // Two stacked circles fake a soft radial falloff (Graphics.fill has no gradient support).
-      aura.circle(cx, cy, baseR).fill({ color: INTERACTABLE_AURA_COLOR, alpha: INTERACTABLE_AURA_LAYER_ALPHA })
-      aura.circle(cx, cy, baseR * 0.6).fill({ color: INTERACTABLE_AURA_COLOR, alpha: INTERACTABLE_AURA_LAYER_ALPHA })
+      // Soft fill for a touch of glow, plus a crisp stroked ring — the ring is what actually
+      // reads as "tap this" at a glance regardless of the background art underneath it.
+      aura.circle(cx, cy, baseR).fill({ color: INTERACTABLE_AURA_COLOR, alpha: INTERACTABLE_AURA_FILL_ALPHA })
+      aura.circle(cx, cy, baseR).stroke({ color: INTERACTABLE_AURA_COLOR, alpha: INTERACTABLE_AURA_RING_ALPHA, width: INTERACTABLE_AURA_RING_WIDTH })
       aura.eventMode = 'none'   // purely decorative — never steals taps from the real hit area
       return aura
     }
@@ -635,12 +646,12 @@ export function HubTownCanvas({
 
       let above: PIXI.Container | null = null
       let aura: PIXI.Graphics | null = null
+      if (INTERACTABLE_AURA_ENABLED && interactableWantsAura(def)) {
+        aura = buildInteractableAura(def.hitRect.w, def.hitRect.h)
+        root.addChild(aura)
+      }
       const decor = (def.decor ?? []).filter(d => d.tileId !== 666)
       if (decor.length > 0) {
-        if (INTERACTABLE_AURA_ENABLED) {
-          aura = buildInteractableAura(def.hitRect.w, def.hitRect.h)
-          root.addChild(aura)
-        }
         if (decor.some(d => d.zlayer === 'above')) {
           above = new PIXI.Container()
           above.position.set(pos.tx * T, pos.ty * T)


### PR DESCRIPTION
## Summary

Follow-up to #1980 — the aura wasn't showing up anywhere, confirmed on both the Ravenwatch market-hall chicken-feed stall (interior) and an exterior object that owns its own decor. Two separate bugs:

- **Coverage gap (confirmed):** the aura was gated on `def.decor.length > 0`, which is only a proxy for "should this glow." The Ravenwatch and Millhaven chicken-feed stalls are pure hit-areas over pre-existing building art (no owned `decor` field at all — see `web/src/data/hub/ravenwatch/config.json:10470-10482`), so they got zero aura unconditionally. Fixed by gating on reaction type instead: `buy`/`buyPack`/`buyHubItem`/`screen`/`quest`/`move` mean "the player is meant to find and use this," which still excludes dialogue+giveItem secrets and dig/forage spots (intentionally non-obvious per `docs/hubworld.md` §7) without relying on decor ownership as a stand-in.
- **Perceptibility (likely):** even where the aura did build, it was two stacked flat-fill circles at ~0.10 alpha each — a soft, gradient-less blur with no defined edge, plausibly too subtle to notice against normal tile art. Swapped for a soft fill plus a crisp stroked ring (the ring is the actual visibility driver), and bumped the pulse range/speed slightly.

All values are still named constants (`INTERACTABLE_AURA_*`) at the top of `web/src/components/hub/HubTownCanvas.tsx` for further iteration.

Note: in-game visual verification wasn't performed this session. If a previously-loaded deployed build was showing nothing, it's also worth a hard refresh / cache clear (this app precaches assets via a service worker) in case that was contributing.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run test -- --run` — 672/672 tests pass
- [x] `npm run build` — production build succeeds
- [ ] In-game check: confirm the ring is now visible around the Ravenwatch market-hall feed stall and an exterior stall, and tune `INTERACTABLE_AURA_*` constants further if needed


---
_Generated by [Claude Code](https://claude.ai/code/session_01GVpD6qEzJmiNJyLqH2gjL3)_