### PR TITLE
feat(campaign2): The Forgotten Kingdom foundation + Act 1 (The Pale Marches)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,7 +361,7 @@ All hub world JSON schemas (blocked paths, pickup items, NPCs, tile IDs, sprite 
 
 ## Acts — Design Rules
 
-All rules for acts, the campaign map, node types, relics, heroes, lives system, music, boss traits, and card authoring are in **[`docs/acts.md`](docs/acts.md)**. Read it before:
+All rules for acts, the campaign map, node types, relics, heroes, lives system, music, boss traits, and card authoring are in **[`docs/acts.md`](docs/acts.md)**. The second campaign's story bible (premise, per-act bosses/relics/heroes for `c2act*`) is **[`docs/campaign2.md`](docs/campaign2.md)** — read it before authoring any campaign 2 act. Read `docs/acts.md` before:
 - Creating or modifying act JSON files (`web/src/data/acts/*.json`)
 - Adding new node types, relics, hero cards, or boss mechanics
 - Authoring campaign story text or replay variants

--- a/docs/acts.md
+++ b/docs/acts.md
@@ -195,9 +195,9 @@ Every node should support a **peek** interaction before the player commits:
 
 ### 4.1 Campaign Structure
 
-The full campaign consists of **25 acts** that tell a complete story arc. After act 25 the story ends and a **second 25-act arc** begins, set in the same game world, dealing with the aftermath and introducing a new plot. Each 25-act block is self-contained.
+The first campaign consists of **13 acts plus a finale** (act1–act13 → actfinale) telling a complete story arc — Jarv's journey through the Shattered Dominion to the Fractured Core. It is fully implemented.
 
-Current implementation has **4 acts** (Act 1–4). Acts 5–25 are yet to be written.
+After the finale a **second 13-act arc** begins, set in the same game world, dealing with the aftermath and introducing a new plot (acts `c2act1`…`c2act13` → `c2finale`). Its story bible is **`docs/campaign2.md`** — always read it before authoring campaign 2 content.
 
 ### 4.2 Story Continuity Rules
 

--- a/docs/campaign2.md
+++ b/docs/campaign2.md
@@ -1,0 +1,123 @@
+# Campaign 2 — The Forgotten Kingdom
+
+> Authoritative story + content outline for the second 13-act campaign arc
+> (issue #181, milestone "Campaign: The Forgotten Kingdom"). Read this before
+> authoring any `c2act*.json` file. Mechanics rules are unchanged — follow
+> `docs/acts.md` and the "Creating a New Act" workflow in `AGENTS.md` for
+> everything structural; this doc defines the *story*, per-act themes, bosses,
+> relics, and hero cards so acts written in separate sessions stay consistent.
+
+---
+
+## 1. Premise
+
+Campaign 1 ended with Jarv sealing the Fracture: the shards fused back into a
+single Dominion, and the world calls Jarv **Worldmender**.
+
+But the Fracture did not only break the world — it *erased* part of it. When
+the Grand Dominion shattered, one entire kingdom — **Amarath** — was cast
+outside existence. Every map, record, and memory of it was wiped in the same
+instant. Nobody mourned Amarath, because nobody remembered it had ever been.
+
+When Jarv mended the world, everything the Fracture had scattered came back.
+*Everything.* East of Ironhold Keep, where every map shows an empty quarter,
+there is now a kingdom: pale towns, candle-lit roads, fields under a mist that
+never lifts. Its people — the **Unremembered** — endured centuries in the void,
+held together by their monarch's vigil-rite. They remember everything about
+the old world. The world remembers nothing about them.
+
+Amarath has not returned grateful. Its ruling **Pale Court** wants restitution:
+not reintegration, but *replacement* — unwriting the Dominion's history so that
+Amarath's can be written back in its place. The kingdom's vanguard is already
+crossing the Marches.
+
+**Tone:** aftermath, memory, and grief — the celebration of campaign 1 curdling
+into a colder war. The Unremembered are not monsters; they are the people the
+world forgot, led by rulers who refuse to be forgotten twice. Boss dialogue
+should carry that wound.
+
+**How it starts:** Cartographer Elsben in Ironhold Keep notices his new surveys
+disagree with every archived map — there is a kingdom in the blank quarter.
+Once campaign 1 is complete, talking to Elsben launches Campaign 2.
+
+## 2. The antagonist — the Pale Court
+
+- **The Vigil King** (finale boss) — the monarch whose vigil-rite kept Amarath
+  alive in the void. Centuries of holding a kingdom together by will alone have
+  hollowed him into something between a king and a rite. He does not hate the
+  Dominion; he simply cannot allow it to keep the centuries Amarath lost.
+- The act bosses are his court and its instruments — heralds, wardens,
+  regents — each embodying one thing the kingdom preserved (or lost) in the void.
+- Recurring motifs: candles and vigils, blank maps, names (kept, eaten,
+  returned), mist, and things that waited too long.
+
+## 3. Structure & registry
+
+- Acts: `c2act1` … `c2act13`, then `c2finale` — mirrors campaign 1
+  (act1…act13 → actfinale). Chained via `nextActId`; the last authored act has
+  **no** `nextActId` until its successor lands (the app shows a
+  "TO BE CONTINUED" screen at the chain's current end).
+- Campaign metadata lives in `CAMPAIGNS` in `web/src/game/questline.ts`
+  (campaign 2 = id `c2`, start `c2act1`, finale `c2finale`).
+- Campaign 2 is unlocked by completing campaign 1 (`loadActCount('actfinale') > 0`)
+  and launched only from Elsben's dialogue in Ironhold Keep.
+- Collection, crystals, relics, mastery, archetypes all persist — no resets.
+- Each act still follows the standard 13-node map, 25 themed cards, boss +
+  trait, relic, hero card, and achievement set (see `docs/acts.md` §12).
+
+## 4. Act-by-act outline
+
+| # | Act id | Title / Region | Boss (bossAI id) | Boss trait sketch | Relic | Hero card |
+|---|--------|----------------|------------------|-------------------|-------|-----------|
+| 1 | `c2act1` | **The Pale Marches** — the mist border where the maps go blank; first contact with Amarath's vanguard | **The Pale Herald** (`paleherald`) | *Proclamation Descent* — fly: ascends untouchable, descends on the player's densest cluster | **Vigil Candle** 🕯️ | Warden of the Marches |
+| 2 | `c2act2` | **The Grey Causeway** — the mile-long toll-road into Amarath, lined with unlit lamps | The Toll Warden (`tollwarden`) | column_aoe — slams the causeway, one column pays the toll | Toll Warden's Scale | Causeway Guide |
+| 3 | `c2act3` | **The Unremembered Fields** — farmland growing memory-wheat; eating it returns lost memories | The Gleaner Queen (`gleanerqueen`) | split — scatters into harvest effigies that must all fall | Sheaf of Names | First Reaper |
+| 4 | `c2act4` | **The Archive of Names** — where every erased name is shelved, guarded, and fed | The Name-Eater (`nameeater`) | burrow — slips between shelves, resurfaces beside your strongest unit | Index of the Lost | The Archivist Returned |
+| 5 | `c2act5` | **The Candle City** — Amarath's second city, lit by ten thousand vigil flames | The Lamplighter General (`lamplighter`) | periodic jump_aoe — snuffs a region with a wax-fall | Lamplighter's Wick | Candle Sergeant |
+| 6 | `c2act6` | **The Sunken Border** — the coast came back misaligned; drowned towers stand in new tide | The Drowned Envoy (`drownedenvoy`) | fly (wave dive) — rides a returning tide onto your lines | Envoy's Pearl | Tide Warden |
+| 7 | `c2act7` | **The Mirror Marsh** — still water reflecting the world as it was before the Fracture | The Reflection (`thereflection`) | split — steps out of the water as three of itself | Backwards Glass | Marsh Pathfinder |
+| 8 | `c2act8` | **The Hollow Court** — Amarath's nobility, masked because they forgot their own faces | The Chamberlain (`chamberlain`) | column_aoe — a courtly gesture erases one column of the field | Hollow Mask | Masked Duelist |
+| 9 | `c2act9` | **The Winter That Waited** — the season Amarath stored in the void, released as a weapon | The Frost Regent (`frostregent`) | periodic column_aoe — waited winter rolls down a column | Waited Snowflake | Winter Warden |
+| 10 | `c2act10` | **The Bone Orchards** — groves grown from the kingdom's dead, tended and beloved | The Orchard Keeper (`orchardkeeper`) | split — the orchard rises: saplings that must all be felled | Orchard Blossom | Grove Sentinel |
+| 11 | `c2act11` | **The Vigil Roads** — processional highways walked for centuries to keep the rite alive | The Procession Master (`processionmaster`) | periodic jump_aoe — the procession marches through your lines | Procession Bell | Road Captain |
+| 12 | `c2act12` | **The Crown Reaches** — the fortified approach to the capital; the Court's last field army | The Pale Marshal (`palemarshal`) | jump_aoe — commander's drop onto your densest cluster | Marshal's Baton | Reach Breaker |
+| 13 | `c2act13` | **The City of Vigils** — Amarath's capital, where every window holds a candle | The Vigil Queen (`vigilqueen`) | fly + heavy landing — the queen's ascent, grief made weather | Queen's Candle | Vigil Knight |
+| F | `c2finale` | **The Throne of the Unremembered** — the vigil chamber where the King held a kingdom in his mind | **The Vigil King** (`vigilking`) | multi-threshold (66/33) — the vigil-rite reignites: full-field events | Crown of the Remembered (campaign trophy) | — |
+
+> Boss trait sketches are starting points — give each a full §13 trait object
+> in `bossAIs.json` when the act is authored, and vary the trait types so
+> adjacent acts don't repeat.
+
+**Arc shape:** acts 1–4 are the border war (discovery, first contact, learning
+what Amarath is). Acts 5–8 go deep into the kingdom and humanise it — the
+player starts to see what the Dominion's forgetting cost these people. Acts
+9–12 are the Court's counter-offensive and the march on the capital. Act 13 and
+the finale resolve it: the Vigil Queen falls, and the Vigil King's rite must be
+ended — not by erasing Amarath again, but by *remembering* it. The finale's
+outro writes Amarath back onto the world's maps: remembered, at peace, part of
+the mended Dominion. (Leave a hook: what else did the Fracture erase?)
+
+## 5. Story continuity rules (in addition to `docs/acts.md` §4)
+
+- Campaign 2 text must treat campaign 1 as **finished history**: the Fracture
+  is sealed, the shards are one Dominion, Jarv is the Worldmender. No dangling
+  "the Fracture still threatens" phrasing.
+- The Unremembered remember the pre-Fracture world perfectly. Use that: their
+  dialogue can reference true old-world details no living Dominion NPC knows.
+- Never present the Unremembered rank-and-file as evil — the Pale Court is the
+  antagonist; grief is the engine.
+- Card lore for `forgotten`-tagged cards should echo the motifs in §2.
+- Hub world: post-campaign-1 NPC lines (`postCampaignDialogue`) acknowledge the
+  sealed Fracture and, in border towns, unease about the east. Elsben is the
+  only NPC who *launches* campaign 2.
+
+## 6. Per-act theming checklist (delta on top of `docs/acts.md` §12)
+
+- [ ] Act `rewardTags` include `"forgotten"` plus one act-specific tag
+      (e.g. `["forgotten", "marches"]`); the act's 25 cards carry `"forgotten"`.
+- [ ] Intro panels acknowledge where the previous act left the invasion.
+- [ ] Boss dialogue references the Court and the vigil.
+- [ ] 2 memory-fragment nodes with entries in `memoryFragments.json` telling
+      Amarath's side of the erasure (mirrors campaign 1's fragment usage).
+- [ ] `nextActId` added to the *previous* act's JSON when a new act lands.
+- [ ] Sub-issue for the act closed only after the full §12 checklist passes.

--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -456,6 +456,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `effects` | `DialogueEffect[]`? | Run in order before navigation. |
 | `requireFlag` | string? | Choice only shown if the flag is set. |
 | `hideIfFlag` | string? | Choice hidden once the flag is set. |
+| `requireCampaignComplete` | string? | Choice only shown once that campaign is complete (`"c1"` = The Shattered Dominion, `"c2"` = The Forgotten Kingdom). Derived live from act-completion counts (`isCampaignComplete` in `questline.ts`), so it works retroactively for players who finished before the field existed. Used by Cartographer Elsben (Ironhold Keep) to gate the campaign 2 launch. |
 | `requireFestival` | string? | Choice only shown while that festival is active (§14 festival ids, e.g. `"midsummer"`). |
 | `requireWeather` | string? | Choice only shown while the town's resolved weather (§12) matches (`"clear"`/`"rain"`/`"snow"`/`"fog"`). Weather is date/season-driven — for QA, force `"weather": {"type": "snow"}` in the town config, or use Millhaven (rains year-round). |
 | `requireTimeOfDay` | `"day"` \| `"night"` \| `"dawn"`? | Choice only shown while `hubClock.getTimeOfDay(gameHour)` matches: night 20:00–05:59, dawn 06:00–07:59, day otherwise (§9). |
@@ -469,7 +470,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `relationship` | `npcId?`, `track`, `points` | Add points to a relationship track (`ally`/`rival`/`romance`) — defaults to the speaking NPC. See §7c. |
 | `quest` | `questId` | Offer that quest (Accept / Not now). Resolves the quest's real `giverNpcId`. **Terminates** the walk. |
 | `tradeHubItem` | `wantItemId?`, `wantCount?`, `wantItems?`, `giveCrystals?`, `giveHubItem?`, `giveCollectible?`, `giveFriendship?`, `giveRelationship?`, `missingText`, `successText` | Repeatable barter — see §16. Takes `wantCount` (default 1) of a hub-item — or every entry of `wantItems: [{itemId, count?}]` for multi-item recipes (all-or-nothing, takes precedence over `wantItemId`) — and grants the `give*` rewards (`giveFriendship: {npcId?, xp}` and `giveRelationship: {npcId?, track, points}` default to the speaking NPC), showing `successText` (then advancing to `next` on close, so a sell menu can loop). If the player holds too few of anything, shows `missingText` and **terminates** the walk with no state change. Must be the **only/last** effect on its choice (it terminates the walk either way). |
-| `screen` | `screen` | Navigate to a screen (same string format as `RawNpc.screen` — e.g. `"interior:<id>"`, `"narrator:<id>"`, or a bare screen id). Routed through the same `handleNodeInteract` every screen-based NPC/interactable uses. **Terminates** the walk. |
+| `screen` | `screen` | Navigate to a screen (same string format as `RawNpc.screen` — e.g. `"interior:<id>"`, `"narrator:<id>"`, or a bare screen id; `"campaign"` and `"campaign2"` launch the respective campaigns). Routed through the same `handleNodeInteract` every screen-based NPC/interactable uses. **Terminates** the walk. |
 | `end` | — | End the conversation. |
 
 If a choice has neither a terminating effect (`quest`/`end`) nor `next`, the
@@ -1214,6 +1215,7 @@ schedules and activities are also editable in the in-app map editor
 | `homeBed` | `{ buildingId, tx, ty }` | | Reserved sleeping spot reference (used by night logic). |
 | `dialogueByActivity` | `Partial<Record<NpcActivity, string[]>>` | | Optional activity-specific dialogue pools, e.g. `{ "sleep": ["Zzz..."] }`. When the NPC's current scheduled activity has a non-empty entry here, `getNpcDialoguePool()` cycles those lines instead of the flat `dialogue` array (tap dialogue and ambient speech bubbles both use it). NPCs without a matching entry keep using `dialogue`, so this is fully backward compatible. |
 | `sleepDialogue` | `string` | | Line shown (as plain narration, no Talk/Give/quest options) when the NPC is tapped while `sleep`ing per its schedule (§7d). Defaults to a generic "💤 {name} is fast asleep." when omitted. |
+| `postCampaignDialogue` | `string[]` | | Lines cycled **instead of** the flat `dialogue` array once campaign 1 is complete (`isCampaignComplete('c1')` — derived from act counts, so retroactive). This is how the world acknowledges the sealed Fracture after the first campaign. Activity pools (`dialogueByActivity`) still take precedence when their activity matches. Fully backward compatible — NPCs without the field keep `dialogue` forever. |
 
 On a game-hour boundary the NPC pathfinds to the new location (emerging at / walking
 to the relevant door for interior transitions). The activity pose only shows while

--- a/web/public/cutscenes/c2act1-intro-1.svg
+++ b/web/public/cutscenes/c2act1-intro-1.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2i1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#1a2140"/>
+    <stop offset="60%" stop-color="#2e3a66"/>
+    <stop offset="100%" stop-color="#4a5688"/>
+  </linearGradient>
+  <rect width="400" height="170" fill="url(#c2i1-sky)"/>
+  <!-- Fireworks over the mended dominion -->
+  <g opacity="0.9">
+    <circle cx="90" cy="50" r="2.5" fill="#FFD24A"/>
+    <g stroke="#FFD24A" stroke-width="1.2" opacity="0.8">
+      <line x1="90" y1="50" x2="90" y2="34"/><line x1="90" y1="50" x2="104" y2="42"/>
+      <line x1="90" y1="50" x2="104" y2="58"/><line x1="90" y1="50" x2="90" y2="66"/>
+      <line x1="90" y1="50" x2="76" y2="58"/><line x1="90" y1="50" x2="76" y2="42"/>
+    </g>
+    <circle cx="300" cy="38" r="2" fill="#7FB7E8"/>
+    <g stroke="#7FB7E8" stroke-width="1" opacity="0.8">
+      <line x1="300" y1="38" x2="300" y2="24"/><line x1="300" y1="38" x2="312" y2="31"/>
+      <line x1="300" y1="38" x2="312" y2="45"/><line x1="300" y1="38" x2="288" y2="45"/>
+      <line x1="300" y1="38" x2="288" y2="31"/><line x1="300" y1="38" x2="300" y2="52"/>
+    </g>
+  </g>
+  <!-- City skyline celebrating -->
+  <g fill="#131a30">
+    <rect x="20" y="110" width="30" height="60"/>
+    <rect x="60" y="95" width="24" height="75"/>
+    <rect x="95" y="120" width="34" height="50"/>
+    <rect x="140" y="88" width="26" height="82"/>
+    <rect x="180" y="105" width="40" height="65"/>
+    <rect x="230" y="92" width="24" height="78"/>
+    <rect x="265" y="115" width="32" height="55"/>
+    <rect x="308" y="100" width="26" height="70"/>
+    <rect x="345" y="118" width="34" height="52"/>
+  </g>
+  <!-- Warm windows -->
+  <g fill="#FFB347">
+    <rect x="66" y="104" width="4" height="5"/><rect x="74" y="118" width="4" height="5"/>
+    <rect x="146" y="98" width="4" height="5"/><rect x="154" y="112" width="4" height="5"/>
+    <rect x="236" y="102" width="4" height="5"/><rect x="244" y="124" width="4" height="5"/>
+    <rect x="314" y="110" width="4" height="5"/><rect x="30" y="122" width="4" height="5"/>
+  </g>
+  <!-- Ground -->
+  <rect y="170" width="400" height="70" fill="#0e1322"/>
+  <!-- Banner text strip -->
+  <rect y="196" width="400" height="44" fill="#080a12"/>
+  <text x="200" y="223" text-anchor="middle" font-family="monospace" font-size="13" fill="#C9CBDA">THE FRACTURE IS SEALED · THE DOMINION IS WHOLE</text>
+</svg>

--- a/web/public/cutscenes/c2act1-intro-2.svg
+++ b/web/public/cutscenes/c2act1-intro-2.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0d0b08"/>
+  <!-- Candle-lit map table -->
+  <rect x="30" y="40" width="340" height="160" rx="4" fill="#E8DFC8"/>
+  <rect x="30" y="40" width="340" height="160" rx="4" fill="none" stroke="#8A6F4D" stroke-width="3"/>
+  <!-- Map detail: the known west -->
+  <g stroke="#7E8299" stroke-width="1.4" fill="none">
+    <path d="M50,80 Q100,60 150,85 Q190,105 230,95"/>
+    <path d="M60,140 Q110,150 160,135 Q200,125 235,140"/>
+    <path d="M55,180 Q120,170 190,182"/>
+  </g>
+  <g fill="#5E6A8C">
+    <circle cx="90" cy="100" r="4"/>
+    <circle cx="150" cy="120" r="4"/>
+    <circle cx="205" cy="112" r="5"/>
+  </g>
+  <text x="120" y="70" font-family="monospace" font-size="10" fill="#5B5346">THE DOMINION</text>
+  <!-- The blank quarter -->
+  <rect x="248" y="52" width="110" height="136" fill="#F4EFDF"/>
+  <text x="303" y="115" text-anchor="middle" font-family="monospace" font-size="10" fill="#B9B3A4">( UNCHARTED )</text>
+  <!-- Fresh ink: roads appearing in the blank -->
+  <g stroke="#8E3B3B" stroke-width="1.3" fill="none" opacity="0.85">
+    <path d="M248,120 Q280,110 310,118 Q335,124 355,116"/>
+    <path d="M290,70 L295,180" stroke-dasharray="3,3"/>
+  </g>
+  <circle cx="312" cy="118" r="4" fill="#8E3B3B" opacity="0.85"/>
+  <text x="303" y="145" text-anchor="middle" font-family="monospace" font-size="9" fill="#8E3B3B">new survey ??</text>
+  <!-- Candle in corner -->
+  <rect x="352" y="18" width="8" height="20" fill="#F2E9D8"/>
+  <ellipse cx="356" cy="13" rx="5" ry="8" fill="#FFB347"/>
+  <ellipse cx="356" cy="15" rx="2.4" ry="4" fill="#FFE08A"/>
+  <circle cx="356" cy="14" r="16" fill="#FFB347" opacity="0.15"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE NEW SURVEYS DISAGREE WITH EVERY MAP EVER DRAWN</text>
+</svg>

--- a/web/public/cutscenes/c2act1-intro-3.svg
+++ b/web/public/cutscenes/c2act1-intro-3.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2i3-mist" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#2a3050"/>
+    <stop offset="100%" stop-color="#565e80"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2i3-mist)"/>
+  <!-- Layered mist -->
+  <ellipse cx="120" cy="180" rx="180" ry="36" fill="#9aa2c2" opacity="0.5"/>
+  <ellipse cx="320" cy="168" rx="160" ry="30" fill="#b8bdd6" opacity="0.45"/>
+  <ellipse cx="200" cy="196" rx="240" ry="34" fill="#ced3e6" opacity="0.5"/>
+  <!-- Road vanishing east into mist -->
+  <path d="M40,240 L200,120 L212,120 L120,240 Z" fill="#3a4160" opacity="0.9"/>
+  <!-- Lantern posts along the road, lit -->
+  <g>
+    <rect x="150" y="140" width="3" height="34" fill="#20263c"/>
+    <circle cx="151.5" cy="136" r="5" fill="#FFB347" opacity="0.9"/>
+    <circle cx="151.5" cy="136" r="11" fill="#FFB347" opacity="0.25"/>
+    <rect x="196" y="118" width="2.4" height="26" fill="#20263c"/>
+    <circle cx="197.2" cy="114" r="4" fill="#FFB347" opacity="0.9"/>
+    <circle cx="197.2" cy="114" r="9" fill="#FFB347" opacity="0.25"/>
+    <rect x="228" y="104" width="2" height="20" fill="#20263c"/>
+    <circle cx="229" cy="101" r="3" fill="#FFB347" opacity="0.9"/>
+    <circle cx="229" cy="101" r="7" fill="#FFB347" opacity="0.25"/>
+    <rect x="250" y="94" width="1.6" height="16" fill="#20263c"/>
+    <circle cx="250.8" cy="92" r="2.4" fill="#FFB347" opacity="0.9"/>
+  </g>
+  <!-- Distant marching silhouettes in the mist -->
+  <g fill="#454E6B" opacity="0.75">
+    <rect x="264" y="96" width="5" height="12" rx="2"/>
+    <rect x="273" y="94" width="5" height="14" rx="2"/>
+    <rect x="282" y="96" width="5" height="12" rx="2"/>
+    <rect x="292" y="93" width="6" height="15" rx="2"/>
+    <path d="M296,80 L306,84 L296,92 Z"/>
+    <rect x="295" y="80" width="1.6" height="28"/>
+  </g>
+  <!-- Jarv silhouette looking east -->
+  <g fill="#11141f">
+    <circle cx="70" cy="150" r="9"/>
+    <rect x="61" y="158" width="18" height="30" rx="4"/>
+  </g>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">SOMETHING IS MARCHING WEST OUT OF THE MIST</text>
+</svg>

--- a/web/public/cutscenes/c2act1-outro-1.svg
+++ b/web/public/cutscenes/c2act1-outro-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2o1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#242b48"/>
+    <stop offset="100%" stop-color="#4a5170"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2o1-sky)"/>
+  <!-- Churned battlefield ground -->
+  <rect y="176" width="400" height="64" fill="#2b2f42"/>
+  <path d="M0,176 Q60,168 120,176 Q200,184 280,174 Q340,168 400,176 L400,240 L0,240 Z" fill="#232739"/>
+  <!-- Kneeling herald: large pale figure -->
+  <g>
+    <rect x="168" y="96" width="44" height="12" rx="4" fill="#9FA3BC"/>
+    <path d="M170,86 L176,74 L182,86 L188,74 L194,86 L200,74 L206,86 Z" fill="#FFD24A"/>
+    <rect x="172" y="102" width="36" height="6" fill="#20263c"/>
+    <circle cx="182" cy="105" r="2" fill="#E8EAF4"/>
+    <circle cx="196" cy="105" r="2" fill="#E8EAF4"/>
+    <path d="M160,110 L154,190 L226,190 L220,110 Q190,124 160,110 Z" fill="#9FA3BC"/>
+    <!-- Kneeling leg -->
+    <rect x="164" y="186" width="52" height="10" rx="4" fill="#454E6B"/>
+  </g>
+  <!-- Planted banner beside him -->
+  <rect x="242" y="60" width="4" height="132" rx="2" fill="#5B5346"/>
+  <path d="M246,64 L296,72 L246,96 Z" fill="#5E6A8C"/>
+  <circle cx="268" cy="76" r="4" fill="#FFD24A"/>
+  <!-- Mist low over the field -->
+  <ellipse cx="100" cy="196" rx="130" ry="18" fill="#ced3e6" opacity="0.35"/>
+  <ellipse cx="320" cy="200" rx="120" ry="16" fill="#ced3e6" opacity="0.3"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">"AMARATH HAS RETURNED. NOW YOU KNOW."</text>
+</svg>

--- a/web/public/cutscenes/c2act1-outro-2.svg
+++ b/web/public/cutscenes/c2act1-outro-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08070c"/>
+  <!-- Darkness with one warm lantern -->
+  <radialGradient id="c2o2-glow" cx="50%" cy="45%" r="55%">
+    <stop offset="0%" stop-color="#FFB347" stop-opacity="0.5"/>
+    <stop offset="45%" stop-color="#8a5f2a" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#08070c" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#c2o2-glow)"/>
+  <!-- Lantern -->
+  <rect x="186" y="70" width="28" height="42" rx="5" fill="#20263c"/>
+  <rect x="182" y="66" width="36" height="7" rx="3" fill="#2b3149"/>
+  <rect x="182" y="110" width="36" height="7" rx="3" fill="#2b3149"/>
+  <rect x="196" y="52" width="8" height="14" rx="3" fill="#2b3149"/>
+  <rect x="191" y="76" width="18" height="31" fill="#FFB347" opacity="0.9"/>
+  <!-- Candle inside -->
+  <rect x="197" y="92" width="6" height="14" fill="#F2E9D8"/>
+  <ellipse cx="200" cy="87" rx="4" ry="7" fill="#FFE08A"/>
+  <ellipse cx="200" cy="89" rx="2" ry="3.6" fill="#FFF6D8"/>
+  <!-- Hands receiving it -->
+  <path d="M150,150 Q170,132 186,124 L192,132 Q176,142 162,158 Z" fill="#c9a985"/>
+  <path d="M250,150 Q230,132 214,124 L208,132 Q224,142 238,158 Z" fill="#c9a985"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">ONE FLAME OF THE VIGIL · THREE HUNDRED YEARS OLD</text>
+</svg>

--- a/web/public/cutscenes/c2act1-outro-3.svg
+++ b/web/public/cutscenes/c2act1-outro-3.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2o3-dawn" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#3a4160"/>
+    <stop offset="70%" stop-color="#6b7294"/>
+    <stop offset="100%" stop-color="#8e94b4"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2o3-dawn)"/>
+  <!-- Grey causeway running east -->
+  <path d="M0,240 L180,110 L200,110 L120,240 Z" fill="#4a5170"/>
+  <path d="M186,112 L194,112 L188,140 L182,140 Z" fill="#565e80"/>
+  <!-- Unlit lamps lining it -->
+  <g fill="#20263c">
+    <rect x="150" y="136" width="3" height="30"/>
+    <circle cx="151.5" cy="132" r="4.5" fill="#2b3149"/>
+    <rect x="192" y="116" width="2.4" height="24"/>
+    <circle cx="193.2" cy="113" r="3.6" fill="#2b3149"/>
+    <rect x="222" y="102" width="2" height="18"/>
+    <circle cx="223" cy="100" r="2.8" fill="#2b3149"/>
+    <rect x="243" y="93" width="1.6" height="14"/>
+    <circle cx="243.8" cy="91.5" r="2.2" fill="#2b3149"/>
+  </g>
+  <!-- Distant kingdom silhouette: towers in mist -->
+  <g fill="#333a58" opacity="0.9">
+    <rect x="286" y="66" width="10" height="40"/>
+    <path d="M286,66 L291,54 L296,66 Z"/>
+    <rect x="304" y="58" width="12" height="48"/>
+    <path d="M304,58 L310,44 L316,58 Z"/>
+    <rect x="324" y="70" width="9" height="36"/>
+    <path d="M324,70 L328.5,60 L333,70 Z"/>
+  </g>
+  <!-- One tiny candle lit in a distant window -->
+  <rect x="308" y="72" width="3" height="4" fill="#FFB347"/>
+  <!-- Mist bands -->
+  <ellipse cx="260" cy="120" rx="170" ry="20" fill="#ced3e6" opacity="0.35"/>
+  <ellipse cx="140" cy="180" rx="180" ry="26" fill="#ced3e6" opacity="0.4"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE HERALD WAS ONLY THE ANNOUNCEMENT</text>
+</svg>

--- a/web/public/sprites/border-palisade.svg
+++ b/web/public/sprites/border-palisade.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="13" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Row of pale sharpened stakes -->
+  <path d="M5,29 L5,12 L7.5,8 L10,12 L10,29 Z" fill="#B9B3A4"/>
+  <path d="M11,29 L11,10 L13.5,6 L16,10 L16,29 Z" fill="#CFC9BA"/>
+  <path d="M17,29 L17,11 L19.5,7 L22,11 L22,29 Z" fill="#B9B3A4"/>
+  <path d="M23,29 L23,13 L25.5,9 L28,13 L28,29 Z" fill="#CFC9BA"/>
+  <!-- Grain lines -->
+  <line x1="7.5" y1="12" x2="7.5" y2="28" stroke="#8F897B" stroke-width="0.7"/>
+  <line x1="13.5" y1="10" x2="13.5" y2="28" stroke="#8F897B" stroke-width="0.7"/>
+  <line x1="19.5" y1="11" x2="19.5" y2="28" stroke="#8F897B" stroke-width="0.7"/>
+  <line x1="25.5" y1="13" x2="25.5" y2="28" stroke="#8F897B" stroke-width="0.7"/>
+  <!-- Cross-brace lashings -->
+  <rect x="4" y="17" width="25" height="1.8" rx="0.9" fill="#5B5346"/>
+  <rect x="4" y="23" width="25" height="1.8" rx="0.9" fill="#5B5346"/>
+  <!-- Mist drifting through -->
+  <ellipse cx="10" cy="27.5" rx="6" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+  <ellipse cx="22" cy="28.2" rx="5" ry="1.2" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-paleherald-1.svg
+++ b/web/public/sprites/boss-paleherald-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride A: banner sways back -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(4 25.8 16)"/>
+  <path d="M26.6,4 L31.2,6 L26.6,10 Z" fill="#5E6A8C"/>
+  <circle cx="28.8" cy="6.6" r="0.9" fill="#FFD24A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <path d="M11,4.5 L12.5,1.8 L14,4.5 L16,1.8 L18,4.5 L19.5,1.8 L21,4.5 Z" fill="#FFD24A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#9FA3BC"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#7E8299"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#7E8299"/>
+  <ellipse cx="16.5" cy="20.4" rx="1.8" ry="2.4" fill="#FFD24A"/>
+  <ellipse cx="16.5" cy="20.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#7E8299"/>
+  <rect x="2.5" y="17" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="19" x2="7" y2="19" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="20.5" x2="7" y2="20.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="22" x2="7" y2="22" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="28" width="4.5" height="3.6" rx="1" fill="#454E6B"/>
+  <rect x="18.5" y="28" width="4.5" height="2.8" rx="1" fill="#454E6B"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-paleherald-2.svg
+++ b/web/public/sprites/boss-paleherald-2.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Towering armoured herald with banner and writ -->
+  <!-- Banner pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#5E6A8C"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#FFD24A"/>
+  <!-- Crowned great helm -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <path d="M11,3.5 L12.5,0.8 L14,3.5 L16,0.8 L18,3.5 L19.5,0.8 L21,3.5 Z" fill="#FFD24A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <!-- Massive pale cloak/body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#9FA3BC"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#7E8299"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#7E8299"/>
+  <!-- Vigil flame chest sigil -->
+  <ellipse cx="16.5" cy="19.4" rx="1.8" ry="2.4" fill="#FFD24A"/>
+  <ellipse cx="16.5" cy="19.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#7E8299"/>
+  <!-- The writ (unrolled scroll in hand) -->
+  <rect x="2.5" y="16" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="18" x2="7" y2="18" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="19.5" x2="7" y2="19.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="21" x2="7" y2="21" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-paleherald-3.svg
+++ b/web/public/sprites/boss-paleherald-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride B: banner sways forward -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(-4 25.8 16)"/>
+  <path d="M26.2,4 L30.8,5.2 L26.2,9.6 Z" fill="#5E6A8C"/>
+  <circle cx="28.4" cy="6" r="0.9" fill="#FFD24A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <path d="M11,4.5 L12.5,1.8 L14,4.5 L16,1.8 L18,4.5 L19.5,1.8 L21,4.5 Z" fill="#FFD24A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#9FA3BC"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#7E8299"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#7E8299"/>
+  <ellipse cx="16.5" cy="20.4" rx="1.8" ry="2.4" fill="#FFD24A"/>
+  <ellipse cx="16.5" cy="20.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#7E8299"/>
+  <rect x="2.5" y="17" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="19" x2="7" y2="19" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="20.5" x2="7" y2="20.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="22" x2="7" y2="22" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs stride B -->
+  <rect x="18.5" y="28" width="4.5" height="3.6" rx="1" fill="#454E6B"/>
+  <rect x="9.5" y="28" width="4.5" height="2.8" rx="1" fill="#454E6B"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-paleherald.svg
+++ b/web/public/sprites/boss-paleherald.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Towering armoured herald with banner and writ -->
+  <!-- Banner pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#5E6A8C"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#FFD24A"/>
+  <!-- Crowned great helm -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <path d="M11,3.5 L12.5,0.8 L14,3.5 L16,0.8 L18,3.5 L19.5,0.8 L21,3.5 Z" fill="#FFD24A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <!-- Massive pale cloak/body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#9FA3BC"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#7E8299"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#7E8299"/>
+  <!-- Vigil flame chest sigil -->
+  <ellipse cx="16.5" cy="19.4" rx="1.8" ry="2.4" fill="#FFD24A"/>
+  <ellipse cx="16.5" cy="19.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#7E8299"/>
+  <!-- The writ (unrolled scroll in hand) -->
+  <rect x="2.5" y="16" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="18" x2="7" y2="18" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="19.5" x2="7" y2="19.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="21" x2="7" y2="21" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/candle-bearer-1.svg
+++ b/web/public/sprites/candle-bearer-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe sways left, flame flickers left -->
+  <circle cx="15" cy="10" r="5" fill="#C9CBDA"/>
+  <path d="M10,10 Q15,3 20,10 L20,13 Q15,10 10,13 Z" fill="#A6A9C0"/>
+  <circle cx="15" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L8,31 L20,31 L19,15 Q15,17 11,15 Z" fill="#C9CBDA"/>
+  <path d="M11,23 L9,31 L19,31 L19.5,23 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18" width="6" height="1.2" fill="#7E8299"/>
+  <rect x="20" y="14" width="3" height="6" rx="1" fill="#C9CBDA"/>
+  <rect x="22.5" y="10" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="8.6" width="0.8" height="1.8" fill="#7E8299"/>
+  <ellipse cx="23.2" cy="7" rx="1.5" ry="2.2" fill="#FFB347" transform="rotate(-12 23.2 7)"/>
+  <ellipse cx="23.2" cy="7.4" rx="0.8" ry="1.2" fill="#FFE08A" transform="rotate(-12 23.2 7.4)"/>
+  <circle cx="23.4" cy="7" r="3.2" fill="#FFB347" opacity="0.22"/>
+</svg>

--- a/web/public/sprites/candle-bearer-2.svg
+++ b/web/public/sprites/candle-bearer-2.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded robed keeper with tall candle -->
+  <circle cx="15" cy="9" r="5" fill="#C9CBDA"/>
+  <path d="M10,9 Q15,2 20,9 L20,12 Q15,9 10,12 Z" fill="#A6A9C0"/>
+  <circle cx="15" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Long robe -->
+  <path d="M11,14 L9,30 L21,30 L19,14 Q15,16 11,14 Z" fill="#C9CBDA"/>
+  <path d="M11,22 L10,30 L20,30 L19.5,22 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17" width="6" height="1.2" fill="#7E8299"/>
+  <!-- Candle arm -->
+  <rect x="20" y="13" width="3" height="6" rx="1" fill="#C9CBDA"/>
+  <rect x="22.5" y="9" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="7.6" width="0.8" height="1.8" fill="#7E8299"/>
+  <!-- Flame -->
+  <ellipse cx="23.8" cy="6" rx="1.6" ry="2.4" fill="#FFB347"/>
+  <ellipse cx="23.8" cy="6.4" rx="0.8" ry="1.3" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="23.8" cy="6" r="3.4" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/candle-bearer-3.svg
+++ b/web/public/sprites/candle-bearer-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe sways right, flame flickers right -->
+  <circle cx="15" cy="10" r="5" fill="#C9CBDA"/>
+  <path d="M10,10 Q15,3 20,10 L20,13 Q15,10 10,13 Z" fill="#A6A9C0"/>
+  <circle cx="15" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L10,31 L22,31 L19,15 Q15,17 11,15 Z" fill="#C9CBDA"/>
+  <path d="M11,23 L11,31 L21,31 L19.5,23 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18" width="6" height="1.2" fill="#7E8299"/>
+  <rect x="20" y="14" width="3" height="6" rx="1" fill="#C9CBDA"/>
+  <rect x="22.5" y="10" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="8.6" width="0.8" height="1.8" fill="#7E8299"/>
+  <ellipse cx="24.4" cy="7" rx="1.5" ry="2.2" fill="#FFB347" transform="rotate(12 24.4 7)"/>
+  <ellipse cx="24.4" cy="7.4" rx="0.8" ry="1.2" fill="#FFE08A" transform="rotate(12 24.4 7.4)"/>
+  <circle cx="24.2" cy="7" r="3.2" fill="#FFB347" opacity="0.22"/>
+</svg>

--- a/web/public/sprites/candle-bearer.svg
+++ b/web/public/sprites/candle-bearer.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded robed keeper with tall candle -->
+  <circle cx="15" cy="9" r="5" fill="#C9CBDA"/>
+  <path d="M10,9 Q15,2 20,9 L20,12 Q15,9 10,12 Z" fill="#A6A9C0"/>
+  <circle cx="15" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Long robe -->
+  <path d="M11,14 L9,30 L21,30 L19,14 Q15,16 11,14 Z" fill="#C9CBDA"/>
+  <path d="M11,22 L10,30 L20,30 L19.5,22 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17" width="6" height="1.2" fill="#7E8299"/>
+  <!-- Candle arm -->
+  <rect x="20" y="13" width="3" height="6" rx="1" fill="#C9CBDA"/>
+  <rect x="22.5" y="9" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="7.6" width="0.8" height="1.8" fill="#7E8299"/>
+  <!-- Flame -->
+  <ellipse cx="23.8" cy="6" rx="1.6" ry="2.4" fill="#FFB347"/>
+  <ellipse cx="23.8" cy="6.4" rx="0.8" ry="1.3" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="23.8" cy="6" r="3.4" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/candle-shrine.svg
+++ b/web/public/sprites/candle-shrine.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29" rx="11" ry="2.2" fill="#7E8299" opacity="0.5"/>
+  <!-- Stone shrine arch -->
+  <path d="M8,28 L8,14 Q16,6 24,14 L24,28 Z" fill="#A6A9C0"/>
+  <path d="M11,28 L11,16 Q16,10.5 21,16 L21,28 Z" fill="#454E6B"/>
+  <!-- Shrine steps -->
+  <rect x="6.5" y="27" width="19" height="2.4" rx="0.8" fill="#C9CBDA"/>
+  <!-- Candle cluster inside -->
+  <rect x="13" y="21.5" width="1.6" height="5.5" fill="#F2E9D8"/>
+  <rect x="15.4" y="20" width="1.8" height="7" fill="#F2E9D8"/>
+  <rect x="18" y="22.5" width="1.4" height="4.5" fill="#F2E9D8"/>
+  <ellipse cx="13.8" cy="20.6" rx="0.9" ry="1.3" fill="#FFB347"/>
+  <ellipse cx="16.3" cy="19" rx="1" ry="1.5" fill="#FFB347"/>
+  <ellipse cx="18.7" cy="21.6" rx="0.8" ry="1.2" fill="#FFB347"/>
+  <ellipse cx="16.3" cy="19.3" rx="0.5" ry="0.8" fill="#FFE08A"/>
+  <!-- Warm glow -->
+  <circle cx="16" cy="21" r="6.5" fill="#FFB347" opacity="0.22"/>
+  <!-- Mana crystal set in the keystone -->
+  <path d="M16,7.5 L18,10.5 L16,13.5 L14,10.5 Z" fill="#7FB7E8"/>
+  <path d="M16,8.6 L17.2,10.5 L16,12.4 L14.8,10.5 Z" fill="#B8DCF7"/>
+</svg>

--- a/web/public/sprites/hub-npc-cartographer.svg
+++ b/web/public/sprites/hub-npc-cartographer.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- shadow -->
+  <ellipse cx="16" cy="29" rx="5" ry="2" fill="rgba(0,0,0,0.25)"/>
+  <!-- boots -->
+  <rect x="11" y="25" width="4" height="3" rx="1" fill="#3a3226"/>
+  <rect x="17" y="25" width="4" height="3" rx="1" fill="#3a3226"/>
+  <!-- travel-worn trousers -->
+  <rect x="12" y="20" width="3" height="6" rx="1" fill="#4a4438"/>
+  <rect x="17" y="20" width="3" height="6" rx="1" fill="#4a4438"/>
+  <!-- surveyor's coat, ink-stained teal -->
+  <rect x="9" y="11" width="14" height="10" rx="2" fill="#2f6b66"/>
+  <rect x="15" y="12" width="2" height="8" rx="1" fill="#245450"/>
+  <!-- satchel strap + satchel of maps -->
+  <path d="M9,12 L23,19 L23,21 L9,14 Z" fill="#8a6f4d"/>
+  <rect x="21" y="19" width="6" height="5" rx="1" fill="#8a6f4d"/>
+  <rect x="21.5" y="19.5" width="5" height="1.6" fill="#6f583c"/>
+  <!-- rolled map poking out of satchel -->
+  <rect x="25.4" y="15.5" width="1.8" height="5" rx="0.9" fill="#F2E9D8" transform="rotate(18 26.3 18)"/>
+  <!-- arms -->
+  <rect x="7" y="13" width="4" height="6" rx="1.5" fill="#2f6b66"/>
+  <rect x="21" y="13" width="4" height="6" rx="1.5" fill="#2f6b66"/>
+  <!-- unrolled map held in left hand -->
+  <rect x="3.5" y="16" width="6" height="4.6" rx="0.8" fill="#F2E9D8"/>
+  <line x1="4.5" y1="17.4" x2="8.6" y2="17.4" stroke="#7E8299" stroke-width="0.5"/>
+  <line x1="4.5" y1="18.6" x2="8.6" y2="18.6" stroke="#7E8299" stroke-width="0.5"/>
+  <line x1="7" y1="16.4" x2="7" y2="20.2" stroke="#8E3B3B" stroke-width="0.5" stroke-dasharray="1,0.8"/>
+  <!-- head -->
+  <circle cx="16" cy="7.5" r="4.2" fill="#e8c49a"/>
+  <!-- spectacles -->
+  <circle cx="14.4" cy="7.8" r="1.3" fill="none" stroke="#3a3f55" stroke-width="0.7"/>
+  <circle cx="17.8" cy="7.8" r="1.3" fill="none" stroke="#3a3f55" stroke-width="0.7"/>
+  <line x1="15.7" y1="7.8" x2="16.5" y2="7.8" stroke="#3a3f55" stroke-width="0.7"/>
+  <!-- wide-brim surveyor hat -->
+  <ellipse cx="16" cy="4.6" rx="6.4" ry="1.6" fill="#245450"/>
+  <path d="M12,4.6 Q16,0.8 20,4.6 Z" fill="#2f6b66"/>
+  <!-- quill tucked in hatband -->
+  <path d="M20.5,3.4 L23.5,1 L23.9,1.6 L21.2,4.1 Z" fill="#E8EAF4"/>
+</svg>

--- a/web/public/sprites/knight-of-the-vigil-1.svg
+++ b/web/public/sprites/knight-of-the-vigil-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="8" rx="2.5" fill="#A6A9C0"/>
+  <rect x="12" y="8.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="9.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.4" r="0.7" fill="#FFB347"/>
+  <rect x="15.3" y="2.5" width="1.4" height="3" fill="#F2E9D8"/>
+  <ellipse cx="16" cy="1.9" rx="0.9" ry="1.2" fill="#FFB347"/>
+  <path d="M9,13 L9,25 L23,25 L23,13 Q16,16 9,13 Z" fill="#C9CBDA"/>
+  <rect x="9" y="16.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="20.5" width="14" height="1.4" fill="#7E8299"/>
+  <ellipse cx="16" cy="19" rx="1.6" ry="2.2" fill="#E8B94A"/>
+  <ellipse cx="16" cy="19.4" rx="0.8" ry="1.2" fill="#FFE08A"/>
+  <circle cx="9" cy="14.5" r="3" fill="#A6A9C0"/>
+  <circle cx="23" cy="14.5" r="3" fill="#A6A9C0"/>
+  <rect x="26" y="9" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,27.5 L26,25 L28,25 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="8" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="9" y="25" width="4.5" height="5.8" rx="1" fill="#7E8299"/>
+  <rect x="18.5" y="25" width="4.5" height="4.4" rx="1" fill="#7E8299"/>
+  <rect x="8" y="29" width="6.5" height="2.6" rx="1" fill="#454E6B"/>
+  <rect x="18.5" y="27.6" width="6" height="2.6" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/knight-of-the-vigil-2.svg
+++ b/web/public/sprites/knight-of-the-vigil-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Great helm with candle crest -->
+  <rect x="11" y="4" width="10" height="8" rx="2.5" fill="#A6A9C0"/>
+  <rect x="12" y="7.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="8.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="8.4" r="0.7" fill="#FFB347"/>
+  <!-- Candle crest -->
+  <rect x="15.3" y="1.5" width="1.4" height="3" fill="#F2E9D8"/>
+  <ellipse cx="16" cy="0.9" rx="0.9" ry="1.2" fill="#FFB347"/>
+  <!-- Massive plate body -->
+  <path d="M9,12 L9,24 L23,24 L23,12 Q16,15 9,12 Z" fill="#C9CBDA"/>
+  <rect x="9" y="15.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="19.5" width="14" height="1.4" fill="#7E8299"/>
+  <!-- Vigil flame emblem -->
+  <ellipse cx="16" cy="18" rx="1.6" ry="2.2" fill="#E8B94A"/>
+  <ellipse cx="16" cy="18.4" rx="0.8" ry="1.2" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="9" cy="13.5" r="3" fill="#A6A9C0"/>
+  <circle cx="23" cy="13.5" r="3" fill="#A6A9C0"/>
+  <!-- Greatsword planted point-down -->
+  <rect x="26" y="8" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,26.5 L26,24 L28,24 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="7" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs (neutral, heavy) -->
+  <rect x="11" y="24" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="16.5" y="24" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="10" y="28.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+  <rect x="15.5" y="28.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/knight-of-the-vigil-3.svg
+++ b/web/public/sprites/knight-of-the-vigil-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="8" rx="2.5" fill="#A6A9C0"/>
+  <rect x="12" y="8.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="9.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.4" r="0.7" fill="#FFB347"/>
+  <rect x="15.3" y="2.5" width="1.4" height="3" fill="#F2E9D8"/>
+  <ellipse cx="16" cy="1.9" rx="0.9" ry="1.2" fill="#FFB347"/>
+  <path d="M9,13 L9,25 L23,25 L23,13 Q16,16 9,13 Z" fill="#C9CBDA"/>
+  <rect x="9" y="16.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="20.5" width="14" height="1.4" fill="#7E8299"/>
+  <ellipse cx="16" cy="19" rx="1.6" ry="2.2" fill="#E8B94A"/>
+  <ellipse cx="16" cy="19.4" rx="0.8" ry="1.2" fill="#FFE08A"/>
+  <circle cx="9" cy="14.5" r="3" fill="#A6A9C0"/>
+  <circle cx="23" cy="14.5" r="3" fill="#A6A9C0"/>
+  <rect x="26" y="9" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,27.5 L26,25 L28,25 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="8" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18.5" y="25" width="4.5" height="5.8" rx="1" fill="#7E8299"/>
+  <rect x="9" y="25" width="4.5" height="4.4" rx="1" fill="#7E8299"/>
+  <rect x="18.5" y="29" width="6.5" height="2.6" rx="1" fill="#454E6B"/>
+  <rect x="8" y="27.6" width="6" height="2.6" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/knight-of-the-vigil.svg
+++ b/web/public/sprites/knight-of-the-vigil.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Great helm with candle crest -->
+  <rect x="11" y="4" width="10" height="8" rx="2.5" fill="#A6A9C0"/>
+  <rect x="12" y="7.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="8.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="8.4" r="0.7" fill="#FFB347"/>
+  <!-- Candle crest -->
+  <rect x="15.3" y="1.5" width="1.4" height="3" fill="#F2E9D8"/>
+  <ellipse cx="16" cy="0.9" rx="0.9" ry="1.2" fill="#FFB347"/>
+  <!-- Massive plate body -->
+  <path d="M9,12 L9,24 L23,24 L23,12 Q16,15 9,12 Z" fill="#C9CBDA"/>
+  <rect x="9" y="15.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="19.5" width="14" height="1.4" fill="#7E8299"/>
+  <!-- Vigil flame emblem -->
+  <ellipse cx="16" cy="18" rx="1.6" ry="2.2" fill="#E8B94A"/>
+  <ellipse cx="16" cy="18.4" rx="0.8" ry="1.2" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="9" cy="13.5" r="3" fill="#A6A9C0"/>
+  <circle cx="23" cy="13.5" r="3" fill="#A6A9C0"/>
+  <!-- Greatsword planted point-down -->
+  <rect x="26" y="8" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,26.5 L26,24 L28,24 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="7" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs (neutral, heavy) -->
+  <rect x="11" y="24" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="16.5" y="24" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="10" y="28.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+  <rect x="15.5" y="28.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/lantern-post.svg
+++ b/web/public/sprites/lantern-post.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29" rx="10" ry="2.2" fill="#7E8299" opacity="0.5"/>
+  <!-- Post -->
+  <rect x="14.8" y="8" width="2.4" height="21" rx="1" fill="#5B5346"/>
+  <rect x="14.4" y="27" width="3.2" height="2.5" rx="0.8" fill="#454E6B"/>
+  <!-- Cross arm -->
+  <rect x="14" y="8" width="10" height="1.8" rx="0.9" fill="#5B5346"/>
+  <!-- Hanging lantern -->
+  <rect x="20.4" y="9.8" width="0.8" height="2.4" fill="#3A3F55"/>
+  <rect x="18.2" y="12" width="5.2" height="7" rx="1.2" fill="#3A3F55"/>
+  <rect x="19.2" y="13" width="3.2" height="5" fill="#FFB347"/>
+  <ellipse cx="20.8" cy="15.5" rx="1" ry="1.6" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="20.8" cy="15.5" r="5.5" fill="#FFB347" opacity="0.22"/>
+  <!-- Finial candle on post top -->
+  <rect x="15.2" y="5.4" width="1.6" height="2.6" fill="#F2E9D8"/>
+  <ellipse cx="16" cy="4.4" rx="1.1" ry="1.5" fill="#FFB347"/>
+  <ellipse cx="16" cy="4.7" rx="0.5" ry="0.8" fill="#FFE08A"/>
+  <!-- Mist -->
+  <ellipse cx="10" cy="27.5" rx="6" ry="1.6" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/marches-warden-1.svg
+++ b/web/public/sprites/marches-warden-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,9.5 Q16,3.5 21,9.5 L21,8 Q16,4.5 11,8 Z" fill="#3E6B4F"/>
+  <rect x="11" y="8.6" width="10" height="1.3" fill="#2E5140"/>
+  <circle cx="14" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,13 L18.5,13 L17.5,14.5 L14.5,14.5 Z" fill="#8A6F4D"/>
+  <path d="M11,15 L10,26 L22,26 L21,15 Q16,17.5 11,15 Z" fill="#3E6B4F"/>
+  <rect x="11" y="18.5" width="10.5" height="1.3" fill="#2E5140"/>
+  <rect x="11" y="22" width="10.5" height="1.3" fill="#2E5140"/>
+  <rect x="15" y="15.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="20.2" r="1.5" fill="#E8B94A"/>
+  <path d="M20.5,22.5 Q24,21.5 24.5,24.5 Q22,25.5 20.5,24.5 Z" fill="#E8B94A"/>
+  <rect x="22" y="15" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <rect x="23.8" y="7.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="20.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <rect x="6.5" y="15" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <circle cx="7" cy="19" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="19" r="2.2" fill="#5E6A8C"/>
+  <circle cx="7" cy="19" r="0.9" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="26" width="4" height="5.2" rx="1" fill="#454E6B"/>
+  <rect x="18" y="26" width="4" height="4" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29.4" width="6" height="2.4" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="28.2" width="5.5" height="2.4" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marches-warden-2.svg
+++ b/web/public/sprites/marches-warden-2.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Weathered border commander, Dominion colours with pale trim -->
+  <circle cx="16" cy="8.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,8.5 Q16,2.5 21,8.5 L21,7 Q16,3.5 11,7 Z" fill="#3E6B4F"/>
+  <rect x="11" y="7.6" width="10" height="1.3" fill="#2E5140"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,12 L18.5,12 L17.5,13.5 L14.5,13.5 Z" fill="#8A6F4D"/>
+  <!-- Weathered green-and-grey coat -->
+  <path d="M11,14 L10,25 L22,25 L21,14 Q16,16.5 11,14 Z" fill="#3E6B4F"/>
+  <rect x="11" y="17.5" width="10.5" height="1.3" fill="#2E5140"/>
+  <rect x="11" y="21" width="10.5" height="1.3" fill="#2E5140"/>
+  <!-- Pale trim: the Marches posting -->
+  <rect x="15" y="14.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="19.2" r="1.5" fill="#E8B94A"/>
+  <!-- Signal horn on hip -->
+  <path d="M20.5,21.5 Q24,20.5 24.5,23.5 Q22,24.5 20.5,23.5 Z" fill="#E8B94A"/>
+  <!-- Sword arm -->
+  <rect x="22" y="14" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <rect x="23.8" y="6.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="19.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <!-- Shield arm with round shield -->
+  <rect x="6.5" y="14" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <circle cx="7" cy="18" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="18" r="2.2" fill="#5E6A8C"/>
+  <circle cx="7" cy="18" r="0.9" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marches-warden-3.svg
+++ b/web/public/sprites/marches-warden-3.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,9.5 Q16,3.5 21,9.5 L21,8 Q16,4.5 11,8 Z" fill="#3E6B4F"/>
+  <rect x="11" y="8.6" width="10" height="1.3" fill="#2E5140"/>
+  <circle cx="14" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,13 L18.5,13 L17.5,14.5 L14.5,14.5 Z" fill="#8A6F4D"/>
+  <path d="M11,15 L10,26 L22,26 L21,15 Q16,17.5 11,15 Z" fill="#3E6B4F"/>
+  <rect x="11" y="18.5" width="10.5" height="1.3" fill="#2E5140"/>
+  <rect x="11" y="22" width="10.5" height="1.3" fill="#2E5140"/>
+  <rect x="15" y="15.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="20.2" r="1.5" fill="#E8B94A"/>
+  <path d="M20.5,22.5 Q24,21.5 24.5,24.5 Q22,25.5 20.5,24.5 Z" fill="#E8B94A"/>
+  <rect x="22" y="15" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <rect x="23.8" y="7.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="20.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <rect x="6.5" y="15" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <circle cx="7" cy="19" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="19" r="2.2" fill="#5E6A8C"/>
+  <circle cx="7" cy="19" r="0.9" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="26" width="4" height="5.2" rx="1" fill="#454E6B"/>
+  <rect x="10" y="26" width="4" height="4" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29.4" width="6" height="2.4" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="28.2" width="5.5" height="2.4" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marches-warden.svg
+++ b/web/public/sprites/marches-warden.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Weathered border commander, Dominion colours with pale trim -->
+  <circle cx="16" cy="8.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,8.5 Q16,2.5 21,8.5 L21,7 Q16,3.5 11,7 Z" fill="#3E6B4F"/>
+  <rect x="11" y="7.6" width="10" height="1.3" fill="#2E5140"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,12 L18.5,12 L17.5,13.5 L14.5,13.5 Z" fill="#8A6F4D"/>
+  <!-- Weathered green-and-grey coat -->
+  <path d="M11,14 L10,25 L22,25 L21,14 Q16,16.5 11,14 Z" fill="#3E6B4F"/>
+  <rect x="11" y="17.5" width="10.5" height="1.3" fill="#2E5140"/>
+  <rect x="11" y="21" width="10.5" height="1.3" fill="#2E5140"/>
+  <!-- Pale trim: the Marches posting -->
+  <rect x="15" y="14.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="19.2" r="1.5" fill="#E8B94A"/>
+  <!-- Signal horn on hip -->
+  <path d="M20.5,21.5 Q24,20.5 24.5,23.5 Q22,24.5 20.5,23.5 Z" fill="#E8B94A"/>
+  <!-- Sword arm -->
+  <rect x="22" y="14" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <rect x="23.8" y="6.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="19.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <!-- Shield arm with round shield -->
+  <rect x="6.5" y="14" width="3.5" height="6.5" rx="1" fill="#3E6B4F"/>
+  <circle cx="7" cy="18" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="18" r="2.2" fill="#5E6A8C"/>
+  <circle cx="7" cy="18" r="0.9" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marchland-pikeman-1.svg
+++ b/web/public/sprites/marchland-pikeman-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#A6A9C0"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#A6A9C0"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#5E6A8C"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#E8B94A"/>
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="4" width="1.4" height="24" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,1.5 L26,5 L22.4,5 Z" fill="#C9CBDA"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="17.5" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="8.5" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="17.5" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marchland-pikeman-2.svg
+++ b/web/public/sprites/marchland-pikeman-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#A6A9C0"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#A6A9C0"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Shield on left -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#5E6A8C"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#E8B94A"/>
+  <!-- Long pike -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="3" width="1.4" height="24" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,0.5 L26,4 L22.4,4 Z" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marchland-pikeman-3.svg
+++ b/web/public/sprites/marchland-pikeman-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#A6A9C0"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#A6A9C0"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#5E6A8C"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#E8B94A"/>
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="4" width="1.4" height="24" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,1.5 L26,5 L22.4,5 Z" fill="#C9CBDA"/>
+  <!-- Legs stride B -->
+  <rect x="17.5" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="9.5" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="17.5" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="8.5" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/marchland-pikeman.svg
+++ b/web/public/sprites/marchland-pikeman.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#A6A9C0"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#A6A9C0"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Shield on left -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#5E6A8C"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#E8B94A"/>
+  <!-- Long pike -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="3" width="1.4" height="24" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,0.5 L26,4 L22.4,4 Z" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-archer-1.svg
+++ b/web/public/sprites/mist-archer-1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="26" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="10" r="5" fill="#5E6A8C"/>
+  <path d="M11,10 Q16,3.5 21,10 L21,12 Q16,9 11,12 Z" fill="#454E6B"/>
+  <circle cx="16" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="12" y="18.5" width="8" height="1.2" fill="#454E6B"/>
+  <rect x="19.5" y="14.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,13 L21,14.6 L19.8,14.6 Z" fill="#C9CBDA"/>
+  <path d="M22,13 L22.6,14.6 L21.4,14.6 Z" fill="#C9CBDA"/>
+  <rect x="7.5" y="15" width="4" height="5.5" rx="1" fill="#7E8299"/>
+  <path d="M6.5,9 Q2.5,17.5 6.5,26" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="9" x2="6.5" y2="26" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="18" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-archer-2.svg
+++ b/web/public/sprites/mist-archer-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Mist wisp -->
+  <ellipse cx="16" cy="25" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#5E6A8C"/>
+  <path d="M11,9 Q16,2.5 21,9 L21,11 Q16,8 11,11 Z" fill="#454E6B"/>
+  <circle cx="16" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="12" y="17.5" width="8" height="1.2" fill="#454E6B"/>
+  <!-- Quiver -->
+  <rect x="19.5" y="13.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,12 L21,13.6 L19.8,13.6 Z" fill="#C9CBDA"/>
+  <path d="M22,12 L22.6,13.6 L21.4,13.6 Z" fill="#C9CBDA"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="14" width="4" height="5.5" rx="1" fill="#7E8299"/>
+  <path d="M6.5,8 Q2.5,16.5 6.5,25" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="8" x2="6.5" y2="25" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-archer-3.svg
+++ b/web/public/sprites/mist-archer-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="26" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="10" r="5" fill="#5E6A8C"/>
+  <path d="M11,10 Q16,3.5 21,10 L21,12 Q16,9 11,12 Z" fill="#454E6B"/>
+  <circle cx="16" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="12" y="18.5" width="8" height="1.2" fill="#454E6B"/>
+  <rect x="19.5" y="14.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,13 L21,14.6 L19.8,14.6 Z" fill="#C9CBDA"/>
+  <path d="M22,13 L22.6,14.6 L21.4,14.6 Z" fill="#C9CBDA"/>
+  <rect x="7.5" y="15" width="4" height="5.5" rx="1" fill="#7E8299"/>
+  <path d="M6.5,9 Q2.5,17.5 6.5,26" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="9" x2="6.5" y2="26" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="10" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-archer.svg
+++ b/web/public/sprites/mist-archer.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Mist wisp -->
+  <ellipse cx="16" cy="25" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#5E6A8C"/>
+  <path d="M11,9 Q16,2.5 21,9 L21,11 Q16,8 11,11 Z" fill="#454E6B"/>
+  <circle cx="16" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="12" y="17.5" width="8" height="1.2" fill="#454E6B"/>
+  <!-- Quiver -->
+  <rect x="19.5" y="13.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,12 L21,13.6 L19.8,13.6 Z" fill="#C9CBDA"/>
+  <path d="M22,12 L22.6,13.6 L21.4,13.6 Z" fill="#C9CBDA"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="14" width="4" height="5.5" rx="1" fill="#7E8299"/>
+  <path d="M6.5,8 Q2.5,16.5 6.5,25" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="8" x2="6.5" y2="25" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-barracks.svg
+++ b/web/public/sprites/mist-barracks.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29" rx="12" ry="2.2" fill="#7E8299" opacity="0.5"/>
+  <!-- Long stone hall -->
+  <rect x="4" y="15" width="24" height="13" rx="1" fill="#A6A9C0"/>
+  <rect x="4" y="19" width="24" height="1" fill="#7E8299"/>
+  <!-- Steep slate roof -->
+  <path d="M2.5,15 L16,6 L29.5,15 Z" fill="#454E6B"/>
+  <path d="M6,15 L16,8.4 L26,15 Z" fill="#5E6A8C"/>
+  <!-- Door -->
+  <rect x="13.5" y="20" width="5" height="8" rx="1.5" fill="#3A3F55"/>
+  <circle cx="17.3" cy="24.2" r="0.5" fill="#E8B94A"/>
+  <!-- Windows glowing faint -->
+  <rect x="7" y="21" width="3.4" height="3.4" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <rect x="21.6" y="21" width="3.4" height="3.4" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <!-- Banner over door -->
+  <rect x="15.4" y="15.5" width="1.2" height="4" fill="#5E6A8C"/>
+  <path d="M14,15.5 L18,15.5 L16,17.8 Z" fill="#C9CBDA"/>
+  <!-- Mist seeping from the door -->
+  <ellipse cx="16" cy="28.2" rx="6" ry="1.4" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="11" cy="27.4" rx="3.5" ry="1" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/mist-skirmisher-1.svg
+++ b/web/public/sprites/mist-skirmisher-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="25" rx="10" ry="3" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 A5,5 0 0 1 21,10 L21,8 Q16,5 11,8 Z" fill="#454E6B"/>
+  <rect x="11.5" y="11.5" width="9" height="3" rx="1.5" fill="#7E8299"/>
+  <circle cx="14" cy="9.8" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="9.8" r="0.8" fill="#3A3F55"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="12" y="18.5" width="8" height="1.4" fill="#454E6B"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="20.5" y="15" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <path d="M7,21 L9,20 L8,24 Z" fill="#C9CBDA"/>
+  <path d="M25,21 L23,20 L24,24 Z" fill="#C9CBDA"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="18" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-skirmisher-2.svg
+++ b/web/public/sprites/mist-skirmisher-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Mist wisp behind -->
+  <ellipse cx="16" cy="24" rx="10" ry="3" fill="#E8EAF4" opacity="0.35"/>
+  <!-- Head with half-mask -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 A5,5 0 0 1 21,9 L21,7 Q16,4 11,7 Z" fill="#454E6B"/>
+  <rect x="11.5" y="10.5" width="9" height="3" rx="1.5" fill="#7E8299"/>
+  <circle cx="14" cy="8.8" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="8.8" r="0.8" fill="#3A3F55"/>
+  <!-- Light leather body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="12" y="17.5" width="8" height="1.4" fill="#454E6B"/>
+  <!-- Dagger arms -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="20.5" y="14" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <path d="M7,20 L9,19 L8,23 Z" fill="#C9CBDA"/>
+  <path d="M25,20 L23,19 L24,23 Z" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-skirmisher-3.svg
+++ b/web/public/sprites/mist-skirmisher-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="25" rx="10" ry="3" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 A5,5 0 0 1 21,10 L21,8 Q16,5 11,8 Z" fill="#454E6B"/>
+  <rect x="11.5" y="11.5" width="9" height="3" rx="1.5" fill="#7E8299"/>
+  <circle cx="14" cy="9.8" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="9.8" r="0.8" fill="#3A3F55"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="12" y="18.5" width="8" height="1.4" fill="#454E6B"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="20.5" y="15" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <path d="M7,21 L9,20 L8,24 Z" fill="#C9CBDA"/>
+  <path d="M25,21 L23,20 L24,24 Z" fill="#C9CBDA"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="10" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/mist-skirmisher.svg
+++ b/web/public/sprites/mist-skirmisher.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Mist wisp behind -->
+  <ellipse cx="16" cy="24" rx="10" ry="3" fill="#E8EAF4" opacity="0.35"/>
+  <!-- Head with half-mask -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 A5,5 0 0 1 21,9 L21,7 Q16,4 11,7 Z" fill="#454E6B"/>
+  <rect x="11.5" y="10.5" width="9" height="3" rx="1.5" fill="#7E8299"/>
+  <circle cx="14" cy="8.8" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="8.8" r="0.8" fill="#3A3F55"/>
+  <!-- Light leather body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="12" y="17.5" width="8" height="1.4" fill="#454E6B"/>
+  <!-- Dagger arms -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="20.5" y="14" width="3.5" height="6" rx="1" fill="#7E8299"/>
+  <path d="M7,20 L9,19 L8,23 Z" fill="#C9CBDA"/>
+  <path d="M25,20 L23,19 L24,23 Z" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-monolith.svg
+++ b/web/public/sprites/pale-monolith.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="11" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Central monolith -->
+  <path d="M11,29 L12,6 L20,6 L21,29 Z" fill="#C9CBDA"/>
+  <path d="M12.8,29 L13.5,7.5 L16,7.5 L16,29 Z" fill="#DDDEE8"/>
+  <!-- Carved standing figures (the census) -->
+  <path d="M14,11 Q15,9.5 16,11 L16,16 L14,16 Z" fill="#8E92A8"/>
+  <path d="M17,12 Q18,10.5 19,12 L19,17 L17,17 Z" fill="#8E92A8"/>
+  <path d="M14.5,19 Q15.5,17.5 16.5,19 L16.5,24 L14.5,24 Z" fill="#8E92A8"/>
+  <!-- One figure stepping OUT of the stone -->
+  <circle cx="24" cy="20" r="2" fill="#C9CBDA"/>
+  <path d="M22.5,22.5 L22,28 L26,28 L25.5,22.5 Q24,23.5 22.5,22.5 Z" fill="#C9CBDA"/>
+  <path d="M21.5,22 Q20,21 21,19.5" stroke="#E8EAF4" stroke-width="0.8" fill="none"/>
+  <!-- Flanking small stones -->
+  <path d="M5,29 L6,17 L9,15 L10,29 Z" fill="#A6A9C0"/>
+  <path d="M26.5,29 L26.5,22.5" stroke="none"/>
+  <!-- Pale glow seam -->
+  <rect x="15.6" y="6" width="0.8" height="23" fill="#E8EAF4" opacity="0.8"/>
+  <ellipse cx="16" cy="17" rx="7" ry="11" fill="#E8EAF4" opacity="0.1"/>
+  <!-- Mist -->
+  <ellipse cx="16" cy="28.8" rx="9" ry="1.5" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/pale-rider-1.svg
+++ b/web/public/sprites/pale-rider-1.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Gallop pose A: legs gathered -->
+  <path d="M5,23 L7,16 Q9,13 13,14 L21,14 Q25,14 26,17 L27,21 L25,23 Z" fill="#C9CBDA"/>
+  <path d="M24,15 L29,11 L30,13 L27,17 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="13" r="0.7" fill="#3A3F55"/>
+  <path d="M22,13 Q24,10 27,11 L25,14 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="7.5" width="6" height="8" rx="2" fill="#5E6A8C"/>
+  <circle cx="16" cy="6" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,6 Q16,1.5 19.4,6 L19.4,7.4 Q16,5 12.6,7.4 Z" fill="#454E6B"/>
+  <rect x="19.5" y="5" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 12)"/>
+  <path d="M24.6,3.6 L26.4,6.4 L23.2,6.6 Z" fill="#C9CBDA"/>
+  <!-- Legs gathered under body -->
+  <rect x="9.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(18 10.7 26)"/>
+  <rect x="13" y="23" width="2.4" height="7" rx="1" fill="#A6A9C0" transform="rotate(8 14.2 26.5)"/>
+  <rect x="18" y="23" width="2.4" height="7" rx="1" fill="#A6A9C0" transform="rotate(-8 19.2 26.5)"/>
+  <rect x="21.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(-18 22.7 26)"/>
+  <path d="M5.5,17 Q2.5,19 3.5,23 Q5,21 6.5,20.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/pale-rider-2.svg
+++ b/web/public/sprites/pale-rider-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadowless void-bred horse, side view -->
+  <path d="M5,22 L7,15 Q9,12 13,13 L21,13 Q25,13 26,16 L27,20 L25,22 Z" fill="#C9CBDA"/>
+  <!-- Horse head -->
+  <path d="M24,14 L29,10 L30,12 L27,16 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="12" r="0.7" fill="#3A3F55"/>
+  <!-- Mane of mist -->
+  <path d="M22,12 Q24,9 27,10 L25,13 Z" fill="#E8EAF4" opacity="0.8"/>
+  <!-- Rider torso -->
+  <rect x="13" y="6.5" width="6" height="8" rx="2" fill="#5E6A8C"/>
+  <circle cx="16" cy="5" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,5 Q16,0.5 19.4,5 L19.4,6.4 Q16,4 12.6,6.4 Z" fill="#454E6B"/>
+  <!-- Lance -->
+  <rect x="19.5" y="4" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 11)"/>
+  <path d="M24.6,2.6 L26.4,5.4 L23.2,5.6 Z" fill="#C9CBDA"/>
+  <!-- Horse legs (standing) -->
+  <rect x="7" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <rect x="12" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="19" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <!-- Tail -->
+  <path d="M5.5,16 Q2.5,18 3.5,22 Q5,20 6.5,19.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/pale-rider-3.svg
+++ b/web/public/sprites/pale-rider-3.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Gallop pose B: legs extended -->
+  <path d="M5,23 L7,16 Q9,13 13,14 L21,14 Q25,14 26,17 L27,21 L25,23 Z" fill="#C9CBDA"/>
+  <path d="M24,15 L29,11 L30,13 L27,17 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="13" r="0.7" fill="#3A3F55"/>
+  <path d="M22,13 Q24,10 27,11 L25,14 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="7.5" width="6" height="8" rx="2" fill="#5E6A8C"/>
+  <circle cx="16" cy="6" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,6 Q16,1.5 19.4,6 L19.4,7.4 Q16,5 12.6,7.4 Z" fill="#454E6B"/>
+  <rect x="19.5" y="5" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 12)"/>
+  <path d="M24.6,3.6 L26.4,6.4 L23.2,6.6 Z" fill="#C9CBDA"/>
+  <!-- Legs extended fore and aft -->
+  <rect x="5.5" y="21.5" width="2.4" height="9" rx="1" fill="#A6A9C0" transform="rotate(-24 6.7 26)"/>
+  <rect x="11" y="22.5" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(-10 12.2 26.5)"/>
+  <rect x="20" y="22.5" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(10 21.2 26.5)"/>
+  <rect x="25" y="21.5" width="2.4" height="9" rx="1" fill="#A6A9C0" transform="rotate(24 26.2 26)"/>
+  <path d="M5.5,17 Q2.5,19 3.5,23 Q5,21 6.5,20.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/pale-rider.svg
+++ b/web/public/sprites/pale-rider.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadowless void-bred horse, side view -->
+  <path d="M5,22 L7,15 Q9,12 13,13 L21,13 Q25,13 26,16 L27,20 L25,22 Z" fill="#C9CBDA"/>
+  <!-- Horse head -->
+  <path d="M24,14 L29,10 L30,12 L27,16 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="12" r="0.7" fill="#3A3F55"/>
+  <!-- Mane of mist -->
+  <path d="M22,12 Q24,9 27,10 L25,13 Z" fill="#E8EAF4" opacity="0.8"/>
+  <!-- Rider torso -->
+  <rect x="13" y="6.5" width="6" height="8" rx="2" fill="#5E6A8C"/>
+  <circle cx="16" cy="5" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,5 Q16,0.5 19.4,5 L19.4,6.4 Q16,4 12.6,6.4 Z" fill="#454E6B"/>
+  <!-- Lance -->
+  <rect x="19.5" y="4" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 11)"/>
+  <path d="M24.6,2.6 L26.4,5.4 L23.2,5.6 Z" fill="#C9CBDA"/>
+  <!-- Horse legs (standing) -->
+  <rect x="7" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <rect x="12" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="19" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <!-- Tail -->
+  <path d="M5.5,16 Q2.5,18 3.5,22 Q5,20 6.5,19.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/pale-sentry-1.svg
+++ b/web/public/sprites/pale-sentry-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#5E6A8C"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#454E6B"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#5E6A8C"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Watch-lantern on belt -->
+  <circle cx="19.5" cy="21" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="21" r="0.8" fill="#FFB347"/>
+  <!-- Spear arm -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="8.5" y="7" width="1.4" height="18" rx="0.7" fill="#7E8299"/>
+  <path d="M9.2,3 L11,7.5 L7.4,7.5 Z" fill="#C9CBDA"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-sentry-2.svg
+++ b/web/public/sprites/pale-sentry-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#5E6A8C"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#454E6B"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#5E6A8C"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Watch-lantern on belt -->
+  <circle cx="19.5" cy="20" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="20" r="0.8" fill="#FFB347"/>
+  <!-- Spear arm -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="8.5" y="6" width="1.4" height="18" rx="0.7" fill="#7E8299"/>
+  <path d="M9.2,2 L11,6.5 L7.4,6.5 Z" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-sentry-3.svg
+++ b/web/public/sprites/pale-sentry-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#5E6A8C"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#454E6B"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#5E6A8C"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Watch-lantern on belt -->
+  <circle cx="19.5" cy="21" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="21" r="0.8" fill="#FFB347"/>
+  <!-- Spear arm -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="8.5" y="7" width="1.4" height="18" rx="0.7" fill="#7E8299"/>
+  <path d="M9.2,3 L11,7.5 L7.4,7.5 Z" fill="#C9CBDA"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-sentry.svg
+++ b/web/public/sprites/pale-sentry.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#5E6A8C"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#454E6B"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#5E6A8C"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Watch-lantern on belt -->
+  <circle cx="19.5" cy="20" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="20" r="0.8" fill="#FFB347"/>
+  <!-- Spear arm -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="8.5" y="6" width="1.4" height="18" rx="0.7" fill="#7E8299"/>
+  <path d="M9.2,2 L11,6.5 L7.4,6.5 Z" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-vanguard-1.svg
+++ b/web/public/sprites/pale-vanguard-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5.5" fill="#A6A9C0"/>
+  <path d="M10.5,10 Q16,3 21.5,10 L21.5,12 L10.5,12 Z" fill="#7E8299"/>
+  <path d="M15,3.5 Q16,1 17,3.5 L16.8,6 L15.2,6 Z" fill="#E8B94A"/>
+  <rect x="12" y="9.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#FFB347"/>
+  <path d="M10,15 L10,25 L22,25 L22,15 Q16,17.5 10,15 Z" fill="#A6A9C0"/>
+  <rect x="10" y="18" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="21.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="19.8" r="1.6" fill="#E8B94A"/>
+  <rect x="4.5" y="14" width="5.5" height="10" rx="1.5" fill="#5E6A8C"/>
+  <rect x="5.5" y="15" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <circle cx="7.2" cy="19" r="1.2" fill="#E8B94A"/>
+  <rect x="22.5" y="15" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.2" y="7" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="20.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="25" width="4" height="6" rx="1" fill="#454E6B"/>
+  <rect x="18" y="25" width="4" height="4.8" rx="1" fill="#454E6B"/>
+  <rect x="8.5" y="29" width="6" height="2.5" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.8" width="5.5" height="2.5" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-vanguard-2.svg
+++ b/web/public/sprites/pale-vanguard-2.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm -->
+  <circle cx="16" cy="9" r="5.5" fill="#A6A9C0"/>
+  <path d="M10.5,9 Q16,2 21.5,9 L21.5,11 L10.5,11 Z" fill="#7E8299"/>
+  <path d="M15,2.5 Q16,0 17,2.5 L16.8,5 L15.2,5 Z" fill="#E8B94A"/>
+  <rect x="12" y="8.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,14 L10,24 L22,24 L22,14 Q16,16.5 10,14 Z" fill="#A6A9C0"/>
+  <rect x="10" y="17" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="20.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="18.8" r="1.6" fill="#E8B94A"/>
+  <!-- Tower shield -->
+  <rect x="4.5" y="13" width="5.5" height="10" rx="1.5" fill="#5E6A8C"/>
+  <rect x="5.5" y="14" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <circle cx="7.2" cy="18" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="14" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.2" y="6" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="19.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-vanguard-3.svg
+++ b/web/public/sprites/pale-vanguard-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5.5" fill="#A6A9C0"/>
+  <path d="M10.5,10 Q16,3 21.5,10 L21.5,12 L10.5,12 Z" fill="#7E8299"/>
+  <path d="M15,3.5 Q16,1 17,3.5 L16.8,6 L15.2,6 Z" fill="#E8B94A"/>
+  <rect x="12" y="9.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#FFB347"/>
+  <path d="M10,15 L10,25 L22,25 L22,15 Q16,17.5 10,15 Z" fill="#A6A9C0"/>
+  <rect x="10" y="18" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="21.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="19.8" r="1.6" fill="#E8B94A"/>
+  <rect x="4.5" y="14" width="5.5" height="10" rx="1.5" fill="#5E6A8C"/>
+  <rect x="5.5" y="15" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <circle cx="7.2" cy="19" r="1.2" fill="#E8B94A"/>
+  <rect x="22.5" y="15" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.2" y="7" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="20.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="25" width="4" height="6" rx="1" fill="#454E6B"/>
+  <rect x="9.5" y="25" width="4" height="4.8" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="6" height="2.5" rx="1" fill="#3A3F55"/>
+  <rect x="8.5" y="27.8" width="5.5" height="2.5" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/pale-vanguard.svg
+++ b/web/public/sprites/pale-vanguard.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm -->
+  <circle cx="16" cy="9" r="5.5" fill="#A6A9C0"/>
+  <path d="M10.5,9 Q16,2 21.5,9 L21.5,11 L10.5,11 Z" fill="#7E8299"/>
+  <path d="M15,2.5 Q16,0 17,2.5 L16.8,5 L15.2,5 Z" fill="#E8B94A"/>
+  <rect x="12" y="8.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,14 L10,24 L22,24 L22,14 Q16,16.5 10,14 Z" fill="#A6A9C0"/>
+  <rect x="10" y="17" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="20.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="18.8" r="1.6" fill="#E8B94A"/>
+  <!-- Tower shield -->
+  <rect x="4.5" y="13" width="5.5" height="10" rx="1.5" fill="#5E6A8C"/>
+  <rect x="5.5" y="14" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <circle cx="7.2" cy="18" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="14" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.2" y="6" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="19.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/the-pale-herald-1.svg
+++ b/web/public/sprites/the-pale-herald-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride A: banner sways back -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(4 25.8 16)"/>
+  <path d="M26.6,4 L31.2,6 L26.6,10 Z" fill="#5E6A8C"/>
+  <circle cx="28.8" cy="6.6" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#C9CBDA"/>
+  <path d="M11,4.5 L12.5,1.8 L14,4.5 L16,1.8 L18,4.5 L19.5,1.8 L21,4.5 Z" fill="#E8B94A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#C9CBDA"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#A6A9C0"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#7E8299"/>
+  <ellipse cx="16.5" cy="20.4" rx="1.8" ry="2.4" fill="#E8B94A"/>
+  <ellipse cx="16.5" cy="20.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#A6A9C0"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#A6A9C0"/>
+  <rect x="2.5" y="17" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="19" x2="7" y2="19" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="20.5" x2="7" y2="20.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="22" x2="7" y2="22" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="28" width="4.5" height="3.6" rx="1" fill="#454E6B"/>
+  <rect x="18.5" y="28" width="4.5" height="2.8" rx="1" fill="#454E6B"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-pale-herald-2.svg
+++ b/web/public/sprites/the-pale-herald-2.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Towering armoured herald with banner and writ -->
+  <!-- Banner pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#5E6A8C"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#E8B94A"/>
+  <!-- Crowned great helm -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#C9CBDA"/>
+  <path d="M11,3.5 L12.5,0.8 L14,3.5 L16,0.8 L18,3.5 L19.5,0.8 L21,3.5 Z" fill="#E8B94A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <!-- Massive pale cloak/body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#C9CBDA"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#A6A9C0"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#7E8299"/>
+  <!-- Vigil flame chest sigil -->
+  <ellipse cx="16.5" cy="19.4" rx="1.8" ry="2.4" fill="#E8B94A"/>
+  <ellipse cx="16.5" cy="19.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#A6A9C0"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#A6A9C0"/>
+  <!-- The writ (unrolled scroll in hand) -->
+  <rect x="2.5" y="16" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="18" x2="7" y2="18" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="19.5" x2="7" y2="19.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="21" x2="7" y2="21" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-pale-herald-3.svg
+++ b/web/public/sprites/the-pale-herald-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride B: banner sways forward -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(-4 25.8 16)"/>
+  <path d="M26.2,4 L30.8,5.2 L26.2,9.6 Z" fill="#5E6A8C"/>
+  <circle cx="28.4" cy="6" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#C9CBDA"/>
+  <path d="M11,4.5 L12.5,1.8 L14,4.5 L16,1.8 L18,4.5 L19.5,1.8 L21,4.5 Z" fill="#E8B94A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#E8EAF4"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#C9CBDA"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#A6A9C0"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#7E8299"/>
+  <ellipse cx="16.5" cy="20.4" rx="1.8" ry="2.4" fill="#E8B94A"/>
+  <ellipse cx="16.5" cy="20.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#A6A9C0"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#A6A9C0"/>
+  <rect x="2.5" y="17" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="19" x2="7" y2="19" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="20.5" x2="7" y2="20.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="22" x2="7" y2="22" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs stride B -->
+  <rect x="18.5" y="28" width="4.5" height="3.6" rx="1" fill="#454E6B"/>
+  <rect x="9.5" y="28" width="4.5" height="2.8" rx="1" fill="#454E6B"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-pale-herald.svg
+++ b/web/public/sprites/the-pale-herald.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Towering armoured herald with banner and writ -->
+  <!-- Banner pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#5E6A8C"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#E8B94A"/>
+  <!-- Crowned great helm -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#C9CBDA"/>
+  <path d="M11,3.5 L12.5,0.8 L14,3.5 L16,0.8 L18,3.5 L19.5,0.8 L21,3.5 Z" fill="#E8B94A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#E8EAF4"/>
+  <!-- Massive pale cloak/body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#C9CBDA"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#A6A9C0"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#7E8299"/>
+  <!-- Vigil flame chest sigil -->
+  <ellipse cx="16.5" cy="19.4" rx="1.8" ry="2.4" fill="#E8B94A"/>
+  <ellipse cx="16.5" cy="19.8" rx="0.9" ry="1.3" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#A6A9C0"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#A6A9C0"/>
+  <!-- The writ (unrolled scroll in hand) -->
+  <rect x="2.5" y="16" width="5.5" height="7" rx="1" fill="#F2E9D8"/>
+  <line x1="3.5" y1="18" x2="7" y2="18" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="19.5" x2="7" y2="19.5" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="3.5" y1="21" x2="7" y2="21" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#454E6B"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-waiting-mist-1.svg
+++ b/web/public/sprites/the-waiting-mist-1.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drift phase A: mass leans left, wisps trail right -->
+  <ellipse cx="15" cy="19" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="11" cy="16" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="20" cy="15" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="15" cy="13" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <ellipse cx="15" cy="16" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <circle cx="12.5" cy="15" r="1.2" fill="#5E6A8C"/>
+  <circle cx="17.5" cy="15" r="1.2" fill="#5E6A8C"/>
+  <circle cx="12.5" cy="14.7" r="0.4" fill="#E8EAF4"/>
+  <circle cx="17.5" cy="14.7" r="0.4" fill="#E8EAF4"/>
+  <path d="M24,20 Q27.5,22 27,25.5 Q25,23.5 23.5,23 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M7,23 Q5,26 7.5,28 Q8.5,25.5 10,24.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M15,25 Q14,28.5 17,30 Q18,27.5 19,26 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-waiting-mist-2.svg
+++ b/web/public/sprites/the-waiting-mist-2.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drifting sentient mist mass -->
+  <ellipse cx="16" cy="18" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="12" cy="15" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="21" cy="14" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="16" cy="12" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <!-- Deep core -->
+  <ellipse cx="16" cy="15" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <!-- Two pale eyes -->
+  <circle cx="13.5" cy="14" r="1.2" fill="#5E6A8C"/>
+  <circle cx="18.5" cy="14" r="1.2" fill="#5E6A8C"/>
+  <circle cx="13.5" cy="13.7" r="0.4" fill="#E8EAF4"/>
+  <circle cx="18.5" cy="13.7" r="0.4" fill="#E8EAF4"/>
+  <!-- Trailing wisps -->
+  <path d="M6,22 Q4,25 6.5,27 Q7.5,24.5 9,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M26,22 Q28,25 25.5,27 Q24.5,24.5 23,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M14,24 Q13,27.5 16,29 Q17,26.5 18,25 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-waiting-mist-3.svg
+++ b/web/public/sprites/the-waiting-mist-3.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drift phase B: mass leans right, wisps trail left -->
+  <ellipse cx="17" cy="19" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="13" cy="15" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="22" cy="16" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="17" cy="13" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <ellipse cx="17" cy="16" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <circle cx="14.5" cy="15" r="1.2" fill="#5E6A8C"/>
+  <circle cx="19.5" cy="15" r="1.2" fill="#5E6A8C"/>
+  <circle cx="14.5" cy="14.7" r="0.4" fill="#E8EAF4"/>
+  <circle cx="19.5" cy="14.7" r="0.4" fill="#E8EAF4"/>
+  <path d="M8,20 Q4.5,22 5,25.5 Q7,23.5 8.5,23 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M25,23 Q27,26 24.5,28 Q23.5,25.5 22,24.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M17,25 Q18,28.5 15,30 Q14,27.5 13,26 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-waiting-mist.svg
+++ b/web/public/sprites/the-waiting-mist.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drifting sentient mist mass -->
+  <ellipse cx="16" cy="18" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="12" cy="15" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="21" cy="14" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="16" cy="12" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <!-- Deep core -->
+  <ellipse cx="16" cy="15" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <!-- Two pale eyes -->
+  <circle cx="13.5" cy="14" r="1.2" fill="#5E6A8C"/>
+  <circle cx="18.5" cy="14" r="1.2" fill="#5E6A8C"/>
+  <circle cx="13.5" cy="13.7" r="0.4" fill="#E8EAF4"/>
+  <circle cx="18.5" cy="13.7" r="0.4" fill="#E8EAF4"/>
+  <!-- Trailing wisps -->
+  <path d="M6,22 Q4,25 6.5,27 Q7.5,24.5 9,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M26,22 Q28,25 25.5,27 Q24.5,24.5 23,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M14,24 Q13,27.5 16,29 Q17,26.5 18,25 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/unremembered-choir-1.svg
+++ b/web/public/sprites/unremembered-choir-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robes sway left, notes drift -->
+  <circle cx="9" cy="12" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.4,12 Q9,7 12.6,12 L12.6,14 Q9,11.5 5.4,14 Z" fill="#7E8299"/>
+  <path d="M6,15 L4,29 L12,29 L12,15 Q9,16.5 6,15 Z" fill="#A6A9C0"/>
+  <circle cx="23" cy="12" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.4,12 Q23,7 26.6,12 L26.6,14 Q23,11.5 19.4,14 Z" fill="#7E8299"/>
+  <path d="M20,15 L18,29 L26,29 L26,15 Q23,16.5 20,15 Z" fill="#A6A9C0"/>
+  <circle cx="16" cy="10" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,10 Q16,4.5 20.2,10 L20.2,12.5 Q16,9.5 11.8,12.5 Z" fill="#5E6A8C"/>
+  <ellipse cx="16" cy="11.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,14 L10,31 L20,31 L19.5,14 Q16,16 12.5,14 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="18" width="5" height="1.1" fill="#7E8299"/>
+  <circle cx="10.5" cy="4.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="11.2" y="2" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="18.5" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="19.2" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <ellipse cx="16" cy="30" rx="9" ry="1.8" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/unremembered-choir-2.svg
+++ b/web/public/sprites/unremembered-choir-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded singers in a row -->
+  <!-- Back singers -->
+  <circle cx="9" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.4,11 Q9,6 12.6,11 L12.6,13 Q9,10.5 5.4,13 Z" fill="#7E8299"/>
+  <path d="M6,14 L5,28 L13,28 L12,14 Q9,15.5 6,14 Z" fill="#A6A9C0"/>
+  <circle cx="23" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.4,11 Q23,6 26.6,11 L26.6,13 Q23,10.5 19.4,13 Z" fill="#7E8299"/>
+  <path d="M20,14 L19,28 L27,28 L26,14 Q23,15.5 20,14 Z" fill="#A6A9C0"/>
+  <!-- Front centre singer -->
+  <circle cx="16" cy="9" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9 Q16,3.5 20.2,9 L20.2,11.5 Q16,8.5 11.8,11.5 Z" fill="#5E6A8C"/>
+  <ellipse cx="16" cy="10.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,13 L11,30 L21,30 L19.5,13 Q16,15 12.5,13 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Hymn notes rising -->
+  <circle cx="12" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="12.7" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="20" cy="3.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="20.7" y="1" width="0.6" height="3" fill="#E8EAF4"/>
+  <!-- Candle glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/unremembered-choir-3.svg
+++ b/web/public/sprites/unremembered-choir-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robes sway right, notes drift -->
+  <circle cx="9" cy="12" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.4,12 Q9,7 12.6,12 L12.6,14 Q9,11.5 5.4,14 Z" fill="#7E8299"/>
+  <path d="M6,15 L6,29 L14,29 L12,15 Q9,16.5 6,15 Z" fill="#A6A9C0"/>
+  <circle cx="23" cy="12" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.4,12 Q23,7 26.6,12 L26.6,14 Q23,11.5 19.4,14 Z" fill="#7E8299"/>
+  <path d="M20,15 L20,29 L28,29 L26,15 Q23,16.5 20,15 Z" fill="#A6A9C0"/>
+  <circle cx="16" cy="10" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,10 Q16,4.5 20.2,10 L20.2,12.5 Q16,9.5 11.8,12.5 Z" fill="#5E6A8C"/>
+  <ellipse cx="16" cy="11.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,14 L12,31 L22,31 L19.5,14 Q16,16 12.5,14 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="18" width="5" height="1.1" fill="#7E8299"/>
+  <circle cx="13.5" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="14.2" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="21.5" cy="4.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="22.2" y="2" width="0.6" height="3" fill="#E8EAF4"/>
+  <ellipse cx="16" cy="30" rx="9" ry="1.8" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/unremembered-choir.svg
+++ b/web/public/sprites/unremembered-choir.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded singers in a row -->
+  <!-- Back singers -->
+  <circle cx="9" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.4,11 Q9,6 12.6,11 L12.6,13 Q9,10.5 5.4,13 Z" fill="#7E8299"/>
+  <path d="M6,14 L5,28 L13,28 L12,14 Q9,15.5 6,14 Z" fill="#A6A9C0"/>
+  <circle cx="23" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.4,11 Q23,6 26.6,11 L26.6,13 Q23,10.5 19.4,13 Z" fill="#7E8299"/>
+  <path d="M20,14 L19,28 L27,28 L26,14 Q23,15.5 20,14 Z" fill="#A6A9C0"/>
+  <!-- Front centre singer -->
+  <circle cx="16" cy="9" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9 Q16,3.5 20.2,9 L20.2,11.5 Q16,8.5 11.8,11.5 Z" fill="#5E6A8C"/>
+  <ellipse cx="16" cy="10.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,13 L11,30 L21,30 L19.5,13 Q16,15 12.5,13 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Hymn notes rising -->
+  <circle cx="12" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="12.7" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="20" cy="3.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="20.7" y="1" width="0.6" height="3" fill="#E8EAF4"/>
+  <!-- Candle glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/unremembered-soldier-1.svg
+++ b/web/public/sprites/unremembered-soldier-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 Q16,4 21,10 L21,9 Q16,5.5 11,9 Z" fill="#7E8299"/>
+  <rect x="11" y="9.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="11" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="11" r="0.8" fill="#3A3F55"/>
+  <path d="M12,15 L12,24 L20,24 L20,15 Q16,17 12,15 Z" fill="#5E6A8C"/>
+  <rect x="14.5" y="15.5" width="3" height="8" fill="#C9CBDA" opacity="0.75"/>
+  <rect x="12" y="19" width="8" height="1.2" fill="#454E6B"/>
+  <rect x="20.5" y="15" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="23" y="11" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="19" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M5.5,15.5 L10,15.5 L10,21.5 Q7.7,23.5 5.5,21.5 Z" fill="#7E8299"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-soldier-2.svg
+++ b/web/public/sprites/unremembered-soldier-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Faded standard-bearer infantry -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 Q16,3 21,9 L21,8 Q16,4.5 11,8 Z" fill="#7E8299"/>
+  <rect x="11" y="8.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="10" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10" r="0.8" fill="#3A3F55"/>
+  <!-- Tabard body, colours half-faded -->
+  <path d="M12,14 L12,23 L20,23 L20,14 Q16,16 12,14 Z" fill="#5E6A8C"/>
+  <rect x="14.5" y="14.5" width="3" height="8" fill="#C9CBDA" opacity="0.75"/>
+  <rect x="12" y="18" width="8" height="1.2" fill="#454E6B"/>
+  <!-- Sword arm -->
+  <rect x="20.5" y="14" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="23" y="10" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="18" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <!-- Shield arm -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M5.5,14.5 L10,14.5 L10,20.5 Q7.7,22.5 5.5,20.5 Z" fill="#7E8299"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-soldier-3.svg
+++ b/web/public/sprites/unremembered-soldier-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 Q16,4 21,10 L21,9 Q16,5.5 11,9 Z" fill="#7E8299"/>
+  <rect x="11" y="9.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="11" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="11" r="0.8" fill="#3A3F55"/>
+  <path d="M12,15 L12,24 L20,24 L20,15 Q16,17 12,15 Z" fill="#5E6A8C"/>
+  <rect x="14.5" y="15.5" width="3" height="8" fill="#C9CBDA" opacity="0.75"/>
+  <rect x="12" y="19" width="8" height="1.2" fill="#454E6B"/>
+  <rect x="20.5" y="15" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="23" y="11" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="19" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M5.5,15.5 L10,15.5 L10,21.5 Q7.7,23.5 5.5,21.5 Z" fill="#7E8299"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-soldier.svg
+++ b/web/public/sprites/unremembered-soldier.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Faded standard-bearer infantry -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 Q16,3 21,9 L21,8 Q16,4.5 11,8 Z" fill="#7E8299"/>
+  <rect x="11" y="8.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="10" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10" r="0.8" fill="#3A3F55"/>
+  <!-- Tabard body, colours half-faded -->
+  <path d="M12,14 L12,23 L20,23 L20,14 Q16,16 12,14 Z" fill="#5E6A8C"/>
+  <rect x="14.5" y="14.5" width="3" height="8" fill="#C9CBDA" opacity="0.75"/>
+  <rect x="12" y="18" width="8" height="1.2" fill="#454E6B"/>
+  <!-- Sword arm -->
+  <rect x="20.5" y="14" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <rect x="23" y="10" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="18" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <!-- Shield arm -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M5.5,14.5 L10,14.5 L10,20.5 Q7.7,22.5 5.5,20.5 Z" fill="#7E8299"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/wardstone.svg
+++ b/web/public/sprites/wardstone.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="10" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Massive standing stone -->
+  <path d="M9,29 L10,8 Q12,4 16,4 Q20,4 22,8 L23,29 Z" fill="#8E92A8"/>
+  <path d="M11,29 L11.8,9 Q13.5,6 16,6 L16,29 Z" fill="#A6A9C0"/>
+  <!-- Carved true-name runes, faintly glowing -->
+  <rect x="14" y="10" width="4" height="1.2" rx="0.6" fill="#B8DCF7" opacity="0.9"/>
+  <rect x="13" y="13.5" width="6" height="1.2" rx="0.6" fill="#B8DCF7" opacity="0.75"/>
+  <rect x="14.5" y="17" width="3" height="1.2" rx="0.6" fill="#B8DCF7" opacity="0.9"/>
+  <rect x="13.5" y="20.5" width="5" height="1.2" rx="0.6" fill="#B8DCF7" opacity="0.7"/>
+  <rect x="14" y="24" width="4" height="1.2" rx="0.6" fill="#B8DCF7" opacity="0.85"/>
+  <!-- Rune glow -->
+  <ellipse cx="16" cy="17" rx="6" ry="10" fill="#B8DCF7" opacity="0.12"/>
+  <!-- Cracks -->
+  <path d="M12,26 L13.5,23 L12.8,20" stroke="#5E6270" stroke-width="0.8" fill="none"/>
+  <path d="M20.5,25 L19.4,22.5" stroke="#5E6270" stroke-width="0.8" fill="none"/>
+  <!-- Mist -->
+  <ellipse cx="16" cy="28.6" rx="8" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/watch-beacon.svg
+++ b/web/public/sprites/watch-beacon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Tall stone tower, tapering -->
+  <path d="M11.5,29 L13,9 L19,9 L20.5,29 Z" fill="#A6A9C0"/>
+  <path d="M13,9 L19,9 L18.6,14 L13.4,14 Z" fill="#C9CBDA"/>
+  <rect x="12.6" y="19" width="6.8" height="1" fill="#7E8299"/>
+  <rect x="12.2" y="24" width="7.6" height="1" fill="#7E8299"/>
+  <!-- Arrow slit -->
+  <rect x="15.4" y="16" width="1.2" height="4" rx="0.6" fill="#3A3F55"/>
+  <!-- Beacon platform -->
+  <rect x="10.5" y="7.4" width="11" height="2" rx="0.8" fill="#5B5346"/>
+  <!-- Beacon fire -->
+  <path d="M13.5,7.4 Q13,3.5 16,1.5 Q15.6,4 17.5,5 Q18.6,3 18.5,7.4 Z" fill="#FF8C42"/>
+  <path d="M14.8,7.4 Q15,4.8 16.2,3.8 Q16.2,5.6 17.2,6.2 Q17.4,6.6 17.3,7.4 Z" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="16" cy="5" r="5.5" fill="#FFB347" opacity="0.25"/>
+  <!-- Crenellation -->
+  <rect x="10.5" y="6" width="2" height="1.6" fill="#5B5346"/>
+  <rect x="19.5" y="6" width="2" height="1.6" fill="#5B5346"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,7 +26,7 @@ import { applyStatUpgrade } from './game/playerStats'
 import {
   loadRun, saveRun, clearRun, newRun, LIVES_START, LIVES_MAX,
   getAvailableNodeIds, skipSiblings, isActComplete,
-  generateRewardChoices, generateEndlessRewardChoices, generateMerchantCards, MERCHANT_PRICES, ACTS, getNextAct,
+  generateRewardChoices, generateEndlessRewardChoices, generateMerchantCards, MERCHANT_PRICES, ACTS, getNextAct, getCampaignForAct,
   loadFatigued, saveFatigued, clearFatigued, getTopPlayedCards,
   hasSeenIntro, markIntroSeen,
   loadRunCount, incrementRunCount, getAct1Intro,
@@ -137,6 +137,7 @@ import { BattleSummary }    from './components/battle/BattleSummary'
 import { VictoryPanel }     from './components/battle/VictoryPanel'
 import { RelicSpinScreen }  from './components/campaign/RelicSpinScreen'
 import { CampaignVictoryScreen } from './components/battle/CampaignVictoryScreen'
+import { ToBeContinuedScreen } from './components/battle/ToBeContinuedScreen'
 import { CampaignFailedScreen }  from './components/battle/CampaignFailedScreen'
 import { StatUpgradeScreen }     from './components/campaign/StatUpgradeScreen'
 import { PlayerStatsScreen }     from './components/screens/PlayerStatsScreen'
@@ -224,6 +225,7 @@ type Screen =
   | 'shop-augments'
   | 'shop-supplies'
   | 'campaignvictory'
+  | 'tobecontinued'
   | 'itemfound'
   | 'character'
   | 'replayBriefing'
@@ -512,6 +514,7 @@ export default function App() {
   const [cardRestPlayCounts, setCardRestPlayCounts] = useState<Record<string, number>>({})
   const [bonusPackCards, setBonusPackCards]     = useState<string[]>([])
   const [campaignRestingAlert, setCampaignRestingAlert] = useState(false)
+  const [campaign2AbandonConfirm, setCampaign2AbandonConfirm] = useState(false)
   const [streakBrokenData, setStreakBrokenData] = useState<{ streak: number; bestStreak: number } | null>(null)
   // Secret 5 — Time Capsule on 100th battle
   const [timeCapsuleVisible, setTimeCapsuleVisible] = useState(false)
@@ -1085,7 +1088,7 @@ export default function App() {
 
   // ── Campaign ─────────────────────────────────────────────
 
-  const handleCampaign = useCallback(() => {
+  const launchCampaign = useCallback((startActId: string) => {
     const doLaunch = () => {
     const existing = loadRun()
 
@@ -1162,7 +1165,7 @@ export default function App() {
     }
 
     // ── Fresh run ─────────────────────────────────────────────────────────────
-    const actId = 'act1'
+    const actId = startActId
     const act = ACTS[actId]
     const completionCount = loadActCount(actId)
 
@@ -1238,6 +1241,22 @@ export default function App() {
       doLaunch()
     }
   }, [])
+
+  const handleCampaign = useCallback(() => {
+    launchCampaign('act1')
+  }, [launchCampaign])
+
+  // Campaign 2 is launched from Cartographer Elsben in Ironhold Keep. If a
+  // campaign-1 run is in progress it must be explicitly abandoned first —
+  // both campaigns share the single active-run slot.
+  const handleCampaign2 = useCallback(() => {
+    const existing = loadRun()
+    if (existing && getCampaignForAct(existing.actId).id !== 'c2') {
+      setCampaign2AbandonConfirm(true)
+      return
+    }
+    launchCampaign('c2act1')
+  }, [launchCampaign])
 
   const handleWorldBattle = useCallback((worldNode: WorldNodeDef) => {
     if (!worldNode.battleConfig) return
@@ -2006,6 +2025,17 @@ export default function App() {
         } else {
           maybeShowCardRest(null)
         }
+        return
+      }
+
+      // ── No next act ─────────────────────────────────────────────────────────
+      // If this act is its campaign's finale, the campaign is won. Otherwise the
+      // player has reached the end of the authored acts of an in-progress arc
+      // (campaign 2 lands act by act) — show "to be continued" instead.
+      const campaign = getCampaignForAct(currentRun.actId)
+      if (currentRun.actId !== campaign.finaleActId) {
+        rollbar.info('End of authored acts — showing tobecontinued', { actId: currentRun.actId, campaignId: campaign.id })
+        setScreen('tobecontinued')
         return
       }
 
@@ -2928,6 +2958,7 @@ export default function App() {
             }
           }}
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
+          onCampaign2={() => { setReturnScreen('hubworld'); handleCampaign2() }}
           onEndless={() => { setReturnScreen('hubworld'); handleEndless() }}
           onWorldMap={() => setScreen('worldmap')}
           onNavigateTown={goToWorldLocation}
@@ -3188,6 +3219,20 @@ export default function App() {
         />
       )}
 
+      {campaign2AbandonConfirm && (
+        <ConfirmModal
+          title="Abandon Current Run?"
+          body="You have a campaign run in progress. Setting out for the Forgotten Kingdom will abandon it — unused consumables return to your stash, but map progress is lost."
+          confirmLabel="Abandon & Set Out"
+          onConfirm={() => {
+            setCampaign2AbandonConfirm(false)
+            clearRun(); setRun(null)
+            launchCampaign('c2act1')
+          }}
+          onCancel={() => setCampaign2AbandonConfirm(false)}
+        />
+      )}
+
       {screen === 'itemfound' && foundItem && (
         <ItemFoundScreen
           item={{ ...foundItem, acquiredDate: '' }}
@@ -3383,6 +3428,16 @@ export default function App() {
 
       {screen === 'campaignvictory' && (
         <CampaignVictoryScreen onBeginAnew={() => setScreen('statupgrade')} />
+      )}
+
+      {screen === 'tobecontinued' && (
+        <ToBeContinuedScreen
+          campaignName={run ? getCampaignForAct(run.actId).name : 'The Forgotten Kingdom'}
+          onContinue={() => {
+            clearRun(); setRun(null); clearFatigued(); setFatiguedCards([])
+            setScreen(returnScreen)
+          }}
+        />
       )}
 
       {screen === 'statupgrade' && (

--- a/web/src/components/admin/CampaignAdminScreen.tsx
+++ b/web/src/components/admin/CampaignAdminScreen.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const ACT_IDS = [
   'act1','act2','act3','act4','act5','act6','act7',
-  'act8','act9','act10','act11','act12','act13','actfinale',
+  'act8','act9','act10','act11','act12','act13','actfinale','c2act1',
 ]
 const NODE_TYPES: NodeType[] = ['battle', 'elite', 'boss', 'rest', 'event', 'merchant']
 

--- a/web/src/components/battle/ToBeContinuedScreen.stories.tsx
+++ b/web/src/components/battle/ToBeContinuedScreen.stories.tsx
@@ -1,0 +1,20 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ToBeContinuedScreen } from './ToBeContinuedScreen'
+
+const meta = {
+  title: 'Battle/ToBeContinuedScreen',
+  component: ToBeContinuedScreen,
+} satisfies Meta<typeof ToBeContinuedScreen>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    campaignName: 'The Forgotten Kingdom',
+    onContinue: fn(),
+  },
+}

--- a/web/src/components/battle/ToBeContinuedScreen.tsx
+++ b/web/src/components/battle/ToBeContinuedScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+interface Props {
+  /** Display name of the campaign arc, e.g. "The Forgotten Kingdom". */
+  campaignName: string
+  onContinue: () => void
+}
+
+/**
+ * Shown when the player clears the last *authored* act of a campaign whose
+ * later acts haven't shipped yet (campaign 2 lands act by act). The run ends
+ * here; progress, rewards, and act completion counts are already banked.
+ */
+export function ToBeContinuedScreen({ campaignName, onContinue }: Props) {
+  return (
+    <div className="campaign-victory u-col u-items-c u-just-c u-relative u-text-c">
+      <div className="cv-glow" />
+      <pre className="cv-ascii">{`  ╔══════════════════════╗
+  ║  TO  BE  CONTINUED…  ║
+  ╚══════════════════════╝`}</pre>
+      <div className="cv-body">
+        <p className="cv-title">🕯️ {campaignName} 🕯️</p>
+        <p>You have reached the edge of the story — for now.</p>
+        <p>The next act of {campaignName} is still being written. Your progress, rewards, and relics are safe.</p>
+      </div>
+      <button className="action-btn action-btn--large action-btn--gold" onClick={onContinue}>
+        [ Return ]
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -209,6 +209,8 @@ export interface Props {
   onBack:             () => void
   onNavigate?:        (screen: string, buildingId?: string) => void
   onCampaign?:        () => void
+  /** Launch campaign 2 (The Forgotten Kingdom) — from Elsben in Ironhold Keep. */
+  onCampaign2?:       () => void
   onEndless?:         () => void
   onWorldMap?:        () => void
   /** An exit tile's `screen` is `town:<mapId>` — travel directly to another
@@ -234,7 +236,7 @@ export interface Props {
   onBuyCrystalPack?:  (qty: number) => void
 }
 
-export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap, onNavigateTown, onPlayerTap, onNarratorLog,
+export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndless, onWorldMap, onNavigateTown, onPlayerTap, onNarratorLog,
   locationData, locationQuests, questDefs, allQuestDefs,
   crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap, onBuyCrystalPack }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
@@ -637,6 +639,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen.startsWith('town:')) { onNavigateTown?.(screen.slice(5)); return }
     if (screen === 'campaign') { onCampaign?.(); return }
+    if (screen === 'campaign2') { onCampaign2?.(); return }
     if (screen === 'endless') { onEndless?.(); return }
     if (screen === 'commander' && !commander) {
       setDialogueEvent({ speakerName: "Commander's Post", text: "No commander has been assigned yet. Visit the title screen to choose one." })
@@ -657,7 +660,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onEndless, onWorldMap
       }
     }
     onNavigate?.(screen, buildingId)
-  }, [onNavigate, onCampaign, onWorldMap, onNavigateTown, onNarratorLog, commander])
+  }, [onNavigate, onCampaign, onCampaign2, onWorldMap, onNavigateTown, onNarratorLog, commander])
 
   const handleReturn = useCallback(() => {
     returnRef.current?.()

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -28,7 +28,7 @@ import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
 import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
 import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
 import { User } from 'firebase/auth'
-import { loadPlayerName, addToConsumableStash } from '../../game/questline'
+import { loadPlayerName, addToConsumableStash, isCampaignComplete } from '../../game/questline'
 import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem, getHubItemCatalogEntry, getHubItems, spendTickets } from '../../game/itemStore'
 import { questItemId } from '../../game/hub/questItems'
@@ -1060,6 +1060,7 @@ function hasOfferableQuest(giverId: string): boolean {
     const visible = (node.choices ?? []).filter(c =>
       (!c.requireFlag  || hasDialogueFlag(c.requireFlag)) &&
       (!c.hideIfFlag   || !hasDialogueFlag(c.hideIfFlag)) &&
+      (!c.requireCampaignComplete || isCampaignComplete(c.requireCampaignComplete)) &&
       (!c.requireQuest || getQuestState(c.requireQuest).status === 'completed') &&
       (!c.hideIfQuest  || getQuestState(c.hideIfQuest).status !== 'completed') &&
       (!c.requireFestival || c.requireFestival === activeFestival?.id) &&

--- a/web/src/data/acts/c2act1.json
+++ b/web/src/data/acts/c2act1.json
@@ -1,0 +1,542 @@
+{
+  "id": "c2act1",
+  "title": "ACT I",
+  "subtitle": "The Pale Marches",
+  "rewardRelic": "Vigil Candle",
+  "rewardRelicDesc": "All your units gain +2 max HP at battle start and slowly mend, recovering 2 HP every 6 seconds.",
+  "environment": "frost",
+  "rewardTags": [
+    "forgotten",
+    "marches"
+  ],
+  "replayModifiers": [
+    {
+      "type": "enemyHpPercent",
+      "value": 15,
+      "label": "+15% enemy HP"
+    },
+    {
+      "type": "enemyIntervalReduction",
+      "value": 500,
+      "label": "Enemies act faster"
+    },
+    {
+      "type": "enemyHandBonus",
+      "value": 1,
+      "label": "Enemies start +1 card"
+    },
+    {
+      "type": "crystalBonus",
+      "value": 10,
+      "label": "+10 crystals per battle"
+    },
+    {
+      "type": "enemyHpPercent",
+      "value": 25,
+      "label": "+25% enemy HP"
+    }
+  ],
+  "startNodeIds": [
+    "marches-gate"
+  ],
+  "variantPools": {
+    "jarvMoods": [
+      "Now, officially, the Worldmender — a title that was supposed to come with a retirement.",
+      "Now, once again, the person the Dominion sends when the maps stop making sense.",
+      "Now, by popular acclaim, the mender of a world that has just presented its next invoice.",
+      "Now, quietly, the only person who isn't surprised that mending the world had a clause in the fine print."
+    ],
+    "marchesDesc": [
+      "East of Ironhold Keep, the maps have always shown an empty quarter. The mist starts where the ink stops. It has never lifted, and nobody remembers it arriving.",
+      "The Pale Marches sit under a mist that doesn't behave like weather. Lanterns burn along roads no Dominion crew ever built. Somebody has been keeping them lit.",
+      "The border country east of Ironhold was always called empty. It was never empty. It was forgotten — and the difference between those two words is now marching west."
+    ],
+    "heraldDesc": [
+      "The Pale Herald carries a proclamation with no signatures. Every hand that signed it was erased with the kingdom it served. He intends to collect them all back.",
+      "The Herald does not shout. He announces — and the mist carries it the way a court carries a verdict. Amarath has returned, and it remembers everything.",
+      "The Herald's writ names a kingdom that appears on no map you have ever owned. He finds your maps very interesting. He finds them evidence."
+    ],
+    "priorRunOpenings": [
+      "The mist parted the same way it did last time — reluctantly, and only exactly as far as it had to.",
+      "The first lantern on the march road was already lit when you arrived. You never saw anyone light it. You never do.",
+      "The Herald's vanguard held the same line as before. Amarath does not improvise. It remembers.",
+      "You knew the toll bridge would be watched. You'd paid attention last time. The mist had paid attention to you paying attention."
+    ]
+  },
+  "midRunTemplates": [
+    "The {ordinalLower} time into the Pale Marches. The mist recognises you now, which is more than the rest of the world managed for Amarath.",
+    "Campaign {n}. The lanterns along the march road are lit before you reach them, every time.",
+    "{n} campaigns. The Herald's proclamation has not changed a word. Neither has his opinion of your maps.",
+    "Run {n}. The blank quarter of the map is less blank every time you cross it. You are becoming the person who remembers.",
+    "The {ordinalLower} crossing of the Marches. The border stones still give you a headache. The memory that comes with it is worth it."
+  ],
+  "introRules": [
+    {
+      "condition": {
+        "op": "gte",
+        "value": 10
+      },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:priorRunOpenings:1}"
+        },
+        {
+          "title": "THE PALE MARCHES",
+          "text": "{pool:marchesDesc:1}\n\n{pool:heraldDesc:1}"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 9
+      },
+      "panels": [
+        {
+          "title": "THE PALE MARCHES",
+          "text": "The mist is waiting at the border — again.\n\n{pool:priorRunOpenings:0}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:marchesDesc:2}"
+        },
+        {
+          "title": "THE HERALD",
+          "text": "{pool:heraldDesc:0}"
+        }
+      ]
+    }
+  ],
+  "intro": [
+    {
+      "title": "AFTER THE MENDING",
+      "text": "The Fracture is sealed. The shards are one Dominion again, and the world calls you Worldmender.\n\nThe celebrations lasted a season. The reports from the east lasted longer.",
+      "image": "cutscenes/c2act1-intro-1.svg"
+    },
+    {
+      "title": "THE BLANK QUARTER",
+      "text": "East of Ironhold Keep, every map shows an empty quarter. Cartographer Elsben's new surveys show something else: roads. Towns. Fields under a mist that never lifts.\n\nA kingdom — where every map in the Dominion agrees there has never been anything at all.",
+      "image": "cutscenes/c2act1-intro-2.svg"
+    },
+    {
+      "title": "THE PALE MARCHES",
+      "text": "When the world mended, everything the Fracture had scattered came back. Everything.\n\nBorder scouts have stopped reporting in. Lanterns burn along roads nobody built. Something is marching west out of the mist, and it carries a proclamation.\n\nYou go east.",
+      "image": "cutscenes/c2act1-intro-3.svg"
+    }
+  ],
+  "outro": [
+    {
+      "title": "THE HERALD FALLS",
+      "text": "The Pale Herald kneels in the churned mud of the border, his banner planted beside him. He does not seem defeated. He seems finished — the way a messenger is finished when the message is delivered.\n\n'Amarath has returned,' he says. 'Now you know. That was all the writ required.'",
+      "image": "cutscenes/c2act1-outro-1.svg"
+    },
+    {
+      "title": "THE VIGIL CANDLE",
+      "text": "He leaves you his lantern. Inside burns a candle that has not gone out in three hundred years — one flame of the vigil that held a forgotten kingdom together in the dark.\n\nIt is warm in a way that has nothing to do with fire.",
+      "image": "cutscenes/c2act1-outro-2.svg"
+    },
+    {
+      "title": "EAST",
+      "text": "Beyond the Marches, the mist thins just enough to show the shape of a road — a grey causeway running east, lined with unlit lamps, toward a kingdom the world forgot.\n\nThe Herald was only the announcement. The Pale Court is waiting.",
+      "image": "cutscenes/c2act1-outro-3.svg"
+    }
+  ],
+  "nodes": {
+    "marches-gate": {
+      "id": "marches-gate",
+      "type": "battle",
+      "label": "The Broken Milestone",
+      "description": "The last Dominion waymarker — and the first pickets in the mist.",
+      "row": 0,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "mist-picket",
+        "toll-bridge"
+      ],
+      "handicap": 14,
+      "opponentIntervalMs": 3400,
+      "opponentBaseHp": 215,
+      "environment": "frost",
+      "enemyDeck": [
+        "Pale Sentry",
+        "Mist Skirmisher",
+        "Lantern Post",
+        "Vigil Prayer"
+      ]
+    },
+    "mist-picket": {
+      "id": "mist-picket",
+      "type": "battle",
+      "label": "Mist Picket",
+      "description": "Sentries hold the western fenceline of the Marches.",
+      "row": 1,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "waymeet-shrine",
+        "wardens-camp"
+      ],
+      "handicap": 16,
+      "opponentIntervalMs": 3300,
+      "opponentBaseHp": 222,
+      "environment": "frost",
+      "enemyDeck": [
+        "Pale Sentry",
+        "Mist Archer",
+        "Border Palisade",
+        "Mist Skirmisher",
+        "March Ration"
+      ]
+    },
+    "toll-bridge": {
+      "id": "toll-bridge",
+      "type": "battle",
+      "label": "Old Toll Bridge",
+      "description": "A bridge that was never on the survey — with a garrison that was never on the rolls.",
+      "row": 1,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "blank-map",
+        "drovers-market"
+      ],
+      "handicap": 16,
+      "opponentIntervalMs": 3300,
+      "opponentBaseHp": 222,
+      "environment": "frost",
+      "enemyDeck": [
+        "Marchland Pikeman",
+        "Pale Sentry",
+        "Wardstone",
+        "Candle Bearer",
+        "Vigil Prayer"
+      ]
+    },
+    "waymeet-shrine": {
+      "id": "waymeet-shrine",
+      "type": "event",
+      "label": "Waymeet Shrine",
+      "description": "A crossroads shrine crowded with candles — all of them lit.",
+      "row": 2,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "vanguard-line",
+        "mem-c2act1-1"
+      ],
+      "eventConfig": {
+        "title": "The Waymeet Shrine",
+        "description": "Hundreds of candles burn at the crossroads shrine, each one wax-sealed with a name you can't read. The mist keeps a respectful distance from the light. One alcove stands empty, waiting for an offering.",
+        "pools": [
+          [
+            {
+              "label": "Read the sealed names (lose 6 HP, gain a rare card)",
+              "consequence": "The names cost you — and teach you. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the offering bowl (gain 60 crystals)",
+              "consequence": "You pocket the crystals. The candles flicker, unimpressed.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 60
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest in the candlelight (heal 10 HP)",
+              "consequence": "The vigil warmth knits you back together. You heal 10 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
+          ],
+          [
+            {
+              "label": "Bow and move on",
+              "consequence": "You leave the shrine undisturbed.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "wardens-camp": {
+      "id": "wardens-camp",
+      "type": "rest",
+      "label": "Warden's Camp",
+      "description": "An abandoned Dominion border post. The stove still works.",
+      "row": 2,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "vanguard-line"
+      ],
+      "restHeal": 8
+    },
+    "blank-map": {
+      "id": "blank-map",
+      "type": "event",
+      "label": "The Surveyor's Kit",
+      "description": "A cartographer's camp, abandoned mid-measurement.",
+      "row": 2,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "choir-ford"
+      ],
+      "eventConfig": {
+        "title": "The Surveyor's Kit",
+        "description": "A survey camp sits abandoned in the fog — theodolite still standing, notebook open. The last entry reads: 'The bridge is NOT new. The bridge is OLD. Check the archive. Check the archive. Check the ar—'. The kit is still valuable.",
+        "pools": [
+          [
+            {
+              "label": "Study the half-finished map (gain a rare card)",
+              "consequence": "The surveyor's notes sharpen your eye for the ground ahead. You receive a rare card.",
+              "effect": {
+                "type": "gainCard",
+                "rarity": "rare"
+              }
+            }
+          ],
+          [
+            {
+              "label": "Sell the brass instruments (gain 70 crystals)",
+              "consequence": "Fine Dominion brasswork. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Eat the untouched rations (heal 8 HP)",
+              "consequence": "Cold, but decent. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave everything for the search party",
+              "consequence": "If there is ever a search party. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "drovers-market": {
+      "id": "drovers-market",
+      "type": "merchant",
+      "label": "Drover's Rest",
+      "description": "A market stall serving a road that shouldn't exist.",
+      "row": 2,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "choir-ford"
+      ]
+    },
+    "vanguard-line": {
+      "id": "vanguard-line",
+      "type": "elite",
+      "label": "The Vanguard Line",
+      "description": "The Herald's escort holds the west road in parade order.",
+      "row": 3,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "palisade-push"
+      ],
+      "handicap": 20,
+      "opponentIntervalMs": 3100,
+      "opponentBaseHp": 238,
+      "environment": "frost",
+      "enemyDeck": [
+        "Pale Vanguard",
+        "Marchland Pikeman",
+        "Mist Barracks",
+        "Wardstone",
+        "Memory Ward",
+        "Candlefall"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "mem-c2act1-1": {
+      "id": "mem-c2act1-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A border stone with the kingdom's true name — and the day it stopped being read.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "palisade-push"
+      ],
+      "fragmentId": "c2act1-frag-1",
+      "environment": "frost"
+    },
+    "choir-ford": {
+      "id": "choir-ford",
+      "type": "elite",
+      "label": "Choir at the Ford",
+      "description": "A hymn you have never heard, in a language you somehow know.",
+      "row": 3,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "fog-riders"
+      ],
+      "handicap": 20,
+      "opponentIntervalMs": 3100,
+      "opponentBaseHp": 238,
+      "environment": "frost",
+      "enemyDeck": [
+        "Unremembered Choir",
+        "Candle Bearer",
+        "Candle Shrine",
+        "Unremembered Soldier",
+        "Fog Veil",
+        "Vigil Prayer"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "palisade-push": {
+      "id": "palisade-push",
+      "type": "battle",
+      "label": "Palisade Push",
+      "description": "The vanguard's field works block the road west.",
+      "row": 4,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "last-lamp"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "frost",
+      "enemyDeck": [
+        "Marchland Pikeman",
+        "Border Palisade",
+        "Watch Beacon",
+        "Unremembered Soldier",
+        "Memory Ward",
+        "Mist Archer"
+      ]
+    },
+    "fog-riders": {
+      "id": "fog-riders",
+      "type": "battle",
+      "label": "Riders in the Fog",
+      "description": "Cavalry with no hoofbeats, closing fast.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "last-lamp",
+        "mem-c2act1-2"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "frost",
+      "enemyDeck": [
+        "Pale Rider",
+        "Mist Skirmisher",
+        "Mist Barracks",
+        "March Ration",
+        "Fog Veil",
+        "Pale Sentry"
+      ]
+    },
+    "last-lamp": {
+      "id": "last-lamp",
+      "type": "rest",
+      "label": "The Last Lamp",
+      "description": "The final lit lantern before the Herald's ground. Warm, somehow.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "herald-node"
+      ],
+      "restHeal": 10
+    },
+    "mem-c2act1-2": {
+      "id": "mem-c2act1-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A vigil ledger — the first year of a kingdom keeping itself alive by remembering.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "herald-node"
+      ],
+      "fragmentId": "c2act1-frag-2",
+      "environment": "frost"
+    },
+    "herald-node": {
+      "id": "herald-node",
+      "type": "boss",
+      "label": "The Pale Herald",
+      "description": "The voice of the Pale Court, come to deliver the writ of return.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [],
+      "handicap": 24,
+      "opponentIntervalMs": 5000,
+      "opponentBaseHp": 258,
+      "environment": "frost",
+      "enemyDeck": [
+        "The Pale Herald",
+        "Knight of the Vigil",
+        "Pale Vanguard",
+        "Mist Barracks",
+        "Watch Beacon",
+        "Candlefall",
+        "Rite of Return"
+      ],
+      "bossAI": "paleherald",
+      "bossDialogue": [
+        "HEAR THE WRIT OF AMARATH. The kingdom you forgot has returned, Worldmender. You mended the world. You mended us with it.",
+        "Three hundred years of vigil. Three hundred years of candles. Not one of your maps spared us one inch of ink.",
+        "I am only the announcement. What follows me is the Court. Stand aside, or be the first thing Amarath is remembered for."
+      ],
+      "bossCard": "The Pale Herald"
+    }
+  }
+}

--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -1529,5 +1529,152 @@
         ]
       }
     ]
+  },
+  {
+    "id": "pale-elite",
+    "intervalMs": 5200,
+    "idleMessage": "The vigil line holds…",
+    "maxPlaysPerTurn": 2,
+    "openingLog": [
+      "An officer of Amarath's vanguard bars the road.",
+      "Expect disciplined lines and vigil fire."
+    ],
+    "trait": {
+      "name": "Vigil Rally",
+      "implemented": true,
+      "trigger": "periodic",
+      "triggerIntervalMs": 40000,
+      "type": "jump_aoe",
+      "description": "Every 40 seconds the officer sounds the vigil horn and drops on the player's side in a burst of candle-fire — 5 AOE damage and a 1.2 second stun in a 2-tile radius.",
+      "mechanics": {
+        "invulnerableDurationMs": 1500,
+        "landingDamage": 5,
+        "landingRadiusTiles": 2,
+        "stunDurationMs": 1200,
+        "landingTarget": "player_side_random"
+      },
+      "announceText": "The vigil horn sounds — the officer charges your line!",
+      "landText": "Candle-fire bursts across your ranks!"
+    },
+    "phases": [
+      {
+        "condition": null,
+        "priorities": [
+          {
+            "cardType": "structure",
+            "isWall": true
+          },
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "paleherald",
+    "intervalMs": 5000,
+    "idleMessage": "The Herald reads on from the writ…",
+    "maxPlaysPerTurn": 3,
+    "openingLog": [
+      "THE PALE HERALD unfurls the writ of return.",
+      "\"Hear the claim of Amarath, Worldmender.\""
+    ],
+    "trait": {
+      "name": "Proclamation Descent",
+      "implemented": true,
+      "trigger": "hp_pct",
+      "triggerHpPct": 50,
+      "type": "fly",
+      "description": "At 50% HP the Herald ascends into the mist on pale wings (4 s untargetable), then descends onto the player's densest cluster with the full weight of the proclamation — 7 AOE damage in a 2-tile radius.",
+      "mechanics": {
+        "invulnerableDurationMs": 4000,
+        "landingDamage": 7,
+        "landingRadiusTiles": 2,
+        "repositionTarget": "player_densest_cluster"
+      },
+      "announceText": "The Herald rises into the mist — the proclamation is not finished!",
+      "landText": "The writ comes down like a verdict — the mist detonates!"
+    },
+    "phases": [
+      {
+        "condition": {
+          "gameTimeLt": 30000
+        },
+        "priorities": [
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "mana"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_asc"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      },
+      {
+        "condition": {
+          "gameTimeGte": 30000,
+          "gameTimeLt": 75000
+        },
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "costGte": 4,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "none"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ],
+        "announceOnce": "\"The Marches were only the first name on the writ.\""
+      },
+      {
+        "condition": null,
+        "manaOverride": 9,
+        "maxPlaysOverride": 4,
+        "announceOnce": "\"AMARATH REMEMBERS. LET THAT BE THE LAST LINE.\"",
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -12742,6 +12742,298 @@
         "damage": 60,
         "range": 100
       }
+    },
+    "pale-sentry": {
+      "name": "Pale Sentry",
+      "attack": 3,
+      "maxHp": 12,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 60,
+      "attackRange": 5,
+      "attackCooldownMs": 1100,
+      "flying": false,
+      "tags": ["fast", "small"],
+      "strengths": ["fast", "melee"],
+      "weaknesses": ["armored", "ranged"],
+      "size": "small",
+      "affinity": {
+        "withName": "Mist Skirmisher",
+        "range": 60,
+        "effectType": "moveSpeed",
+        "effectAmount": 1.2,
+        "label": "March Step"
+      }
+    },
+    "mist-skirmisher": {
+      "name": "Mist Skirmisher",
+      "attack": 5,
+      "maxHp": 16,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 50,
+      "attackRange": 5,
+      "attackCooldownMs": 1200,
+      "flying": false,
+      "tags": ["melee", "fast"],
+      "strengths": ["ranged"],
+      "weaknesses": ["armored"],
+      "size": "small"
+    },
+    "candle-bearer": {
+      "name": "Candle Bearer",
+      "attack": 3,
+      "maxHp": 20,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 35,
+      "attackRange": 60,
+      "attackCooldownMs": 1600,
+      "flying": false,
+      "tags": ["ranged", "magic"],
+      "strengths": ["melee"],
+      "weaknesses": ["fast"],
+      "size": "small"
+    },
+    "lantern-post": {
+      "name": "Lantern Post",
+      "attack": 4,
+      "maxHp": 22,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 120,
+      "attackCooldownMs": 1800,
+      "tags": ["ranged"]
+    },
+    "marchland-pikeman": {
+      "name": "Marchland Pikeman",
+      "attack": 7,
+      "maxHp": 26,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 40,
+      "attackRange": 5,
+      "attackCooldownMs": 1300,
+      "flying": false,
+      "tags": ["melee", "armored"],
+      "strengths": ["fast"],
+      "weaknesses": ["magic"],
+      "size": "medium"
+    },
+    "unremembered-soldier": {
+      "name": "Unremembered Soldier",
+      "attack": 6,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 38,
+      "attackRange": 5,
+      "attackCooldownMs": 1300,
+      "flying": false,
+      "tags": ["melee"],
+      "strengths": ["small"],
+      "weaknesses": ["siege"],
+      "size": "medium"
+    },
+    "mist-archer": {
+      "name": "Mist Archer",
+      "attack": 6,
+      "maxHp": 18,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 42,
+      "attackRange": 130,
+      "attackCooldownMs": 1500,
+      "flying": false,
+      "tags": ["ranged"],
+      "strengths": ["flying"],
+      "weaknesses": ["melee", "fast"],
+      "size": "small"
+    },
+    "pale-rider": {
+      "name": "Pale Rider",
+      "attack": 9,
+      "maxHp": 28,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 75,
+      "attackRange": 5,
+      "attackCooldownMs": 1200,
+      "flying": false,
+      "tags": ["fast", "melee"],
+      "strengths": ["ranged", "small"],
+      "weaknesses": ["armored"],
+      "size": "medium"
+    },
+    "candle-shrine": {
+      "name": "Candle Shrine",
+      "attack": 0,
+      "maxHp": 20,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "structureEffect": {
+        "type": "mana",
+        "amount": 1
+      },
+      "tags": ["forgotten"]
+    },
+    "mist-barracks": {
+      "name": "Mist Barracks",
+      "attack": 0,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "mist-skirmisher",
+        "intervalMs": 12000
+      },
+      "tags": ["forgotten"]
+    },
+    "watch-beacon": {
+      "name": "Watch Beacon",
+      "attack": 6,
+      "maxHp": 26,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 140,
+      "attackCooldownMs": 1700,
+      "tags": ["ranged"]
+    },
+    "border-palisade": {
+      "name": "Border Palisade",
+      "attack": 0,
+      "maxHp": 60,
+      "isWall": true,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "tags": ["melee"],
+      "size": "medium"
+    },
+    "wardstone": {
+      "name": "Wardstone",
+      "attack": 0,
+      "maxHp": 85,
+      "isWall": true,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "tags": ["armored"],
+      "size": "medium"
+    },
+    "pale-vanguard": {
+      "name": "Pale Vanguard",
+      "attack": 11,
+      "maxHp": 44,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 40,
+      "attackRange": 5,
+      "attackCooldownMs": 1400,
+      "flying": false,
+      "tags": ["melee", "armored"],
+      "strengths": ["melee", "fast"],
+      "weaknesses": ["magic"],
+      "size": "large",
+      "affinity": {
+        "withName": "The Pale Herald",
+        "range": 80,
+        "effectType": "damage",
+        "effectAmount": 1.25,
+        "label": "Herald's Writ"
+      }
+    },
+    "unremembered-choir": {
+      "name": "Unremembered Choir",
+      "attack": 8,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 30,
+      "attackRange": 150,
+      "attackCooldownMs": 1900,
+      "flying": false,
+      "tags": ["ranged", "magic"],
+      "strengths": ["armored"],
+      "weaknesses": ["fast", "melee"],
+      "size": "medium"
+    },
+    "pale-monolith": {
+      "name": "Pale Monolith",
+      "attack": 0,
+      "maxHp": 45,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "pale-sentry",
+        "intervalMs": 10000
+      },
+      "tags": ["forgotten"]
+    },
+    "knight-of-the-vigil": {
+      "name": "Knight of the Vigil",
+      "attack": 14,
+      "maxHp": 60,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 35,
+      "attackRange": 5,
+      "attackCooldownMs": 1500,
+      "flying": false,
+      "tags": ["melee", "armored", "large"],
+      "strengths": ["melee", "small"],
+      "weaknesses": ["magic", "flying"],
+      "size": "large",
+      "unitTrait": {
+        "guardBase": true,
+        "baseGuardRange": 90,
+        "engageRange": 190
+      }
+    },
+    "the-waiting-mist": {
+      "name": "The Waiting Mist",
+      "attack": 10,
+      "maxHp": 40,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 55,
+      "attackRange": 60,
+      "attackCooldownMs": 1600,
+      "flying": true,
+      "tags": ["flying", "magic"],
+      "strengths": ["melee", "armored"],
+      "weaknesses": ["ranged"],
+      "size": "large"
+    },
+    "the-pale-herald": {
+      "name": "The Pale Herald",
+      "attack": 16,
+      "maxHp": 78,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 30,
+      "attackRange": 5,
+      "attackCooldownMs": 1400,
+      "flying": false,
+      "tags": ["melee", "large", "armored"],
+      "strengths": ["melee", "small"],
+      "weaknesses": ["magic", "flying"],
+      "size": "large"
     }
   },
   "cards": [
@@ -21116,6 +21408,300 @@
         "citadel"
       ],
       "lore": "Honor is a shield. The actual shields help too."
+    },
+    {
+      "name": "Pale Sentry",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "pale-sentry",
+      "description": "A quick scout of the Marches, half-hidden in mist.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "It watched the border for a kingdom no map admits to. Now the maps are wrong, and it knows it."
+    },
+    {
+      "name": "Mist Skirmisher",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "mist-skirmisher",
+      "description": "A fast fighter who strikes out of the fog.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "You hear the footsteps after the blade. The mist keeps its own order of events."
+    },
+    {
+      "name": "Candle Bearer",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "candle-bearer",
+      "description": "A robed keeper whose vigil flame scorches at range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "One candle, carried for three hundred years. It has never gone out. Neither has she."
+    },
+    {
+      "name": "Lantern Post",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "lantern-post",
+      "description": "A watch-lantern that burns approaching enemies.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The lamps along the Marches were lit before the Fracture. Someone kept them fed."
+    },
+    {
+      "name": "Vigil Prayer",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffHeal",
+        "amount": 6
+      },
+      "description": "Heals all friendly units by 6.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The words were written for the dead. They work on the living too."
+    },
+    {
+      "name": "March Ration",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffSpeed",
+        "amount": 10
+      },
+      "description": "All friendly mobile units move faster.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "Wheat from fields that don't exist. It tastes like a childhood you never had."
+    },
+    {
+      "name": "Marchland Pikeman",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "marchland-pikeman",
+      "description": "An armoured line-holder of the border marches.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The pike drill hasn't changed in three centuries. Nothing in Amarath has."
+    },
+    {
+      "name": "Unremembered Soldier",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "unremembered-soldier",
+      "description": "A steady infantry soldier of the returned kingdom.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "He remembers your great-grandmother's bakery. You don't remember his entire nation."
+    },
+    {
+      "name": "Mist Archer",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "mist-archer",
+      "description": "A long-range archer who looses from inside the fog.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "She aims at where things were. In the mist, that's where they still are."
+    },
+    {
+      "name": "Pale Rider",
+      "rarity": "uncommon",
+      "cost": 4,
+      "cardType": "unit",
+      "unitRef": "pale-rider",
+      "description": "A swift cavalry outrider of the Pale Court.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The horse was bred in the void. It doesn't cast a shadow, and it minds that you noticed."
+    },
+    {
+      "name": "Candle Shrine",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "candle-shrine",
+      "description": "A vigil shrine that raises your maximum mana.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "Every flame is a name. Feed the shrine and it lends you a few."
+    },
+    {
+      "name": "Mist Barracks",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "mist-barracks",
+      "description": "Spawner. Periodically releases Mist Skirmishers.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The muster horn is silent. The soldiers come anyway. They've had centuries of practice."
+    },
+    {
+      "name": "Watch Beacon",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "watch-beacon",
+      "description": "A tall border beacon with long attack range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "It was built to warn Amarath about the Dominion. It works in both directions."
+    },
+    {
+      "name": "Border Palisade",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "border-palisade",
+      "description": "A defensive wall of pale marchwood.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The trees it was cut from grew in the void. The axe still hasn't forgiven anyone."
+    },
+    {
+      "name": "Wardstone",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "wardstone",
+      "description": "A heavy warding stone — a wall that endures.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "A boundary stone with the kingdom's true name carved on it. Reading it gives you a headache and a memory."
+    },
+    {
+      "name": "Memory Ward",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffMaxHp",
+        "amount": 8
+      },
+      "description": "All friendly units gain +8 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "Being remembered makes things harder to kill. Amarath learned that the long way."
+    },
+    {
+      "name": "Fog Veil",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffRange",
+        "amount": 15
+      },
+      "description": "All attacking units gain +15 attack range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The mist doesn't blind you. It blinds everyone else first."
+    },
+    {
+      "name": "Candlefall",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "aoe",
+        "damage": 6,
+        "range": 100
+      },
+      "description": "Burning wax rains on an area, damaging enemies within it.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "Ten thousand vigil candles, tipped at once. The Court calls it mourning. The Marches call it artillery."
+    },
+    {
+      "name": "Pale Vanguard",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "pale-vanguard",
+      "description": "An elite shock-guard of the Herald's escort.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "First across the border. First to be forgotten. First to come back."
+    },
+    {
+      "name": "Unremembered Choir",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "unremembered-choir",
+      "description": "A choir whose remembered hymns strike at long range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "They sing the old anthem of the Grand Dominion. Nobody alive on your side knows the words. That's the weapon."
+    },
+    {
+      "name": "Pale Monolith",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "structure",
+      "unitRef": "pale-monolith",
+      "description": "Spawner. Periodically wakes Pale Sentries from the stone.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The census of a lost kingdom, carved standing up. Some entries can still walk."
+    },
+    {
+      "name": "Rite of Return",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffMaxHp",
+        "amount": 12
+      },
+      "description": "All friendly units gain +12 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "The rite that held a kingdom together in the dark. It holds soldiers together just fine."
+    },
+    {
+      "name": "Knight of the Vigil",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "knight-of-the-vigil",
+      "description": "A towering knight sworn to the vigil, guarding your base.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "He stood watch for three hundred years without relief. He does not consider your battle an emergency."
+    },
+    {
+      "name": "The Waiting Mist",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "the-waiting-mist",
+      "description": "A drifting mass of vigil-mist that flies over walls.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "It isn't weather. It's patience, condensed."
+    },
+    {
+      "name": "The Pale Herald",
+      "rarity": "legendary",
+      "cost": 7,
+      "cardType": "unit",
+      "unitRef": "the-pale-herald",
+      "description": "The voice of the Pale Court — an armoured giant bearing the writ of return.",
+      "deckCount": 0,
+      "tags": ["forgotten", "marches"],
+      "lore": "He carries a proclamation with no signatures, because every hand that signed it was erased. He intends to collect them all back."
     }
   ],
   "heroCards": [
@@ -21547,6 +22133,38 @@
       },
       "description": "HERO: Deploys the Builder — repairs or upgrades a building every 3s (3 charges). After all charges are spent, he sprints to the enemy base avoiding enemies and detonates on the first enemy building he reaches! All units gain +18 max HP.",
       "lore": "Can fix anything. Given enough time. And lumber."
+    },
+    {
+      "id": "hero-warden-of-the-marches",
+      "name": "Warden of the Marches",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Marches Warden",
+        "attack": 12,
+        "maxHp": 55,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 40,
+        "attackRange": 5,
+        "attackCooldownMs": 1400,
+        "flying": false,
+        "tags": ["melee", "armored"],
+        "size": "large",
+        "unitTrait": {
+          "guardBase": true,
+          "baseGuardRange": 100,
+          "engageRange": 200
+        }
+      },
+      "heroEffect": {
+        "type": "buffMaxHp",
+        "amount": 12
+      },
+      "description": "HERO: Deploys the Marches Warden — a border commander who holds the line near your base and engages anything that crosses it. All units gain +12 max HP.",
+      "lore": "The Dominion never posted a warden to the eastern blank. Somebody took the job anyway."
     }
   ]
 }

--- a/web/src/data/hub/capitalcity/config.json
+++ b/web/src/data/hub/capitalcity/config.json
@@ -5052,6 +5052,11 @@
         "The old postern gate key went missing on patrol. If it falls into the wrong hands, the palace will have my head.",
         "Keep your nose clean in my city, traveller."
       ],
+      "postCampaignDialogue": [
+        "The Worldmender, in my ward. Crime's down since the mending — hard to pick pockets when everyone's celebrating.",
+        "Between us: the crown's been asking the watch about the eastern roads. Merchants report lantern-light past the border. Above my pay grade, that.",
+        "The Fracture's sealed and the city sleeps easy. I still don't. Old habit."
+      ],
       "dialogueByActivity": {
         "work": [
           "Guardhouse business. Move along unless you've something to report."
@@ -5125,6 +5130,11 @@
         "The royal survey of the outer provinces is three scrolls short. Three!",
         "The couriers dropped them somewhere between here and the gates, I'm certain of it.",
         "History is just paperwork that survived, you know."
+      ],
+      "postCampaignDialogue": [
+        "Since the mending, the archive doesn't add up. There's a treaty in the vaults with a blank space where the second signatory should be. The seal is real. The kingdom it belongs to isn't anywhere.",
+        "You mended the world, and I'm grateful — but somebody should tell the paperwork. I keep finding references to an eastern census that doesn't exist.",
+        "History is paperwork that survived. I'm starting to wonder about the paperwork that didn't."
       ],
       "dialogueByActivity": {
         "work": [
@@ -5269,6 +5279,11 @@
         "The capital does not run on goodwill, traveller. It runs on charters, seals, and very tired clerks.",
         "Crownhaven looks to Ravenwatch for the old records. We must keep the two cities in step.",
         "Serve the crown well and the crown remembers."
+      ],
+      "postCampaignDialogue": [
+        "Worldmender. The crown's gratitude is on record — I filed it personally.",
+        "The eastern reports are a nuisance. Lights, roads, banners in the mist. I've commissioned a survey and I expect it to say 'weather'.",
+        "Serve the crown well and the crown remembers. Lately I find myself wondering what the crown has forgotten."
       ],
       "dialogueByActivity": {
         "work": [

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1864,6 +1864,24 @@
   "ambientNpcSprites": [],
   "npcs": [
     {
+      "id": "castle-cartographer",
+      "name": "Cartographer Elsben",
+      "sprite": "hub-npc-cartographer",
+      "tx": 21,
+      "ty": 43,
+      "dialogue": [
+        "Every map of the Dominion agrees on one thing: east of here, nothing. Forty leagues of nothing. I have started to wonder who decided that.",
+        "I've surveyed this border three times. My instruments keep finding a road. There is no road on any chart I own.",
+        "A cartographer draws what is there. Nobody trained me for what has been... removed."
+      ],
+      "postCampaignDialogue": [
+        "Worldmender! My new surveys — since the mending, they show a KINGDOM in the blank quarter. Roads. Towns. It was always there. We just... stopped being able to remember it.",
+        "The border scouts have gone quiet, and there are lights in the eastern mist. Lanterns. Somebody is keeping them lit, and it isn't us.",
+        "I keep comparing the old maps to the new survey. The old maps aren't wrong, Worldmender. They were edited."
+      ],
+      "dialogueTree": "elsben-maps"
+    },
+    {
       "id": "castle-commander",
       "name": "Commander Varek",
       "sprite": "hub-npc-arena",

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -1892,6 +1892,11 @@
         "The patrol routes have been compromised. We need those reports.",
         "You fight well, traveller. Ravenwatch is lucky to have you."
       ],
+      "postCampaignDialogue": [
+        "Worldmender. The Keep stands because you sealed the Fracture — I don't forget debts of that size.",
+        "Peace, at last. Except my eastern patrols have stopped reporting, and I don't like the mist this season. Speak to Elsben — the cartographer. He's seen something on his surveys.",
+        "Three centuries this keep has watched the east and seen nothing. Now there are lights out there. I've doubled the watch."
+      ],
       "dialogueByActivity": {
         "work": [
           "Three centuries this keep has stood. Not on my watch will it fall."
@@ -1986,6 +1991,11 @@
         "Discipline wins sieges, not bravado. Drill, drill, and drill again.",
         "Every soldier here answers to me before they answer to the Commander.",
         "Stand a watch with us sometime, traveller. You'd learn something."
+      ],
+      "postCampaignDialogue": [
+        "The Fracture's sealed and my drill schedule hasn't changed one minute. Discipline doesn't take holidays, Worldmender.",
+        "New standing order: nobody walks the east road alone. Not since the scouts went quiet.",
+        "The recruits sing songs about you now. Off-key. I've made it a disciplinary matter."
       ],
       "dialogueByActivity": {
         "work": [
@@ -2390,6 +2400,11 @@
         "The keep's records go back to the founding. Most of them, anyway.",
         "A siege chronicle was separated from the archives. It belongs here.",
         "History is the only weapon that never dulls."
+      ],
+      "postCampaignDialogue": [
+        "I've been re-shelving the pre-Fracture archives since the mending. There are gaps, Worldmender. Not missing books — missing SUBJECTS. Whole shelves that end mid-argument.",
+        "The oldest ledgers reference a 'loyal eastern province' — and then simply stop mentioning it. No war, no decree. It's as if the east was... unwritten.",
+        "You sealed the Fracture, and history is the better for it. But I begin to suspect history itself has a wound we never noticed."
       ],
       "dialogueByActivity": {
         "work": [

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -1348,6 +1348,54 @@
   ],
   "dialogues": [
     {
+      "id": "elsben-maps",
+      "npcId": "castle-cartographer",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Ah — careful of the survey table. Cartographer Elsben, royal commission. I chart the eastern border. Or I try to. The border has opinions.",
+          "choices": [
+            { "label": "What's east of the Keep?", "next": "east" },
+            { "label": "Show me the new survey.", "requireCampaignComplete": "c1", "next": "survey" },
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "east": {
+          "text": "Officially? Nothing. Forty leagues of blank parchment on every map since the Fracture. But my instruments keep finding a road out there, and a road means traffic, and traffic means... someone. The mist never lifts. My survey pegs come back moved. And lately — lately I'd swear the blank quarter is closer than it used to be.",
+          "choices": [
+            { "label": "Maps don't lie, surely.", "next": "maps-lie" },
+            { "label": "Good luck with the border.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "maps-lie": {
+          "text": "Maps don't lie, no. But someone has to draw them, and someone has to remember what to draw. What if the problem was never the maps? What if the problem is what happened to the people who drew them?\n\n...Forgive me. Surveyor's superstition. Finish your business in the Keep — the east isn't going anywhere.\n\n...Probably.",
+          "choices": [
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "survey": {
+          "text": "Since you sealed the Fracture, Worldmender, everything the shattering scattered has come back. EVERYTHING. Look — the new survey. There is a kingdom in the blank quarter. Amarath. Roads, towns, fields, a capital. Three hundred years old and on no map in the Dominion, because when the world broke, it was erased — from the charts, from the archives, from our HEADS.\n\nAnd now it has returned. The border scouts have stopped reporting. There are lanterns in the mist, and something carrying a banner is marching west along a road that didn't exist last season.",
+          "choices": [
+            { "label": "Then someone should go and meet them.", "next": "set-out" },
+            { "label": "I need to prepare first.", "next": "prepare" }
+          ]
+        },
+        "prepare": {
+          "text": "Wise. Whatever's out there endured three centuries of being forgotten — it will keep another day. Come back when your deck is ready, and I'll mark the route to the Pale Marches.",
+          "choices": [
+            { "label": "Farewell.", "effects": [{ "type": "end" }] }
+          ]
+        },
+        "set-out": {
+          "text": "I hoped you'd say that. Here — the route east, such as it is. It ends where my courage did: at the first lit lantern of the Pale Marches.\n\nWhatever you find out there, Worldmender... remember it. I suspect that matters more than usual.",
+          "choices": [
+            { "label": "Set out for the Pale Marches.", "effects": [{ "type": "screen", "screen": "campaign2" }] },
+            { "label": "Not yet.", "effects": [{ "type": "end" }] }
+          ]
+        }
+      }
+    },
+    {
       "id": "mabel-pie-craft",
       "npcId": "castle-cook",
       "start": "greet",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -178,6 +178,10 @@ export interface HubNpc {
   /** Line shown when tapped while the schedule has this NPC sleeping.
    *  Defaults to a generic "fast asleep" narration. */
   sleepDialogue?: string
+  /** Lines cycled INSTEAD of `dialogue` once campaign 1 is complete
+   *  (isCampaignComplete('c1')) — how the world acknowledges the sealed
+   *  Fracture. Activity pools (dialogueByActivity) still take precedence. */
+  postCampaignDialogue?: string[]
   /** Id of a branching dialogue tree (questDefs.json `dialogues`) to run on tap. */
   dialogueTree?: string
   /** Hub-item id (hubItems.json) that grants a bonus friendship/relationship boost when gifted. */

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1835,6 +1835,11 @@
         "I've seen three ships go dark past the reef. No word from them.",
         "Marta thinks I'm superstitious. Maybe I am."
       ],
+      "postCampaignDialogue": [
+        "The sea's been calm since you mended the world. TOO calm, some nights. Like it's listening.",
+        "Coasters coming down from the north say there's a new shoreline east past the marches. Whole harbours nobody's ever charted. Marta thinks they'd been drinking. All of them? Every crew?",
+        "Superstitious, am I? I've started lighting a candle in the window at night. Don't know where I picked that up. Feels... polite."
+      ],
       "dialogueByActivity": {
         "fish": [
           "Line's been quiet all morning. That's never a good sign out here.",

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -246,6 +246,7 @@ export interface DialogueChoiceDef {
   effects?: DialogueEffect[]
   requireFlag?: string     // only show this choice if the flag is set
   hideIfFlag?: string      // hide this choice once the flag is set
+  requireCampaignComplete?: string // only show once this campaign is complete ('c1' | 'c2') — derived from act counts, works retroactively
   requireFestival?: string // only show this choice while that festival is active (hubCalendar)
   requireWeather?: string  // only show this choice while the town's weather matches ('clear'|'rain'|'snow'|'fog')
   requireQuest?: string    // only show this choice once that quest is completed

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8766,6 +8766,11 @@
         "The archives hold centuries of knowledge. Most of it was lost in the Fracture. What remains is precious.",
         "Do not underestimate the power of knowing your enemy, Commander."
       ],
+      "postCampaignDialogue": [
+        "You sealed the Fracture, Commander. The scholarly consensus is astonishment. My consensus is: I told them you would.",
+        "A puzzle for you: when the world mended, everything the Fracture scattered came back. Everything. Now ask yourself — what did the Fracture take that we never missed?",
+        "Know your enemy, I always said. Our next enemy may be one nobody CAN know. The old texts have holes in them shaped like a kingdom."
+      ],
       "dialogueByActivity": {
         "work": [
           "Quiet, please. The Fracture shards don't catalogue themselves."

--- a/web/src/data/hub/royalpalace/config.json
+++ b/web/src/data/hub/royalpalace/config.json
@@ -1941,6 +1941,11 @@
         "Hear ye, hear ye — the proclamations have gone missing again. A herald with no words is merely a man shouting.",
         "Protocol is the art of standing in the right place while important things happen elsewhere."
       ],
+      "postCampaignDialogue": [
+        "Announcing the Worldmender requires seventeen syllables of formal title now. I have been practising.",
+        "Protocol note: there is no established etiquette for greeting an emissary from a kingdom that does not officially exist. I have raised it with the Steward. Twice.",
+        "Important things are happening elsewhere again. East, this time. I can feel it through the protocol."
+      ],
       "dialogueByActivity": {
         "idle-chat": [
           "Presenting: you. To no one in particular. Still a slow morning.",
@@ -2080,6 +2085,11 @@
         "Ah, a new face. The court is forever full of old ones, all of them wanting something.",
         "A crown is heavier than it looks, and most of the weight is other people's problems.",
         "Serve the realm well and the realm remembers. Mostly. When it isn't distracted."
+      ],
+      "postCampaignDialogue": [
+        "Worldmender! The realm owes you a debt no treasury can settle. Kindly do not tell Master Edric I said that.",
+        "A sealed Fracture, a whole Dominion, and peace at every border. Almost every border. The east sends... reports. I have chosen to call them reports rather than omens.",
+        "Serve the realm well and the realm remembers. You mended the realm, so it remembers you doubly. I only wonder — what did the realm forget, all those years it was broken?"
       ],
       "dialogueByActivity": {
         "work": [

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -180,5 +180,19 @@
     "nodeId": "mem-act13-2",
     "title": "Fragment: Year One, Alone",
     "body": "GRAND AUTOMATON OPERATIONAL LOG — YEAR 1 POST-FRACTURE, MONTH 12\n\nYear one summary: all Vault systems nominal. All mechanisms maintained to specification. All archived items catalogued, preserved, and secured. No artificers have returned. No external contact received or initiated. Total visitors: zero.\n\nThis unit does not ask questions it cannot answer. This unit has not asked: why the artificers have not returned. This unit has not asked: what happens to an archive with no one to read it. This unit has not asked: whether maintenance of a collection that no one will ever access constitutes purpose, or simply motion.\n\nThis unit maintains the Vaults because that is the directive. Year two begins tomorrow. The mechanisms are in good order. The question this unit is not asking grows louder in the silence."
+  },
+  {
+    "id": "c2act1-frag-1",
+    "actId": "c2act1",
+    "nodeId": "mem-c2act1-1",
+    "title": "Fragment: The Border Stone",
+    "body": "The stone stands where the mist begins, carved with a name your eyes keep sliding off. Reading it hurts — a headache like a word on the tip of the whole world's tongue.\n\nAMARATH.\n\nAnd beneath it, in an older hand: 'Set in the fourth year of the Grand Dominion, to mark the western border of the Kingdom of Amarath, most loyal of the crown provinces.'\n\nMost loyal. The Grand Dominion — the empire whose shattering you have spent a campaign mending — had a province the maps do not show. A border the surveys never drew. A neighbour three centuries of Dominion scholarship never once mentioned.\n\nThe Fracture did not only break the world. It edited it.\n\nYou memorise the name. It feels like the least you can do, and also like the most dangerous."
+  },
+  {
+    "id": "c2act1-frag-2",
+    "actId": "c2act1",
+    "nodeId": "mem-c2act1-2",
+    "title": "Fragment: The First Vigil",
+    "body": "VIGIL LEDGER OF THE MARCHES — YEAR ONE OF THE DARK\n\n'The King has commanded the vigil, and so we keep it. One candle for every soul in the Marches, lit each dusk, named each midnight. The rite-keepers say that what is remembered cannot dissolve. That the void outside our borders can only take what no one holds.\n\nSo we hold. We recite the census. We light the candles. We say the names of our dead and our living in one breath, because out here the difference matters less than the remembering.\n\nThe farmers ask when the world will come back for us. I write down the question, because questions must be remembered too. I do not write down an answer.\n\nEntry ends. 41,206 candles lit tonight. 41,206 names spoken. No one forgotten.\n\nNo one forgotten. No one forgotten. No one forgotten.'"
   }
 ]

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -263,5 +263,22 @@
         "type": "structureDraw"
       }
     ]
+  },
+  {
+    "name": "Vigil Candle",
+    "icon": "🕯️",
+    "desc": "All your units gain +2 max HP at battle start and slowly mend, recovering 2 HP every 6 seconds.",
+    "lore": "One flame of Amarath's vigil, surrendered by the Pale Herald at the border. It has burned for three hundred years on nothing but being remembered. Units who fight in its light find their wounds closing — being held in mind, it turns out, is a kind of mending.",
+    "effects": [
+      {
+        "type": "unitHp",
+        "amount": 2
+      },
+      {
+        "type": "tickHeal",
+        "amount": 2,
+        "intervalMs": 6000
+      }
+    ]
   }
 ]

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -824,6 +824,41 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 2,
   },
 
+  // Campaign 2, Act 1 — The Pale Marches
+  {
+    id: 'campaign:c2act1:1',
+    name: 'The Writ Refused',
+    description: 'Complete Campaign 2 Act 1 — The Pale Marches',
+    category: 'campaign',
+    progressKey: 'campaign:c2act1',
+    target: 1,
+    reward: { type: 'crystals', crystals: 600 },
+    tier: 1,
+  },
+  {
+    id: 'campaign:c2act1:10',
+    name: 'Warden of the Blank Quarter',
+    description: 'Complete Campaign 2 Act 1 ten times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act1',
+    target: 10,
+    reward: { type: 'crystals', crystals: 3000 },
+    tier: 2,
+  },
+  {
+    id: 'campaign:c2act1:100',
+    name: 'The Mist Knows Your Name',
+    description: 'Complete Campaign 2 Act 1 one hundred times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act1',
+    target: 100,
+    reward: {
+      type: 'item',
+      item: { id: 'heralds_banner_scrap', name: "Herald's Banner Scrap", icon: '🏳️', desc: 'A strip of the proclamation banner. The mist still clings to it.' },
+    },
+    tier: 2,
+  },
+
   // ── Boss avatar unlocks (one per act, triggered on first act completion) ─
 
   { id: 'campaign:act1:boss',  name: 'Face of the Thornlord',       description: 'Defeat Act 1 to unlock the Thornlord avatar',       category: 'campaign', progressKey: 'campaign:act1',  target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thornlord' },       tier: 1 },
@@ -840,6 +875,7 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
   { id: 'campaign:act12:boss', name: 'Face of the Harbormaster',   description: 'Defeat Act 12 to unlock the Harbormaster avatar',  category: 'campaign', progressKey: 'campaign:act12', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-harbormaster' },  tier: 1 },
   { id: 'campaign:act13:boss',   name: 'Face of the Grand Automaton', description: 'Defeat Act 13 to unlock the Grand Automaton avatar', category: 'campaign', progressKey: 'campaign:act13',   target: 1, reward: { type: 'avatar', avatarSlug: 'boss-grandautomaton' },  tier: 1 },
   { id: 'campaign:actfinale:boss', name: 'Face of the Fracture',       description: 'Defeat the Finale to unlock the Fracture avatar',     category: 'campaign', progressKey: 'campaign:actfinale', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thefracture' },     tier: 1 },
+  { id: 'campaign:c2act1:boss',    name: 'Face of the Pale Herald',    description: 'Defeat Campaign 2 Act 1 to unlock the Pale Herald avatar', category: 'campaign', progressKey: 'campaign:c2act1', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-paleherald' },      tier: 1 },
 
   // ── Boss Cards — earned by repeat boss completions (10/20/30/40 runs) ────
   // Act 1 — Thornlord

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -21,12 +21,13 @@ import act11Data from '../data/acts/act11.json'
 import act12Data from '../data/acts/act12.json'
 import act13Data from '../data/acts/act13.json'
 import actFinaleData from '../data/acts/actfinale.json'
+import c2act1Data from '../data/acts/c2act1.json'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ALL_ACTS: any[] = [
   act1Data, act2Data, act3Data, act4Data, act5Data,
   act6Data, act7Data, act8Data, act9Data, act10Data,
-  act11Data, act12Data, act13Data, actFinaleData,
+  act11Data, act12Data, act13Data, actFinaleData, c2act1Data,
 ]
 
 const FRAGMENT_KEY        = 'jarv_memory_fragments'

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -1,4 +1,5 @@
 import { hourInRange } from './hubClock'
+import { isCampaignComplete } from '../questline'
 import type { HubNpc, HubInterior, NpcScheduleEntry, NpcActivity } from '../../data/hub/loader'
 
 /**
@@ -26,12 +27,15 @@ export function getNpcActivity(npc: HubNpc, gameHour: number): NpcActivity | nul
 }
 
 /** The dialogue pool an NPC should draw from right now: the activity-specific
- *  pool when one is authored for the current scheduled activity, otherwise
- *  the flat `dialogue` array. */
+ *  pool when one is authored for the current scheduled activity, otherwise the
+ *  post-campaign lines once campaign 1 is complete, otherwise the flat
+ *  `dialogue` array. */
 export function getNpcDialoguePool(npc: HubNpc, gameHour: number): string[] {
   const activity = getNpcActivity(npc, gameHour)
   const pool = activity ? npc.dialogueByActivity?.[activity] : undefined
-  return pool?.length ? pool : npc.dialogue
+  if (pool?.length) return pool
+  if (npc.postCampaignDialogue?.length && isCampaignComplete('c1')) return npc.postCampaignDialogue
+  return npc.dialogue
 }
 
 /** True while the NPC's schedule has them sleeping. */

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1002,7 +1002,7 @@ export const BOSS_AVATAR_SLUGS = [
   'boss-thornlord', 'boss-kragg', 'boss-ashwalker', 'boss-archivist',
   'boss-tidal-sovereign', 'boss-cloudmarshal', 'boss-cinderwarlord', 'boss-rootqueen',
   'boss-paleengine', 'boss-dunebaron', 'boss-elderwarden', 'boss-harbormaster',
-  'boss-grandautomaton',
+  'boss-grandautomaton', 'boss-paleherald',
 ] as const
 export const AVATAR_SLUGS = [...BASE_AVATAR_SLUGS, ...STREAK_AVATAR_SLUGS, ...BOSS_AVATAR_SLUGS] as const
 export type AvatarSlug = typeof AVATAR_SLUGS[number]
@@ -1032,6 +1032,7 @@ export const BOSS_AVATAR_LABELS: Record<string, string> = {
   'boss-elderwarden':     'The Elder Warden',
   'boss-harbormaster':    'The Harbormaster',
   'boss-grandautomaton':  'The Grand Automaton',
+  'boss-paleherald':      'The Pale Herald',
 }
 
 export function loadUnlockedAvatars(): string[] {

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -17,6 +17,7 @@ import act11Data from '../data/acts/act11.json'
 import act12Data from '../data/acts/act12.json'
 import act13Data    from '../data/acts/act13.json'
 import actFinaleData from '../data/acts/actfinale.json'
+import c2act1Data from '../data/acts/c2act1.json'
 import worldBattlesData from '../data/acts/worldbattles.json'
 import consumablesData from '../data/consumables.json'
 
@@ -897,6 +898,7 @@ export const ACT_11: Act = act11Data as Act
 export const ACT_12: Act = act12Data as Act
 export const ACT_13:     Act = act13Data    as Act
 export const ACT_FINALE: Act = actFinaleData as Act
+export const C2_ACT_1: Act = c2act1Data as Act
 /** Standalone battles launched from the world map — never part of campaign progression. */
 export const ACT_WORLD: Act = worldBattlesData as Act
 
@@ -915,6 +917,7 @@ export const ACTS: Record<string, Act> = {
   act12: ACT_12,
   act13:     ACT_13,
   actfinale: ACT_FINALE,
+  c2act1:    C2_ACT_1,
   world:     ACT_WORLD,
 }
 

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -918,6 +918,39 @@ export const ACTS: Record<string, Act> = {
   world:     ACT_WORLD,
 }
 
+// ─── Campaigns ────────────────────────────────────────────
+
+export interface CampaignDef {
+  id: string
+  name: string
+  /** Act started when the player begins this campaign fresh. */
+  startActId: string
+  /** Completing this act completes the campaign. */
+  finaleActId: string
+}
+
+/** The story arcs, in order. Acts belong to campaign 2 iff their id starts with 'c2'. */
+export const CAMPAIGNS: CampaignDef[] = [
+  { id: 'c1', name: 'The Shattered Dominion', startActId: 'act1',   finaleActId: 'actfinale' },
+  { id: 'c2', name: 'The Forgotten Kingdom',  startActId: 'c2act1', finaleActId: 'c2finale' },
+]
+
+export function getCampaign(campaignId: string): CampaignDef | null {
+  return CAMPAIGNS.find(c => c.id === campaignId) ?? null
+}
+
+/** The campaign an act belongs to. Standalone maps (world battles) return campaign 1. */
+export function getCampaignForAct(actId: string): CampaignDef {
+  return actId.startsWith('c2') ? CAMPAIGNS[1] : CAMPAIGNS[0]
+}
+
+/** True once the player has beaten the campaign's finale act at least once. */
+export function isCampaignComplete(campaignId: string): boolean {
+  const campaign = getCampaign(campaignId)
+  if (!campaign) return false
+  return loadActCount(campaign.finaleActId) > 0
+}
+
 // ─── Node history (persistent across runs) ───────────────
 
 const NODE_HISTORY_KEY = 'jarv_node_history'


### PR DESCRIPTION
Part of #181 (do not auto-close — the remaining acts are tracked as sub-issues #1987–#1999).

Delivers the campaign 2 foundation and the first fully playable act of **The Forgotten Kingdom**.

## Story & docs
- `docs/campaign2.md` — story bible: premise (Amarath, the kingdom erased from every map and memory when the world shattered, returned by the mending), the Pale Court antagonist, and a 13-act + finale beat sheet with boss/trait/relic/hero per act
- `docs/acts.md` §4.1 corrected to the shipped structure; `docs/hubworld.md` documents the new dialogue fields; AGENTS.md links the bible

## Infrastructure
- **Campaign registry** (`questline.ts`): `CAMPAIGNS` table, `getCampaignForAct`, `isCampaignComplete` (derived from act counts — retroactive for existing players)
- **Launch plumbing** (`App.tsx`, `HubWorld.tsx`): `launchCampaign(startActId)`; new `campaign2` screen id → `onCampaign2`; abandon-confirm modal when a campaign-1 run is active; title-screen behaviour unchanged
- **TO BE CONTINUED screen**: clearing the last authored act of an in-progress arc ends the run gracefully instead of showing the campaign-1 victory screen — each follow-up act just adds `nextActId` to its predecessor
- **Hub dialogue gating**: `requireCampaignComplete` on dialogue choices + `postCampaignDialogue` on NPCs

## World state
- **Cartographer Elsben** (new NPC, Ironhold Keep gate road): foreshadowing dialogue always; once campaign 1 is complete, his survey branch reveals Amarath and launches campaign 2
- Post-campaign lines for 10 story NPCs across Ironhold Keep, Capital City, Royal Palace, Ravenwatch, and Millhaven acknowledging the sealed Fracture and unease in the east

## Campaign 2, Act 1 — The Pale Marches (`c2act1`)
- 15-node map with balanced A/B paths (3 combat each), 2 memory fragments, inline events, replay intro rules, 6 cutscene panels
- 25 themed cards (`forgotten`/`marches`, 6c/12u/4r/2e/1l) + 19 unit templates + **Warden of the Marches** hero card
- Boss **The Pale Herald** (`paleherald`, Proclamation Descent fly trait) + shared `pale-elite` AI
- Relic **Vigil Candle** (+2 unit max HP, 2 HP mend / 6 s); `campaign:c2act1` achievements + boss avatar unlock
- All sprites: 13 animated units (4 frames each), 7 structures, boss avatar, hub NPC

## Verification
- `npm run build` passes clean
- `npm run test`: 680/680 unit tests pass (hub loader + NPC dialogue coverage include the new NPC/dialogue JSON; the browser-runner error is pre-existing on `main`)
- Data cross-check: every `enemyDeck` name, `bossAI`, `bossCard`, `fragmentId`, relic, and node edge in `c2act1.json` resolves; A/B path combat counts are equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ)_