### PR TITLE
fix(hub): prevent user drag from panning the HubTown camera

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -225,7 +225,10 @@ export function HubTownCanvas({
   const lastScheduleHourRef   = useRef(gameHour ?? 12)
 
   usePixiApp(containerRef, MAP_W, MAP_H, (app) => {
-    app.canvas.style.touchAction = 'pan-x pan-y'
+    // The camera follows the avatar; user drags must never pan the viewport,
+    // so suppress all browser touch gestures on the canvas. Taps still fire
+    // as pointer events.
+    app.canvas.style.touchAction = 'none'
 
     // ── Camera ─────────────────────────────────────────────────────────────────
     // All world content lives in worldRoot so the canvas can stay viewport-sized

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -2053,9 +2053,12 @@ function hasOfferableQuest(giverId: string): boolean {
         className="nm-map nm-map--camp"
         style={{ position: 'relative', flex: 1, overflow: 'hidden' }}
       >
+        {/* overflow: hidden keeps this a scroll container the follow-camera can
+            drive via scrollLeft/scrollTop while blocking user drag/wheel/scrollbar
+            scrolling, which would shift the camera off the avatar. */}
         <div
           ref={scrollRef}
-          style={{ overflowX: 'auto', overflowY: 'auto', width: '100%', height: '100%' }}
+          style={{ overflowX: 'hidden', overflowY: 'hidden', width: '100%', height: '100%' }}
         >
           <HubTownCanvas
             onAreaEnter={handleAreaEnter}


### PR DESCRIPTION
## Problem

Dragging the screen in HubTownCanvas shifted the camera/viewport off the avatar and glitched the view.

The hub camera follows the avatar by programmatically setting `scrollLeft`/`scrollTop` on the viewport container, but that container was user-scrollable (`overflow: auto`) and the Pixi canvas allowed browser touch panning (`touch-action: pan-x pan-y`). A user drag therefore scrolled the container directly, fighting the follow-camera and the sticky canvas layout.

## Fix

Lock the viewport to programmatic scrolling only:

- **HubWorld.tsx** — the viewport container now uses `overflow: hidden` on both axes. It remains a scroll container, so script-driven `scrollLeft`/`scrollTop` (the follow-camera, the initial centering, and the minimap's viewport read) all keep working, but drag/wheel/scrollbar scrolling by the user is blocked.
- **HubTownCanvas.tsx** — the canvas's `touch-action` changes from `pan-x pan-y` to `none`, so touch drags no longer trigger browser pan gestures. Taps still fire as pointer events, so tap-to-move and tapping NPCs/pickups/buildings are unaffected.

The terrain editor and node map canvases keep their `pan-x pan-y` behavior — panning is intentional there.

## Verification

- `tsc --noEmit` passes.
- No existing tests cover these components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhVmvEw8SmNBxpVWqemfsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhVmvEw8SmNBxpVWqemfsr)_