### PR TITLE
Fix aura regression: exterior interactables became untappable

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -638,12 +638,27 @@ export function HubTownCanvas({
     ): void {
       const pos = interactableMovesRef?.current.get(def.id) ?? { tx: def.tx, ty: def.ty }
       const decor = (def.decor ?? []).filter(d => d.tileId !== 666)
+
+      // Aura is a standalone sibling of root (not its child) added to target *before* root,
+      // so it paints behind root/static decor via plain insertion order — needed because
+      // interiorLayer (unlike spriteLayer) isn't sortableChildren, so zIndex alone wouldn't
+      // order it there. eventMode 'none' (set in buildInteractableAura) keeps it out of
+      // hit-testing entirely, so it can never itself intercept a tap.
+      let aura: PIXI.Graphics | null = null
+      if (INTERACTABLE_AURA_ENABLED && interactableWantsAura(def)) {
+        const auraColor = def.building ? INTERACTABLE_AURA_COLOR_INTERIOR : INTERACTABLE_AURA_COLOR_EXTERIOR
+        aura = buildInteractableAura(def.hitRect.w, def.hitRect.h, auraColor)
+        aura.position.set(pos.tx * T, pos.ty * T)
+        aura.zIndex = interactableZIndex(def, pos.ty) - 2   // behind root and same-row static decor when zIndex-sorted
+        target.addChild(aura)
+      }
+
       const root = new PIXI.Container()
       root.position.set(pos.tx * T, pos.ty * T)
-      // Pure hit-area interactables (no owned decor) overlay pre-existing static art — sit one
-      // tick below the usual tie-breaking zIndex so the aura renders behind that art, not in
-      // front of it (the +1.5 in interactableZIndex is meant to protect *owned* decor sprites).
-      root.zIndex = decor.length > 0 ? interactableZIndex(def, pos.ty) : interactableZIndex(def, pos.ty) - 1
+      // Tap hit-testing depends on this zIndex on layers that are sortableChildren (spriteLayer
+      // is; interiorLayer isn't) — always use the tie-winning value, never lower it for aura-only
+      // objects, or overlapping objects can start winning taps instead.
+      root.zIndex = interactableZIndex(def, pos.ty)
       root.eventMode = 'static'
       root.cursor    = 'pointer'
       root.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
@@ -653,12 +668,6 @@ export function HubTownCanvas({
       target.addChild(root)
 
       let above: PIXI.Container | null = null
-      let aura: PIXI.Graphics | null = null
-      if (INTERACTABLE_AURA_ENABLED && interactableWantsAura(def)) {
-        const auraColor = def.building ? INTERACTABLE_AURA_COLOR_INTERIOR : INTERACTABLE_AURA_COLOR_EXTERIOR
-        aura = buildInteractableAura(def.hitRect.w, def.hitRect.h, auraColor)
-        root.addChild(aura)
-      }
       if (decor.length > 0) {
         if (decor.some(d => d.zlayer === 'above')) {
           above = new PIXI.Container()


### PR DESCRIPTION
## Summary

Regression from #1983: exterior interactables like flowers (forage spots) could no longer be tapped, while the notice board (which owns decor) still worked.

**Root cause:** #1983 lowered `root.zIndex` by 1 for aura-only interactables (no owned `decor` — forage flowers, hit-area `buyHubItem` stalls) so the aura would render behind their static art. But `spriteLayer.sortableChildren = true`, and Pixi's pointer hit-testing depends on that same zIndex to resolve which overlapping interactive object wins a tap. Lowering it broke tapping for exactly the objects it was applied to, while owned-decor objects (whose zIndex was untouched) kept working — matching the reported symptom precisely.

**Fix:**
- `root.zIndex` is reverted to unconditionally use the tie-winning value (`interactableZIndex(def, pos.ty)`) for every interactable — this is what hit-testing depends on and needed to go back to the known-working value.
- The aura is now built as a **standalone sibling of `root`** (not its child), added to `target` *before* `root` so it paints behind via plain insertion order. This also fixes a latent issue for interiors: `interiorLayer` (unlike `spriteLayer`) isn't `sortableChildren`, so the zIndex-only approach from #1983 wouldn't have ordered the aura correctly there either — insertion order is a more robust fix that works regardless of whether the layer sorts by zIndex. The aura keeps `eventMode: 'none'`, so it can never itself intercept a tap no matter its own zIndex.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run test -- --run` — 672/672 tests pass
- [x] `npm run build` — production build succeeds
- [ ] In-game check: confirm exterior interactables (flowers, stalls) are tappable again, and that the aura still renders behind decor in both exterior and interior contexts — this was a hit-testing regression, so tap behavior specifically should be re-verified carefully


---
_Generated by [Claude Code](https://claude.ai/code/session_01GVpD6qEzJmiNJyLqH2gjL3)_