### PR TITLE
feat(campaign2): Act II — The Grey Causeway (c2act2)

### DIFF
--- a/web/public/cutscenes/c2act2-intro-1.svg
+++ b/web/public/cutscenes/c2act2-intro-1.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a2i1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#242b48"/>
+    <stop offset="100%" stop-color="#4a5170"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a2i1-sky)"/>
+  <!-- Churned battlefield ground, receding behind -->
+  <rect y="176" width="400" height="64" fill="#2b2f42"/>
+  <path d="M0,176 Q60,168 120,176 Q200,184 280,174 Q340,168 400,176 L400,240 L0,240 Z" fill="#232739"/>
+  <!-- Planted banner, now distant and abandoned -->
+  <rect x="70" y="80" width="3" height="96" rx="1.5" fill="#5B5346" opacity="0.7"/>
+  <path d="M73,84 L103,90 L73,102 Z" fill="#5E6A8C" opacity="0.6"/>
+  <!-- Jarv silhouette walking east, carrying the lantern -->
+  <g fill="#11141f">
+    <circle cx="220" cy="150" r="10"/>
+    <rect x="209" y="160" width="22" height="34" rx="4"/>
+  </g>
+  <rect x="234" y="172" width="8" height="12" rx="1.5" fill="#20263c"/>
+  <rect x="236" y="168" width="4" height="6" fill="#FFB347" opacity="0.9"/>
+  <circle cx="238" cy="178" r="7" fill="#FFB347" opacity="0.25"/>
+  <!-- Road ahead into the mist -->
+  <path d="M260,240 L320,140 L332,140 L280,240 Z" fill="#3a4160" opacity="0.85"/>
+  <ellipse cx="260" cy="196" rx="140" ry="24" fill="#ced3e6" opacity="0.35"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE HERALD WAS ONLY THE ANNOUNCEMENT</text>
+</svg>

--- a/web/public/cutscenes/c2act2-intro-2.svg
+++ b/web/public/cutscenes/c2act2-intro-2.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a2i2-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#1c2138"/>
+    <stop offset="100%" stop-color="#565e80"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a2i2-sky)"/>
+  <!-- The causeway running dead straight into the distance -->
+  <path d="M40,240 L184,60 L216,60 L280,240 Z" fill="#4a5170"/>
+  <path d="M186,62 L214,62 L250,190 L150,190 Z" fill="#3a4160" opacity="0.5"/>
+  <!-- Grey stone joints -->
+  <g stroke="#5c6488" stroke-width="1" opacity="0.6">
+    <line x1="160" y1="200" x2="240" y2="200"/>
+    <line x1="176" y1="150" x2="228" y2="150"/>
+    <line x1="190" y1="110" x2="212" y2="110"/>
+  </g>
+  <!-- Rows of unlit lamps down both sides -->
+  <g fill="#20263c">
+    <rect x="120" y="178" width="3.4" height="34" /><circle cx="121.7" cy="174" r="5" fill="#2b3149"/>
+    <rect x="280" y="178" width="3.4" height="34"/><circle cx="281.7" cy="174" r="5" fill="#2b3149"/>
+    <rect x="164" y="120" width="2.4" height="24"/><circle cx="165.2" cy="117" r="3.6" fill="#2b3149"/>
+    <rect x="236" y="120" width="2.4" height="24"/><circle cx="237.2" cy="117" r="3.6" fill="#2b3149"/>
+    <rect x="190" y="82" width="1.6" height="14"/><circle cx="190.8" cy="80" r="2.2" fill="#2b3149"/>
+    <rect x="210" y="82" width="1.6" height="14"/><circle cx="210.8" cy="80" r="2.2" fill="#2b3149"/>
+  </g>
+  <!-- Mist -->
+  <ellipse cx="200" cy="200" rx="200" ry="26" fill="#ced3e6" opacity="0.4"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">A MILE OF LAMPS, LIT FOR GUESTS WHO NEVER CAME</text>
+</svg>

--- a/web/public/cutscenes/c2act2-intro-3.svg
+++ b/web/public/cutscenes/c2act2-intro-3.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0d0b08"/>
+  <!-- Tollhouse counter with an open ledger -->
+  <rect x="30" y="60" width="340" height="140" rx="4" fill="#E8DFC8"/>
+  <rect x="30" y="60" width="340" height="140" rx="4" fill="none" stroke="#8A6F4D" stroke-width="3"/>
+  <!-- Open ledger book -->
+  <path d="M90,90 L200,78 L310,90 L310,180 L200,168 L90,180 Z" fill="#F2E9D8"/>
+  <line x1="200" y1="78" x2="200" y2="168" stroke="#8A6F4D" stroke-width="1.4"/>
+  <g stroke="#5B5346" stroke-width="1">
+    <line x1="102" y1="104" x2="188" y2="98"/>
+    <line x1="102" y1="120" x2="188" y2="114"/>
+    <line x1="102" y1="136" x2="188" y2="130"/>
+    <line x1="102" y1="152" x2="188" y2="146"/>
+    <line x1="212" y1="98" x2="298" y2="104"/>
+    <line x1="212" y1="114" x2="298" y2="120"/>
+    <line x1="212" y1="130" x2="298" y2="136"/>
+  </g>
+  <!-- A single fresh, empty line waiting -->
+  <line x1="212" y1="146" x2="298" y2="152" stroke="#8E3B3B" stroke-width="1.4" opacity="0.8"/>
+  <text x="255" y="163" text-anchor="middle" font-family="monospace" font-size="8" fill="#8E3B3B">next entry ?</text>
+  <!-- Distant kingdom silhouette through the tollhouse window -->
+  <g fill="#333a58" opacity="0.85">
+    <rect x="330" y="30" width="10" height="30" rx="1"/>
+    <rect x="345" y="20" width="12" height="40" rx="1"/>
+  </g>
+  <!-- Candle on the ledger -->
+  <rect x="330" y="130" width="6" height="16" fill="#F2E9D8"/>
+  <ellipse cx="333" cy="124" rx="3.4" ry="5.6" fill="#FFB347"/>
+  <circle cx="333" cy="126" r="12" fill="#FFB347" opacity="0.18"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THREE CENTURIES OF NAMES. NONE FROM OUTSIDE. YET.</text>
+</svg>

--- a/web/public/cutscenes/c2act2-outro-1.svg
+++ b/web/public/cutscenes/c2act2-outro-1.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a2o1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#242b48"/>
+    <stop offset="100%" stop-color="#4a5170"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a2o1-sky)"/>
+  <!-- Causeway stone ground -->
+  <rect y="176" width="400" height="64" fill="#3a3f52"/>
+  <path d="M0,176 Q60,170 120,176 Q200,182 280,174 Q340,170 400,176 L400,240 L0,240 Z" fill="#2f3446"/>
+  <!-- Kneeling Toll Warden -->
+  <g>
+    <rect x="168" y="96" width="44" height="12" rx="4" fill="#9FA3BC"/>
+    <rect x="184" y="86" width="12" height="4" fill="#7E8299"/>
+    <circle cx="184" cy="86" r="2" fill="#454E6B"/>
+    <circle cx="196" cy="86" r="2" fill="#454E6B"/>
+    <rect x="172" y="102" width="36" height="6" fill="#20263c"/>
+    <circle cx="182" cy="105" r="2" fill="#FFB347"/>
+    <circle cx="196" cy="105" r="2" fill="#FFB347"/>
+    <path d="M160,110 L154,190 L226,190 L220,110 Q190,124 160,110 Z" fill="#9FA3BC"/>
+    <!-- Kneeling leg -->
+    <rect x="164" y="186" width="52" height="10" rx="4" fill="#3A3F55"/>
+  </g>
+  <!-- Toll scale, still held out, tipping -->
+  <rect x="238" y="120" width="3" height="48" fill="#7E8299"/>
+  <rect x="222" y="112" width="34" height="4" rx="2" fill="#8A6F4D" transform="rotate(-8 239 114)"/>
+  <path d="M220,134 Q228,142 236,134 Z" fill="#454E6B"/>
+  <path d="M244,124 Q252,132 260,124 Z" fill="#454E6B"/>
+  <!-- Mist low over the field -->
+  <ellipse cx="100" cy="196" rx="130" ry="18" fill="#ced3e6" opacity="0.35"/>
+  <ellipse cx="320" cy="200" rx="120" ry="16" fill="#ced3e6" opacity="0.3"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">"THAT WAS ALWAYS THE TOLL. NOT THAT IT HAD TO BE MINE."</text>
+</svg>

--- a/web/public/cutscenes/c2act2-outro-2.svg
+++ b/web/public/cutscenes/c2act2-outro-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#08070c"/>
+  <!-- Darkness with the scale catching a faint gold light -->
+  <radialGradient id="c2a2o2-glow" cx="50%" cy="45%" r="55%">
+    <stop offset="0%" stop-color="#E8B94A" stop-opacity="0.4"/>
+    <stop offset="45%" stop-color="#5a4a1f" stop-opacity="0.2"/>
+    <stop offset="100%" stop-color="#08070c" stop-opacity="0"/>
+  </radialGradient>
+  <rect width="400" height="240" fill="url(#c2a2o2-glow)"/>
+  <!-- The scale, held aloft -->
+  <rect x="197" y="70" width="6" height="60" fill="#7E8299"/>
+  <rect x="160" y="64" width="80" height="5" rx="2.5" fill="#8A6F4D"/>
+  <line x1="168" y1="69" x2="168" y2="96" stroke="#7E8299" stroke-width="1"/>
+  <path d="M150,96 Q168,112 186,96 Z" fill="#454E6B"/>
+  <line x1="232" y1="69" x2="232" y2="96" stroke="#7E8299" stroke-width="1"/>
+  <path d="M214,96 Q232,112 250,96 Z" fill="#454E6B"/>
+  <circle cx="200" cy="61" r="2.4" fill="#E8B94A"/>
+  <!-- Hands receiving it -->
+  <path d="M150,170 Q170,152 186,144 L192,152 Q176,162 162,178 Z" fill="#c9a985"/>
+  <path d="M250,170 Q230,152 214,144 L208,152 Q224,162 238,178 Z" fill="#c9a985"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">A SCALE THAT HAS NEVER ONCE COME OUT EVEN</text>
+</svg>

--- a/web/public/cutscenes/c2act2-outro-3.svg
+++ b/web/public/cutscenes/c2act2-outro-3.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a2o3-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#3a4160"/>
+    <stop offset="70%" stop-color="#6b7294"/>
+    <stop offset="100%" stop-color="#8e94b4"/>
+  </linearGradient>
+  <rect width="400" height="180" fill="url(#c2a2o3-sky)"/>
+  <!-- Fields of pale grain, rows receding -->
+  <rect y="150" width="400" height="90" fill="#4a5170"/>
+  <g stroke="#c9cf7a" stroke-width="1.2" opacity="0.7">
+    <line x1="20" y1="240" x2="60" y2="160"/>
+    <line x1="70" y1="240" x2="100" y2="160"/>
+    <line x1="120" y1="240" x2="140" y2="160"/>
+    <line x1="180" y1="240" x2="190" y2="160"/>
+    <line x1="240" y1="240" x2="240" y2="160"/>
+    <line x1="300" y1="240" x2="290" y2="160"/>
+    <line x1="350" y1="240" x2="330" y2="160"/>
+  </g>
+  <g fill="#d8dc9e" opacity="0.6">
+    <ellipse cx="60" cy="158" rx="6" ry="3"/>
+    <ellipse cx="140" cy="158" rx="6" ry="3"/>
+    <ellipse cx="240" cy="158" rx="6" ry="3"/>
+    <ellipse cx="330" cy="158" rx="6" ry="3"/>
+  </g>
+  <!-- Distant Court towers still on the horizon -->
+  <g fill="#333a58" opacity="0.8">
+    <rect x="286" y="96" width="9" height="40"/>
+    <path d="M286,96 L290.5,84 L295,96 Z"/>
+    <rect x="304" y="88" width="11" height="48"/>
+    <path d="M304,88 L309.5,74 L315,88 Z"/>
+  </g>
+  <!-- Mist bands -->
+  <ellipse cx="200" cy="160" rx="220" ry="18" fill="#ced3e6" opacity="0.35"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">SOMEWHERE IN THAT GRAIN, AMARATH GROWS BACK WHAT IT LOST</text>
+</svg>

--- a/web/public/sprites/boss-tollwarden-1.svg
+++ b/web/public/sprites/boss-tollwarden-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride A: standard sways back -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(4 25.8 16)"/>
+  <path d="M26.6,4 L31.2,6 L26.6,10 Z" fill="#454E6B"/>
+  <circle cx="28.8" cy="6.6" r="0.9" fill="#FFD24A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="1.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="2.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="1.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="1.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#9FA3BC"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#7E8299"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#454E6B"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#FFD24A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#7E8299"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#454E6B"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="28" width="4.5" height="3.6" rx="1" fill="#3A3F55"/>
+  <rect x="18.5" y="28" width="4.5" height="2.8" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-tollwarden-2.svg
+++ b/web/public/sprites/boss-tollwarden-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#454E6B"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#FFD24A"/>
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="0.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="1.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="0.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="0.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#9FA3BC"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#7E8299"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#454E6B"/>
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#FFD24A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="14" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#7E8299"/>
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#454E6B"/>
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-tollwarden-3.svg
+++ b/web/public/sprites/boss-tollwarden-3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride B: standard sways forward -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(-4 25.8 16)"/>
+  <path d="M26.2,4 L30.8,5.2 L26.2,9.6 Z" fill="#454E6B"/>
+  <circle cx="28.4" cy="6" r="0.9" fill="#FFD24A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="1.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="2.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="1.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="1.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#9FA3BC"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#7E8299"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#454E6B"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#FFD24A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#7E8299"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#454E6B"/>
+  <!-- Legs stride B -->
+  <rect x="18.5" y="28" width="4.5" height="3.6" rx="1" fill="#3A3F55"/>
+  <rect x="9.5" y="28" width="4.5" height="2.8" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-tollwarden.svg
+++ b/web/public/sprites/boss-tollwarden.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Towering tollgate lord with standard and scale -->
+  <!-- Toll standard pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#454E6B"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#FFD24A"/>
+  <!-- Great helm with scale crest -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="0.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="1.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="0.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="0.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <!-- Massive grey cloak/body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#9FA3BC"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#7E8299"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#454E6B"/>
+  <!-- Toll-coin chest sigil -->
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#FFD24A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#7E8299"/>
+  <!-- The toll scale held out -->
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#454E6B"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/candle-warden-1.svg
+++ b/web/public/sprites/candle-warden-1.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe sways left, flame flickers left -->
+  <circle cx="15" cy="10" r="5" fill="#A6A9C0"/>
+  <path d="M10,10 Q15,3 20,10 L20,13 Q15,10 10,13 Z" fill="#7E8299"/>
+  <circle cx="15" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L8,31 L20,31 L19,15 Q15,17 11,15 Z" fill="#A6A9C0"/>
+  <path d="M11,23 L9,31 L19,31 L19.5,23 Z" fill="#7E8299"/>
+  <rect x="12" y="18" width="6" height="1.2" fill="#5E6A8C"/>
+  <rect x="14" y="19.6" width="2.4" height="1.6" rx="0.3" fill="#E8B94A"/>
+  <rect x="20" y="14" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="22.5" y="10" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="8.6" width="0.8" height="1.8" fill="#5E6A8C"/>
+  <ellipse cx="23.2" cy="7" rx="1.5" ry="2.2" fill="#FFB347" transform="rotate(-12 23.2 7)"/>
+  <ellipse cx="23.2" cy="7.4" rx="0.8" ry="1.2" fill="#FFE08A" transform="rotate(-12 23.2 7.4)"/>
+  <circle cx="23.4" cy="7" r="3.2" fill="#FFB347" opacity="0.22"/>
+</svg>

--- a/web/public/sprites/candle-warden-2.svg
+++ b/web/public/sprites/candle-warden-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded robed keeper with tall candle -->
+  <circle cx="15" cy="9" r="5" fill="#A6A9C0"/>
+  <path d="M10,9 Q15,2 20,9 L20,12 Q15,9 10,12 Z" fill="#7E8299"/>
+  <circle cx="15" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Long robe -->
+  <path d="M11,14 L9,30 L21,30 L19,14 Q15,16 11,14 Z" fill="#A6A9C0"/>
+  <path d="M11,22 L10,30 L20,30 L19.5,22 Z" fill="#7E8299"/>
+  <rect x="12" y="17" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Toll tag on belt -->
+  <rect x="14" y="18.6" width="2.4" height="1.6" rx="0.3" fill="#E8B94A"/>
+  <!-- Candle arm -->
+  <rect x="20" y="13" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="22.5" y="9" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="7.6" width="0.8" height="1.8" fill="#5E6A8C"/>
+  <!-- Flame -->
+  <ellipse cx="23.8" cy="6" rx="1.6" ry="2.4" fill="#FFB347"/>
+  <ellipse cx="23.8" cy="6.4" rx="0.8" ry="1.3" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="23.8" cy="6" r="3.4" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/candle-warden-3.svg
+++ b/web/public/sprites/candle-warden-3.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robe sways right, flame flickers right -->
+  <circle cx="15" cy="10" r="5" fill="#A6A9C0"/>
+  <path d="M10,10 Q15,3 20,10 L20,13 Q15,10 10,13 Z" fill="#7E8299"/>
+  <circle cx="15" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L10,31 L22,31 L19,15 Q15,17 11,15 Z" fill="#A6A9C0"/>
+  <path d="M11,23 L11,31 L21,31 L19.5,23 Z" fill="#7E8299"/>
+  <rect x="12" y="18" width="6" height="1.2" fill="#5E6A8C"/>
+  <rect x="14" y="19.6" width="2.4" height="1.6" rx="0.3" fill="#E8B94A"/>
+  <rect x="20" y="14" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="22.5" y="10" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="8.6" width="0.8" height="1.8" fill="#5E6A8C"/>
+  <ellipse cx="24.4" cy="7" rx="1.5" ry="2.2" fill="#FFB347" transform="rotate(12 24.4 7)"/>
+  <ellipse cx="24.4" cy="7.4" rx="0.8" ry="1.2" fill="#FFE08A" transform="rotate(12 24.4 7.4)"/>
+  <circle cx="24.2" cy="7" r="3.2" fill="#FFB347" opacity="0.22"/>
+</svg>

--- a/web/public/sprites/candle-warden.svg
+++ b/web/public/sprites/candle-warden.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded robed keeper with tall candle -->
+  <circle cx="15" cy="9" r="5" fill="#A6A9C0"/>
+  <path d="M10,9 Q15,2 20,9 L20,12 Q15,9 10,12 Z" fill="#7E8299"/>
+  <circle cx="15" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="14" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Long robe -->
+  <path d="M11,14 L9,30 L21,30 L19,14 Q15,16 11,14 Z" fill="#A6A9C0"/>
+  <path d="M11,22 L10,30 L20,30 L19.5,22 Z" fill="#7E8299"/>
+  <rect x="12" y="17" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Toll tag on belt -->
+  <rect x="14" y="18.6" width="2.4" height="1.6" rx="0.3" fill="#E8B94A"/>
+  <!-- Candle arm -->
+  <rect x="20" y="13" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="22.5" y="9" width="2.6" height="9" rx="0.8" fill="#F2E9D8"/>
+  <rect x="23.4" y="7.6" width="0.8" height="1.8" fill="#5E6A8C"/>
+  <!-- Flame -->
+  <ellipse cx="23.8" cy="6" rx="1.6" ry="2.4" fill="#FFB347"/>
+  <ellipse cx="23.8" cy="6.4" rx="0.8" ry="1.3" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="23.8" cy="6" r="3.4" fill="#FFB347" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/causeway-archer-1.svg
+++ b/web/public/sprites/causeway-archer-1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="26" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3.5 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <rect x="19.5" y="14.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,13 L21,14.6 L19.8,14.6 Z" fill="#E8B94A"/>
+  <path d="M22,13 L22.6,14.6 L21.4,14.6 Z" fill="#E8B94A"/>
+  <rect x="7.5" y="15" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,9 Q2.5,17.5 6.5,26" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="9" x2="6.5" y2="26" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="18" y="23" width="3.5" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29.5" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.7" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-archer-2.svg
+++ b/web/public/sprites/causeway-archer-2.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="25" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2.5 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <rect x="19.5" y="13.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,12 L21,13.6 L19.8,13.6 Z" fill="#E8B94A"/>
+  <path d="M22,12 L22.6,13.6 L21.4,13.6 Z" fill="#E8B94A"/>
+  <rect x="7.5" y="14" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,8 Q2.5,16.5 6.5,25" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="8" x2="6.5" y2="25" stroke="#E8EAF4" stroke-width="0.7"/>
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-archer-3.svg
+++ b/web/public/sprites/causeway-archer-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="26" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3.5 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <rect x="19.5" y="14.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,13 L21,14.6 L19.8,14.6 Z" fill="#E8B94A"/>
+  <path d="M22,13 L22.6,14.6 L21.4,14.6 Z" fill="#E8B94A"/>
+  <rect x="7.5" y="15" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,9 Q2.5,17.5 6.5,26" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="9" x2="6.5" y2="26" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="10" y="23" width="3.5" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29.5" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.7" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-archer.svg
+++ b/web/public/sprites/causeway-archer.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Mist wisp -->
+  <ellipse cx="16" cy="25" rx="9" ry="2.5" fill="#E8EAF4" opacity="0.35"/>
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2.5 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <!-- Toll-tag quiver -->
+  <rect x="19.5" y="13.5" width="3.5" height="8" rx="1" fill="#8A6F4D"/>
+  <path d="M20.4,12 L21,13.6 L19.8,13.6 Z" fill="#E8B94A"/>
+  <path d="M22,12 L22.6,13.6 L21.4,13.6 Z" fill="#E8B94A"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="14" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,8 Q2.5,16.5 6.5,25" stroke="#8A6F4D" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="8" x2="6.5" y2="25" stroke="#E8EAF4" stroke-width="0.7"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-chorus-1.svg
+++ b/web/public/sprites/causeway-chorus-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robes sway left, notes drift -->
+  <circle cx="9" cy="12" r="3.6" fill="#9FA3BC"/>
+  <path d="M5.4,12 Q9,7 12.6,12 L12.6,14 Q9,11.5 5.4,14 Z" fill="#7E8299"/>
+  <path d="M6,15 L4,29 L12,29 L12,15 Q9,16.5 6,15 Z" fill="#9FA3BC"/>
+  <circle cx="23" cy="12" r="3.6" fill="#9FA3BC"/>
+  <path d="M19.4,12 Q23,7 26.6,12 L26.6,14 Q23,11.5 19.4,14 Z" fill="#7E8299"/>
+  <path d="M20,15 L18,29 L26,29 L26,15 Q23,16.5 20,15 Z" fill="#9FA3BC"/>
+  <circle cx="16" cy="10" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,10 Q16,4.5 20.2,10 L20.2,12.5 Q16,9.5 11.8,12.5 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="11.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,14 L10,31 L20,31 L19.5,14 Q16,16 12.5,14 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="18" width="5" height="1.1" fill="#7E8299"/>
+  <circle cx="10.5" cy="4.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="11.2" y="2" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="18.5" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="19.2" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <ellipse cx="16" cy="30" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/causeway-chorus-2.svg
+++ b/web/public/sprites/causeway-chorus-2.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="9" cy="11" r="3.6" fill="#9FA3BC"/>
+  <path d="M5.4,11 Q9,6 12.6,11 L12.6,13 Q9,10.5 5.4,13 Z" fill="#7E8299"/>
+  <path d="M6,14 L5,28 L13,28 L12,14 Q9,15.5 6,14 Z" fill="#9FA3BC"/>
+  <circle cx="23" cy="11" r="3.6" fill="#9FA3BC"/>
+  <path d="M19.4,11 Q23,6 26.6,11 L26.6,13 Q23,10.5 19.4,13 Z" fill="#7E8299"/>
+  <path d="M20,14 L19,28 L27,28 L26,14 Q23,15.5 20,14 Z" fill="#9FA3BC"/>
+  <circle cx="16" cy="9" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9 Q16,3.5 20.2,9 L20.2,11.5 Q16,8.5 11.8,11.5 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="10.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,13 L11,30 L21,30 L19.5,13 Q16,15 12.5,13 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17" width="5" height="1.1" fill="#7E8299"/>
+  <circle cx="12" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="12.7" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="20" cy="3.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="20.7" y="1" width="0.6" height="3" fill="#E8EAF4"/>
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/causeway-chorus-3.svg
+++ b/web/public/sprites/causeway-chorus-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Robes sway right, notes drift -->
+  <circle cx="9" cy="12" r="3.6" fill="#9FA3BC"/>
+  <path d="M5.4,12 Q9,7 12.6,12 L12.6,14 Q9,11.5 5.4,14 Z" fill="#7E8299"/>
+  <path d="M6,15 L6,29 L14,29 L12,15 Q9,16.5 6,15 Z" fill="#9FA3BC"/>
+  <circle cx="23" cy="12" r="3.6" fill="#9FA3BC"/>
+  <path d="M19.4,12 Q23,7 26.6,12 L26.6,14 Q23,11.5 19.4,14 Z" fill="#7E8299"/>
+  <path d="M20,15 L20,29 L28,29 L26,15 Q23,16.5 20,15 Z" fill="#9FA3BC"/>
+  <circle cx="16" cy="10" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,10 Q16,4.5 20.2,10 L20.2,12.5 Q16,9.5 11.8,12.5 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="11.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,14 L12,31 L22,31 L19.5,14 Q16,16 12.5,14 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="18" width="5" height="1.1" fill="#7E8299"/>
+  <circle cx="13.5" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="14.2" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="21.5" cy="4.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="22.2" y="2" width="0.6" height="3" fill="#E8EAF4"/>
+  <ellipse cx="16" cy="30" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/causeway-chorus.svg
+++ b/web/public/sprites/causeway-chorus.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded tollsingers in a row -->
+  <!-- Back singers -->
+  <circle cx="9" cy="11" r="3.6" fill="#9FA3BC"/>
+  <path d="M5.4,11 Q9,6 12.6,11 L12.6,13 Q9,10.5 5.4,13 Z" fill="#7E8299"/>
+  <path d="M6,14 L5,28 L13,28 L12,14 Q9,15.5 6,14 Z" fill="#9FA3BC"/>
+  <circle cx="23" cy="11" r="3.6" fill="#9FA3BC"/>
+  <path d="M19.4,11 Q23,6 26.6,11 L26.6,13 Q23,10.5 19.4,13 Z" fill="#7E8299"/>
+  <path d="M20,14 L19,28 L27,28 L26,14 Q23,15.5 20,14 Z" fill="#9FA3BC"/>
+  <!-- Front centre singer -->
+  <circle cx="16" cy="9" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9 Q16,3.5 20.2,9 L20.2,11.5 Q16,8.5 11.8,11.5 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="10.5" rx="1" ry="1.4" fill="#3A3F55"/>
+  <path d="M12.5,13 L11,30 L21,30 L19.5,13 Q16,15 12.5,13 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Toll-song notes rising -->
+  <circle cx="12" cy="4" r="0.9" fill="#E8EAF4"/>
+  <rect x="12.7" y="1.5" width="0.6" height="3" fill="#E8EAF4"/>
+  <circle cx="20" cy="3.5" r="0.9" fill="#E8EAF4"/>
+  <rect x="20.7" y="1" width="0.6" height="3" fill="#E8EAF4"/>
+  <!-- Toll-bell glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/causeway-lamp.svg
+++ b/web/public/sprites/causeway-lamp.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29" rx="10" ry="2.2" fill="#7E8299" opacity="0.5"/>
+  <!-- Stone post -->
+  <rect x="14.6" y="9" width="2.8" height="20" rx="1" fill="#A6A9C0"/>
+  <rect x="14.2" y="27" width="3.6" height="2.5" rx="0.8" fill="#5E6A8C"/>
+  <!-- Cross arm -->
+  <rect x="10" y="9" width="12" height="1.8" rx="0.9" fill="#A6A9C0"/>
+  <!-- Hanging lamp (unlit-until-triggered look) -->
+  <rect x="18.6" y="10.6" width="0.8" height="2.4" fill="#3A3F55"/>
+  <rect x="16" y="12.8" width="6" height="7.6" rx="1.2" fill="#3A3F55"/>
+  <rect x="17.1" y="13.8" width="3.8" height="5.6" fill="#FFB347"/>
+  <ellipse cx="19" cy="16.6" rx="1.1" ry="1.8" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="19" cy="16.6" r="5.8" fill="#FFB347" opacity="0.2"/>
+  <!-- Toll bell finial on post top -->
+  <path d="M14.4,6 L17.6,6 L17,9 L15,9 Z" fill="#E8B94A"/>
+  <circle cx="16" cy="5.4" r="1" fill="#E8B94A"/>
+  <!-- Mist -->
+  <ellipse cx="10" cy="27.5" rx="6" ry="1.6" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/causeway-rail.svg
+++ b/web/public/sprites/causeway-rail.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="13" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Row of quarried grey stone posts -->
+  <rect x="5" y="12" width="5" height="17" rx="0.6" fill="#B9B3A4"/>
+  <rect x="11" y="10" width="5" height="19" rx="0.6" fill="#CFC9BA"/>
+  <rect x="17" y="11" width="5" height="18" rx="0.6" fill="#B9B3A4"/>
+  <rect x="23" y="13" width="5" height="16" rx="0.6" fill="#CFC9BA"/>
+  <!-- Chisel marks -->
+  <line x1="7.5" y1="14" x2="7.5" y2="27" stroke="#8F897B" stroke-width="0.7"/>
+  <line x1="13.5" y1="12" x2="13.5" y2="27" stroke="#8F897B" stroke-width="0.7"/>
+  <line x1="19.5" y1="13" x2="19.5" y2="27" stroke="#8F897B" stroke-width="0.7"/>
+  <line x1="25.5" y1="15" x2="25.5" y2="27" stroke="#8F897B" stroke-width="0.7"/>
+  <!-- Iron cross-rails -->
+  <rect x="4" y="17" width="25" height="1.6" rx="0.8" fill="#3A3F55"/>
+  <rect x="4" y="23" width="25" height="1.6" rx="0.8" fill="#3A3F55"/>
+  <!-- Mist drifting through -->
+  <ellipse cx="10" cy="27.5" rx="6" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+  <ellipse cx="22" cy="28.2" rx="5" ry="1.2" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/causeway-sentry-1.svg
+++ b/web/public/sprites/causeway-sentry-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Tally lantern -->
+  <circle cx="19.5" cy="21" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="21" r="0.8" fill="#FFB347"/>
+  <!-- Tally rod arm -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#7E8299"/>
+  <rect x="8.5" y="7" width="1.4" height="18" rx="0.7" fill="#8A6F4D"/>
+  <rect x="7.6" y="9" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="12" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="15" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-sentry-2.svg
+++ b/web/public/sprites/causeway-sentry-2.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Tally lantern -->
+  <circle cx="19.5" cy="20" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="20" r="0.8" fill="#FFB347"/>
+  <!-- Tally rod arm -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#7E8299"/>
+  <rect x="8.5" y="6" width="1.4" height="18" rx="0.7" fill="#8A6F4D"/>
+  <rect x="7.6" y="8" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="11" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="14" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-sentry-3.svg
+++ b/web/public/sprites/causeway-sentry-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Tally lantern -->
+  <circle cx="19.5" cy="21" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="21" r="0.8" fill="#FFB347"/>
+  <!-- Tally rod arm -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#7E8299"/>
+  <rect x="8.5" y="7" width="1.4" height="18" rx="0.7" fill="#8A6F4D"/>
+  <rect x="7.6" y="9" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="12" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="15" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/causeway-sentry.svg
+++ b/web/public/sprites/causeway-sentry.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#3A3F55"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#3A3F55"/>
+  <!-- Slim cloaked body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Tally lantern -->
+  <circle cx="19.5" cy="20" r="1.6" fill="#E8B94A"/>
+  <circle cx="19.5" cy="20" r="0.8" fill="#FFB347"/>
+  <!-- Tally rod arm -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#7E8299"/>
+  <rect x="8.5" y="6" width="1.4" height="18" rx="0.7" fill="#8A6F4D"/>
+  <rect x="7.6" y="8" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="11" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <rect x="7.6" y="14" width="3.2" height="0.8" fill="#C9CBDA"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-guide-1.svg
+++ b/web/public/sprites/grey-guide-1.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,9.5 Q16,3.5 21,9.5 L21,8 Q16,4.5 11,8 Z" fill="#5E6A8C"/>
+  <rect x="11" y="8.6" width="10" height="1.3" fill="#454E6B"/>
+  <circle cx="14" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,13 L18.5,13 L17.5,14.5 L14.5,14.5 Z" fill="#8A6F4D"/>
+  <path d="M11,15 L10,26 L22,26 L21,15 Q16,17.5 11,15 Z" fill="#5E6A8C"/>
+  <rect x="11" y="18.5" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="11" y="22" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="15" y="15.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="20.2" r="1.5" fill="#E8B94A"/>
+  <rect x="20.6" y="22" width="2.2" height="2" rx="0.4" fill="#3A3F55"/>
+  <circle cx="21.7" cy="23" r="1" fill="#FFB347"/>
+  <rect x="22" y="15" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <rect x="23.8" y="7.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="20.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <rect x="6.5" y="15" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <circle cx="7" cy="19" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="19" r="2.2" fill="#454E6B"/>
+  <circle cx="7" cy="19" r="0.9" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="26" width="4" height="5.2" rx="1" fill="#454E6B"/>
+  <rect x="18" y="26" width="4" height="4" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29.4" width="6" height="2.4" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="28.2" width="5.5" height="2.4" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-guide-2.svg
+++ b/web/public/sprites/grey-guide-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,8.5 Q16,2.5 21,8.5 L21,7 Q16,3.5 11,7 Z" fill="#5E6A8C"/>
+  <rect x="11" y="7.6" width="10" height="1.3" fill="#454E6B"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,12 L18.5,12 L17.5,13.5 L14.5,13.5 Z" fill="#8A6F4D"/>
+  <path d="M11,14 L10,25 L22,25 L21,14 Q16,16.5 11,14 Z" fill="#5E6A8C"/>
+  <rect x="11" y="17.5" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="11" y="21" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="15" y="14.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="19.2" r="1.5" fill="#E8B94A"/>
+  <rect x="20.6" y="21" width="2.2" height="2" rx="0.4" fill="#3A3F55"/>
+  <circle cx="21.7" cy="22" r="1" fill="#FFB347"/>
+  <rect x="22" y="14" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <rect x="23.8" y="6.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="19.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <rect x="6.5" y="14" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <circle cx="7" cy="18" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="18" r="2.2" fill="#454E6B"/>
+  <circle cx="7" cy="18" r="0.9" fill="#E8B94A"/>
+  <rect x="12" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-guide-3.svg
+++ b/web/public/sprites/grey-guide-3.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,9.5 Q16,3.5 21,9.5 L21,8 Q16,4.5 11,8 Z" fill="#5E6A8C"/>
+  <rect x="11" y="8.6" width="10" height="1.3" fill="#454E6B"/>
+  <circle cx="14" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,13 L18.5,13 L17.5,14.5 L14.5,14.5 Z" fill="#8A6F4D"/>
+  <path d="M11,15 L10,26 L22,26 L21,15 Q16,17.5 11,15 Z" fill="#5E6A8C"/>
+  <rect x="11" y="18.5" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="11" y="22" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="15" y="15.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="20.2" r="1.5" fill="#E8B94A"/>
+  <rect x="20.6" y="22" width="2.2" height="2" rx="0.4" fill="#3A3F55"/>
+  <circle cx="21.7" cy="23" r="1" fill="#FFB347"/>
+  <rect x="22" y="15" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <rect x="23.8" y="7.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="20.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <rect x="6.5" y="15" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <circle cx="7" cy="19" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="19" r="2.2" fill="#454E6B"/>
+  <circle cx="7" cy="19" r="0.9" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="26" width="4" height="5.2" rx="1" fill="#454E6B"/>
+  <rect x="10" y="26" width="4" height="4" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29.4" width="6" height="2.4" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="28.2" width="5.5" height="2.4" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-guide.svg
+++ b/web/public/sprites/grey-guide.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Weathered causeway pathfinder, vigil-grey coat with pale trim -->
+  <circle cx="16" cy="8.5" r="5" fill="#E3D9CF"/>
+  <path d="M11,8.5 Q16,2.5 21,8.5 L21,7 Q16,3.5 11,7 Z" fill="#5E6A8C"/>
+  <rect x="11" y="7.6" width="10" height="1.3" fill="#454E6B"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#3A3F55"/>
+  <path d="M13.5,12 L18.5,12 L17.5,13.5 L14.5,13.5 Z" fill="#8A6F4D"/>
+  <!-- Weathered grey coat -->
+  <path d="M11,14 L10,25 L22,25 L21,14 Q16,16.5 11,14 Z" fill="#5E6A8C"/>
+  <rect x="11" y="17.5" width="10.5" height="1.3" fill="#454E6B"/>
+  <rect x="11" y="21" width="10.5" height="1.3" fill="#454E6B"/>
+  <!-- Pale trim: the causeway posting -->
+  <rect x="15" y="14.5" width="2.4" height="10" fill="#C9CBDA" opacity="0.85"/>
+  <circle cx="16.2" cy="19.2" r="1.5" fill="#E8B94A"/>
+  <!-- Guide's lantern on hip -->
+  <rect x="20.6" y="21" width="2.2" height="2" rx="0.4" fill="#3A3F55"/>
+  <circle cx="21.7" cy="22" r="1" fill="#FFB347"/>
+  <!-- Sword arm -->
+  <rect x="22" y="14" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <rect x="23.8" y="6.5" width="1.7" height="14" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22.2" y="19.4" width="4.8" height="1.5" rx="0.7" fill="#8A6F4D"/>
+  <!-- Shield arm with round shield -->
+  <rect x="6.5" y="14" width="3.5" height="6.5" rx="1" fill="#5E6A8C"/>
+  <circle cx="7" cy="18" r="3.6" fill="#7E8299"/>
+  <circle cx="7" cy="18" r="2.2" fill="#454E6B"/>
+  <circle cx="7" cy="18" r="0.9" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-mile-runner-1.svg
+++ b/web/public/sprites/grey-mile-runner-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="25" rx="10" ry="3" fill="#E8EAF4" opacity="0.3"/>
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 A5,5 0 0 1 21,10 L21,8 Q16,5 11,8 Z" fill="#3A3F55"/>
+  <rect x="11.5" y="11.5" width="9" height="3" rx="1.5" fill="#A6A9C0"/>
+  <circle cx="14" cy="9.8" r="0.8" fill="#454E6B"/>
+  <circle cx="18" cy="9.8" r="0.8" fill="#454E6B"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18.5" width="8" height="1.4" fill="#7E8299"/>
+  <rect x="20.5" y="14" width="4.5" height="6.5" rx="1" fill="#8A6F4D"/>
+  <rect x="20.9" y="15.8" width="3.7" height="0.8" fill="#C9CBDA"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="20.5" y="20.5" width="3.5" height="4" rx="1" fill="#A6A9C0"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="18" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-mile-runner-2.svg
+++ b/web/public/sprites/grey-mile-runner-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dust wisp behind -->
+  <ellipse cx="16" cy="24" rx="10" ry="3" fill="#E8EAF4" opacity="0.3"/>
+  <!-- Head with half-mask -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 A5,5 0 0 1 21,9 L21,7 Q16,4 11,7 Z" fill="#3A3F55"/>
+  <rect x="11.5" y="10.5" width="9" height="3" rx="1.5" fill="#A6A9C0"/>
+  <circle cx="14" cy="8.8" r="0.8" fill="#454E6B"/>
+  <circle cx="18" cy="8.8" r="0.8" fill="#454E6B"/>
+  <!-- Light body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17.5" width="8" height="1.4" fill="#7E8299"/>
+  <!-- Courier satchel on back -->
+  <rect x="20.5" y="13" width="4.5" height="6.5" rx="1" fill="#8A6F4D"/>
+  <rect x="20.9" y="14.8" width="3.7" height="0.8" fill="#C9CBDA"/>
+  <!-- Arms -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="20.5" y="19.5" width="3.5" height="4" rx="1" fill="#A6A9C0"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-mile-runner-3.svg
+++ b/web/public/sprites/grey-mile-runner-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="25" rx="10" ry="3" fill="#E8EAF4" opacity="0.3"/>
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 A5,5 0 0 1 21,10 L21,8 Q16,5 11,8 Z" fill="#3A3F55"/>
+  <rect x="11.5" y="11.5" width="9" height="3" rx="1.5" fill="#A6A9C0"/>
+  <circle cx="14" cy="9.8" r="0.8" fill="#454E6B"/>
+  <circle cx="18" cy="9.8" r="0.8" fill="#454E6B"/>
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18.5" width="8" height="1.4" fill="#7E8299"/>
+  <rect x="20.5" y="14" width="4.5" height="6.5" rx="1" fill="#8A6F4D"/>
+  <rect x="20.9" y="15.8" width="3.7" height="0.8" fill="#C9CBDA"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="20.5" y="20.5" width="3.5" height="4" rx="1" fill="#A6A9C0"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="23" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="10" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-mile-runner.svg
+++ b/web/public/sprites/grey-mile-runner.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Dust wisp behind -->
+  <ellipse cx="16" cy="24" rx="10" ry="3" fill="#E8EAF4" opacity="0.3"/>
+  <!-- Head with half-mask -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 A5,5 0 0 1 21,9 L21,7 Q16,4 11,7 Z" fill="#3A3F55"/>
+  <rect x="11.5" y="10.5" width="9" height="3" rx="1.5" fill="#A6A9C0"/>
+  <circle cx="14" cy="8.8" r="0.8" fill="#454E6B"/>
+  <circle cx="18" cy="8.8" r="0.8" fill="#454E6B"/>
+  <!-- Light body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17.5" width="8" height="1.4" fill="#7E8299"/>
+  <!-- Courier satchel on back -->
+  <rect x="20.5" y="13" width="4.5" height="6.5" rx="1" fill="#8A6F4D"/>
+  <rect x="20.9" y="14.8" width="3.7" height="0.8" fill="#C9CBDA"/>
+  <!-- Arms -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="20.5" y="19.5" width="3.5" height="4" rx="1" fill="#A6A9C0"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/grey-rider-1.svg
+++ b/web/public/sprites/grey-rider-1.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Gallop pose A: legs gathered -->
+  <path d="M5,23 L7,16 Q9,13 13,14 L21,14 Q25,14 26,17 L27,21 L25,23 Z" fill="#C9CBDA"/>
+  <path d="M24,15 L29,11 L30,13 L27,17 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="13" r="0.7" fill="#3A3F55"/>
+  <path d="M22,13 Q24,10 27,11 L25,14 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="7.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="6" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,6 Q16,1.5 19.4,6 L19.4,7.4 Q16,5 12.6,7.4 Z" fill="#3A3F55"/>
+  <rect x="19.5" y="5" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 12)"/>
+  <path d="M24.6,3.6 L26.4,6.4 L23.2,6.6 Z" fill="#E8B94A"/>
+  <!-- Legs gathered under body -->
+  <rect x="9.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(18 10.7 26)"/>
+  <rect x="13" y="23" width="2.4" height="7" rx="1" fill="#A6A9C0" transform="rotate(8 14.2 26.5)"/>
+  <rect x="18" y="23" width="2.4" height="7" rx="1" fill="#A6A9C0" transform="rotate(-8 19.2 26.5)"/>
+  <rect x="21.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(-18 22.7 26)"/>
+  <path d="M5.5,17 Q2.5,19 3.5,23 Q5,21 6.5,20.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/grey-rider-2.svg
+++ b/web/public/sprites/grey-rider-2.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M5,22 L7,15 Q9,12 13,13 L21,13 Q25,13 26,16 L27,20 L25,22 Z" fill="#C9CBDA"/>
+  <path d="M24,14 L29,10 L30,12 L27,16 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="12" r="0.7" fill="#3A3F55"/>
+  <path d="M22,12 Q24,9 27,10 L25,13 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="6.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="5" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,5 Q16,0.5 19.4,5 L19.4,6.4 Q16,4 12.6,6.4 Z" fill="#3A3F55"/>
+  <rect x="19.5" y="4" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 11)"/>
+  <path d="M24.6,2.6 L26.4,5.4 L23.2,5.6 Z" fill="#E8B94A"/>
+  <rect x="7" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <rect x="12" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="19" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <path d="M5.5,16 Q2.5,18 3.5,22 Q5,20 6.5,19.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/grey-rider-3.svg
+++ b/web/public/sprites/grey-rider-3.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Gallop pose B: legs extended -->
+  <path d="M5,23 L7,16 Q9,13 13,14 L21,14 Q25,14 26,17 L27,21 L25,23 Z" fill="#C9CBDA"/>
+  <path d="M24,15 L29,11 L30,13 L27,17 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="13" r="0.7" fill="#3A3F55"/>
+  <path d="M22,13 Q24,10 27,11 L25,14 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="7.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="6" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,6 Q16,1.5 19.4,6 L19.4,7.4 Q16,5 12.6,7.4 Z" fill="#3A3F55"/>
+  <rect x="19.5" y="5" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 12)"/>
+  <path d="M24.6,3.6 L26.4,6.4 L23.2,6.6 Z" fill="#E8B94A"/>
+  <!-- Legs extended fore and aft -->
+  <rect x="5.5" y="21.5" width="2.4" height="9" rx="1" fill="#A6A9C0" transform="rotate(-24 6.7 26)"/>
+  <rect x="11" y="22.5" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(-10 12.2 26.5)"/>
+  <rect x="20" y="22.5" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(10 21.2 26.5)"/>
+  <rect x="25" y="21.5" width="2.4" height="9" rx="1" fill="#A6A9C0" transform="rotate(24 26.2 26)"/>
+  <path d="M5.5,17 Q2.5,19 3.5,23 Q5,21 6.5,20.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/grey-rider.svg
+++ b/web/public/sprites/grey-rider.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadowless void-bred horse, side view -->
+  <path d="M5,22 L7,15 Q9,12 13,13 L21,13 Q25,13 26,16 L27,20 L25,22 Z" fill="#C9CBDA"/>
+  <!-- Horse head -->
+  <path d="M24,14 L29,10 L30,12 L27,16 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="12" r="0.7" fill="#3A3F55"/>
+  <!-- Mane of mist -->
+  <path d="M22,12 Q24,9 27,10 L25,13 Z" fill="#E8EAF4" opacity="0.8"/>
+  <!-- Rider torso -->
+  <rect x="13" y="6.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="5" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,5 Q16,0.5 19.4,5 L19.4,6.4 Q16,4 12.6,6.4 Z" fill="#3A3F55"/>
+  <!-- Toll lance with pennant -->
+  <rect x="19.5" y="4" width="1.2" height="14" rx="0.6" fill="#8A6F4D" transform="rotate(18 20 11)"/>
+  <path d="M24.6,2.6 L26.4,5.4 L23.2,5.6 Z" fill="#E8B94A"/>
+  <!-- Horse legs (standing) -->
+  <rect x="7" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <rect x="12" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="19" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <!-- Tail -->
+  <path d="M5.5,16 Q2.5,18 3.5,22 Q5,20 6.5,19.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/knight-of-the-toll-1.svg
+++ b/web/public/sprites/knight-of-the-toll-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="8" rx="2.5" fill="#9FA3BC"/>
+  <rect x="12" y="8.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="9.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.4" r="0.7" fill="#FFB347"/>
+  <rect x="15.3" y="2.5" width="1.4" height="2.4" fill="#8A6F4D"/>
+  <rect x="14.4" y="3.5" width="3.2" height="1" fill="#7E8299"/>
+  <circle cx="14.4" cy="4.9" r="0.9" fill="#454E6B"/>
+  <circle cx="17.6" cy="4.9" r="0.9" fill="#454E6B"/>
+  <path d="M9,13 L9,25 L23,25 L23,13 Q16,16 9,13 Z" fill="#B9BDD4"/>
+  <rect x="9" y="16.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="20.5" width="14" height="1.4" fill="#7E8299"/>
+  <circle cx="16" cy="19" r="1.8" fill="#E8B94A"/>
+  <circle cx="16" cy="19" r="1" fill="#FFE08A"/>
+  <circle cx="9" cy="14.5" r="3" fill="#9FA3BC"/>
+  <circle cx="23" cy="14.5" r="3" fill="#9FA3BC"/>
+  <rect x="26" y="9" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,27.5 L26,25 L28,25 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="8" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="9" y="25" width="4.5" height="5.8" rx="1" fill="#7E8299"/>
+  <rect x="18.5" y="25" width="4.5" height="4.4" rx="1" fill="#7E8299"/>
+  <rect x="8" y="29" width="6.5" height="2.6" rx="1" fill="#454E6B"/>
+  <rect x="18.5" y="27.6" width="6" height="2.6" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/knight-of-the-toll-2.svg
+++ b/web/public/sprites/knight-of-the-toll-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="8" rx="2.5" fill="#9FA3BC"/>
+  <rect x="12" y="8.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="9.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.4" r="0.7" fill="#FFB347"/>
+  <rect x="15.3" y="1" width="1.4" height="2.4" fill="#8A6F4D"/>
+  <rect x="14.4" y="2" width="3.2" height="1" fill="#7E8299"/>
+  <circle cx="14.4" cy="3.4" r="0.9" fill="#454E6B"/>
+  <circle cx="17.6" cy="3.4" r="0.9" fill="#454E6B"/>
+  <path d="M9,13 L9,25 L23,25 L23,13 Q16,16 9,13 Z" fill="#B9BDD4"/>
+  <rect x="9" y="16.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="20.5" width="14" height="1.4" fill="#7E8299"/>
+  <circle cx="16" cy="19" r="1.8" fill="#E8B94A"/>
+  <circle cx="16" cy="19" r="1" fill="#FFE08A"/>
+  <circle cx="9" cy="14.5" r="3" fill="#9FA3BC"/>
+  <circle cx="23" cy="14.5" r="3" fill="#9FA3BC"/>
+  <rect x="26" y="9" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,27.5 L26,25 L28,25 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="8" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <rect x="11" y="25" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="16.5" y="25" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="10" y="29.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+  <rect x="15.5" y="29.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/knight-of-the-toll-3.svg
+++ b/web/public/sprites/knight-of-the-toll-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="11" y="5" width="10" height="8" rx="2.5" fill="#9FA3BC"/>
+  <rect x="12" y="8.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="9.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.4" r="0.7" fill="#FFB347"/>
+  <rect x="15.3" y="2.5" width="1.4" height="2.4" fill="#8A6F4D"/>
+  <rect x="14.4" y="3.5" width="3.2" height="1" fill="#7E8299"/>
+  <circle cx="14.4" cy="4.9" r="0.9" fill="#454E6B"/>
+  <circle cx="17.6" cy="4.9" r="0.9" fill="#454E6B"/>
+  <path d="M9,13 L9,25 L23,25 L23,13 Q16,16 9,13 Z" fill="#B9BDD4"/>
+  <rect x="9" y="16.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="20.5" width="14" height="1.4" fill="#7E8299"/>
+  <circle cx="16" cy="19" r="1.8" fill="#E8B94A"/>
+  <circle cx="16" cy="19" r="1" fill="#FFE08A"/>
+  <circle cx="9" cy="14.5" r="3" fill="#9FA3BC"/>
+  <circle cx="23" cy="14.5" r="3" fill="#9FA3BC"/>
+  <rect x="26" y="9" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,27.5 L26,25 L28,25 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="8" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18.5" y="25" width="4.5" height="5.8" rx="1" fill="#7E8299"/>
+  <rect x="9" y="25" width="4.5" height="4.4" rx="1" fill="#7E8299"/>
+  <rect x="18.5" y="29" width="6.5" height="2.6" rx="1" fill="#454E6B"/>
+  <rect x="8" y="27.6" width="6" height="2.6" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/knight-of-the-toll.svg
+++ b/web/public/sprites/knight-of-the-toll.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Great helm with toll-scale crest -->
+  <rect x="11" y="5" width="10" height="8" rx="2.5" fill="#9FA3BC"/>
+  <rect x="12" y="8.5" width="8" height="1.8" fill="#3A3F55"/>
+  <circle cx="14" cy="9.4" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.4" r="0.7" fill="#FFB347"/>
+  <!-- Scale crest -->
+  <rect x="15.3" y="1" width="1.4" height="2.4" fill="#8A6F4D"/>
+  <rect x="14.4" y="2" width="3.2" height="1" fill="#7E8299"/>
+  <circle cx="14.4" cy="3.4" r="0.9" fill="#454E6B"/>
+  <circle cx="17.6" cy="3.4" r="0.9" fill="#454E6B"/>
+  <!-- Massive plate body -->
+  <path d="M9,13 L9,25 L23,25 L23,13 Q16,16 9,13 Z" fill="#B9BDD4"/>
+  <rect x="9" y="16.5" width="14" height="1.4" fill="#7E8299"/>
+  <rect x="9" y="20.5" width="14" height="1.4" fill="#7E8299"/>
+  <!-- Toll-coin emblem -->
+  <circle cx="16" cy="19" r="1.8" fill="#E8B94A"/>
+  <circle cx="16" cy="19" r="1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="9" cy="14.5" r="3" fill="#9FA3BC"/>
+  <circle cx="23" cy="14.5" r="3" fill="#9FA3BC"/>
+  <!-- Greatsword planted point-down -->
+  <rect x="26" y="9" width="2" height="16" rx="1" fill="#C9CBDA"/>
+  <path d="M27,27.5 L26,25 L28,25 Z" fill="#C9CBDA"/>
+  <rect x="24.6" y="8" width="4.8" height="1.6" rx="0.8" fill="#E8B94A"/>
+  <!-- Legs (neutral, heavy) -->
+  <rect x="11" y="25" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="16.5" y="25" width="4.5" height="6" rx="1" fill="#7E8299"/>
+  <rect x="10" y="29.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+  <rect x="15.5" y="29.5" width="6.5" height="3" rx="1" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/milestone-cairn.svg
+++ b/web/public/sprites/milestone-cairn.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="10" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Stacked milestones -->
+  <rect x="8" y="24" width="16" height="5" rx="0.8" fill="#8E92A8"/>
+  <rect x="9.5" y="18.5" width="13" height="5.5" rx="0.8" fill="#9FA3BC"/>
+  <rect x="11" y="13" width="10" height="5.5" rx="0.8" fill="#A6A9C0"/>
+  <rect x="12.5" y="8" width="7" height="5" rx="0.8" fill="#C9CBDA"/>
+  <!-- Carved mile numerals -->
+  <rect x="14" y="10" width="4" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.85"/>
+  <rect x="13" y="15.3" width="6" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.75"/>
+  <rect x="12" y="20.6" width="8" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.7"/>
+  <rect x="11" y="26" width="10" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.65"/>
+  <!-- Mist -->
+  <ellipse cx="16" cy="28.6" rx="8" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/milestone-effigy.svg
+++ b/web/public/sprites/milestone-effigy.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="10" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Standing milestone effigy, humanoid silhouette carved in stone -->
+  <path d="M11,29 L11.5,18 Q11.5,10 16,8 Q20.5,10 20.5,18 L21,29 Z" fill="#9FA3BC"/>
+  <circle cx="16" cy="8.5" r="4" fill="#A6A9C0"/>
+  <path d="M12.3,8.5 Q16,3 19.7,8.5 L19.7,10 Q16,7.5 12.3,10 Z" fill="#8E92A8"/>
+  <!-- Carved toll-count numerals, faintly glowing -->
+  <rect x="14" y="14" width="4" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.85"/>
+  <rect x="13" y="17.5" width="6" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.7"/>
+  <rect x="14" y="21" width="4" height="1.2" rx="0.6" fill="#E8B94A" opacity="0.8"/>
+  <!-- Rune glow -->
+  <ellipse cx="16" cy="17" rx="6" ry="10" fill="#E8B94A" opacity="0.1"/>
+  <!-- Cracks -->
+  <path d="M12,26 L13.5,23 L12.8,20" stroke="#5E6270" stroke-width="0.8" fill="none"/>
+  <path d="M20.5,25 L19.4,22.5" stroke="#5E6270" stroke-width="0.8" fill="none"/>
+  <!-- Mist -->
+  <ellipse cx="16" cy="28.6" rx="8" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-endless-ledger-1.svg
+++ b/web/public/sprites/the-endless-ledger-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drift phase A: mass leans left, wisps trail right -->
+  <ellipse cx="15" cy="19" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="11" cy="16" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="20" cy="15" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="15" cy="13" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <ellipse cx="15" cy="16" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <path d="M10.5,16.5 L15,15.4 L19.5,16.5 L19.5,21 L15,20 L10.5,21 Z" fill="#F2E9D8"/>
+  <line x1="15" y1="15.4" x2="15" y2="20" stroke="#8A6F4D" stroke-width="0.5"/>
+  <circle cx="12.5" cy="15" r="1.1" fill="#E8B94A"/>
+  <circle cx="17.5" cy="15" r="1.1" fill="#E8B94A"/>
+  <circle cx="12.5" cy="14.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="17.5" cy="14.7" r="0.4" fill="#FFE08A"/>
+  <path d="M24,20 Q27.5,22 27,25.5 Q25,23.5 23.5,23 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M7,23 Q5,26 7.5,28 Q8.5,25.5 10,24.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M15,25 Q14,28.5 17,30 Q18,27.5 19,26 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-endless-ledger-2.svg
+++ b/web/public/sprites/the-endless-ledger-2.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <ellipse cx="16" cy="18" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="12" cy="15" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="21" cy="14" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="16" cy="12" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <ellipse cx="16" cy="15" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <path d="M11.5,15.5 L16,14.4 L20.5,15.5 L20.5,20 L16,19 L11.5,20 Z" fill="#F2E9D8"/>
+  <line x1="16" y1="14.4" x2="16" y2="19" stroke="#8A6F4D" stroke-width="0.5"/>
+  <line x1="12.4" y1="16.4" x2="15.4" y2="16" stroke="#8A6F4D" stroke-width="0.35"/>
+  <line x1="12.4" y1="17.8" x2="15.4" y2="17.4" stroke="#8A6F4D" stroke-width="0.35"/>
+  <line x1="16.6" y1="16" x2="19.6" y2="16.4" stroke="#8A6F4D" stroke-width="0.35"/>
+  <line x1="16.6" y1="17.4" x2="19.6" y2="17.8" stroke="#8A6F4D" stroke-width="0.35"/>
+  <circle cx="13.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="18.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="13.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="18.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <path d="M6,22 Q4,25 6.5,27 Q7.5,24.5 9,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M26,22 Q28,25 25.5,27 Q24.5,24.5 23,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M14,24 Q13,27.5 16,29 Q17,26.5 18,25 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-endless-ledger-3.svg
+++ b/web/public/sprites/the-endless-ledger-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drift phase B: mass leans right, wisps trail left -->
+  <ellipse cx="17" cy="19" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="13" cy="15" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="22" cy="16" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="17" cy="13" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <ellipse cx="17" cy="16" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <path d="M12.5,16.5 L17,15.4 L21.5,16.5 L21.5,21 L17,20 L12.5,21 Z" fill="#F2E9D8"/>
+  <line x1="17" y1="15.4" x2="17" y2="20" stroke="#8A6F4D" stroke-width="0.5"/>
+  <circle cx="14.5" cy="15" r="1.1" fill="#E8B94A"/>
+  <circle cx="19.5" cy="15" r="1.1" fill="#E8B94A"/>
+  <circle cx="14.5" cy="14.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="19.5" cy="14.7" r="0.4" fill="#FFE08A"/>
+  <path d="M8,20 Q4.5,22 5,25.5 Q7,23.5 8.5,23 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M25,23 Q27,26 24.5,28 Q23.5,25.5 22,24.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M17,25 Q18,28.5 15,30 Q14,27.5 13,26 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-endless-ledger.svg
+++ b/web/public/sprites/the-endless-ledger.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drifting sentient ledger-mist -->
+  <ellipse cx="16" cy="18" rx="12" ry="7" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="12" cy="15" rx="7" ry="5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="21" cy="14" rx="6" ry="4.5" fill="#E8EAF4" opacity="0.7"/>
+  <ellipse cx="16" cy="12" rx="8" ry="5" fill="#F4F5FA" opacity="0.8"/>
+  <!-- Deep core -->
+  <ellipse cx="16" cy="15" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <!-- Open ledger book carried within -->
+  <path d="M11.5,15.5 L16,14.4 L20.5,15.5 L20.5,20 L16,19 L11.5,20 Z" fill="#F2E9D8"/>
+  <line x1="16" y1="14.4" x2="16" y2="19" stroke="#8A6F4D" stroke-width="0.5"/>
+  <line x1="12.4" y1="16.4" x2="15.4" y2="16" stroke="#8A6F4D" stroke-width="0.35"/>
+  <line x1="12.4" y1="17.8" x2="15.4" y2="17.4" stroke="#8A6F4D" stroke-width="0.35"/>
+  <line x1="16.6" y1="16" x2="19.6" y2="16.4" stroke="#8A6F4D" stroke-width="0.35"/>
+  <line x1="16.6" y1="17.4" x2="19.6" y2="17.8" stroke="#8A6F4D" stroke-width="0.35"/>
+  <!-- Two pale toll-gold eyes -->
+  <circle cx="13.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="18.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="13.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="18.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <!-- Trailing wisps -->
+  <path d="M6,22 Q4,25 6.5,27 Q7.5,24.5 9,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M26,22 Q28,25 25.5,27 Q24.5,24.5 23,23.5 Z" fill="#E8EAF4" opacity="0.5"/>
+  <path d="M14,24 Q13,27.5 16,29 Q17,26.5 18,25 Z" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-toll-warden-1.svg
+++ b/web/public/sprites/the-toll-warden-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride A: standard sways back -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(4 25.8 16)"/>
+  <path d="M26.6,4 L31.2,6 L26.6,10 Z" fill="#454E6B"/>
+  <circle cx="28.8" cy="6.6" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="1.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="2.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="1.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="1.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#9FA3BC"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#7E8299"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#454E6B"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#7E8299"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#454E6B"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="28" width="4.5" height="3.6" rx="1" fill="#3A3F55"/>
+  <rect x="18.5" y="28" width="4.5" height="2.8" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-toll-warden-2.svg
+++ b/web/public/sprites/the-toll-warden-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#454E6B"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="0.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="1.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="0.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="0.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#9FA3BC"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#7E8299"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#454E6B"/>
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="14" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#7E8299"/>
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#454E6B"/>
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-toll-warden-3.svg
+++ b/web/public/sprites/the-toll-warden-3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride B: standard sways forward -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(-4 25.8 16)"/>
+  <path d="M26.2,4 L30.8,5.2 L26.2,9.6 Z" fill="#454E6B"/>
+  <circle cx="28.4" cy="6" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="1.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="2.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="1.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="1.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#9FA3BC"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#7E8299"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#454E6B"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#7E8299"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#454E6B"/>
+  <!-- Legs stride B -->
+  <rect x="18.5" y="28" width="4.5" height="3.6" rx="1" fill="#3A3F55"/>
+  <rect x="9.5" y="28" width="4.5" height="2.8" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-toll-warden.svg
+++ b/web/public/sprites/the-toll-warden.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Towering tollgate lord with standard and scale -->
+  <!-- Toll standard pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,3 L31.5,4.5 L26.6,9 Z" fill="#454E6B"/>
+  <circle cx="29" cy="5.5" r="0.9" fill="#E8B94A"/>
+  <!-- Great helm with scale crest -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#9FA3BC"/>
+  <rect x="14.4" y="0.6" width="3.2" height="1" fill="#7E8299"/>
+  <rect x="15.3" y="1.6" width="1.4" height="2" fill="#8A6F4D"/>
+  <circle cx="14.4" cy="0.6" r="1" fill="#454E6B"/>
+  <circle cx="17.6" cy="0.6" r="1" fill="#454E6B"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <!-- Massive grey cloak/body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#9FA3BC"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#7E8299"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#454E6B"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#454E6B"/>
+  <!-- Toll-coin chest sigil -->
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#7E8299"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#7E8299"/>
+  <!-- The toll scale held out -->
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#8A6F4D"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#454E6B"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#454E6B"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#3A3F55"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/toll-barracks.svg
+++ b/web/public/sprites/toll-barracks.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29" rx="12" ry="2.2" fill="#7E8299" opacity="0.5"/>
+  <!-- Long stone hall -->
+  <rect x="4" y="15" width="24" height="13" rx="1" fill="#9FA3BC"/>
+  <rect x="4" y="19" width="24" height="1" fill="#7E8299"/>
+  <!-- Steep slate roof -->
+  <path d="M2.5,15 L16,6 L29.5,15 Z" fill="#3A3F55"/>
+  <path d="M6,15 L16,8.4 L26,15 Z" fill="#454E6B"/>
+  <!-- Door -->
+  <rect x="13.5" y="20" width="5" height="8" rx="1.5" fill="#3A3F55"/>
+  <circle cx="17.3" cy="24.2" r="0.5" fill="#E8B94A"/>
+  <!-- Windows glowing faint -->
+  <rect x="7" y="21" width="3.4" height="3.4" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <rect x="21.6" y="21" width="3.4" height="3.4" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <!-- Toll banner over door -->
+  <rect x="15.4" y="15.5" width="1.2" height="4" fill="#5E6A8C"/>
+  <path d="M14,15.5 L18,15.5 L16,17.8 Z" fill="#E8B94A"/>
+  <!-- Mist seeping from the door -->
+  <ellipse cx="16" cy="28.2" rx="6" ry="1.4" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="11" cy="27.4" rx="3.5" ry="1" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/toll-escort-1.svg
+++ b/web/public/sprites/toll-escort-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,10 Q16,3 21.5,10 L21.5,12 L10.5,12 Z" fill="#7E8299"/>
+  <path d="M15,3.5 Q16,1 17,3.5 L16.8,6 L15.2,6 Z" fill="#E8B94A"/>
+  <rect x="12" y="9.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#FFB347"/>
+  <path d="M10,15 L10,25 L22,25 L22,15 Q16,17.5 10,15 Z" fill="#9FA3BC"/>
+  <rect x="10" y="18" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="21.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="19.8" r="1.6" fill="#E8B94A"/>
+  <rect x="4.5" y="14" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="15" width="3.5" height="8" rx="1" fill="#3A3F55"/>
+  <circle cx="7.2" cy="19" r="1.2" fill="#E8B94A"/>
+  <rect x="22.5" y="15" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="7" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="20.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="25" width="4" height="6" rx="1" fill="#454E6B"/>
+  <rect x="18" y="25" width="4" height="4.8" rx="1" fill="#454E6B"/>
+  <rect x="8.5" y="29" width="6" height="2.5" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.8" width="5.5" height="2.5" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/toll-escort-2.svg
+++ b/web/public/sprites/toll-escort-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,9 Q16,2 21.5,9 L21.5,11 L10.5,11 Z" fill="#7E8299"/>
+  <path d="M15,2.5 Q16,0 17,2.5 L16.8,5 L15.2,5 Z" fill="#E8B94A"/>
+  <rect x="12" y="8.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#FFB347"/>
+  <path d="M10,14 L10,24 L22,24 L22,14 Q16,16.5 10,14 Z" fill="#9FA3BC"/>
+  <rect x="10" y="17" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="20.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="18.8" r="1.6" fill="#E8B94A"/>
+  <rect x="4.5" y="13" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="14" width="3.5" height="8" rx="1" fill="#3A3F55"/>
+  <circle cx="7.2" cy="18" r="1.2" fill="#E8B94A"/>
+  <rect x="22.5" y="14" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="6" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="19.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/toll-escort-3.svg
+++ b/web/public/sprites/toll-escort-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,10 Q16,3 21.5,10 L21.5,12 L10.5,12 Z" fill="#7E8299"/>
+  <path d="M15,3.5 Q16,1 17,3.5 L16.8,6 L15.2,6 Z" fill="#E8B94A"/>
+  <rect x="12" y="9.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#FFB347"/>
+  <path d="M10,15 L10,25 L22,25 L22,15 Q16,17.5 10,15 Z" fill="#9FA3BC"/>
+  <rect x="10" y="18" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="21.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="19.8" r="1.6" fill="#E8B94A"/>
+  <rect x="4.5" y="14" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="15" width="3.5" height="8" rx="1" fill="#3A3F55"/>
+  <circle cx="7.2" cy="19" r="1.2" fill="#E8B94A"/>
+  <rect x="22.5" y="15" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="7" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="20.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="25" width="4" height="6" rx="1" fill="#454E6B"/>
+  <rect x="9.5" y="25" width="4" height="4.8" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="6" height="2.5" rx="1" fill="#3A3F55"/>
+  <rect x="8.5" y="27.8" width="5.5" height="2.5" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/toll-escort.svg
+++ b/web/public/sprites/toll-escort.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm -->
+  <circle cx="16" cy="9" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,9 Q16,2 21.5,9 L21.5,11 L10.5,11 Z" fill="#7E8299"/>
+  <path d="M15,2.5 Q16,0 17,2.5 L16.8,5 L15.2,5 Z" fill="#E8B94A"/>
+  <rect x="12" y="8.5" width="8" height="2" fill="#3A3F55"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,14 L10,24 L22,24 L22,14 Q16,16.5 10,14 Z" fill="#9FA3BC"/>
+  <rect x="10" y="17" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="20.5" width="12" height="1.3" fill="#7E8299"/>
+  <circle cx="16" cy="18.8" r="1.6" fill="#E8B94A"/>
+  <!-- Toll ledger shield -->
+  <rect x="4.5" y="13" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="14" width="3.5" height="8" rx="1" fill="#3A3F55"/>
+  <circle cx="7.2" cy="18" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="14" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="6" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="19.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/tollgate-pikeman-1.svg
+++ b/web/public/sprites/tollgate-pikeman-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#9FA3BC"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#454E6B"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#E8B94A"/>
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="5" width="1.4" height="23" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,1.5 L26,5 L22.4,5 Z" fill="#C9CBDA"/>
+  <rect x="21.6" y="6" width="3.8" height="2.4" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="8.5" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/tollgate-pikeman-2.svg
+++ b/web/public/sprites/tollgate-pikeman-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#9FA3BC"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Toll shield on left -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#454E6B"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#E8B94A"/>
+  <!-- Toll halberd -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="4" width="1.4" height="23" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,0.5 L26,4 L22.4,4 Z" fill="#C9CBDA"/>
+  <rect x="21.6" y="5" width="3.8" height="2.4" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/tollgate-pikeman-3.svg
+++ b/web/public/sprites/tollgate-pikeman-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#3A3F55"/>
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#9FA3BC"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#454E6B"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#E8B94A"/>
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="5" width="1.4" height="23" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,1.5 L26,5 L22.4,5 Z" fill="#C9CBDA"/>
+  <rect x="21.6" y="6" width="3.8" height="2.4" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="9.5" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="8.5" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/tollgate-pikeman.svg
+++ b/web/public/sprites/tollgate-pikeman.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#3A3F55"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#9FA3BC"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Toll shield on left -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#454E6B"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#E8B94A"/>
+  <!-- Toll halberd -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="4" width="1.4" height="23" rx="0.7" fill="#8A6F4D"/>
+  <path d="M24.2,0.5 L26,4 L22.4,4 Z" fill="#C9CBDA"/>
+  <rect x="21.6" y="5" width="3.8" height="2.4" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-toll-taker-1.svg
+++ b/web/public/sprites/unremembered-toll-taker-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 Q16,4 21,10 L21,9 Q16,5.5 11,9 Z" fill="#7E8299"/>
+  <rect x="11" y="9.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="11" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="11" r="0.8" fill="#3A3F55"/>
+  <path d="M12,15 L12,24 L20,24 L20,15 Q16,17 12,15 Z" fill="#454E6B"/>
+  <rect x="14.5" y="15.5" width="3" height="8" fill="#E8B94A" opacity="0.6"/>
+  <rect x="12" y="19" width="8" height="1.2" fill="#5E6A8C"/>
+  <rect x="20.5" y="15" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="23" y="11" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="19" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="5.4" y="15.5" width="4.6" height="6.5" rx="0.6" fill="#8A6F4D"/>
+  <line x1="6" y1="17.2" x2="9.4" y2="17.2" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="18.6" x2="9.4" y2="18.6" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="20" x2="9.4" y2="20" stroke="#E3D9CF" stroke-width="0.5"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-toll-taker-2.svg
+++ b/web/public/sprites/unremembered-toll-taker-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 Q16,3 21,9 L21,8 Q16,4.5 11,8 Z" fill="#7E8299"/>
+  <rect x="11" y="8.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="10" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10" r="0.8" fill="#3A3F55"/>
+  <path d="M12,14 L12,23 L20,23 L20,14 Q16,16 12,14 Z" fill="#454E6B"/>
+  <rect x="14.5" y="14.5" width="3" height="8" fill="#E8B94A" opacity="0.6"/>
+  <rect x="12" y="18" width="8" height="1.2" fill="#5E6A8C"/>
+  <rect x="20.5" y="14" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="23" y="10" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="18" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="5.4" y="14.5" width="4.6" height="6.5" rx="0.6" fill="#8A6F4D"/>
+  <line x1="6" y1="16.2" x2="9.4" y2="16.2" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="17.6" x2="9.4" y2="17.6" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="19" x2="9.4" y2="19" stroke="#E3D9CF" stroke-width="0.5"/>
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-toll-taker-3.svg
+++ b/web/public/sprites/unremembered-toll-taker-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M11,10 Q16,4 21,10 L21,9 Q16,5.5 11,9 Z" fill="#7E8299"/>
+  <rect x="11" y="9.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="11" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="11" r="0.8" fill="#3A3F55"/>
+  <path d="M12,15 L12,24 L20,24 L20,15 Q16,17 12,15 Z" fill="#454E6B"/>
+  <rect x="14.5" y="15.5" width="3" height="8" fill="#E8B94A" opacity="0.6"/>
+  <rect x="12" y="19" width="8" height="1.2" fill="#5E6A8C"/>
+  <rect x="20.5" y="15" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="23" y="11" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="19" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <rect x="8" y="15" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="5.4" y="15.5" width="4.6" height="6.5" rx="0.6" fill="#8A6F4D"/>
+  <line x1="6" y1="17.2" x2="9.4" y2="17.2" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="18.6" x2="9.4" y2="18.6" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="20" x2="9.4" y2="20" stroke="#E3D9CF" stroke-width="0.5"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/unremembered-toll-taker.svg
+++ b/web/public/sprites/unremembered-toll-taker.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Faded toll-collector infantry -->
+  <circle cx="16" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M11,9 Q16,3 21,9 L21,8 Q16,4.5 11,8 Z" fill="#7E8299"/>
+  <rect x="11" y="8.6" width="10" height="1.2" fill="#7E8299"/>
+  <circle cx="14" cy="10" r="0.8" fill="#3A3F55"/>
+  <circle cx="18" cy="10" r="0.8" fill="#3A3F55"/>
+  <!-- Tabard body, coin-gold sash half-faded -->
+  <path d="M12,14 L12,23 L20,23 L20,14 Q16,16 12,14 Z" fill="#454E6B"/>
+  <rect x="14.5" y="14.5" width="3" height="8" fill="#E8B94A" opacity="0.6"/>
+  <rect x="12" y="18" width="8" height="1.2" fill="#5E6A8C"/>
+  <!-- Sword arm -->
+  <rect x="20.5" y="14" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="23" y="10" width="1.6" height="9" rx="0.8" fill="#C9CBDA"/>
+  <rect x="22" y="18" width="3.6" height="1.4" rx="0.6" fill="#E8B94A"/>
+  <!-- Ledger-board arm -->
+  <rect x="8" y="14" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="5.4" y="14.5" width="4.6" height="6.5" rx="0.6" fill="#8A6F4D"/>
+  <line x1="6" y1="16.2" x2="9.4" y2="16.2" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="17.6" x2="9.4" y2="17.6" stroke="#E3D9CF" stroke-width="0.5"/>
+  <line x1="6" y1="19" x2="9.4" y2="19" stroke="#E3D9CF" stroke-width="0.5"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/watchlamp-tower.svg
+++ b/web/public/sprites/watchlamp-tower.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Tall stone tower, tapering -->
+  <path d="M11.5,29 L13,9 L19,9 L20.5,29 Z" fill="#9FA3BC"/>
+  <path d="M13,9 L19,9 L18.6,14 L13.4,14 Z" fill="#C9CBDA"/>
+  <rect x="12.6" y="19" width="6.8" height="1" fill="#7E8299"/>
+  <rect x="12.2" y="24" width="7.6" height="1" fill="#7E8299"/>
+  <!-- Arrow slit -->
+  <rect x="15.4" y="16" width="1.2" height="4" rx="0.6" fill="#3A3F55"/>
+  <!-- Beacon platform -->
+  <rect x="10.5" y="7.4" width="11" height="2" rx="0.8" fill="#454E6B"/>
+  <!-- Beacon lamp -->
+  <rect x="14.4" y="2" width="3.2" height="5.4" rx="1" fill="#3A3F55"/>
+  <ellipse cx="16" cy="3.6" rx="1.1" ry="1.7" fill="#FFB347"/>
+  <ellipse cx="16" cy="4" rx="0.55" ry="0.9" fill="#FFE08A"/>
+  <!-- Glow -->
+  <circle cx="16" cy="4.6" r="5.5" fill="#FFB347" opacity="0.25"/>
+  <!-- Crenellation -->
+  <rect x="10.5" y="6" width="2" height="1.6" fill="#454E6B"/>
+  <rect x="19.5" y="6" width="2" height="1.6" fill="#454E6B"/>
+</svg>

--- a/web/public/sprites/weighbridge-shrine.svg
+++ b/web/public/sprites/weighbridge-shrine.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29" rx="11" ry="2.2" fill="#7E8299" opacity="0.5"/>
+  <!-- Stone weighbridge base -->
+  <rect x="6.5" y="24" width="19" height="4.6" rx="1" fill="#A6A9C0"/>
+  <rect x="6.5" y="24" width="19" height="1.4" fill="#C9CBDA"/>
+  <!-- Scale post -->
+  <rect x="15.2" y="8" width="1.6" height="16" fill="#7E8299"/>
+  <!-- Scale beam -->
+  <rect x="8" y="8" width="16" height="1.4" rx="0.7" fill="#8A6F4D"/>
+  <!-- Hanging pans -->
+  <line x1="9" y1="9.4" x2="9" y2="14" stroke="#7E8299" stroke-width="0.6"/>
+  <path d="M6,14 Q9,16.5 12,14 Z" fill="#5E6A8C"/>
+  <line x1="23" y1="9.4" x2="23" y2="14" stroke="#7E8299" stroke-width="0.6"/>
+  <path d="M20,14 Q23,16.5 26,14 Z" fill="#5E6A8C"/>
+  <!-- Mana crystal set at the crossbeam -->
+  <path d="M16,4 L18,7 L16,10 L14,7 Z" fill="#7FB7E8"/>
+  <path d="M16,5.2 L17.2,7 L16,8.8 L14.8,7 Z" fill="#B8DCF7"/>
+  <!-- Candle glow -->
+  <ellipse cx="16" cy="26.2" rx="2" ry="1.2" fill="#FFB347"/>
+  <circle cx="16" cy="20" r="6" fill="#7FB7E8" opacity="0.15"/>
+</svg>

--- a/web/src/components/admin/CampaignAdminScreen.tsx
+++ b/web/src/components/admin/CampaignAdminScreen.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const ACT_IDS = [
   'act1','act2','act3','act4','act5','act6','act7',
-  'act8','act9','act10','act11','act12','act13','actfinale','c2act1',
+  'act8','act9','act10','act11','act12','act13','actfinale','c2act1','c2act2',
 ]
 const NODE_TYPES: NodeType[] = ['battle', 'elite', 'boss', 'rest', 'event', 'merchant']
 

--- a/web/src/data/acts/c2act1.json
+++ b/web/src/data/acts/c2act1.json
@@ -1,5 +1,6 @@
 {
   "id": "c2act1",
+  "nextActId": "c2act2",
   "title": "ACT I",
   "subtitle": "The Pale Marches",
   "rewardRelic": "Vigil Candle",

--- a/web/src/data/acts/c2act2.json
+++ b/web/src/data/acts/c2act2.json
@@ -1,0 +1,551 @@
+{
+  "id": "c2act2",
+  "title": "ACT II",
+  "subtitle": "The Grey Causeway",
+  "rewardRelic": "Toll Warden's Scale",
+  "rewardRelicDesc": "Your base gains +10 max HP, and every card you play permanently adds +1 attack to all your units — the scale keeps its own ledger.",
+  "environment": "ruins",
+  "rewardTags": [
+    "forgotten",
+    "causeway"
+  ],
+  "replayModifiers": [
+    {
+      "type": "enemyHpPercent",
+      "value": 15,
+      "label": "+15% enemy HP"
+    },
+    {
+      "type": "enemyIntervalReduction",
+      "value": 500,
+      "label": "Enemies act faster"
+    },
+    {
+      "type": "enemyHandBonus",
+      "value": 1,
+      "label": "Enemies start +1 card"
+    },
+    {
+      "type": "crystalBonus",
+      "value": 10,
+      "label": "+10 crystals per battle"
+    },
+    {
+      "type": "enemyHpPercent",
+      "value": 25,
+      "label": "+25% enemy HP"
+    }
+  ],
+  "startNodeIds": [
+    "causeway-gate"
+  ],
+  "variantPools": {
+    "jarvMoods": [
+      "Now, one border further east, carrying a candle that has not gone out since the Marches.",
+      "Now, walking a road the Dominion's maps never drew, toward a toll no map ever priced.",
+      "Now, the person Amarath sent its Herald to warn, walking into the warning anyway.",
+      "Now, still the Worldmender, discovering that mending a world does not stop it from billing you."
+    ],
+    "causewayDesc": [
+      "The Grey Causeway runs a mile dead straight into Amarath, stone the colour of old rain. Every lamp along it stands unlit, waiting for a traveller worth the oil.",
+      "This is the road every Dominion envoy should have walked to Amarath, and none ever did. Three hundred years of lamps lit for guests who never came.",
+      "The causeway does not feel abandoned. It feels attended — swept, mended, watched. Something has been keeping this road ready the entire time nobody used it."
+    ],
+    "wardenDesc": [
+      "The Toll Warden keeps a ledger with no entries from outside Amarath. He intends to fix that personally, one traveller at a time.",
+      "He does not ask for coin. He asks for the centuries the Dominion's forgetting cost his kingdom, and he does not believe you have brought enough.",
+      "Eleven generations of his family have kept this gate. He is the first to keep it for a road nobody walked. He has not once considered closing it."
+    ],
+    "priorRunOpenings": [
+      "The first lamp on the causeway was cold when you reached it, same as always — it only lights once you're closer than the Warden thinks proper.",
+      "You remembered the milestones this time. The causeway remembered you remembering them.",
+      "The tollhouse ledger was still open to the same page. You are becoming a repeat entry.",
+      "The Warden's scale was already out when you arrived. He does not believe in being surprised twice."
+    ]
+  },
+  "midRunTemplates": [
+    "The {ordinalLower} walk down the Grey Causeway. The lamps light a little sooner every time — for you, at least.",
+    "Campaign {n}. The Warden's ledger has a whole page for you now, all of it unpaid by his accounting.",
+    "{n} tolls collected, by his count. You have stopped arguing about the number.",
+    "Run {n}. The causeway is a mile long every time, and every time it feels like it's getting shorter.",
+    "The {ordinalLower} crossing. You know the milestones by name now. Amarath had names for them first."
+  ],
+  "introRules": [
+    {
+      "condition": {
+        "op": "gte",
+        "value": 10
+      },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:priorRunOpenings:1}"
+        },
+        {
+          "title": "THE GREY CAUSEWAY",
+          "text": "{pool:causewayDesc:1}\n\n{pool:wardenDesc:1}"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 9
+      },
+      "panels": [
+        {
+          "title": "THE GREY CAUSEWAY",
+          "text": "The lamps are still unlit at the gate — again.\n\n{pool:priorRunOpenings:0}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:causewayDesc:2}"
+        },
+        {
+          "title": "THE TOLL WARDEN",
+          "text": "{pool:wardenDesc:0}"
+        }
+      ]
+    }
+  ],
+  "intro": [
+    {
+      "title": "THE HERALD'S WRIT",
+      "text": "The Pale Herald knelt in the mud of the border and told you the truth as he understood it: Amarath has returned, and it remembers everything.\n\nHe left you his lantern. The candle inside has not gone out since.",
+      "image": "cutscenes/c2act2-intro-1.svg"
+    },
+    {
+      "title": "THE GREY CAUSEWAY",
+      "text": "Beyond the Marches, the mist thins into a road: a mile of grey stone running dead straight into Amarath, lined with lamps that have never once been lit for a guest.\n\nThe Herald was only the announcement. This is the toll road into the kingdom itself.",
+      "image": "cutscenes/c2act2-intro-2.svg"
+    },
+    {
+      "title": "THE COURT WAITS",
+      "text": "Every Dominion envoy who should have walked this causeway in three hundred years, never did. Amarath kept the lamps lit anyway, and kept a ledger of everyone who owed it a toll.\n\nYou are about to be the first entry from outside in three centuries. You go east.",
+      "image": "cutscenes/c2act2-intro-3.svg"
+    }
+  ],
+  "outro": [
+    {
+      "title": "THE WARDEN'S FALL",
+      "text": "The Toll Warden goes down at the gate he has kept for three hundred years, his scale still balanced in one hand. He does not look surprised. He looks, for the first time, like a man who has finally been asked a fair price and paid it.\n\n'Centuries,' he says. 'That was always the toll. Nobody said it had to be my centuries you spent.'",
+      "image": "cutscenes/c2act2-outro-1.svg"
+    },
+    {
+      "title": "THE TOLL WARDEN'S SCALE",
+      "text": "He leaves you the scale from around his neck — the one that weighed every traveller who never came. It still tips, faintly, on its own. It has not found balance in three hundred years, and it does not stop looking.",
+      "image": "cutscenes/c2act2-outro-2.svg"
+    },
+    {
+      "title": "THE FIELDS BEYOND",
+      "text": "Past the last unlit lamp, the causeway opens onto farmland: rows of pale grain under the same unmoving mist, growing something that isn't wheat.\n\nThe Unremembered Fields. Somewhere in that grain, Amarath grows back everything the Dominion's forgetting took from it. The Court is still waiting at the end of it.",
+      "image": "cutscenes/c2act2-outro-3.svg"
+    }
+  ],
+  "nodes": {
+    "causeway-gate": {
+      "id": "causeway-gate",
+      "type": "battle",
+      "label": "The Sundered Tollgate",
+      "description": "The first gate on the causeway — its arm broken, its ledger still open.",
+      "row": 0,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "unlit-mile",
+        "farthing-crossing"
+      ],
+      "handicap": 16,
+      "opponentIntervalMs": 3300,
+      "opponentBaseHp": 222,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Causeway Sentry",
+        "Grey Mile Runner",
+        "Causeway Lamp",
+        "Toll Chit"
+      ]
+    },
+    "unlit-mile": {
+      "id": "unlit-mile",
+      "type": "battle",
+      "label": "The Unlit Mile",
+      "description": "A stretch of causeway where every lamp has stood cold for three hundred years.",
+      "row": 1,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "lamplighters-vigil",
+        "waystation-hearth"
+      ],
+      "handicap": 18,
+      "opponentIntervalMs": 3200,
+      "opponentBaseHp": 230,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Causeway Sentry",
+        "Causeway Archer",
+        "Causeway Rail",
+        "Grey Mile Runner",
+        "Debtor's Pace"
+      ]
+    },
+    "farthing-crossing": {
+      "id": "farthing-crossing",
+      "type": "battle",
+      "label": "The Farthing Crossing",
+      "description": "A minor crossroads garrisoned like it still matters — because to Amarath, it does.",
+      "row": 1,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-ledger-of-fares",
+        "tollmans-cart"
+      ],
+      "handicap": 18,
+      "opponentIntervalMs": 3200,
+      "opponentBaseHp": 230,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Tollgate Pikeman",
+        "Causeway Sentry",
+        "Milestone Cairn",
+        "Candle Warden",
+        "Toll Chit"
+      ]
+    },
+    "lamplighters-vigil": {
+      "id": "lamplighters-vigil",
+      "type": "event",
+      "label": "The Lamplighter's Vigil",
+      "description": "A solitary lamplighter still tends lamps that haven't held a flame in three centuries.",
+      "row": 2,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-toll-collectors",
+        "mem-c2act2-1"
+      ],
+      "eventConfig": {
+        "title": "The Lamplighter's Vigil",
+        "description": "She moves lamp to lamp with a taper and a spare tin of oil, relighting wicks that go dark again the moment she passes. She has done this every dusk for three hundred years. She does not look tired. She looks like someone with a job that still matters to her.",
+        "pools": [
+          [
+            {
+              "label": "Help relight the vigil lamps (lose 6 HP, gain a rare card)",
+              "consequence": "The work is honest and it costs you. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the spare oil reserve (gain 60 crystals)",
+              "consequence": "She doesn't seem to mind. There is always more oil where three centuries came from. You gain 60 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 60
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest by the one lit lamp (heal 10 HP)",
+              "consequence": "The warmth is real, even if the guest it was meant for never was. You heal 10 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave her to her work",
+              "consequence": "You leave the lamplighter to her vigil.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "waystation-hearth": {
+      "id": "waystation-hearth",
+      "type": "rest",
+      "label": "The Waystation Hearth",
+      "description": "A traveller's waystation, kept ready for guests who never arrived.",
+      "row": 2,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-toll-collectors"
+      ],
+      "restHeal": 9
+    },
+    "the-ledger-of-fares": {
+      "id": "the-ledger-of-fares",
+      "type": "event",
+      "label": "The Ledger of Fares",
+      "description": "An abandoned tollhouse, its strongbox open and its ledger still recording names.",
+      "row": 2,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "the-unpaid-line"
+      ],
+      "eventConfig": {
+        "title": "The Ledger of Fares",
+        "description": "The tollhouse is empty but not abandoned — the ledger on the counter is open to today's page, ink still wet, though no hand is in sight. Every name on every page above it is Amarath's own. The strongbox beside it has never once been emptied by a Dominion traveller.",
+        "pools": [
+          [
+            {
+              "label": "Read the fare ledger (lose 6 HP, gain a rare card)",
+              "consequence": "Three hundred years of names, and yours is about to be the first from outside. It costs you. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Pocket the strongbox (gain 70 crystals)",
+              "consequence": "Coin nobody was ever going to collect. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Eat the tollhouse rations (heal 8 HP)",
+              "consequence": "Preserved past any reasonable shelf life, and somehow still good. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the ledger unread",
+              "consequence": "Some debts are better left unclaimed. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "tollmans-cart": {
+      "id": "tollmans-cart",
+      "type": "merchant",
+      "label": "The Tollman's Cart",
+      "description": "A merchant's cart parked at a crossing that hasn't seen trade in centuries.",
+      "row": 2,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-unpaid-line"
+      ]
+    },
+    "the-toll-collectors": {
+      "id": "the-toll-collectors",
+      "type": "elite",
+      "label": "The Toll Collectors",
+      "description": "A file of collectors holding the causeway in strict, patient order.",
+      "row": 3,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "milestone-forty"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Toll Escort",
+        "Tollgate Pikeman",
+        "Toll Barracks",
+        "Milestone Cairn",
+        "Ledger of Debts",
+        "Toll Bell Peal"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "mem-c2act2-1": {
+      "id": "mem-c2act2-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A tollgate charter, founding the causeway on a toll of one memory freely given.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "milestone-forty"
+      ],
+      "fragmentId": "c2act2-frag-1",
+      "environment": "ruins"
+    },
+    "the-unpaid-line": {
+      "id": "the-unpaid-line",
+      "type": "elite",
+      "label": "The Unpaid Line",
+      "description": "A queue of collectors, still holding places for travellers who never came.",
+      "row": 3,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-long-dark-mile"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Causeway Chorus",
+        "Candle Warden",
+        "Weighbridge Shrine",
+        "Unremembered Toll-Taker",
+        "Grey Mist Veil",
+        "Toll Chit"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "milestone-forty": {
+      "id": "milestone-forty",
+      "type": "battle",
+      "label": "Milestone Forty",
+      "description": "A stacked cairn marking the causeway's fortieth mile, and its garrison.",
+      "row": 4,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-final-lamp"
+      ],
+      "handicap": 24,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 254,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Tollgate Pikeman",
+        "Causeway Rail",
+        "Watchlamp Tower",
+        "Unremembered Toll-Taker",
+        "Ledger of Debts",
+        "Causeway Archer"
+      ]
+    },
+    "the-long-dark-mile": {
+      "id": "the-long-dark-mile",
+      "type": "battle",
+      "label": "The Long Dark Mile",
+      "description": "The causeway's final stretch, where even the mist gives up trying to lighten it.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-final-lamp",
+        "mem-c2act2-2"
+      ],
+      "handicap": 24,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 254,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Grey Rider",
+        "Grey Mile Runner",
+        "Toll Barracks",
+        "Debtor's Pace",
+        "Grey Mist Veil",
+        "Causeway Sentry"
+      ]
+    },
+    "the-final-lamp": {
+      "id": "the-final-lamp",
+      "type": "rest",
+      "label": "The Final Lamp",
+      "description": "The last lamp before the tollgate proper. Someone has already lit it.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "tollwarden-node"
+      ],
+      "restHeal": 11
+    },
+    "mem-c2act2-2": {
+      "id": "mem-c2act2-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A court chronicle entry on the Toll Warden's appointment — and his vow.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "tollwarden-node"
+      ],
+      "fragmentId": "c2act2-frag-2",
+      "environment": "ruins"
+    },
+    "tollwarden-node": {
+      "id": "tollwarden-node",
+      "type": "boss",
+      "label": "The Toll Warden",
+      "description": "Eleven generations of gatekeepers end here, with a scale that has never once balanced.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [],
+      "handicap": 26,
+      "opponentIntervalMs": 5000,
+      "opponentBaseHp": 268,
+      "environment": "ruins",
+      "enemyDeck": [
+        "The Toll Warden",
+        "Knight of the Toll",
+        "Toll Escort",
+        "Toll Barracks",
+        "Watchlamp Tower",
+        "Toll Bell Peal",
+        "Writ of Passage"
+      ],
+      "bossAI": "tollwarden",
+      "bossDialogue": [
+        "You crossed the Marches. You have not yet paid to cross the causeway, Worldmender. Every traveller pays.",
+        "Three hundred years unlit, these lamps. Three hundred years of tolls nobody came to collect. I have been keeping the ledger open for you specifically.",
+        "The Court sent the Herald to announce us. It sent me to collect. Stand at the gate, or be entered in the ledger as unpaid."
+      ],
+      "bossCard": "The Toll Warden"
+    }
+  }
+}

--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -1676,5 +1676,103 @@
         ]
       }
     ]
+  },
+  {
+    "id": "tollwarden",
+    "intervalMs": 5000,
+    "idleMessage": "The scale on his belt does not move on its own…",
+    "maxPlaysPerTurn": 3,
+    "openingLog": [
+      "THE TOLL WARDEN plants his standard at the causeway's centre.",
+      "\"Every traveller pays. You will not be the exception, Worldmender.\""
+    ],
+    "trait": {
+      "name": "Toll of the Mile",
+      "implemented": true,
+      "trigger": "periodic",
+      "triggerIntervalMs": 45000,
+      "type": "column_aoe",
+      "description": "Every 45 seconds the causeway itself exacts its toll — a column of buried milestones ignites underfoot, dealing 7 damage to all units caught in that column and slowing them for 4 seconds.",
+      "mechanics": {
+        "pulseDamage": 7,
+        "pulseColumn": "random",
+        "slowDurationMs": 4000,
+        "slowFactor": 0.5,
+        "chargeUpMs": 1500
+      },
+      "announceText": "The causeway stones begin to glow underfoot — the toll is due!",
+      "fireText": "THE TOLL IS PAID — a column of the causeway ignites!"
+    },
+    "phases": [
+      {
+        "condition": {
+          "gameTimeLt": 30000
+        },
+        "priorities": [
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "mana"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_asc"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      },
+      {
+        "condition": {
+          "gameTimeGte": 30000,
+          "gameTimeLt": 75000
+        },
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "costGte": 4,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "none"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ],
+        "announceOnce": "\"The Marches were only the toll road's threshold.\""
+      },
+      {
+        "condition": null,
+        "manaOverride": 9,
+        "maxPlaysOverride": 4,
+        "announceOnce": "\"NO TRAVELLER PASSES UNWEIGHED. PAY, OR BE WEIGHED ANYWAY.\"",
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -13034,6 +13034,298 @@
       "strengths": ["melee", "small"],
       "weaknesses": ["magic", "flying"],
       "size": "large"
+    },
+    "causeway-sentry": {
+      "name": "Causeway Sentry",
+      "attack": 3,
+      "maxHp": 13,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 58,
+      "attackRange": 5,
+      "attackCooldownMs": 1100,
+      "flying": false,
+      "tags": ["fast", "small"],
+      "strengths": ["fast", "melee"],
+      "weaknesses": ["armored", "ranged"],
+      "size": "small",
+      "affinity": {
+        "withName": "Grey Mile Runner",
+        "range": 60,
+        "effectType": "moveSpeed",
+        "effectAmount": 1.15,
+        "label": "Mile Marker"
+      }
+    },
+    "grey-mile-runner": {
+      "name": "Grey Mile Runner",
+      "attack": 5,
+      "maxHp": 17,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 52,
+      "attackRange": 5,
+      "attackCooldownMs": 1200,
+      "flying": false,
+      "tags": ["melee", "fast"],
+      "strengths": ["ranged"],
+      "weaknesses": ["armored"],
+      "size": "small"
+    },
+    "candle-warden": {
+      "name": "Candle Warden",
+      "attack": 4,
+      "maxHp": 21,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 34,
+      "attackRange": 65,
+      "attackCooldownMs": 1600,
+      "flying": false,
+      "tags": ["ranged", "magic"],
+      "strengths": ["melee"],
+      "weaknesses": ["fast"],
+      "size": "small"
+    },
+    "causeway-lamp": {
+      "name": "Causeway Lamp",
+      "attack": 4,
+      "maxHp": 23,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 125,
+      "attackCooldownMs": 1800,
+      "tags": ["ranged"]
+    },
+    "tollgate-pikeman": {
+      "name": "Tollgate Pikeman",
+      "attack": 7,
+      "maxHp": 28,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 40,
+      "attackRange": 5,
+      "attackCooldownMs": 1300,
+      "flying": false,
+      "tags": ["melee", "armored"],
+      "strengths": ["fast"],
+      "weaknesses": ["magic"],
+      "size": "medium"
+    },
+    "unremembered-toll-taker": {
+      "name": "Unremembered Toll-Taker",
+      "attack": 6,
+      "maxHp": 32,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 38,
+      "attackRange": 5,
+      "attackCooldownMs": 1300,
+      "flying": false,
+      "tags": ["melee"],
+      "strengths": ["small"],
+      "weaknesses": ["siege"],
+      "size": "medium"
+    },
+    "causeway-archer": {
+      "name": "Causeway Archer",
+      "attack": 6,
+      "maxHp": 19,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 42,
+      "attackRange": 135,
+      "attackCooldownMs": 1500,
+      "flying": false,
+      "tags": ["ranged"],
+      "strengths": ["flying"],
+      "weaknesses": ["melee", "fast"],
+      "size": "small"
+    },
+    "grey-rider": {
+      "name": "Grey Rider",
+      "attack": 9,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 76,
+      "attackRange": 5,
+      "attackCooldownMs": 1200,
+      "flying": false,
+      "tags": ["fast", "melee"],
+      "strengths": ["ranged", "small"],
+      "weaknesses": ["armored"],
+      "size": "medium"
+    },
+    "weighbridge-shrine": {
+      "name": "Weighbridge Shrine",
+      "attack": 0,
+      "maxHp": 21,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "structureEffect": {
+        "type": "mana",
+        "amount": 1
+      },
+      "tags": ["forgotten"]
+    },
+    "toll-barracks": {
+      "name": "Toll Barracks",
+      "attack": 0,
+      "maxHp": 32,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "grey-mile-runner",
+        "intervalMs": 12000
+      },
+      "tags": ["forgotten"]
+    },
+    "watchlamp-tower": {
+      "name": "Watchlamp Tower",
+      "attack": 6,
+      "maxHp": 28,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 145,
+      "attackCooldownMs": 1700,
+      "tags": ["ranged"]
+    },
+    "causeway-rail": {
+      "name": "Causeway Rail",
+      "attack": 0,
+      "maxHp": 64,
+      "isWall": true,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "tags": ["melee"],
+      "size": "medium"
+    },
+    "milestone-cairn": {
+      "name": "Milestone Cairn",
+      "attack": 0,
+      "maxHp": 90,
+      "isWall": true,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "tags": ["armored"],
+      "size": "medium"
+    },
+    "toll-escort": {
+      "name": "Toll Escort",
+      "attack": 12,
+      "maxHp": 47,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 40,
+      "attackRange": 5,
+      "attackCooldownMs": 1400,
+      "flying": false,
+      "tags": ["melee", "armored"],
+      "strengths": ["melee", "fast"],
+      "weaknesses": ["magic"],
+      "size": "large",
+      "affinity": {
+        "withName": "The Toll Warden",
+        "range": 80,
+        "effectType": "damage",
+        "effectAmount": 1.25,
+        "label": "Warden's Toll"
+      }
+    },
+    "causeway-chorus": {
+      "name": "Causeway Chorus",
+      "attack": 8,
+      "maxHp": 32,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 30,
+      "attackRange": 155,
+      "attackCooldownMs": 1900,
+      "flying": false,
+      "tags": ["ranged", "magic"],
+      "strengths": ["armored"],
+      "weaknesses": ["fast", "melee"],
+      "size": "medium"
+    },
+    "milestone-effigy": {
+      "name": "Milestone Effigy",
+      "attack": 0,
+      "maxHp": 48,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "causeway-sentry",
+        "intervalMs": 10000
+      },
+      "tags": ["forgotten"]
+    },
+    "knight-of-the-toll": {
+      "name": "Knight of the Toll",
+      "attack": 15,
+      "maxHp": 64,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 35,
+      "attackRange": 5,
+      "attackCooldownMs": 1500,
+      "flying": false,
+      "tags": ["melee", "armored", "large"],
+      "strengths": ["melee", "small"],
+      "weaknesses": ["magic", "flying"],
+      "size": "large",
+      "unitTrait": {
+        "guardBase": true,
+        "baseGuardRange": 90,
+        "engageRange": 190
+      }
+    },
+    "the-endless-ledger": {
+      "name": "The Endless Ledger",
+      "attack": 11,
+      "maxHp": 43,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 56,
+      "attackRange": 60,
+      "attackCooldownMs": 1600,
+      "flying": true,
+      "tags": ["flying", "magic"],
+      "strengths": ["melee", "armored"],
+      "weaknesses": ["ranged"],
+      "size": "large"
+    },
+    "the-toll-warden": {
+      "name": "The Toll Warden",
+      "attack": 17,
+      "maxHp": 84,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 30,
+      "attackRange": 5,
+      "attackCooldownMs": 1400,
+      "flying": false,
+      "tags": ["melee", "large", "armored"],
+      "strengths": ["melee", "small"],
+      "weaknesses": ["magic", "flying"],
+      "size": "large"
     }
   },
   "cards": [
@@ -21702,6 +21994,300 @@
       "deckCount": 0,
       "tags": ["forgotten", "marches"],
       "lore": "He carries a proclamation with no signatures, because every hand that signed it was erased. He intends to collect them all back."
+    },
+    {
+      "name": "Causeway Sentry",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "causeway-sentry",
+      "description": "A watcher of the toll-road, counting travellers no map remembers.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "She counts every traveller on the road, because someone must, and because the counting is the closest thing left to a name."
+    },
+    {
+      "name": "Grey Mile Runner",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "grey-mile-runner",
+      "description": "A swift courier who never stops running the causeway.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "He has run this mile for three hundred years without once arriving anywhere. The road doesn't end. It just keeps being paid for."
+    },
+    {
+      "name": "Candle Warden",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "candle-warden",
+      "description": "A robed toll-keeper whose single candle scorches at range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "One flame, carried at arm's length down an unlit road. She doesn't call it courage. She calls it the job."
+    },
+    {
+      "name": "Causeway Lamp",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "causeway-lamp",
+      "description": "An unlit watch-lamp that ignites against approaching enemies.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Unlit until you're close enough to owe something. Then it burns exactly bright enough to see the toll board."
+    },
+    {
+      "name": "Toll Chit",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffHeal",
+        "amount": 6
+      },
+      "description": "Heals all friendly units by 6.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "A scrap of paper that says a debt was paid. It is worth nothing anywhere else in the world, and everything here."
+    },
+    {
+      "name": "Debtor's Pace",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffSpeed",
+        "amount": 10
+      },
+      "description": "All friendly mobile units move faster.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Walk faster and the toll stays the same. Amarath was never in the business of mercy — only arithmetic."
+    },
+    {
+      "name": "Tollgate Pikeman",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "tollgate-pikeman",
+      "description": "An armoured line-holder guarding the tollgate.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "He has held this gate since before the causeway had a name for what crosses it. He is very good at his one job."
+    },
+    {
+      "name": "Unremembered Toll-Taker",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "unremembered-toll-taker",
+      "description": "A steady infantry collector of the returned kingdom.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "She remembers every coin that ever crossed this road, and the face of everyone who paid it. Yours is the first she doesn't."
+    },
+    {
+      "name": "Causeway Archer",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "causeway-archer",
+      "description": "A long-range archer loosing from the mile markers.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "She shoots at silhouettes on the mile markers, because the mist gives her nothing else to aim at."
+    },
+    {
+      "name": "Grey Rider",
+      "rarity": "uncommon",
+      "cost": 4,
+      "cardType": "unit",
+      "unitRef": "grey-rider",
+      "description": "A swift outrider patrolling the causeway.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "The horse doesn't tire. Three hundred years of not-existing does that to a thing."
+    },
+    {
+      "name": "Weighbridge Shrine",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "weighbridge-shrine",
+      "description": "A toll-weighing shrine that raises your maximum mana.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Every traveller is weighed here — not in pounds, in years remembered. Amarath keeps very careful scales."
+    },
+    {
+      "name": "Toll Barracks",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "toll-barracks",
+      "description": "Spawner. Periodically releases Grey Mile Runners.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Quarters for a garrison that was never relieved, on a road that was never finished being built."
+    },
+    {
+      "name": "Watchlamp Tower",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "watchlamp-tower",
+      "description": "A tall causeway tower with long attack range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Built to watch travellers arrive. Nobody built it to watch them leave."
+    },
+    {
+      "name": "Causeway Rail",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "causeway-rail",
+      "description": "A defensive rail of quarried grey stone.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Stone quarried from a kingdom that technically didn't exist yet. It holds up fine anyway."
+    },
+    {
+      "name": "Milestone Cairn",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "milestone-cairn",
+      "description": "A stacked cairn of milestones — a wall that endures.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Stacked from the actual milestones — every one that used to mark a mile nobody could find on a map."
+    },
+    {
+      "name": "Ledger of Debts",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffMaxHp",
+        "amount": 8
+      },
+      "description": "All friendly units gain +8 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Every name that ever crossed unpaid is written here. The ink has never faded. It has had nothing else to do."
+    },
+    {
+      "name": "Grey Mist Veil",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffRange",
+        "amount": 15
+      },
+      "description": "All attacking units gain +15 attack range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "The mist over the causeway isn't fog. It's the accumulated breath of everyone still waiting to be let through."
+    },
+    {
+      "name": "Toll Bell Peal",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "aoe",
+        "damage": 6,
+        "range": 100
+      },
+      "description": "The toll bell tolls, damaging enemies within its ring.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "One bell, rung for every traveller who couldn't pay. It has not stopped ringing since the day Amarath vanished."
+    },
+    {
+      "name": "Toll Escort",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "toll-escort",
+      "description": "An elite guard of the Toll Warden's retinue.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Sworn to the Warden's ledger before sworn to any king. The debt outlived the kingdom that recorded it."
+    },
+    {
+      "name": "Causeway Chorus",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "causeway-chorus",
+      "description": "A chorus whose toll-song strikes at long range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "They sing the toll-song at the gate — the same four verses, three hundred years running. Nobody has ever heard the fifth."
+    },
+    {
+      "name": "Milestone Effigy",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "structure",
+      "unitRef": "milestone-effigy",
+      "description": "Spawner. Periodically wakes Causeway Sentries from stone.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Carved in the shape of a mile marker, and just as patient. It remembers exactly how far you have left to go."
+    },
+    {
+      "name": "Writ of Passage",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffMaxHp",
+        "amount": 12
+      },
+      "description": "All friendly units gain +12 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "Signed by a chancellor who was erased before the ink dried. It is somehow still the only document that matters here."
+    },
+    {
+      "name": "Knight of the Toll",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "knight-of-the-toll",
+      "description": "A towering knight who guards the tollgate above all else.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "He has never once let a debtor pass free. He has also never once demanded a debt he thought unfair."
+    },
+    {
+      "name": "The Endless Ledger",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "the-endless-ledger",
+      "description": "A drifting ledger of debts that flies over walls.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "It has no pages. It doesn't need them. Every toll ever owed is written on it, and none of them are crossed out."
+    },
+    {
+      "name": "The Toll Warden",
+      "rarity": "legendary",
+      "cost": 7,
+      "cardType": "unit",
+      "unitRef": "the-toll-warden",
+      "description": "The lord of the causeway — a titan demanding a toll no traveller can pay.",
+      "deckCount": 0,
+      "tags": ["forgotten", "causeway"],
+      "lore": "He does not ask for coin. He asks for centuries — the ones the Dominion's forgetting cost his kingdom. No traveller has ever had that much to give."
     }
   ],
   "heroCards": [
@@ -22165,6 +22751,38 @@
       },
       "description": "HERO: Deploys the Marches Warden — a border commander who holds the line near your base and engages anything that crosses it. All units gain +12 max HP.",
       "lore": "The Dominion never posted a warden to the eastern blank. Somebody took the job anyway."
+    },
+    {
+      "id": "hero-causeway-guide",
+      "name": "Causeway Guide",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Grey Guide",
+        "attack": 13,
+        "maxHp": 58,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 42,
+        "attackRange": 5,
+        "attackCooldownMs": 1400,
+        "flying": false,
+        "tags": ["melee", "armored"],
+        "size": "large",
+        "unitTrait": {
+          "guardBase": true,
+          "baseGuardRange": 95,
+          "engageRange": 195
+        }
+      },
+      "heroEffect": {
+        "type": "buffMaxHp",
+        "amount": 14
+      },
+      "description": "HERO: Deploys the Grey Guide — a causeway pathfinder who holds the line near your base and engages anything that crosses it. All units gain +14 max HP.",
+      "lore": "No map shows the causeway's true turns. She walked it before the mist had a name for it, and she still knows every unlit lamp by heart."
     }
   ]
 }

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -194,5 +194,19 @@
     "nodeId": "mem-c2act1-2",
     "title": "Fragment: The First Vigil",
     "body": "VIGIL LEDGER OF THE MARCHES — YEAR ONE OF THE DARK\n\n'The King has commanded the vigil, and so we keep it. One candle for every soul in the Marches, lit each dusk, named each midnight. The rite-keepers say that what is remembered cannot dissolve. That the void outside our borders can only take what no one holds.\n\nSo we hold. We recite the census. We light the candles. We say the names of our dead and our living in one breath, because out here the difference matters less than the remembering.\n\nThe farmers ask when the world will come back for us. I write down the question, because questions must be remembered too. I do not write down an answer.\n\nEntry ends. 41,206 candles lit tonight. 41,206 names spoken. No one forgotten.\n\nNo one forgotten. No one forgotten. No one forgotten.'"
+  },
+  {
+    "id": "c2act2-frag-1",
+    "actId": "c2act2",
+    "nodeId": "mem-c2act2-1",
+    "title": "Fragment: The First Toll",
+    "body": "TOLLGATE CHARTER OF THE GREY CAUSEWAY — FOUNDING ENTRY\n\n'By the King's grant, the causeway is raised from the Marches to the capital, a mile of good grey stone, so that any envoy of the wider Dominion may walk to Amarath under lit lamps and be received as a guest, not a trespasser.\n\nThe toll is set at one memory, freely given: a traveller's name, spoken aloud at the gate, entered in this ledger, and never struck out. This is the whole of the price. No coin. No coin was ever needed. Amarath asked only to be known by the people who used its road.\n\nIn three hundred years no Dominion envoy has walked the causeway to pay it. The lamps were lit anyway, every dusk, for guests who did not come, because a gate that stops expecting guests is a wall.\n\nThe ledger is long. The names in it are all Amarath's own. We have been paying our own toll, to ourselves, for a very long time.'"
+  },
+  {
+    "id": "c2act2-frag-2",
+    "actId": "c2act2",
+    "nodeId": "mem-c2act2-2",
+    "title": "Fragment: The Warden's Watch",
+    "body": "FROM THE COURT CHRONICLE OF AMARATH, ENTRY ON THE APPOINTMENT OF THE TOLL WARDEN\n\n'He was not born cruel. He was born to a family that had kept the gate for eleven generations, and he kept it as they had: fairly, patiently, one name at a time.\n\nWhen the Fracture took us, he did not stop. He stood at an empty causeway, under lamps no one saw, and levied a toll from a road that led nowhere anyone remembered. Three hundred years, he says, is not a debt he invented. It is the debt the wider world ran up simply by forgetting his kingdom existed. He intends to collect it the only way he knows: one traveller, one toll, at a time.\n\nHe does not want your coin, Worldmender. He never did. He wants the years back, and there is no ledger entry for that — only a man at a gate, still counting, because stopping would mean admitting the gate was never going to open.'"
   }
 ]

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -280,5 +280,21 @@
         "intervalMs": 6000
       }
     ]
+  },
+  {
+    "name": "Toll Warden's Scale",
+    "icon": "⚖️",
+    "desc": "Your base gains +10 max HP, and every card you play permanently adds +1 attack to all your units — the scale keeps its own ledger.",
+    "lore": "Taken from around the Toll Warden's neck when he fell. It has weighed every traveller who crossed the causeway for three hundred years, tipping further from balance every time. It has not once come out even.",
+    "effects": [
+      {
+        "type": "baseHp",
+        "amount": 10
+      },
+      {
+        "type": "onPlayAtk",
+        "amount": 1
+      }
+    ]
   }
 ]

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -859,6 +859,41 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 2,
   },
 
+  // Campaign 2, Act 2 — The Grey Causeway
+  {
+    id: 'campaign:c2act2:1',
+    name: 'The Toll Unpaid',
+    description: 'Complete Campaign 2 Act 2 — The Grey Causeway',
+    category: 'campaign',
+    progressKey: 'campaign:c2act2',
+    target: 1,
+    reward: { type: 'crystals', crystals: 650 },
+    tier: 1,
+  },
+  {
+    id: 'campaign:c2act2:10',
+    name: 'Warden of the Milestones',
+    description: 'Complete Campaign 2 Act 2 ten times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act2',
+    target: 10,
+    reward: { type: 'crystals', crystals: 3200 },
+    tier: 2,
+  },
+  {
+    id: 'campaign:c2act2:100',
+    name: 'The Causeway Remembers Your Step',
+    description: 'Complete Campaign 2 Act 2 one hundred times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act2',
+    target: 100,
+    reward: {
+      type: 'item',
+      item: { id: 'tollwardens_ledger_page', name: "Toll Warden's Ledger Page", icon: '📜', desc: 'A single page from a ledger three centuries deep. Your name is on it now.' },
+    },
+    tier: 2,
+  },
+
   // ── Boss avatar unlocks (one per act, triggered on first act completion) ─
 
   { id: 'campaign:act1:boss',  name: 'Face of the Thornlord',       description: 'Defeat Act 1 to unlock the Thornlord avatar',       category: 'campaign', progressKey: 'campaign:act1',  target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thornlord' },       tier: 1 },
@@ -876,6 +911,7 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
   { id: 'campaign:act13:boss',   name: 'Face of the Grand Automaton', description: 'Defeat Act 13 to unlock the Grand Automaton avatar', category: 'campaign', progressKey: 'campaign:act13',   target: 1, reward: { type: 'avatar', avatarSlug: 'boss-grandautomaton' },  tier: 1 },
   { id: 'campaign:actfinale:boss', name: 'Face of the Fracture',       description: 'Defeat the Finale to unlock the Fracture avatar',     category: 'campaign', progressKey: 'campaign:actfinale', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thefracture' },     tier: 1 },
   { id: 'campaign:c2act1:boss',    name: 'Face of the Pale Herald',    description: 'Defeat Campaign 2 Act 1 to unlock the Pale Herald avatar', category: 'campaign', progressKey: 'campaign:c2act1', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-paleherald' },      tier: 1 },
+  { id: 'campaign:c2act2:boss',    name: 'Face of the Toll Warden',    description: 'Defeat Campaign 2 Act 2 to unlock the Toll Warden avatar', category: 'campaign', progressKey: 'campaign:c2act2', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-tollwarden' },      tier: 1 },
 
   // ── Boss Cards — earned by repeat boss completions (10/20/30/40 runs) ────
   // Act 1 — Thornlord

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -22,12 +22,13 @@ import act12Data from '../data/acts/act12.json'
 import act13Data from '../data/acts/act13.json'
 import actFinaleData from '../data/acts/actfinale.json'
 import c2act1Data from '../data/acts/c2act1.json'
+import c2act2Data from '../data/acts/c2act2.json'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ALL_ACTS: any[] = [
   act1Data, act2Data, act3Data, act4Data, act5Data,
   act6Data, act7Data, act8Data, act9Data, act10Data,
-  act11Data, act12Data, act13Data, actFinaleData, c2act1Data,
+  act11Data, act12Data, act13Data, actFinaleData, c2act1Data, c2act2Data,
 ]
 
 const FRAGMENT_KEY        = 'jarv_memory_fragments'

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -18,6 +18,7 @@ import act12Data from '../data/acts/act12.json'
 import act13Data    from '../data/acts/act13.json'
 import actFinaleData from '../data/acts/actfinale.json'
 import c2act1Data from '../data/acts/c2act1.json'
+import c2act2Data from '../data/acts/c2act2.json'
 import worldBattlesData from '../data/acts/worldbattles.json'
 import consumablesData from '../data/consumables.json'
 
@@ -899,6 +900,7 @@ export const ACT_12: Act = act12Data as Act
 export const ACT_13:     Act = act13Data    as Act
 export const ACT_FINALE: Act = actFinaleData as Act
 export const C2_ACT_1: Act = c2act1Data as Act
+export const C2_ACT_2: Act = c2act2Data as Act
 /** Standalone battles launched from the world map — never part of campaign progression. */
 export const ACT_WORLD: Act = worldBattlesData as Act
 
@@ -918,6 +920,7 @@ export const ACTS: Record<string, Act> = {
   act13:     ACT_13,
   actfinale: ACT_FINALE,
   c2act1:    C2_ACT_1,
+  c2act2:    C2_ACT_2,
   world:     ACT_WORLD,
 }
 

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1005,7 +1005,7 @@ export const BOSS_AVATAR_SLUGS = [
   'boss-thornlord', 'boss-kragg', 'boss-ashwalker', 'boss-archivist',
   'boss-tidal-sovereign', 'boss-cloudmarshal', 'boss-cinderwarlord', 'boss-rootqueen',
   'boss-paleengine', 'boss-dunebaron', 'boss-elderwarden', 'boss-harbormaster',
-  'boss-grandautomaton', 'boss-paleherald',
+  'boss-grandautomaton', 'boss-paleherald', 'boss-tollwarden',
 ] as const
 export const AVATAR_SLUGS = [...BASE_AVATAR_SLUGS, ...STREAK_AVATAR_SLUGS, ...BOSS_AVATAR_SLUGS] as const
 export type AvatarSlug = typeof AVATAR_SLUGS[number]
@@ -1036,6 +1036,7 @@ export const BOSS_AVATAR_LABELS: Record<string, string> = {
   'boss-harbormaster':    'The Harbormaster',
   'boss-grandautomaton':  'The Grand Automaton',
   'boss-paleherald':      'The Pale Herald',
+  'boss-tollwarden':      'The Toll Warden',
 }
 
 export function loadUnlockedAvatars(): string[] {


### PR DESCRIPTION
Closes #1987 (part of #181 — The Forgotten Kingdom).

Implements Campaign 2, Act 2 per `docs/campaign2.md` §4 row 2, mirroring the c2act1 pattern. **Authored by a Sonnet agent session; independently reviewed** — see review notes below.

## Content
- **Act map** `c2act2.json`: 15-node Grey Causeway map (The Sundered Tollgate → The Toll Warden), balanced A/B paths (3 combat each), 2 memory-fragment detours, inline events, replay intro rules, difficulty 16→26 / 222→268 HP (one step above Act 1's 14→24)
- **25 cards** tagged `forgotten`/`causeway` (6c/12u/4r/2e/1l) + templates + **Causeway Guide** hero card (+14 max HP); legendary **The Toll Warden** doubles as the boss card
- **Boss** `tollwarden` — *Toll of the Mile*: periodic (45 s) column AOE, 7 damage + 50 % slow for 4 s, 1.5 s charge-up; elites reuse `pale-elite`
- **Relic** *Toll Warden's Scale*: +10 base HP, +1 ATK to all units per card played
- **Story**: intro picks up from the Herald's defeat at the Marches; outro hands over the Scale and teases Act 3 (The Unremembered Fields); fragments tell the causeway's charter and the Warden's vow in the bible's grief-not-villainy voice
- Achievements `campaign:c2act2` (1/10/100) + `boss-tollwarden` avatar unlock; registered in `questline.ts`/`codex.ts`/`CampaignAdminScreen`; **`c2act1.json` gains `nextActId: "c2act2"`** so the arc now continues instead of ending at TO BE CONTINUED
- Sprites: 13 animated units (4 frames each), 7 structures, boss avatar; 6 cutscene panels

## Review (independent of the authoring agent)
- Cross-checked every `enemyDeck` name, `bossAI`, `bossCard`, `fragmentId`, `childIds` target, and the relic name/desc pairing — all resolve; no duplicate card/template names; no unreachable nodes; all sprite files present
- Rebased onto latest `main` (post-#2002); `npm run build` clean; 680/680 unit tests pass (the browser-runner error is pre-existing on `main`)
- Diff footprint is exactly the expected file set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ)_