### PR TITLE
fix(hub): implement the 'screen' dialogue effect so Elsben launches campaign 2

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1178,6 +1178,12 @@ function hasOfferableQuest(giverId: string): boolean {
           })
           return
         }
+        case 'screen':
+          // Navigate to a screen (campaign2, interior:<id>, …) through the same
+          // router every screen-based NPC/interactable uses. Terminates the walk.
+          setDialogueEvent(null)
+          handleNodeInteract(eff.screen)
+          return
         case 'end':
           ended = true
           break

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -238,6 +238,7 @@ export type DialogueEffect =
       giveRelationship?: { npcId?: string; track: RelationshipTrack; points: number }
       missingText: string
       successText: string }
+  | { type: 'screen'; screen: string }          // navigate to a screen (same ids as RawNpc.screen, e.g. 'campaign2', 'interior:<id>') — terminates the walk
   | { type: 'end' }                             // end the conversation
 
 export interface DialogueChoiceDef {


### PR DESCRIPTION
Fixes the bug where tapping **"Set out for the Pale Marches."** in Cartographer Elsben's dialogue did nothing.

**Root cause:** `docs/hubworld.md` §7b documents a `screen` DialogueEffect ("routed through `handleNodeInteract`, terminates the walk"), but it was never actually implemented — the `DialogueEffect` union in `questDefs.ts` had no `screen` variant and `applyChoice` in `HubWorld.tsx` had no case for it. Elsben's tree (merged in #2001) used the documented effect; at runtime the walker fell through the switch as a no-op and simply closed the dialogue. Dialogue JSON isn't typechecked against the union, so the build couldn't catch it.

**Fix:**
- `web/src/data/hub/questDefs.ts`: add `{ type: 'screen'; screen: string }` to `DialogueEffect`
- `web/src/components/hub/HubWorld.tsx` (`applyChoice`): close the dialogue, route the id through the same `handleNodeInteract` every screen-based NPC/interactable uses, and terminate the walk — exactly the documented behaviour

This also makes the effect work for any future dialogue tree (`interior:<id>`, `campaign`, `campaign2`, etc.), not just Elsben.

**Verification:** `npm run build` clean; hub loader + NPC dialogue coverage tests pass (190/190). The tap path is now: choice → `screen` effect → `handleNodeInteract('campaign2')` → `onCampaign2` → `handleCampaign2` (fresh c2 run, or abandon-confirm if a campaign-1 run is active).

Refs #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ)_