### PR TITLE
feat(campaign2): Act IV — The Archive of Names (c2act4)

### DIFF
--- a/web/public/cutscenes/c2act4-intro-1.svg
+++ b/web/public/cutscenes/c2act4-intro-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a4i1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#242b48"/>
+    <stop offset="100%" stop-color="#4a5170"/>
+  </linearGradient>
+  <rect width="400" height="176" fill="url(#c2a4i1-sky)"/>
+  <!-- Fields giving way to dressed stone threshold -->
+  <rect y="176" width="200" height="64" fill="#4a4634"/>
+  <rect x="200" y="176" width="200" height="64" fill="#2b3149"/>
+  <g stroke="#D9C27E" stroke-width="1" opacity="0.5">
+    <line x1="20" y1="240" x2="50" y2="180"/>
+    <line x1="70" y1="240" x2="90" y2="180"/>
+    <line x1="120" y1="240" x2="130" y2="180"/>
+    <line x1="170" y1="240" x2="175" y2="180"/>
+  </g>
+  <!-- Shelving hall threshold, doorway aglow -->
+  <rect x="250" y="90" width="80" height="90" fill="#12141f"/>
+  <rect x="262" y="102" width="56" height="78" fill="#E8B94A" opacity="0.18"/>
+  <!-- Jarv silhouette walking toward the threshold, carrying the sheaf -->
+  <g fill="#11141f">
+    <circle cx="200" cy="150" r="10"/>
+    <rect x="189" y="160" width="22" height="34" rx="4"/>
+  </g>
+  <rect x="178" y="170" width="18" height="1.6" fill="#D9C27E" transform="rotate(-6 187 171)"/>
+  <path d="M174,168 Q178,172 182,168 Z" fill="#454E6B"/>
+  <path d="M190,166 Q194,170 198,166 Z" fill="#454E6B"/>
+  <!-- Mist bands -->
+  <ellipse cx="200" cy="180" rx="220" ry="18" fill="#ced3e6" opacity="0.3"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE FIELDS SIMPLY STOP BEING FIELDS</text>
+</svg>

--- a/web/public/cutscenes/c2act4-intro-2.svg
+++ b/web/public/cutscenes/c2act4-intro-2.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a4i2-hall" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#171b28"/>
+    <stop offset="100%" stop-color="#2b3149"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a4i2-hall)"/>
+  <!-- Aisle floor -->
+  <rect y="176" width="400" height="24" fill="#12141f"/>
+  <!-- Rows of shelving receding into the dark -->
+  <g fill="#3a4160">
+    <rect x="20" y="40" width="30" height="140"/>
+    <rect x="80" y="52" width="24" height="128"/>
+    <rect x="130" y="62" width="20" height="118"/>
+    <rect x="250" y="62" width="20" height="118"/>
+    <rect x="296" y="52" width="24" height="128"/>
+    <rect x="350" y="40" width="30" height="140"/>
+  </g>
+  <!-- Reading-lamps along the aisle -->
+  <g fill="#E8B94A">
+    <circle cx="35" cy="70" r="3"/>
+    <circle cx="92" cy="80" r="2.6"/>
+    <circle cx="140" cy="90" r="2.2"/>
+    <circle cx="260" cy="90" r="2.2"/>
+    <circle cx="308" cy="80" r="2.6"/>
+    <circle cx="365" cy="70" r="3"/>
+  </g>
+  <g fill="#FFB347" opacity="0.25">
+    <circle cx="35" cy="70" r="9"/>
+    <circle cx="92" cy="80" r="8"/>
+    <circle cx="308" cy="80" r="8"/>
+    <circle cx="365" cy="70" r="9"/>
+  </g>
+  <!-- Vanishing aisle mist -->
+  <ellipse cx="200" cy="130" rx="80" ry="60" fill="#0a0c14" opacity="0.4"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">AISLE AFTER AISLE, LIT BY LAMPS THAT NEVER GO DARK</text>
+</svg>

--- a/web/public/cutscenes/c2act4-intro-3.svg
+++ b/web/public/cutscenes/c2act4-intro-3.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a4i3-hall" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0e1019"/>
+    <stop offset="100%" stop-color="#1e2436"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a4i3-hall)"/>
+  <rect y="176" width="400" height="24" fill="#0a0c14"/>
+  <!-- Dark stacks looming close -->
+  <g fill="#171b28">
+    <rect x="0" y="20" width="60" height="160"/>
+    <rect x="340" y="20" width="60" height="160"/>
+  </g>
+  <!-- A hooded archivist, distant, back turned -->
+  <g fill="#2b3149" opacity="0.8">
+    <circle cx="130" cy="150" r="7"/>
+    <rect x="118" y="160" width="24" height="24" rx="4"/>
+  </g>
+  <!-- Two candle-gold eyes watching from between the shelves -->
+  <circle cx="270" cy="120" r="2.4" fill="#FFB347"/>
+  <circle cx="284" cy="118" r="2.4" fill="#FFB347"/>
+  <circle cx="277" cy="119" r="16" fill="#FFB347" opacity="0.12"/>
+  <!-- Loose pages drifting -->
+  <g fill="#F2E9D8" opacity="0.5">
+    <rect x="250" y="140" width="4" height="5" transform="rotate(15 252 142)"/>
+    <rect x="300" y="150" width="4" height="5" transform="rotate(-12 302 152)"/>
+  </g>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">SOMETHING WATCHES FROM BETWEEN THE SHELVES</text>
+</svg>

--- a/web/public/cutscenes/c2act4-outro-1.svg
+++ b/web/public/cutscenes/c2act4-outro-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a4o1-hall" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#171b28"/>
+    <stop offset="100%" stop-color="#2b3149"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a4o1-hall)"/>
+  <rect y="176" width="400" height="24" fill="#12141f"/>
+  <!-- Toppled, closing shelving around the fallen Name-Eater -->
+  <g fill="#171b28">
+    <rect x="30" y="60" width="24" height="120"/>
+    <rect x="346" y="60" width="24" height="120"/>
+  </g>
+  <!-- The Name-Eater, folded down among the stacks -->
+  <g>
+    <rect x="180" y="120" width="40" height="40" rx="10" fill="#2B2F3E"/>
+    <path d="M185,120 Q200,100 215,120 L215,128 Q200,116 185,128 Z" fill="#F2E9D8" opacity="0.8"/>
+    <circle cx="192" cy="140" r="2.2" fill="#FFB347" opacity="0.5"/>
+    <circle cx="208" cy="140" r="2.2" fill="#FFB347" opacity="0.5"/>
+    <rect x="185" y="160" width="30" height="16" rx="4" fill="#454E6B"/>
+  </g>
+  <ellipse cx="200" cy="182" rx="70" ry="10" fill="#E8B94A" opacity="0.12"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">"I WAS NEVER UNFED, ONLY UNGOVERNED"</text>
+</svg>

--- a/web/public/cutscenes/c2act4-outro-2.svg
+++ b/web/public/cutscenes/c2act4-outro-2.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a4o2-bg" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#1e2436"/>
+    <stop offset="100%" stop-color="#3a4160"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a4o2-bg)"/>
+  <!-- Close study of the Index of the Lost, held up -->
+  <ellipse cx="200" cy="100" rx="90" ry="70" fill="#E8B94A" opacity="0.1"/>
+  <rect x="150" y="60" width="100" height="80" rx="4" fill="#2B2F3E"/>
+  <rect x="158" y="68" width="84" height="64" fill="#F2E9D8"/>
+  <g stroke="#7E8299" stroke-width="1.4">
+    <line x1="166" y1="82" x2="234" y2="82"/>
+    <line x1="166" y1="94" x2="234" y2="94"/>
+    <line x1="166" y1="106" x2="234" y2="106"/>
+    <line x1="166" y1="118" x2="220" y2="118"/>
+  </g>
+  <circle cx="200" cy="100" r="10" fill="#E8B94A"/>
+  <circle cx="200" cy="100" r="5" fill="#FFE08A"/>
+  <!-- Hands holding it (silhouette) -->
+  <rect x="146" y="128" width="16" height="20" rx="4" fill="#11141f"/>
+  <rect x="238" y="128" width="16" height="20" rx="4" fill="#11141f"/>
+  <!-- Mist bands -->
+  <ellipse cx="200" cy="176" rx="200" ry="16" fill="#ced3e6" opacity="0.25"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">INDEX OF THE LOST</text>
+</svg>

--- a/web/public/cutscenes/c2act4-outro-3.svg
+++ b/web/public/cutscenes/c2act4-outro-3.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a0c14"/>
+  <linearGradient id="c2a4o3-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#171b28"/>
+    <stop offset="100%" stop-color="#3a4160"/>
+  </linearGradient>
+  <rect width="400" height="200" fill="url(#c2a4o3-sky)"/>
+  <!-- Archive rooftops giving way to the Candle City skyline -->
+  <rect y="176" width="400" height="64" fill="#2b3149"/>
+  <g fill="#171b28">
+    <rect x="10" y="130" width="20" height="46"/>
+    <rect x="36" y="118" width="18" height="58"/>
+  </g>
+  <!-- Ten thousand vigil flames across a distant skyline -->
+  <g fill="#3a4160">
+    <rect x="90" y="90" width="16" height="86"/>
+    <rect x="112" y="70" width="16" height="106"/>
+    <rect x="134" y="100" width="16" height="76"/>
+    <rect x="170" y="60" width="18" height="116"/>
+    <rect x="196" y="80" width="16" height="96"/>
+    <rect x="220" y="50" width="18" height="126"/>
+    <rect x="246" y="86" width="16" height="90"/>
+    <rect x="270" y="66" width="18" height="110"/>
+    <rect x="296" y="96" width="16" height="80"/>
+    <rect x="330" y="76" width="18" height="100"/>
+  </g>
+  <g fill="#FFB347" opacity="0.85">
+    <circle cx="96" cy="102" r="1.4"/>
+    <circle cx="118" cy="86" r="1.4"/>
+    <circle cx="140" cy="112" r="1.4"/>
+    <circle cx="176" cy="76" r="1.6"/>
+    <circle cx="202" cy="94" r="1.4"/>
+    <circle cx="226" cy="66" r="1.6"/>
+    <circle cx="252" cy="100" r="1.4"/>
+    <circle cx="276" cy="82" r="1.6"/>
+    <circle cx="302" cy="110" r="1.4"/>
+    <circle cx="336" cy="90" r="1.6"/>
+  </g>
+  <ellipse cx="230" cy="130" rx="150" ry="30" fill="#FFB347" opacity="0.1"/>
+  <!-- Mist bands -->
+  <ellipse cx="200" cy="180" rx="220" ry="18" fill="#ced3e6" opacity="0.3"/>
+  <!-- Caption -->
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">TEN THOUSAND VIGIL FLAMES, STILL BURNING</text>
+</svg>

--- a/web/public/sprites/archive-warden-1.svg
+++ b/web/public/sprites/archive-warden-1.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm (body 1px lower mid-stride) -->
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#9FA3BC"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed tome carried as a shield -->
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#E8B94A"/>
+  <!-- Warden's rod -->
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="6" width="1.4" height="12" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="6" width="3.8" height="2" rx="0.4" fill="#E8B94A"/>
+  <circle cx="24.2" cy="5" r="1.6" fill="#E8B94A"/>
+  <circle cx="24.2" cy="5" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/archive-warden-2.svg
+++ b/web/public/sprites/archive-warden-2.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#9FA3BC"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed tome carried as a shield -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#E8B94A"/>
+  <!-- Warden's rod -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="5" width="1.4" height="12" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="5" width="3.8" height="2" rx="0.4" fill="#E8B94A"/>
+  <circle cx="24.2" cy="4" r="1.6" fill="#E8B94A"/>
+  <circle cx="24.2" cy="4" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/archive-warden-3.svg
+++ b/web/public/sprites/archive-warden-3.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm (body 1px lower mid-stride) -->
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#9FA3BC"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed tome carried as a shield -->
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#E8B94A"/>
+  <!-- Warden's rod -->
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="6" width="1.4" height="12" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="6" width="3.8" height="2" rx="0.4" fill="#E8B94A"/>
+  <circle cx="24.2" cy="5" r="1.6" fill="#E8B94A"/>
+  <circle cx="24.2" cy="5" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/archive-warden.svg
+++ b/web/public/sprites/archive-warden.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#9FA3BC"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed tome carried as a shield -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#E8B94A"/>
+  <!-- Warden's rod -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="5" width="1.4" height="12" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="5" width="3.8" height="2" rx="0.4" fill="#E8B94A"/>
+  <circle cx="24.2" cy="4" r="1.6" fill="#E8B94A"/>
+  <circle cx="24.2" cy="4" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/boss-nameeater-1.svg
+++ b/web/public/sprites/boss-nameeater-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride A: hook sways back -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(4 25.8 16)"/>
+  <path d="M26.6,3.5 Q32.5,5 30.5,10.5 Q27.8,7.5 26.6,3.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="4" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,4.5 Q13,1 15,4 Q16,1.5 17,4 Q19,1 21,4.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="1.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#454E6B"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#F2E9D8"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="28" width="4.5" height="3.6" rx="1" fill="#2B2F3E"/>
+  <rect x="18.5" y="28" width="4.5" height="2.8" rx="1" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-nameeater-2.svg
+++ b/web/public/sprites/boss-nameeater-2.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Binding-hook pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,2.5 Q32.5,4 30.5,9.5 Q27.8,6.5 26.6,2.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="3" r="0.9" fill="#E8B94A"/>
+  <!-- Ink-dark head-mass, crowned in loose pages -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,3.5 Q13,0 15,3 Q16,0.5 17,3 Q19,0 21,3.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="0.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <!-- Massive cloaked body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#454E6B"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#2B2F3E"/>
+  <!-- Sealed-name chest sigil -->
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <!-- Ledger-scale held out -->
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#F2E9D8"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-nameeater-3.svg
+++ b/web/public/sprites/boss-nameeater-3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride B: hook sways forward -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(-4 25.8 16)"/>
+  <path d="M26.6,3.5 Q32.5,5 30.5,10.5 Q27.8,7.5 26.6,3.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="4" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,4.5 Q13,1 15,4 Q16,1.5 17,4 Q19,1 21,4.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="1.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#454E6B"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#F2E9D8"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="28" width="4.5" height="3.6" rx="1" fill="#2B2F3E"/>
+  <rect x="9" y="28" width="4.5" height="2.8" rx="1" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/boss-nameeater.svg
+++ b/web/public/sprites/boss-nameeater.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Binding-hook pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,2.5 Q32.5,4 30.5,9.5 Q27.8,6.5 26.6,2.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="3" r="0.9" fill="#E8B94A"/>
+  <!-- Ink-dark head-mass, crowned in loose pages -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,3.5 Q13,0 15,3 Q16,0.5 17,3 Q19,0 21,3.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="0.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <!-- Massive cloaked body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#454E6B"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#2B2F3E"/>
+  <!-- Sealed-name chest sigil -->
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <!-- Ledger-scale held out -->
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#F2E9D8"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/cataloguer-automaton.svg
+++ b/web/public/sprites/cataloguer-automaton.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="12" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Reading-room alcove -->
+  <rect x="4" y="15" width="24" height="13" rx="1" fill="#9FA3BC"/>
+  <rect x="4" y="19" width="24" height="1" fill="#7E8299"/>
+  <!-- Peaked gable roof -->
+  <path d="M2.5,15 L16,6 L29.5,15 Z" fill="#2B2F3E"/>
+  <path d="M6,15 L16,8.4 L26,15 Z" fill="#454E6B"/>
+  <!-- Ridge lines -->
+  <line x1="9" y1="13" x2="13" y2="10.4" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="13" y1="13" x2="16.5" y2="10.6" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="19" y1="13" x2="15.5" y2="10.6" stroke="#7E8299" stroke-width="0.6"/>
+  <line x1="23" y1="13" x2="19" y2="10.4" stroke="#7E8299" stroke-width="0.6"/>
+  <!-- Sealed door -->
+  <rect x="13.5" y="20" width="5" height="8" rx="1.5" fill="#2B2F3E"/>
+  <circle cx="17.3" cy="24.2" r="0.5" fill="#E8B94A"/>
+  <!-- Windows glowing faint -->
+  <rect x="7" y="21" width="3.4" height="3.4" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <rect x="21.6" y="21" width="3.4" height="3.4" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <!-- Sealed-page banner over door -->
+  <rect x="15.4" y="15.5" width="1.2" height="4" fill="#5E6A8C"/>
+  <path d="M14,15.5 L18,15.5 L16,17.8 Z" fill="#F2E9D8"/>
+  <!-- Mist seeping from the door -->
+  <ellipse cx="16" cy="28.2" rx="6" ry="1.4" fill="#E8EAF4" opacity="0.55"/>
+  <ellipse cx="11" cy="27.4" rx="3.5" ry="1" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/choir-of-sealed-names-1.svg
+++ b/web/public/sprites/choir-of-sealed-names-1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded choristers in a row (drifting shift A) -->
+  <circle cx="8.6" cy="11.4" r="3.6" fill="#A6A9C0"/>
+  <path d="M5,11.4 Q8.6,6.4 12.2,11.4 L12.2,13.4 Q8.6,10.9 5,13.4 Z" fill="#7E8299"/>
+  <path d="M5.6,14.4 L4.6,28.4 L12.6,28.4 L11.6,14.4 Q8.6,15.9 5.6,14.4 Z" fill="#A6A9C0"/>
+  <circle cx="23.4" cy="10.6" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.8,10.6 Q23.4,5.6 27,10.6 L27,12.6 Q23.4,10.1 19.8,12.6 Z" fill="#7E8299"/>
+  <path d="M20.4,13.6 L19.4,27.6 L27.4,27.6 L26.4,13.6 Q23.4,15.1 20.4,13.6 Z" fill="#A6A9C0"/>
+  <!-- Front centre chorister -->
+  <circle cx="16" cy="8.6" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,8.6 Q16,3.1 20.2,8.6 L20.2,11.1 Q16,8.1 11.8,11.1 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="10.1" rx="1" ry="1.4" fill="#2B2F3E"/>
+  <path d="M12.5,12.6 L11,29.6 L21,29.6 L19.5,12.6 Q16,14.6 12.5,12.6 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="16.6" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Sealed-name glyphs rising -->
+  <path d="M12,2.6 L12.9,3.6 L12,4.6 L11.1,3.6 Z" fill="#F2E9D8"/>
+  <path d="M20,3 L20.9,4 L20,5 L19.1,4 Z" fill="#F2E9D8"/>
+  <!-- Candle-gold glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/choir-of-sealed-names-2.svg
+++ b/web/public/sprites/choir-of-sealed-names-2.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded choristers in a row -->
+  <circle cx="9" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.4,11 Q9,6 12.6,11 L12.6,13 Q9,10.5 5.4,13 Z" fill="#7E8299"/>
+  <path d="M6,14 L5,28 L13,28 L12,14 Q9,15.5 6,14 Z" fill="#A6A9C0"/>
+  <circle cx="23" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.4,11 Q23,6 26.6,11 L26.6,13 Q23,10.5 19.4,13 Z" fill="#7E8299"/>
+  <path d="M20,14 L19,28 L27,28 L26,14 Q23,15.5 20,14 Z" fill="#A6A9C0"/>
+  <!-- Front centre chorister -->
+  <circle cx="16" cy="9" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9 Q16,3.5 20.2,9 L20.2,11.5 Q16,8.5 11.8,11.5 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="10.5" rx="1" ry="1.4" fill="#2B2F3E"/>
+  <path d="M12.5,13 L11,30 L21,30 L19.5,13 Q16,15 12.5,13 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Sealed-name glyphs rising -->
+  <path d="M12,3 L12.9,4 L12,5 L11.1,4 Z" fill="#F2E9D8"/>
+  <path d="M20,2.6 L20.9,3.6 L20,4.6 L19.1,3.6 Z" fill="#F2E9D8"/>
+  <!-- Candle-gold glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/choir-of-sealed-names-3.svg
+++ b/web/public/sprites/choir-of-sealed-names-3.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded choristers in a row (drifting shift B) -->
+  <circle cx="9.4" cy="10.6" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.8,10.6 Q9.4,5.6 13,10.6 L13,12.6 Q9.4,10.1 5.8,12.6 Z" fill="#7E8299"/>
+  <path d="M6.4,13.6 L5.4,27.6 L13.4,27.6 L12.4,13.6 Q9.4,15.1 6.4,13.6 Z" fill="#A6A9C0"/>
+  <circle cx="22.6" cy="11.4" r="3.6" fill="#A6A9C0"/>
+  <path d="M19,11.4 Q22.6,6.4 26.2,11.4 L26.2,13.4 Q22.6,10.9 19,13.4 Z" fill="#7E8299"/>
+  <path d="M19.6,14.4 L18.6,28.4 L26.6,28.4 L25.6,14.4 Q22.6,15.9 19.6,14.4 Z" fill="#A6A9C0"/>
+  <!-- Front centre chorister -->
+  <circle cx="16" cy="9.4" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9.4 Q16,3.9 20.2,9.4 L20.2,11.9 Q16,8.9 11.8,11.9 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="10.9" rx="1" ry="1.4" fill="#2B2F3E"/>
+  <path d="M12.5,13.4 L11,30.4 L21,30.4 L19.5,13.4 Q16,15.4 12.5,13.4 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17.4" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Sealed-name glyphs rising -->
+  <path d="M12,3.4 L12.9,4.4 L12,5.4 L11.1,4.4 Z" fill="#F2E9D8"/>
+  <path d="M20,2.2 L20.9,3.2 L20,4.2 L19.1,3.2 Z" fill="#F2E9D8"/>
+  <!-- Candle-gold glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/choir-of-sealed-names.svg
+++ b/web/public/sprites/choir-of-sealed-names.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Three hooded choristers in a row -->
+  <circle cx="9" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M5.4,11 Q9,6 12.6,11 L12.6,13 Q9,10.5 5.4,13 Z" fill="#7E8299"/>
+  <path d="M6,14 L5,28 L13,28 L12,14 Q9,15.5 6,14 Z" fill="#A6A9C0"/>
+  <circle cx="23" cy="11" r="3.6" fill="#A6A9C0"/>
+  <path d="M19.4,11 Q23,6 26.6,11 L26.6,13 Q23,10.5 19.4,13 Z" fill="#7E8299"/>
+  <path d="M20,14 L19,28 L27,28 L26,14 Q23,15.5 20,14 Z" fill="#A6A9C0"/>
+  <!-- Front centre chorister -->
+  <circle cx="16" cy="9" r="4.2" fill="#C9CBDA"/>
+  <path d="M11.8,9 Q16,3.5 20.2,9 L20.2,11.5 Q16,8.5 11.8,11.5 Z" fill="#454E6B"/>
+  <ellipse cx="16" cy="10.5" rx="1" ry="1.4" fill="#2B2F3E"/>
+  <path d="M12.5,13 L11,30 L21,30 L19.5,13 Q16,15 12.5,13 Z" fill="#C9CBDA"/>
+  <rect x="13.5" y="17" width="5" height="1.1" fill="#7E8299"/>
+  <!-- Sealed-name glyphs rising -->
+  <path d="M12,3 L12.9,4 L12,5 L11.1,4 Z" fill="#F2E9D8"/>
+  <path d="M20,2.6 L20.9,3.6 L20,4.6 L19.1,3.6 Z" fill="#F2E9D8"/>
+  <!-- Candle-gold glow at feet -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="1.8" fill="#E8B94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/hollow-cataloguer-1.svg
+++ b/web/public/sprites/hollow-cataloguer-1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Empty hood (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#5E6A8C"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#2B2F3E"/>
+  <circle cx="16" cy="11" r="3" fill="#1B1D28"/>
+  <!-- Robed body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#5E6A8C"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#2B2F3E"/>
+  <!-- Ledger tucked at hip -->
+  <rect x="19.5" y="15.5" width="4" height="5" rx="1" fill="#2B2F3E"/>
+  <rect x="20" y="16.2" width="3" height="3.5" fill="#F2E9D8"/>
+  <!-- Quill hand -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M7,15 Q4,12.5 5.5,9 Q7.4,11 8,14 Z" fill="#F2E9D8"/>
+  <circle cx="5.6" cy="9.4" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/hollow-cataloguer-2.svg
+++ b/web/public/sprites/hollow-cataloguer-2.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Empty hood -->
+  <circle cx="16" cy="9" r="5" fill="#5E6A8C"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#2B2F3E"/>
+  <circle cx="16" cy="10" r="3" fill="#1B1D28"/>
+  <!-- Robed body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#5E6A8C"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#2B2F3E"/>
+  <!-- Ledger tucked at hip -->
+  <rect x="19.5" y="14.5" width="4" height="5" rx="1" fill="#2B2F3E"/>
+  <rect x="20" y="15.2" width="3" height="3.5" fill="#F2E9D8"/>
+  <!-- Quill hand -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M7,14 Q4,11.5 5.5,8 Q7.4,10 8,13 Z" fill="#F2E9D8"/>
+  <circle cx="5.6" cy="8.4" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/hollow-cataloguer-3.svg
+++ b/web/public/sprites/hollow-cataloguer-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Empty hood (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#5E6A8C"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#2B2F3E"/>
+  <circle cx="16" cy="11" r="3" fill="#1B1D28"/>
+  <!-- Robed body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#5E6A8C"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#2B2F3E"/>
+  <!-- Ledger tucked at hip -->
+  <rect x="19.5" y="15.5" width="4" height="5" rx="1" fill="#2B2F3E"/>
+  <rect x="20" y="16.2" width="3" height="3.5" fill="#F2E9D8"/>
+  <!-- Quill hand -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M7,15 Q4,12.5 5.5,9 Q7.4,11 8,14 Z" fill="#F2E9D8"/>
+  <circle cx="5.6" cy="9.4" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/hollow-cataloguer.svg
+++ b/web/public/sprites/hollow-cataloguer.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Empty hood -->
+  <circle cx="16" cy="9" r="5" fill="#5E6A8C"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#2B2F3E"/>
+  <circle cx="16" cy="10" r="3" fill="#1B1D28"/>
+  <!-- Robed body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#5E6A8C"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#2B2F3E"/>
+  <!-- Ledger tucked at hip -->
+  <rect x="19.5" y="14.5" width="4" height="5" rx="1" fill="#2B2F3E"/>
+  <rect x="20" y="15.2" width="3" height="3.5" fill="#F2E9D8"/>
+  <!-- Quill hand -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#5E6A8C"/>
+  <path d="M7,14 Q4,11.5 5.5,8 Q7.4,10 8,13 Z" fill="#F2E9D8"/>
+  <circle cx="5.6" cy="8.4" r="0.7" fill="#2B2F3E"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/index-engine.svg
+++ b/web/public/sprites/index-engine.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="10" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Cabinet body -->
+  <rect x="9" y="10" width="14" height="19" rx="4" fill="#A6A9C0"/>
+  <rect x="9" y="10" width="14" height="3.4" rx="1.6" fill="#C9CBDA"/>
+  <!-- Cataloguing gear -->
+  <circle cx="16" cy="6.5" r="3" fill="#7E8299"/>
+  <circle cx="16" cy="6.5" r="1.4" fill="#C9CBDA"/>
+  <rect x="15.4" y="2.6" width="1.2" height="2" fill="#7E8299"/>
+  <!-- Bands -->
+  <rect x="9" y="16" width="14" height="1.2" fill="#7E8299"/>
+  <rect x="9" y="21" width="14" height="1.2" fill="#7E8299"/>
+  <!-- Glowing index-card window -->
+  <path d="M16,19 L18.4,22 L16,25 L13.6,22 Z" fill="#E8B94A"/>
+  <path d="M16,20.2 L17.2,22 L16,23.8 L14.8,22 Z" fill="#FFE08A"/>
+  <!-- Sealed drawer -->
+  <rect x="13.5" y="25" width="5" height="4" rx="0.8" fill="#2B2F3E"/>
+  <!-- Glow -->
+  <circle cx="16" cy="22" r="6" fill="#E8B94A" opacity="0.18"/>
+</svg>

--- a/web/public/sprites/index-warden-1.svg
+++ b/web/public/sprites/index-warden-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm (body 1px lower mid-stride) -->
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#9FA3BC"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed ledger-shield on left -->
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#F2E9D8"/>
+  <!-- Short blade -->
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="8" width="1.4" height="9" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="14" width="3.8" height="1.6" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/index-warden-2.svg
+++ b/web/public/sprites/index-warden-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#9FA3BC"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed ledger-shield on left -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#F2E9D8"/>
+  <!-- Short blade -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="7" width="1.4" height="9" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="13" width="3.8" height="1.6" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/index-warden-3.svg
+++ b/web/public/sprites/index-warden-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm (body 1px lower mid-stride) -->
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#9FA3BC"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed ledger-shield on left -->
+  <path d="M6,15 L11,15 L11,22 Q8.5,24 6,22 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="18.5" r="1.4" fill="#F2E9D8"/>
+  <!-- Short blade -->
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="8" width="1.4" height="9" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="14" width="3.8" height="1.6" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/index-warden.svg
+++ b/web/public/sprites/index-warden.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Kettle helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#9FA3BC"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#9FA3BC"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#7E8299"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#7E8299"/>
+  <!-- Sealed ledger-shield on left -->
+  <path d="M6,14 L11,14 L11,21 Q8.5,23 6,21 Z" fill="#2B2F3E"/>
+  <circle cx="8.5" cy="17.5" r="1.4" fill="#F2E9D8"/>
+  <!-- Short blade -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#9FA3BC"/>
+  <rect x="23.5" y="7" width="1.4" height="9" rx="0.7" fill="#C9CBDA"/>
+  <rect x="21.6" y="13" width="3.8" height="1.6" rx="0.4" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lamp-acolyte-1.svg
+++ b/web/public/sprites/lamp-acolyte-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Robed body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Held reading-lamp -->
+  <circle cx="7.8" cy="10" r="5" fill="#FFB347" opacity="0.15"/>
+  <rect x="7" y="11" width="1.6" height="12" rx="0.8" fill="#454E6B"/>
+  <rect x="5.5" y="8" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="7.8" cy="10" r="1" fill="#FFE08A"/>
+  <!-- Sealed book at hip -->
+  <rect x="20" y="16" width="3.5" height="4.5" rx="0.6" fill="#2B2F3E"/>
+  <rect x="20.4" y="16.4" width="2.7" height="3.7" fill="#F2E9D8"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lamp-acolyte-2.svg
+++ b/web/public/sprites/lamp-acolyte-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Robed body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Held reading-lamp -->
+  <circle cx="7.8" cy="9" r="5" fill="#FFB347" opacity="0.15"/>
+  <rect x="7" y="10" width="1.6" height="12" rx="0.8" fill="#454E6B"/>
+  <rect x="5.5" y="7" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="7.8" cy="9" r="1" fill="#FFE08A"/>
+  <!-- Sealed book at hip -->
+  <rect x="20" y="15" width="3.5" height="4.5" rx="0.6" fill="#2B2F3E"/>
+  <rect x="20.4" y="15.4" width="2.7" height="3.7" fill="#F2E9D8"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lamp-acolyte-3.svg
+++ b/web/public/sprites/lamp-acolyte-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Robed body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#7E8299"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Held reading-lamp -->
+  <circle cx="7.8" cy="10" r="5" fill="#FFB347" opacity="0.15"/>
+  <rect x="7" y="11" width="1.6" height="12" rx="0.8" fill="#454E6B"/>
+  <rect x="5.5" y="8" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="7.8" cy="10" r="1" fill="#FFE08A"/>
+  <!-- Sealed book at hip -->
+  <rect x="20" y="16" width="3.5" height="4.5" rx="0.6" fill="#2B2F3E"/>
+  <rect x="20.4" y="16.4" width="2.7" height="3.7" fill="#F2E9D8"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lamp-acolyte.svg
+++ b/web/public/sprites/lamp-acolyte.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Robed body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#7E8299"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#5E6A8C"/>
+  <!-- Held reading-lamp -->
+  <circle cx="7.8" cy="9" r="5" fill="#FFB347" opacity="0.15"/>
+  <rect x="7" y="10" width="1.6" height="12" rx="0.8" fill="#454E6B"/>
+  <rect x="5.5" y="7" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="7.8" cy="9" r="1" fill="#FFE08A"/>
+  <!-- Sealed book at hip -->
+  <rect x="20" y="15" width="3.5" height="4.5" rx="0.6" fill="#2B2F3E"/>
+  <rect x="20.4" y="15.4" width="2.7" height="3.7" fill="#F2E9D8"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lectern-archer-1.svg
+++ b/web/public/sprites/lectern-archer-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3.5 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Body -->
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <!-- Book quiver -->
+  <rect x="19.5" y="14.5" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <path d="M20.4,13 L21,14.6 L19.8,14.6 Z" fill="#F2E9D8"/>
+  <path d="M22,13 L22.6,14.6 L21.4,14.6 Z" fill="#F2E9D8"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="15" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,9 Q2.5,17.5 6.5,26" stroke="#454E6B" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="9" x2="6.5" y2="26" stroke="#C9CBDA" stroke-width="0.7"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="23" width="3.5" height="7.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29.5" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="28" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lectern-archer-2.svg
+++ b/web/public/sprites/lectern-archer-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2.5 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <!-- Book quiver -->
+  <rect x="19.5" y="13.5" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <path d="M20.4,12 L21,13.6 L19.8,13.6 Z" fill="#F2E9D8"/>
+  <path d="M22,12 L22.6,13.6 L21.4,13.6 Z" fill="#F2E9D8"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="14" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,8 Q2.5,16.5 6.5,25" stroke="#454E6B" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="8" x2="6.5" y2="25" stroke="#C9CBDA" stroke-width="0.7"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lectern-archer-3.svg
+++ b/web/public/sprites/lectern-archer-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#7E8299"/>
+  <path d="M11,10 Q16,3.5 21,10 L21,12 Q16,9 11,12 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Body -->
+  <path d="M12,15 L12,23 L20,23 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="12" y="18.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <!-- Book quiver -->
+  <rect x="19.5" y="14.5" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <path d="M20.4,13 L21,14.6 L19.8,14.6 Z" fill="#F2E9D8"/>
+  <path d="M22,13 L22.6,14.6 L21.4,14.6 Z" fill="#F2E9D8"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="15" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,9 Q2.5,17.5 6.5,26" stroke="#454E6B" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="9" x2="6.5" y2="26" stroke="#C9CBDA" stroke-width="0.7"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="23" width="3.5" height="7.5" rx="1" fill="#454E6B"/>
+  <rect x="10" y="23" width="3.5" height="6" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29.5" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="28" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/lectern-archer.svg
+++ b/web/public/sprites/lectern-archer.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#7E8299"/>
+  <path d="M11,9 Q16,2.5 21,9 L21,11 Q16,8 11,11 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="2.8" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Body -->
+  <path d="M12,14 L12,22 L20,22 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="12" y="17.5" width="8" height="1.2" fill="#5E6A8C"/>
+  <!-- Book quiver -->
+  <rect x="19.5" y="13.5" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <path d="M20.4,12 L21,13.6 L19.8,13.6 Z" fill="#F2E9D8"/>
+  <path d="M22,12 L22.6,13.6 L21.4,13.6 Z" fill="#F2E9D8"/>
+  <!-- Bow arm and bow -->
+  <rect x="7.5" y="14" width="4" height="5.5" rx="1" fill="#A6A9C0"/>
+  <path d="M6.5,8 Q2.5,16.5 6.5,25" stroke="#454E6B" stroke-width="1.5" fill="none"/>
+  <line x1="6.5" y1="8" x2="6.5" y2="25" stroke="#C9CBDA" stroke-width="0.7"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="22" width="3.5" height="8" rx="1" fill="#454E6B"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/reading-lamp.svg
+++ b/web/public/sprites/reading-lamp.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Post -->
+  <rect x="14.8" y="12" width="2.4" height="17.5" rx="1" fill="#454E6B"/>
+  <!-- Bracket arm -->
+  <rect x="9" y="13" width="7" height="1.6" rx="0.8" fill="#7E8299"/>
+  <!-- Lamp head glow -->
+  <circle cx="16" cy="9" r="7" fill="#FFB347" opacity="0.15"/>
+  <circle cx="16" cy="9" r="5" fill="#E8B94A"/>
+  <rect x="13" y="6" width="6" height="6" rx="1" fill="none" stroke="#2B2F3E" stroke-width="0.6"/>
+  <circle cx="16" cy="9" r="2.6" fill="#FFE08A"/>
+  <!-- Base -->
+  <rect x="11" y="28" width="10" height="2" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/reading-room-sentry.svg
+++ b/web/public/sprites/reading-room-sentry.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="10" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Standing carved sentinel, humanoid silhouette -->
+  <path d="M11,29 L11.5,18 Q11.5,10 16,8 Q20.5,10 20.5,18 L21,29 Z" fill="#9FA3BC"/>
+  <circle cx="16" cy="8.5" r="4" fill="#C9CBDA"/>
+  <path d="M12.3,8.5 Q16,3 19.7,8.5 L19.7,10 Q16,7.5 12.3,10 Z" fill="#454E6B"/>
+  <!-- Carved rune tallies, faintly glowing -->
+  <rect x="14" y="14" width="4" height="1.2" rx="0.6" fill="#FFB347" opacity="0.85"/>
+  <rect x="13" y="17.5" width="6" height="1.2" rx="0.6" fill="#FFB347" opacity="0.7"/>
+  <rect x="14" y="21" width="4" height="1.2" rx="0.6" fill="#FFB347" opacity="0.8"/>
+  <!-- Rune glow -->
+  <ellipse cx="16" cy="17" rx="6" ry="10" fill="#FFB347" opacity="0.1"/>
+  <!-- Chipped stone wisps -->
+  <path d="M12,26 L13.5,23 L12.8,20" stroke="#454E6B" stroke-width="0.8" fill="none"/>
+  <path d="M20.5,25 L19.4,22.5" stroke="#454E6B" stroke-width="0.8" fill="none"/>
+  <!-- Mist -->
+  <ellipse cx="16" cy="28.6" rx="8" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/register-bearer-1.svg
+++ b/web/public/sprites/register-bearer-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Helm (body 1px lower mid-stride) -->
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#7E8299"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#7E8299"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#5E6A8C"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#5E6A8C"/>
+  <!-- Sealed register carried as a shield -->
+  <rect x="5" y="14" width="6" height="11" rx="1" fill="#2B2F3E"/>
+  <rect x="6" y="15" width="4" height="9" fill="#F2E9D8"/>
+  <circle cx="8" cy="19.5" r="1.3" fill="#E8B94A"/>
+  <!-- Sealing mace -->
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#7E8299"/>
+  <circle cx="23.5" cy="11" r="3" fill="#9FA3BC"/>
+  <circle cx="22.4" cy="10" r="0.6" fill="#454E6B"/>
+  <circle cx="24.6" cy="10" r="0.6" fill="#454E6B"/>
+  <circle cx="23.5" cy="12.4" r="0.6" fill="#454E6B"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/register-bearer-2.svg
+++ b/web/public/sprites/register-bearer-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#7E8299"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#7E8299"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#5E6A8C"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#5E6A8C"/>
+  <!-- Sealed register carried as a shield -->
+  <rect x="5" y="13" width="6" height="11" rx="1" fill="#2B2F3E"/>
+  <rect x="6" y="14" width="4" height="9" fill="#F2E9D8"/>
+  <circle cx="8" cy="18.5" r="1.3" fill="#E8B94A"/>
+  <!-- Sealing mace -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#7E8299"/>
+  <circle cx="23.5" cy="10" r="3" fill="#9FA3BC"/>
+  <circle cx="22.4" cy="9" r="0.6" fill="#454E6B"/>
+  <circle cx="24.6" cy="9" r="0.6" fill="#454E6B"/>
+  <circle cx="23.5" cy="11.4" r="0.6" fill="#454E6B"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/register-bearer-3.svg
+++ b/web/public/sprites/register-bearer-3.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Helm (body 1px lower mid-stride) -->
+  <circle cx="15" cy="10" r="5" fill="#E3D9CF"/>
+  <path d="M9,10 Q15,2.5 21,10 L22,11 L8,11 Z" fill="#7E8299"/>
+  <circle cx="13.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="11.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,15 L11,24 L20,24 L20,15 Q15.5,17 11,15 Z" fill="#7E8299"/>
+  <rect x="11" y="17" width="9" height="1.2" fill="#5E6A8C"/>
+  <rect x="11" y="20" width="9" height="1.2" fill="#5E6A8C"/>
+  <!-- Sealed register carried as a shield -->
+  <rect x="5" y="14" width="6" height="11" rx="1" fill="#2B2F3E"/>
+  <rect x="6" y="15" width="4" height="9" fill="#F2E9D8"/>
+  <circle cx="8" cy="19.5" r="1.3" fill="#E8B94A"/>
+  <!-- Sealing mace -->
+  <rect x="22" y="15" width="3" height="6" rx="1" fill="#7E8299"/>
+  <circle cx="23.5" cy="11" r="3" fill="#9FA3BC"/>
+  <circle cx="22.4" cy="10" r="0.6" fill="#454E6B"/>
+  <circle cx="24.6" cy="10" r="0.6" fill="#454E6B"/>
+  <circle cx="23.5" cy="12.4" r="0.6" fill="#454E6B"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/register-bearer.svg
+++ b/web/public/sprites/register-bearer.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Helm -->
+  <circle cx="15" cy="9" r="5" fill="#E3D9CF"/>
+  <path d="M9,9 Q15,1.5 21,9 L22,10 L8,10 Z" fill="#7E8299"/>
+  <circle cx="13.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="10.5" r="0.7" fill="#2B2F3E"/>
+  <!-- Armoured body -->
+  <path d="M11,14 L11,23 L20,23 L20,14 Q15.5,16 11,14 Z" fill="#7E8299"/>
+  <rect x="11" y="16" width="9" height="1.2" fill="#5E6A8C"/>
+  <rect x="11" y="19" width="9" height="1.2" fill="#5E6A8C"/>
+  <!-- Sealed register carried as a shield -->
+  <rect x="5" y="13" width="6" height="11" rx="1" fill="#2B2F3E"/>
+  <rect x="6" y="14" width="4" height="9" fill="#F2E9D8"/>
+  <circle cx="8" cy="18.5" r="1.3" fill="#E8B94A"/>
+  <!-- Sealing mace -->
+  <rect x="22" y="14" width="3" height="6" rx="1" fill="#7E8299"/>
+  <circle cx="23.5" cy="10" r="3" fill="#9FA3BC"/>
+  <circle cx="22.4" cy="9" r="0.6" fill="#454E6B"/>
+  <circle cx="24.6" cy="9" r="0.6" fill="#454E6B"/>
+  <circle cx="23.5" cy="11.4" r="0.6" fill="#454E6B"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="16" y="23" width="3.5" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/returned-archivist-1.svg
+++ b/web/public/sprites/returned-archivist-1.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hood (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5.5" fill="#7E8299"/>
+  <path d="M10.5,10 Q16,2.5 21.5,10 L21.5,12.5 Q16,9 10.5,12.5 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Long archivist's cloak -->
+  <path d="M10,15 L9,25 L23,25 L22,15 Q16,18 10,15 Z" fill="#A6A9C0"/>
+  <path d="M10,15 L9,25 L13,25 L13.5,16.5 Z" fill="#7E8299"/>
+  <rect x="11" y="19" width="10" height="1.3" fill="#5E6A8C"/>
+  <!-- Her returned name, worn at the belt -->
+  <circle cx="16.5" cy="21.6" r="2" fill="#E8B94A"/>
+  <circle cx="16.5" cy="21.6" r="1" fill="#FFE08A"/>
+  <!-- Grand reading-lamp staff -->
+  <rect x="23" y="15" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.6" y="7" width="1.6" height="14" rx="0.8" fill="#454E6B"/>
+  <circle cx="24.9" cy="5.5" r="6" fill="#FFB347" opacity="0.15"/>
+  <rect x="22.6" y="3.5" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="24.9" cy="5.5" r="1" fill="#FFE08A"/>
+  <!-- Off hand holding a floating sealed book -->
+  <rect x="6" y="15" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <ellipse cx="6.5" cy="13" rx="2.4" ry="1.4" fill="#F2E9D8"/>
+  <line x1="6.5" y1="11.7" x2="6.5" y2="14.3" stroke="#2B2F3E" stroke-width="0.5"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="25" width="4" height="7" rx="1" fill="#454E6B"/>
+  <rect x="18" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="30.5" width="6" height="1.5" rx="0.8" fill="#3A3F55"/>
+  <rect x="17.5" y="29" width="5.5" height="1.5" rx="0.8" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/returned-archivist-2.svg
+++ b/web/public/sprites/returned-archivist-2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hood, a name given back from the stacks -->
+  <circle cx="16" cy="9" r="5.5" fill="#7E8299"/>
+  <path d="M10.5,9 Q16,1.5 21.5,9 L21.5,11.5 Q16,8 10.5,11.5 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Long archivist's cloak -->
+  <path d="M10,14 L9,24 L23,24 L22,14 Q16,17 10,14 Z" fill="#A6A9C0"/>
+  <path d="M10,14 L9,24 L13,24 L13.5,15.5 Z" fill="#7E8299"/>
+  <rect x="11" y="18" width="10" height="1.3" fill="#5E6A8C"/>
+  <!-- Her returned name, worn at the belt -->
+  <circle cx="16.5" cy="20.6" r="2" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1" fill="#FFE08A"/>
+  <!-- Grand reading-lamp staff -->
+  <rect x="23" y="14" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.6" y="6" width="1.6" height="14" rx="0.8" fill="#454E6B"/>
+  <circle cx="24.9" cy="4.5" r="6" fill="#FFB347" opacity="0.15"/>
+  <rect x="22.6" y="2.5" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="24.9" cy="4.5" r="1" fill="#FFE08A"/>
+  <!-- Off hand holding a floating sealed book -->
+  <rect x="6" y="14" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <ellipse cx="6.5" cy="12" rx="2.4" ry="1.4" fill="#F2E9D8"/>
+  <line x1="6.5" y1="10.7" x2="6.5" y2="13.3" stroke="#2B2F3E" stroke-width="0.5"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/returned-archivist-3.svg
+++ b/web/public/sprites/returned-archivist-3.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hood (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5.5" fill="#7E8299"/>
+  <path d="M10.5,10 Q16,2.5 21.5,10 L21.5,12.5 Q16,9 10.5,12.5 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Long archivist's cloak -->
+  <path d="M10,15 L9,25 L23,25 L22,15 Q16,18 10,15 Z" fill="#A6A9C0"/>
+  <path d="M10,15 L9,25 L13,25 L13.5,16.5 Z" fill="#7E8299"/>
+  <rect x="11" y="19" width="10" height="1.3" fill="#5E6A8C"/>
+  <!-- Her returned name, worn at the belt -->
+  <circle cx="16.5" cy="21.6" r="2" fill="#E8B94A"/>
+  <circle cx="16.5" cy="21.6" r="1" fill="#FFE08A"/>
+  <!-- Grand reading-lamp staff -->
+  <rect x="23" y="15" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.6" y="7" width="1.6" height="14" rx="0.8" fill="#454E6B"/>
+  <circle cx="24.9" cy="5.5" r="6" fill="#FFB347" opacity="0.15"/>
+  <rect x="22.6" y="3.5" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="24.9" cy="5.5" r="1" fill="#FFE08A"/>
+  <!-- Off hand holding a floating sealed book -->
+  <rect x="6" y="15" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <ellipse cx="6.5" cy="13" rx="2.4" ry="1.4" fill="#F2E9D8"/>
+  <line x1="6.5" y1="11.7" x2="6.5" y2="14.3" stroke="#2B2F3E" stroke-width="0.5"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="25" width="4" height="7" rx="1" fill="#454E6B"/>
+  <rect x="10" y="25" width="4" height="5.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="30.5" width="6" height="1.5" rx="0.8" fill="#3A3F55"/>
+  <rect x="9" y="29" width="5.5" height="1.5" rx="0.8" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/returned-archivist.svg
+++ b/web/public/sprites/returned-archivist.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hood, a name given back from the stacks -->
+  <circle cx="16" cy="9" r="5.5" fill="#7E8299"/>
+  <path d="M10.5,9 Q16,1.5 21.5,9 L21.5,11.5 Q16,8 10.5,11.5 Z" fill="#5E6A8C"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Long archivist's cloak -->
+  <path d="M10,14 L9,24 L23,24 L22,14 Q16,17 10,14 Z" fill="#A6A9C0"/>
+  <path d="M10,14 L9,24 L13,24 L13.5,15.5 Z" fill="#7E8299"/>
+  <rect x="11" y="18" width="10" height="1.3" fill="#5E6A8C"/>
+  <!-- Her returned name, worn at the belt -->
+  <circle cx="16.5" cy="20.6" r="2" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1" fill="#FFE08A"/>
+  <!-- Grand reading-lamp staff -->
+  <rect x="23" y="14" width="3.5" height="6.5" rx="1" fill="#A6A9C0"/>
+  <rect x="24.6" y="6" width="1.6" height="14" rx="0.8" fill="#454E6B"/>
+  <circle cx="24.9" cy="4.5" r="6" fill="#FFB347" opacity="0.15"/>
+  <rect x="22.6" y="2.5" width="4.6" height="4" rx="1" fill="#E8B94A"/>
+  <circle cx="24.9" cy="4.5" r="1" fill="#FFE08A"/>
+  <!-- Off hand holding a floating sealed book -->
+  <rect x="6" y="14" width="3.5" height="6" rx="1" fill="#A6A9C0"/>
+  <ellipse cx="6.5" cy="12" rx="2.4" ry="1.4" fill="#F2E9D8"/>
+  <line x1="6.5" y1="10.7" x2="6.5" y2="13.3" stroke="#2B2F3E" stroke-width="0.5"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/sealed-courier-1.svg
+++ b/web/public/sprites/sealed-courier-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Gallop pose A: legs gathered -->
+  <path d="M5,23 L7,16 Q9,13 13,14 L21,14 Q25,14 26,17 L27,21 L25,23 Z" fill="#C9CBDA"/>
+  <path d="M24,15 L29,11 L30,13 L27,17 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="13" r="0.7" fill="#3A3F55"/>
+  <path d="M22,13 Q24,10 27,11 L25,14 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="7.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="6" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,6 Q16,1.5 19.4,6 L19.4,7.4 Q16,5 12.6,7.4 Z" fill="#2B2F3E"/>
+  <rect x="19.5" y="5" width="1.2" height="14" rx="0.6" fill="#2B2F3E" transform="rotate(18 20 12)"/>
+  <path d="M24.6,3.6 L26.4,6.4 L23.2,6.6 Z" fill="#F2E9D8"/>
+  <circle cx="26.6" cy="7.8" r="1.6" fill="#E8B94A"/>
+  <!-- Legs gathered under body -->
+  <rect x="9.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(18 10.7 26)"/>
+  <rect x="13" y="23" width="2.4" height="7" rx="1" fill="#A6A9C0" transform="rotate(8 14.2 26.5)"/>
+  <rect x="18" y="23" width="2.4" height="7" rx="1" fill="#A6A9C0" transform="rotate(-8 19.2 26.5)"/>
+  <rect x="21.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(-18 22.7 26)"/>
+  <path d="M5.5,17 Q2.5,19 3.5,23 Q5,21 6.5,20.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/sealed-courier-2.svg
+++ b/web/public/sprites/sealed-courier-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadowless void-bred horse, side view -->
+  <path d="M5,22 L7,15 Q9,12 13,13 L21,13 Q25,13 26,16 L27,20 L25,22 Z" fill="#C9CBDA"/>
+  <!-- Horse head -->
+  <path d="M24,14 L29,10 L30,12 L27,16 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="12" r="0.7" fill="#3A3F55"/>
+  <!-- Mane of mist -->
+  <path d="M22,12 Q24,9 27,10 L25,13 Z" fill="#E8EAF4" opacity="0.8"/>
+  <!-- Rider torso -->
+  <rect x="13" y="6.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="5" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,5 Q16,0.5 19.4,5 L19.4,6.4 Q16,4 12.6,6.4 Z" fill="#2B2F3E"/>
+  <!-- Sealed scroll-case slung across her back, wax-seal pennant -->
+  <rect x="19.5" y="4" width="1.2" height="14" rx="0.6" fill="#2B2F3E" transform="rotate(18 20 11)"/>
+  <path d="M24.6,2.6 L26.4,5.4 L23.2,5.6 Z" fill="#F2E9D8"/>
+  <circle cx="26.6" cy="6.8" r="1.6" fill="#E8B94A"/>
+  <!-- Horse legs (standing) -->
+  <rect x="7" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <rect x="12" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="19" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <!-- Tail -->
+  <path d="M5.5,16 Q2.5,18 3.5,22 Q5,20 6.5,19.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/sealed-courier-3.svg
+++ b/web/public/sprites/sealed-courier-3.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Gallop pose B: legs extended -->
+  <path d="M5,23 L7,16 Q9,13 13,14 L21,14 Q25,14 26,17 L27,21 L25,23 Z" fill="#C9CBDA"/>
+  <path d="M24,15 L29,11 L30,13 L27,17 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="13" r="0.7" fill="#3A3F55"/>
+  <path d="M22,13 Q24,10 27,11 L25,14 Z" fill="#E8EAF4" opacity="0.8"/>
+  <rect x="13" y="7.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="6" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,6 Q16,1.5 19.4,6 L19.4,7.4 Q16,5 12.6,7.4 Z" fill="#2B2F3E"/>
+  <rect x="19.5" y="5" width="1.2" height="14" rx="0.6" fill="#2B2F3E" transform="rotate(18 20 12)"/>
+  <path d="M24.6,3.6 L26.4,6.4 L23.2,6.6 Z" fill="#F2E9D8"/>
+  <circle cx="26.6" cy="7.8" r="1.6" fill="#E8B94A"/>
+  <!-- Legs stretched fore and aft -->
+  <rect x="5.5" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(-24 6.7 26)"/>
+  <rect x="11" y="23.5" width="2.4" height="6.5" rx="1" fill="#A6A9C0" transform="rotate(10 12.2 26.75)"/>
+  <rect x="20" y="23.5" width="2.4" height="6.5" rx="1" fill="#A6A9C0" transform="rotate(-10 21.2 26.75)"/>
+  <rect x="25" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0" transform="rotate(24 26.2 26)"/>
+  <path d="M5.5,17 Q2.5,19 3.5,23 Q5,21 6.5,20.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/sealed-courier.svg
+++ b/web/public/sprites/sealed-courier.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Shadowless void-bred horse, side view -->
+  <path d="M5,22 L7,15 Q9,12 13,13 L21,13 Q25,13 26,16 L27,20 L25,22 Z" fill="#C9CBDA"/>
+  <!-- Horse head -->
+  <path d="M24,14 L29,10 L30,12 L27,16 Z" fill="#C9CBDA"/>
+  <circle cx="27.8" cy="12" r="0.7" fill="#3A3F55"/>
+  <!-- Mane of mist -->
+  <path d="M22,12 Q24,9 27,10 L25,13 Z" fill="#E8EAF4" opacity="0.8"/>
+  <!-- Rider torso -->
+  <rect x="13" y="6.5" width="6" height="8" rx="2" fill="#454E6B"/>
+  <circle cx="16" cy="5" r="3.4" fill="#E3D9CF"/>
+  <path d="M12.6,5 Q16,0.5 19.4,5 L19.4,6.4 Q16,4 12.6,6.4 Z" fill="#2B2F3E"/>
+  <!-- Sealed scroll-case slung across her back, wax-seal pennant -->
+  <rect x="19.5" y="4" width="1.2" height="14" rx="0.6" fill="#2B2F3E" transform="rotate(18 20 11)"/>
+  <path d="M24.6,2.6 L26.4,5.4 L23.2,5.6 Z" fill="#F2E9D8"/>
+  <circle cx="26.6" cy="6.8" r="1.6" fill="#E8B94A"/>
+  <!-- Horse legs (standing) -->
+  <rect x="7" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <rect x="12" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="19" y="22" width="2.4" height="8" rx="1" fill="#A6A9C0"/>
+  <rect x="23.5" y="21" width="2.4" height="9" rx="1" fill="#A6A9C0"/>
+  <!-- Tail -->
+  <path d="M5.5,16 Q2.5,18 3.5,22 Q5,20 6.5,19.5 Z" fill="#E8EAF4" opacity="0.8"/>
+</svg>

--- a/web/public/sprites/sealed-stack.svg
+++ b/web/public/sprites/sealed-stack.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="10" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Stacked sealed registers -->
+  <rect x="8" y="24" width="16" height="5" rx="0.8" fill="#7E8299"/>
+  <rect x="9.5" y="18.5" width="13" height="5.5" rx="0.8" fill="#A6A9C0"/>
+  <rect x="11" y="13" width="10" height="5.5" rx="0.8" fill="#C9CBDA"/>
+  <rect x="12.5" y="8" width="7" height="5" rx="0.8" fill="#F2E9D8"/>
+  <!-- Sealing bands -->
+  <rect x="14" y="10" width="4" height="1.2" rx="0.6" fill="#2B2F3E" opacity="0.85"/>
+  <rect x="13" y="15.3" width="6" height="1.2" rx="0.6" fill="#2B2F3E" opacity="0.75"/>
+  <rect x="12" y="20.6" width="8" height="1.2" rx="0.6" fill="#2B2F3E" opacity="0.7"/>
+  <rect x="11" y="26" width="10" height="1.2" rx="0.6" fill="#2B2F3E" opacity="0.65"/>
+  <!-- Wax seals -->
+  <circle cx="16" cy="10.6" r="0.7" fill="#E8B94A"/>
+  <circle cx="16" cy="15.9" r="0.7" fill="#E8B94A"/>
+  <!-- Mist -->
+  <ellipse cx="16" cy="28.6" rx="8" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/shelf-barricade.svg
+++ b/web/public/sprites/shelf-barricade.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="13" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Row of toppled shelf-boards -->
+  <rect x="5" y="12" width="5" height="17" rx="0.6" fill="#A6A9C0"/>
+  <rect x="11" y="10" width="5" height="19" rx="0.6" fill="#C9CBDA"/>
+  <rect x="17" y="11" width="5" height="18" rx="0.6" fill="#A6A9C0"/>
+  <rect x="23" y="13" width="5" height="16" rx="0.6" fill="#C9CBDA"/>
+  <!-- Grain of the shelving -->
+  <line x1="7.5" y1="14" x2="7.5" y2="27" stroke="#7E8299" stroke-width="0.7"/>
+  <line x1="13.5" y1="12" x2="13.5" y2="27" stroke="#7E8299" stroke-width="0.7"/>
+  <line x1="19.5" y1="13" x2="19.5" y2="27" stroke="#7E8299" stroke-width="0.7"/>
+  <line x1="25.5" y1="15" x2="25.5" y2="27" stroke="#7E8299" stroke-width="0.7"/>
+  <!-- Iron cross-rails -->
+  <rect x="4" y="17" width="25" height="1.6" rx="0.8" fill="#2B2F3E"/>
+  <rect x="4" y="23" width="25" height="1.6" rx="0.8" fill="#2B2F3E"/>
+  <!-- Mist drifting through -->
+  <ellipse cx="10" cy="27.5" rx="6" ry="1.4" fill="#E8EAF4" opacity="0.45"/>
+  <ellipse cx="22" cy="28.2" rx="5" ry="1.2" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/stack-runner-1.svg
+++ b/web/public/sprites/stack-runner-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#A6A9C0"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#454E6B"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Slim robed body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Scroll satchel on back -->
+  <rect x="19.5" y="15.5" width="4" height="5" rx="1" fill="#454E6B"/>
+  <ellipse cx="21.5" cy="15.3" rx="2.2" ry="1" fill="#F2E9D8"/>
+  <rect x="20" y="16.2" width="3" height="1.2" fill="#E8DCA8"/>
+  <!-- Rolled parchment baton -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="6.4" y="13.3" width="4.6" height="2" rx="1" fill="#F2E9D8"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="24" width="3.5" height="7" rx="1" fill="#2B2F3E"/>
+  <rect x="18" y="24" width="3.5" height="5.5" rx="1" fill="#2B2F3E"/>
+  <rect x="9" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="18" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stack-runner-2.svg
+++ b/web/public/sprites/stack-runner-2.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#A6A9C0"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#454E6B"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Slim robed body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Scroll satchel on back -->
+  <rect x="19.5" y="14.5" width="4" height="5" rx="1" fill="#454E6B"/>
+  <ellipse cx="21.5" cy="14.3" rx="2.2" ry="1" fill="#F2E9D8"/>
+  <rect x="20" y="15.2" width="3" height="1.2" fill="#E8DCA8"/>
+  <!-- Rolled parchment baton -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="6.4" y="12.3" width="4.6" height="2" rx="1" fill="#F2E9D8"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#2B2F3E"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stack-runner-3.svg
+++ b/web/public/sprites/stack-runner-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5" fill="#A6A9C0"/>
+  <path d="M11,10 Q16,3 21,10 L21,12 Q16,9 11,12 Z" fill="#454E6B"/>
+  <circle cx="16" cy="11" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="11" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="11" r="0.7" fill="#2B2F3E"/>
+  <!-- Slim robed body -->
+  <path d="M12,15 L11,24 L21,24 L20,15 Q16,17 12,15 Z" fill="#A6A9C0"/>
+  <rect x="13" y="18" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Scroll satchel on back -->
+  <rect x="19.5" y="15.5" width="4" height="5" rx="1" fill="#454E6B"/>
+  <ellipse cx="21.5" cy="15.3" rx="2.2" ry="1" fill="#F2E9D8"/>
+  <rect x="20" y="16.2" width="3" height="1.2" fill="#E8DCA8"/>
+  <!-- Rolled parchment baton -->
+  <rect x="8" y="15" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="6.4" y="13.3" width="4.6" height="2" rx="1" fill="#F2E9D8"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="24" width="3.5" height="7" rx="1" fill="#2B2F3E"/>
+  <rect x="10" y="24" width="3.5" height="5.5" rx="1" fill="#2B2F3E"/>
+  <rect x="18" y="29" width="5.5" height="2.6" rx="1" fill="#3A3F55"/>
+  <rect x="9" y="27.5" width="5" height="2.6" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stack-runner.svg
+++ b/web/public/sprites/stack-runner.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hooded head -->
+  <circle cx="16" cy="9" r="5" fill="#A6A9C0"/>
+  <path d="M11,9 Q16,2 21,9 L21,11 Q16,8 11,11 Z" fill="#454E6B"/>
+  <circle cx="16" cy="10" r="3" fill="#E3D9CF"/>
+  <circle cx="15" cy="10" r="0.7" fill="#2B2F3E"/>
+  <circle cx="17.5" cy="10" r="0.7" fill="#2B2F3E"/>
+  <!-- Slim robed body -->
+  <path d="M12,14 L11,23 L21,23 L20,14 Q16,16 12,14 Z" fill="#A6A9C0"/>
+  <rect x="13" y="17" width="6" height="1.2" fill="#454E6B"/>
+  <!-- Scroll satchel on back -->
+  <rect x="19.5" y="14.5" width="4" height="5" rx="1" fill="#454E6B"/>
+  <ellipse cx="21.5" cy="14.3" rx="2.2" ry="1" fill="#F2E9D8"/>
+  <rect x="20" y="15.2" width="3" height="1.2" fill="#E8DCA8"/>
+  <!-- Rolled parchment baton -->
+  <rect x="8" y="14" width="3" height="6" rx="1" fill="#A6A9C0"/>
+  <rect x="6.4" y="12.3" width="4.6" height="2" rx="1" fill="#F2E9D8"/>
+  <!-- Legs (neutral) -->
+  <rect x="12" y="23" width="3.5" height="7" rx="1" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="3.5" height="7" rx="1" fill="#2B2F3E"/>
+  <rect x="11" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+  <rect x="16" y="28" width="5.5" height="3" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stackbound-knight-1.svg
+++ b/web/public/sprites/stackbound-knight-1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,10 Q16,3 21.5,10 L21.5,12 L10.5,12 Z" fill="#7E8299"/>
+  <path d="M15,3.5 Q16,1 17,3.5 L16.8,6 L15.2,6 Z" fill="#E8B94A"/>
+  <rect x="12" y="9.5" width="8" height="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,15 L10,25 L22,25 L22,15 Q16,17.5 10,15 Z" fill="#9FA3BC"/>
+  <rect x="10" y="18" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="21.5" width="12" height="1.3" fill="#7E8299"/>
+  <!-- Sealed-shelf sigil -->
+  <circle cx="16" cy="19.8" r="2.1" fill="#E8B94A"/>
+  <circle cx="16" cy="19.8" r="1.1" fill="#FFE08A"/>
+  <!-- Book-shield -->
+  <rect x="4.5" y="14" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="15" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <circle cx="7.2" cy="19" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="15" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="7" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="20.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs stride A -->
+  <rect x="10" y="25" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="18" y="25" width="4" height="5" rx="1" fill="#454E6B"/>
+  <rect x="9" y="30.5" width="6" height="1.5" rx="0.8" fill="#3A3F55"/>
+  <rect x="17.5" y="29" width="5.5" height="1.5" rx="0.8" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stackbound-knight-2.svg
+++ b/web/public/sprites/stackbound-knight-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm -->
+  <circle cx="16" cy="9" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,9 Q16,2 21.5,9 L21.5,11 L10.5,11 Z" fill="#7E8299"/>
+  <path d="M15,2.5 Q16,0 17,2.5 L16.8,5 L15.2,5 Z" fill="#E8B94A"/>
+  <rect x="12" y="8.5" width="8" height="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,14 L10,24 L22,24 L22,14 Q16,16.5 10,14 Z" fill="#9FA3BC"/>
+  <rect x="10" y="17" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="20.5" width="12" height="1.3" fill="#7E8299"/>
+  <!-- Sealed-shelf sigil -->
+  <circle cx="16" cy="18.8" r="2.1" fill="#E8B94A"/>
+  <circle cx="16" cy="18.8" r="1.1" fill="#FFE08A"/>
+  <!-- Book-shield -->
+  <rect x="4.5" y="13" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="14" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <circle cx="7.2" cy="18" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="14" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="6" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="19.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stackbound-knight-3.svg
+++ b/web/public/sprites/stackbound-knight-3.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm (body 1px lower mid-stride) -->
+  <circle cx="16" cy="10" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,10 Q16,3 21.5,10 L21.5,12 L10.5,12 Z" fill="#7E8299"/>
+  <path d="M15,3.5 Q16,1 17,3.5 L16.8,6 L15.2,6 Z" fill="#E8B94A"/>
+  <rect x="12" y="9.5" width="8" height="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="10.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="10.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,15 L10,25 L22,25 L22,15 Q16,17.5 10,15 Z" fill="#9FA3BC"/>
+  <rect x="10" y="18" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="21.5" width="12" height="1.3" fill="#7E8299"/>
+  <!-- Sealed-shelf sigil -->
+  <circle cx="16" cy="19.8" r="2.1" fill="#E8B94A"/>
+  <circle cx="16" cy="19.8" r="1.1" fill="#FFE08A"/>
+  <!-- Book-shield -->
+  <rect x="4.5" y="14" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="15" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <circle cx="7.2" cy="19" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="15" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="7" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="20.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="25" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10" y="25" width="4" height="5" rx="1" fill="#454E6B"/>
+  <rect x="17" y="30.5" width="6" height="1.5" rx="0.8" fill="#3A3F55"/>
+  <rect x="9" y="29" width="5.5" height="1.5" rx="0.8" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/stackbound-knight.svg
+++ b/web/public/sprites/stackbound-knight.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Heavy plumed helm -->
+  <circle cx="16" cy="9" r="5.5" fill="#9FA3BC"/>
+  <path d="M10.5,9 Q16,2 21.5,9 L21.5,11 L10.5,11 Z" fill="#7E8299"/>
+  <path d="M15,2.5 Q16,0 17,2.5 L16.8,5 L15.2,5 Z" fill="#E8B94A"/>
+  <rect x="12" y="8.5" width="8" height="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="9.5" r="0.7" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.7" fill="#FFB347"/>
+  <!-- Broad plate body -->
+  <path d="M10,14 L10,24 L22,24 L22,14 Q16,16.5 10,14 Z" fill="#9FA3BC"/>
+  <rect x="10" y="17" width="12" height="1.3" fill="#7E8299"/>
+  <rect x="10" y="20.5" width="12" height="1.3" fill="#7E8299"/>
+  <!-- Sealed-shelf sigil -->
+  <circle cx="16" cy="18.8" r="2.1" fill="#E8B94A"/>
+  <circle cx="16" cy="18.8" r="1.1" fill="#FFE08A"/>
+  <!-- Book-shield -->
+  <rect x="4.5" y="13" width="5.5" height="10" rx="1.5" fill="#454E6B"/>
+  <rect x="5.5" y="14" width="3.5" height="8" rx="1" fill="#2B2F3E"/>
+  <circle cx="7.2" cy="18" r="1.2" fill="#E8B94A"/>
+  <!-- Greatsword -->
+  <rect x="22.5" y="14" width="3.5" height="6.5" rx="1" fill="#9FA3BC"/>
+  <rect x="24.2" y="6" width="1.8" height="15" rx="0.9" fill="#C9CBDA"/>
+  <rect x="22.8" y="19.6" width="4.6" height="1.5" rx="0.7" fill="#E8B94A"/>
+  <!-- Legs (neutral) -->
+  <rect x="11.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="16.5" y="24" width="4" height="6.5" rx="1" fill="#454E6B"/>
+  <rect x="10.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+  <rect x="15.5" y="28.5" width="6" height="2.8" rx="1" fill="#3A3F55"/>
+</svg>

--- a/web/public/sprites/the-name-eater-1.svg
+++ b/web/public/sprites/the-name-eater-1.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride A: hook sways back -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(4 25.8 16)"/>
+  <path d="M26.6,3.5 Q32.5,5 30.5,10.5 Q27.8,7.5 26.6,3.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="4" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,4.5 Q13,1 15,4 Q16,1.5 17,4 Q19,1 21,4.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="1.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#454E6B"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#F2E9D8"/>
+  <!-- Legs stride A -->
+  <rect x="9.5" y="28" width="4.5" height="3.6" rx="1" fill="#2B2F3E"/>
+  <rect x="18.5" y="28" width="4.5" height="2.8" rx="1" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-name-eater-2.svg
+++ b/web/public/sprites/the-name-eater-2.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Binding-hook pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,2.5 Q32.5,4 30.5,9.5 Q27.8,6.5 26.6,2.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="3" r="0.9" fill="#E8B94A"/>
+  <!-- Ink-dark head-mass, crowned in loose pages -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,3.5 Q13,0 15,3 Q16,0.5 17,3 Q19,0 21,3.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="0.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <!-- Massive cloaked body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#454E6B"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#2B2F3E"/>
+  <!-- Sealed-name chest sigil -->
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <!-- Ledger-scale held out -->
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#F2E9D8"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-name-eater-3.svg
+++ b/web/public/sprites/the-name-eater-3.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Stride B: hook sways forward -->
+  <rect x="25" y="3" width="1.6" height="26" rx="0.8" fill="#7E8299" transform="rotate(-4 25.8 16)"/>
+  <path d="M26.6,3.5 Q32.5,5 30.5,10.5 Q27.8,7.5 26.6,3.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="4" r="0.9" fill="#E8B94A"/>
+  <rect x="10.5" y="4.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,4.5 Q13,1 15,4 Q16,1.5 17,4 Q19,1 21,4.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="1.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="2.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="8.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="9.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="9.5" r="0.8" fill="#FFB347"/>
+  <path d="M8,14 L7,28 L25,28 L24,14 Q16,17.5 8,14 Z" fill="#454E6B"/>
+  <path d="M8,14 L7,28 L11,28 L11.5,15.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="18" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="22" width="15" height="1.4" fill="#2B2F3E"/>
+  <circle cx="16.5" cy="20.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="20.6" r="1.1" fill="#FFE08A"/>
+  <circle cx="8.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="15" r="3.2" fill="#2B2F3E"/>
+  <rect x="1.5" y="19.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="17" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="18.2" x2="1.4" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,21.4 Q1.4,23.6 3.4,21.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="18.2" x2="6.6" y2="21.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,21.4 Q6.6,23.6 8.6,21.4 Z" fill="#F2E9D8"/>
+  <!-- Legs stride B -->
+  <rect x="18" y="28" width="4.5" height="3.6" rx="1" fill="#2B2F3E"/>
+  <rect x="9" y="28" width="4.5" height="2.8" rx="1" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="30.5" rx="11" ry="1.5" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-name-eater.svg
+++ b/web/public/sprites/the-name-eater.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Binding-hook pole -->
+  <rect x="25" y="2" width="1.6" height="26" rx="0.8" fill="#7E8299"/>
+  <path d="M26.6,2.5 Q32.5,4 30.5,9.5 Q27.8,6.5 26.6,2.5 Z" fill="#C9CBDA"/>
+  <circle cx="26.6" cy="3" r="0.9" fill="#E8B94A"/>
+  <!-- Ink-dark head-mass, crowned in loose pages -->
+  <rect x="10.5" y="3.5" width="11" height="9" rx="2.5" fill="#2B2F3E"/>
+  <path d="M11,3.5 Q13,0 15,3 Q16,0.5 17,3 Q19,0 21,3.5 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <circle cx="16" cy="0.8" r="0.9" fill="#FFE08A"/>
+  <circle cx="19.5" cy="1.6" r="0.9" fill="#FFE08A"/>
+  <rect x="11.5" y="7.5" width="9" height="2" fill="#454E6B"/>
+  <circle cx="14" cy="8.5" r="0.8" fill="#FFB347"/>
+  <circle cx="18" cy="8.5" r="0.8" fill="#FFB347"/>
+  <!-- Massive cloaked body -->
+  <path d="M8,13 L7,27 L25,27 L24,13 Q16,16.5 8,13 Z" fill="#454E6B"/>
+  <path d="M8,13 L7,27 L11,27 L11.5,14.5 Z" fill="#2B2F3E"/>
+  <rect x="9" y="17" width="15" height="1.4" fill="#2B2F3E"/>
+  <rect x="9" y="21" width="15" height="1.4" fill="#2B2F3E"/>
+  <!-- Sealed-name chest sigil -->
+  <circle cx="16.5" cy="19.6" r="2.1" fill="#E8B94A"/>
+  <circle cx="16.5" cy="19.6" r="1.1" fill="#FFE08A"/>
+  <!-- Pauldrons -->
+  <circle cx="8.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <circle cx="23.5" cy="14" r="3.2" fill="#2B2F3E"/>
+  <!-- Ledger-scale held out -->
+  <rect x="1.5" y="18.5" width="1.2" height="7" fill="#7E8299"/>
+  <rect x="0" y="16" width="8" height="1.2" rx="0.6" fill="#2B2F3E"/>
+  <line x1="1.4" y1="17.2" x2="1.4" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M-0.6,20.4 Q1.4,22.6 3.4,20.4 Z" fill="#F2E9D8"/>
+  <line x1="6.6" y1="17.2" x2="6.6" y2="20.4" stroke="#7E8299" stroke-width="0.5"/>
+  <path d="M4.6,20.4 Q6.6,22.6 8.6,20.4 Z" fill="#F2E9D8"/>
+  <!-- Legs -->
+  <rect x="11" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <rect x="17" y="27" width="4.5" height="4" rx="1" fill="#2B2F3E"/>
+  <!-- Mist at feet -->
+  <ellipse cx="16" cy="30" rx="11" ry="1.8" fill="#E8EAF4" opacity="0.4"/>
+</svg>

--- a/web/public/sprites/the-unbound-index-1.svg
+++ b/web/public/sprites/the-unbound-index-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drift phase A: mass leans left, wisps trail right -->
+  <ellipse cx="15" cy="19" rx="12" ry="7" fill="#F2E9D8" opacity="0.5"/>
+  <ellipse cx="11" cy="16" rx="7" ry="5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="20" cy="15" rx="6" ry="4.5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="15" cy="13" rx="8" ry="5" fill="#FBF6EA" opacity="0.8"/>
+  <ellipse cx="15" cy="16" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <rect x="14.4" y="13" width="1.2" height="10" rx="0.6" fill="#2B2F3E"/>
+  <path d="M15,13 Q21,11.5 20,17.5 Q17,15.5 15,13 Z" fill="#F2E9D8"/>
+  <circle cx="12.5" cy="15" r="1.1" fill="#E8B94A"/>
+  <circle cx="17.5" cy="15" r="1.1" fill="#E8B94A"/>
+  <circle cx="12.5" cy="14.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="17.5" cy="14.7" r="0.4" fill="#FFE08A"/>
+  <path d="M24,20 Q27.5,22 27,25.5 Q25,23.5 23.5,23 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M7,23 Q5,26 7.5,28 Q8.5,25.5 10,24.5 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M15,25 Q14,28.5 17,30 Q18,27.5 19,26 Z" fill="#F2E9D8" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-unbound-index-2.svg
+++ b/web/public/sprites/the-unbound-index-2.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drifting cloud of unbound pages -->
+  <ellipse cx="16" cy="18" rx="12" ry="7" fill="#F2E9D8" opacity="0.5"/>
+  <ellipse cx="12" cy="15" rx="7" ry="5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="21" cy="14" rx="6" ry="4.5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="16" cy="12" rx="8" ry="5" fill="#FBF6EA" opacity="0.8"/>
+  <ellipse cx="16" cy="15" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <rect x="15.4" y="12" width="1.2" height="10" rx="0.6" fill="#2B2F3E"/>
+  <path d="M16,12 Q22,10.5 21,16.5 Q18,14.5 16,12 Z" fill="#F2E9D8"/>
+  <circle cx="13.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="18.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="13.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="18.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <path d="M6,22 Q4,25 6.5,27 Q7.5,24.5 9,23.5 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M26,22 Q28,25 25.5,27 Q24.5,24.5 23,23.5 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M14,24 Q13,27.5 16,29 Q17,26.5 18,25 Z" fill="#F2E9D8" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-unbound-index-3.svg
+++ b/web/public/sprites/the-unbound-index-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drift phase B: mass leans right, wisps trail left -->
+  <ellipse cx="17" cy="17" rx="12" ry="7" fill="#F2E9D8" opacity="0.5"/>
+  <ellipse cx="13" cy="14" rx="7" ry="5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="22" cy="13" rx="6" ry="4.5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="17" cy="11" rx="8" ry="5" fill="#FBF6EA" opacity="0.8"/>
+  <ellipse cx="17" cy="14" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <rect x="16.4" y="11" width="1.2" height="10" rx="0.6" fill="#2B2F3E"/>
+  <path d="M17,11 Q23,9.5 22,15.5 Q19,13.5 17,11 Z" fill="#F2E9D8"/>
+  <circle cx="14.5" cy="12" r="1.1" fill="#E8B94A"/>
+  <circle cx="19.5" cy="12" r="1.1" fill="#E8B94A"/>
+  <circle cx="14.5" cy="11.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="19.5" cy="11.7" r="0.4" fill="#FFE08A"/>
+  <path d="M5,21 Q1.5,23 2,26.5 Q4,24.5 5.5,24 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M25,24 Q23,27 25.5,29 Q26.5,26.5 28,25.5 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M17,24 Q16,27.5 19,29 Q20,26.5 21,25 Z" fill="#F2E9D8" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/the-unbound-index.svg
+++ b/web/public/sprites/the-unbound-index.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Drifting cloud of unbound pages -->
+  <ellipse cx="16" cy="18" rx="12" ry="7" fill="#F2E9D8" opacity="0.5"/>
+  <ellipse cx="12" cy="15" rx="7" ry="5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="21" cy="14" rx="6" ry="4.5" fill="#F2E9D8" opacity="0.65"/>
+  <ellipse cx="16" cy="12" rx="8" ry="5" fill="#FBF6EA" opacity="0.8"/>
+  <!-- Deep core -->
+  <ellipse cx="16" cy="15" rx="5" ry="3.6" fill="#A6A9C0" opacity="0.6"/>
+  <!-- Spectral quill carried within -->
+  <rect x="15.4" y="12" width="1.2" height="10" rx="0.6" fill="#2B2F3E"/>
+  <path d="M16,12 Q22,10.5 21,16.5 Q18,14.5 16,12 Z" fill="#F2E9D8"/>
+  <!-- Two candle-gold eyes -->
+  <circle cx="13.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="18.5" cy="13" r="1.1" fill="#E8B94A"/>
+  <circle cx="13.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <circle cx="18.5" cy="12.7" r="0.4" fill="#FFE08A"/>
+  <!-- Trailing page wisps -->
+  <path d="M6,22 Q4,25 6.5,27 Q7.5,24.5 9,23.5 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M26,22 Q28,25 25.5,27 Q24.5,24.5 23,23.5 Z" fill="#F2E9D8" opacity="0.5"/>
+  <path d="M14,24 Q13,27.5 16,29 Q17,26.5 18,25 Z" fill="#F2E9D8" opacity="0.45"/>
+</svg>

--- a/web/public/sprites/watch-lectern.svg
+++ b/web/public/sprites/watch-lectern.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Ground -->
+  <ellipse cx="16" cy="29.5" rx="9" ry="2" fill="#7E8299" opacity="0.5"/>
+  <!-- Tall timber tower -->
+  <path d="M11.5,29 L13,9 L19,9 L20.5,29 Z" fill="#9FA3BC"/>
+  <path d="M13,9 L19,9 L18.6,14 L13.4,14 Z" fill="#C9CBDA"/>
+  <rect x="12.6" y="19" width="6.8" height="1" fill="#7E8299"/>
+  <rect x="12.2" y="24" width="7.6" height="1" fill="#7E8299"/>
+  <!-- Arrow slit -->
+  <rect x="15.4" y="16" width="1.2" height="4" rx="0.6" fill="#2B2F3E"/>
+  <!-- Lectern platform -->
+  <rect x="10.5" y="7.4" width="11" height="2" rx="0.8" fill="#454E6B"/>
+  <!-- Open book watcher on top -->
+  <path d="M9,5.6 L16,4.2 L16,6.6 L9,7.4 Z" fill="#F2E9D8"/>
+  <path d="M23,5.6 L16,4.2 L16,6.6 L23,7.4 Z" fill="#E3D9CF"/>
+  <rect x="15.4" y="4" width="1.2" height="3" fill="#2B2F3E"/>
+  <circle cx="16" cy="5.2" r="1.1" fill="#FFB347"/>
+  <!-- Glow -->
+  <circle cx="16" cy="5.2" r="5.5" fill="#FFB347" opacity="0.2"/>
+  <!-- Crenellation -->
+  <rect x="10.5" y="6" width="2" height="1.6" fill="#454E6B"/>
+  <rect x="19.5" y="6" width="2" height="1.6" fill="#454E6B"/>
+</svg>

--- a/web/src/components/admin/CampaignAdminScreen.tsx
+++ b/web/src/components/admin/CampaignAdminScreen.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const ACT_IDS = [
   'act1','act2','act3','act4','act5','act6','act7',
-  'act8','act9','act10','act11','act12','act13','actfinale','c2act1','c2act2','c2act3',
+  'act8','act9','act10','act11','act12','act13','actfinale','c2act1','c2act2','c2act3','c2act4',
 ]
 const NODE_TYPES: NodeType[] = ['battle', 'elite', 'boss', 'rest', 'event', 'merchant']
 

--- a/web/src/data/acts/c2act3.json
+++ b/web/src/data/acts/c2act3.json
@@ -1,5 +1,6 @@
 {
   "id": "c2act3",
+  "nextActId": "c2act4",
   "title": "ACT III",
   "subtitle": "The Unremembered Fields",
   "rewardRelic": "Sheaf of Names",

--- a/web/src/data/acts/c2act4.json
+++ b/web/src/data/acts/c2act4.json
@@ -1,0 +1,551 @@
+{
+  "id": "c2act4",
+  "title": "ACT IV",
+  "subtitle": "The Archive of Names",
+  "rewardRelic": "Index of the Lost",
+  "rewardRelicDesc": "All friendly units gain +2 attack and +4 max HP — you carry the shape of what the Archive lost, and it carries you back.",
+  "environment": "vault",
+  "rewardTags": [
+    "forgotten",
+    "archive"
+  ],
+  "replayModifiers": [
+    {
+      "type": "enemyHpPercent",
+      "value": 15,
+      "label": "+15% enemy HP"
+    },
+    {
+      "type": "enemyIntervalReduction",
+      "value": 500,
+      "label": "Enemies act faster"
+    },
+    {
+      "type": "enemyHandBonus",
+      "value": 1,
+      "label": "Enemies start +1 card"
+    },
+    {
+      "type": "crystalBonus",
+      "value": 10,
+      "label": "+10 crystals per battle"
+    },
+    {
+      "type": "enemyHpPercent",
+      "value": 25,
+      "label": "+25% enemy HP"
+    }
+  ],
+  "startNodeIds": [
+    "threshold-stacks"
+  ],
+  "variantPools": {
+    "jarvMoods": [
+      "Now, past the last granary of the fields, carrying a sheaf that has not once stopped being warm.",
+      "Now, the Worldmender, walking into a hall that shelves the things a kingdom refused to let stay lost.",
+      "Now, wondering what it costs a place to keep every name the world dropped, and never once put one back.",
+      "Now, past the Gleaner Queen's fall, learning that the fields were only the outer wall of something far larger."
+    ],
+    "archiveDesc": [
+      "The Archive of Names runs further than the mist should allow — aisle after aisle of sealed registers, lit by reading-lamps that have not gone dark in three centuries.",
+      "This is where Amarath shelved every name the Fracture erased. It does not read like a library. It reads like a held breath, three hundred years long.",
+      "The archivists here do not look up as you pass. They are not the enemy — the Court is. But something moves between the shelves that even they don't fully trust."
+    ],
+    "eaterDesc": [
+      "The Name-Eater has kept the deep stacks since before the current archivists were born. Prisoner and librarian both, the Court says, and has never once clarified which came first.",
+      "It does not hunt for cruelty. It is fed on purpose, on names nobody will miss, and it has spent three centuries disagreeing with the Court about which names those are.",
+      "Eleven wings of shelving answer to it, and it has never once let a name go unread before it was gleaned. It has not decided yet whether yours counts as one it's owed."
+    ],
+    "priorRunOpenings": [
+      "The threshold shelf was still warm when you reached it, same as always — the Archive remembers being entered even when it doesn't remember by whom.",
+      "You knew the aisle markers this time. The dark between the shelves knew you knowing them.",
+      "The reading-lamp at the door was already lit to your usual page. You are becoming a familiar entry.",
+      "The Name-Eater's stacks were already disturbed when you arrived. It does not believe in being surprised twice, either."
+    ]
+  },
+  "midRunTemplates": [
+    "The {ordinalLower} walk through the Archive of Names. The reading-lamps light themselves a little sooner every time.",
+    "Campaign {n}. The deep stacks have a whole shelf reserved for you now, all of it already read.",
+    "{n} entries counted, by the ledger at the door. You have stopped correcting the number.",
+    "Run {n}. The aisles are the same length every time, and every time they feel like they're expecting you.",
+    "The {ordinalLower} crossing. You know the shelf-marks by name now. The Archive had names for them first."
+  ],
+  "introRules": [
+    {
+      "condition": {
+        "op": "gte",
+        "value": 10
+      },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:priorRunOpenings:1}"
+        },
+        {
+          "title": "THE ARCHIVE OF NAMES",
+          "text": "{pool:archiveDesc:1}\n\n{pool:eaterDesc:1}"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 9
+      },
+      "panels": [
+        {
+          "title": "THE ARCHIVE OF NAMES",
+          "text": "The threshold shelf is freshly dusted — again.\n\n{pool:priorRunOpenings:0}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:archiveDesc:2}"
+        },
+        {
+          "title": "THE NAME-EATER",
+          "text": "{pool:eaterDesc:0}"
+        }
+      ]
+    }
+  ],
+  "intro": [
+    {
+      "title": "THE QUEEN'S SHEAF",
+      "text": "The Gleaner Queen fell in three scattered pieces and left you her sheaf anyway — grain that still remembers every name it ever returned. Past the last granary, the fields simply stop, and the ground becomes a threshold of dressed stone shelving.",
+      "image": "cutscenes/c2act4-intro-1.svg"
+    },
+    {
+      "title": "THE ARCHIVE OF NAMES",
+      "text": "Amarath shelves what it cannot bear to lose twice: every erased name, in sealed registers under reading-lamps that have not gone dark in three centuries. It runs further than any hall should. It is not finished being full.",
+      "image": "cutscenes/c2act4-intro-2.svg"
+    },
+    {
+      "title": "THE THING BETWEEN THE SHELVES",
+      "text": "The archivists are not the enemy — the Court is. But somewhere in the deep stacks, something the Court calls both prisoner and librarian keeps its own accounting of who's owed what. You go in anyway, sheaf in hand, to find what the Fracture erased of a kingdom that was never Amarath's to forget.",
+      "image": "cutscenes/c2act4-intro-3.svg"
+    }
+  ],
+  "outro": [
+    {
+      "title": "THE NAME-EATER'S ACCOUNTING",
+      "text": "It does not fall like a monster. It folds, shelf by shelf, the way a ledger closes. \"I was never unfed,\" it says, \"only ungoverned. Tell the Court that, Worldmender, if it still remembers how to listen.\" You take the index it leaves behind. It does not fight you for it.",
+      "image": "cutscenes/c2act4-outro-1.svg"
+    },
+    {
+      "title": "INDEX OF THE LOST",
+      "text": "It leaves you an index bound from every name it ever catalogued and never once misplaced — a record of what was lost, cross-referenced against what came back. Holding it, you know exactly what you're still carrying, and exactly what it cost.",
+      "image": "cutscenes/c2act4-outro-2.svg"
+    },
+    {
+      "title": "THE CANDLE CITY AHEAD",
+      "text": "Past the last reading-room, the shelving gives way to a skyline of ten thousand vigil flames — the Candle City, Amarath's second seat, lit against a dark it has never once trusted to stay gone. Somewhere in it, a Lamplighter General is already counting the wicks that still need tending.",
+      "image": "cutscenes/c2act4-outro-3.svg"
+    }
+  ],
+  "nodes": {
+    "threshold-stacks": {
+      "id": "threshold-stacks",
+      "type": "battle",
+      "label": "The Threshold Stacks",
+      "description": "Where the last turned furrow gives way to the first dressed shelf of the Archive.",
+      "row": 0,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-first-aisle",
+        "the-outer-shelves"
+      ],
+      "handicap": 20,
+      "opponentIntervalMs": 3100,
+      "opponentBaseHp": 238,
+      "environment": "vault",
+      "enemyDeck": [
+        "Stack Runner",
+        "Lamp Acolyte",
+        "Index Warden",
+        "Reading Lamp"
+      ]
+    },
+    "the-first-aisle": {
+      "id": "the-first-aisle",
+      "type": "battle",
+      "label": "The First Aisle",
+      "description": "A shelf-lined aisle still smelling of turned earth from the fields behind it.",
+      "row": 1,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-lantern-vigil",
+        "the-reading-hearth"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "vault",
+      "enemyDeck": [
+        "Stack Runner",
+        "Index Warden",
+        "Shelf Barricade",
+        "Register Bearer",
+        "Quickening Ink"
+      ]
+    },
+    "the-outer-shelves": {
+      "id": "the-outer-shelves",
+      "type": "battle",
+      "label": "The Outer Shelves",
+      "description": "A wing garrisoned like it still needs guarding — because to Amarath, it does.",
+      "row": 1,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-sealed-ledger",
+        "the-catalogue-cart"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "vault",
+      "enemyDeck": [
+        "Lamp Acolyte",
+        "Lectern Archer",
+        "Reading Lamp",
+        "Sealed Stack",
+        "Parchment Poultice"
+      ]
+    },
+    "the-lantern-vigil": {
+      "id": "the-lantern-vigil",
+      "type": "event",
+      "label": "The Lantern Vigil",
+      "description": "A reading-lamp kept lit over a bare shelf, tended by no hand you can see.",
+      "row": 2,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-warden-line",
+        "mem-c2act4-1"
+      ],
+      "eventConfig": {
+        "title": "The Lantern Vigil",
+        "description": "It has burned over this one bare shelf for three hundred years, wick trimmed every dusk by a hand you never see. It does not flicker. It looks like something that still has somewhere to shelve.",
+        "pools": [
+          [
+            {
+              "label": "Trim the vigil-lamp's wick (lose 6 HP, gain a rare card)",
+              "consequence": "The oil is old and it costs you to handle it. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the oil left at its base (gain 60 crystals)",
+              "consequence": "Someone leaves oil for it every dawn, for a lamp that was never quite allowed to matter. You gain 60 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 60
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest in its steady light (heal 10 HP)",
+              "consequence": "The light holds the dark back better than it has any right to. You heal 10 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the vigil undisturbed",
+              "consequence": "You leave the lamp to its watch.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-reading-hearth": {
+      "id": "the-reading-hearth",
+      "type": "rest",
+      "label": "The Reading Hearth",
+      "description": "A working reading-hearth, kept lit for archivists who never stop needing it.",
+      "row": 2,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-warden-line"
+      ],
+      "restHeal": 9
+    },
+    "the-sealed-ledger": {
+      "id": "the-sealed-ledger",
+      "type": "event",
+      "label": "The Sealed Ledger",
+      "description": "An open reading-room, empty of readers but not of record.",
+      "row": 2,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "the-unshelved-row"
+      ],
+      "eventConfig": {
+        "title": "The Sealed Ledger",
+        "description": "The lectern holds a ledger of every shelving recorded in a hand that hasn't held a pen in three hundred years, ink still wet, though no hand is in sight. Every name on every page is Amarath's own. Yours would be the first from outside.",
+        "pools": [
+          [
+            {
+              "label": "Read the sealed ledger (lose 6 HP, gain a rare card)",
+              "consequence": "Three hundred years of names, and yours is about to be the first from outside. It costs you. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the sealed record cache (gain 70 crystals)",
+              "consequence": "A cache nobody was ever going to collect. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest among the reading-room stacks (heal 8 HP)",
+              "consequence": "Quieter than any room has a right to be. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the ledger unread",
+              "consequence": "Some records are better left uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-catalogue-cart": {
+      "id": "the-catalogue-cart",
+      "type": "merchant",
+      "label": "The Catalogue Cart",
+      "description": "A merchant's cart parked at a reading-room that hasn't seen trade in centuries.",
+      "row": 2,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-unshelved-row"
+      ]
+    },
+    "the-warden-line": {
+      "id": "the-warden-line",
+      "type": "elite",
+      "label": "The Warden Line",
+      "description": "A file of archive wardens holding the deep stacks in strict, patient order.",
+      "row": 3,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-deep-stacks"
+      ],
+      "handicap": 26,
+      "opponentIntervalMs": 2800,
+      "opponentBaseHp": 262,
+      "environment": "vault",
+      "enemyDeck": [
+        "Archive Warden",
+        "Register Bearer",
+        "Watch-Lectern",
+        "Sealed Stack",
+        "Marginal Notes",
+        "Silence Bell"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "mem-c2act4-1": {
+      "id": "mem-c2act4-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A founding record of the Archive's very first shelving.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-deep-stacks"
+      ],
+      "fragmentId": "c2act4-frag-1",
+      "environment": "vault"
+    },
+    "the-unshelved-row": {
+      "id": "the-unshelved-row",
+      "type": "elite",
+      "label": "The Unshelved Row",
+      "description": "A row of archivists, still holding places for a cataloguing that never comes.",
+      "row": 3,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-last-registry"
+      ],
+      "handicap": 26,
+      "opponentIntervalMs": 2800,
+      "opponentBaseHp": 262,
+      "environment": "vault",
+      "enemyDeck": [
+        "Choir of Sealed Names",
+        "Hollow Cataloguer",
+        "Cataloguer Automaton",
+        "Sealed Courier",
+        "Lamp-Oil Reserve",
+        "Parchment Poultice"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-deep-stacks": {
+      "id": "the-deep-stacks",
+      "type": "battle",
+      "label": "The Deep Stacks",
+      "description": "Shelving garrisoned like a border, deep enough that the mist forgets to follow.",
+      "row": 4,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-final-lamp"
+      ],
+      "handicap": 28,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 270,
+      "environment": "vault",
+      "enemyDeck": [
+        "Register Bearer",
+        "Shelf Barricade",
+        "Watch-Lectern",
+        "Sealed Courier",
+        "Marginal Notes",
+        "Lectern Archer"
+      ]
+    },
+    "the-last-registry": {
+      "id": "the-last-registry",
+      "type": "battle",
+      "label": "The Last Registry",
+      "description": "The Archive's final registry room, where even the reading-lamps burn lower.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-final-lamp",
+        "mem-c2act4-2"
+      ],
+      "handicap": 28,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 270,
+      "environment": "vault",
+      "enemyDeck": [
+        "Stackbound Knight",
+        "Sealed Courier",
+        "Cataloguer Automaton",
+        "Silence Bell",
+        "Lamp-Oil Reserve",
+        "Hollow Cataloguer"
+      ]
+    },
+    "the-final-lamp": {
+      "id": "the-final-lamp",
+      "type": "rest",
+      "label": "The Final Lamp",
+      "description": "The last reading-lamp before the deep stacks proper. Someone has already trimmed its wick.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "nameeater-node"
+      ],
+      "restHeal": 11
+    },
+    "mem-c2act4-2": {
+      "id": "mem-c2act4-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A librarian's note on the day the Name-Eater first appeared.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "nameeater-node"
+      ],
+      "fragmentId": "c2act4-frag-2",
+      "environment": "vault"
+    },
+    "nameeater-node": {
+      "id": "nameeater-node",
+      "type": "boss",
+      "label": "The Name-Eater",
+      "description": "Eleven wings of shelving end here, with a warden the Court calls both prisoner and librarian.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [],
+      "handicap": 30,
+      "opponentIntervalMs": 5000,
+      "opponentBaseHp": 288,
+      "environment": "vault",
+      "enemyDeck": [
+        "The Name-Eater",
+        "Archive Warden",
+        "Stackbound Knight",
+        "The Unbound Index",
+        "Choir of Sealed Names",
+        "Reading Room Sentry",
+        "Writ of Erasure"
+      ],
+      "bossAI": "nameeater",
+      "bossDialogue": [
+        "You crossed the fields, Worldmender. The Queen gleaned what the world dropped. I keep what the world was made to forget.",
+        "The Court calls me prisoner. The Court also calls me librarian. It has never once had to choose, because I have never once let a shelf go unread.",
+        "Every register in this hall remembers a name the world erased. The Court sent me to see that yours joins them. I have not been hungry in three hundred years for nothing."
+      ],
+      "bossCard": "The Name-Eater"
+    }
+  }
+}

--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -1875,5 +1875,102 @@
         ]
       }
     ]
+  },
+  {
+    "id": "nameeater",
+    "intervalMs": 5000,
+    "idleMessage": "The dark between the shelves does not stay still…",
+    "maxPlaysPerTurn": 3,
+    "openingLog": [
+      "THE NAME-EATER rises from between the deep stacks, ink-dark and crowned in loose pages.",
+      "\"The Queen gleaned what the world dropped. I keep what the world was made to forget. The Court calls me both prisoner and librarian. Ask it which, and it will change the subject.\""
+    ],
+    "trait": {
+      "name": "Between the Shelves",
+      "implemented": true,
+      "trigger": "hp_pct_multi",
+      "triggerHpPcts": [66, 33],
+      "type": "burrow",
+      "description": "At 66% and 33% HP the Name-Eater slips between the shelves — untargetable for a stretch — then resurfaces beside the player's strongest unit, landing hard enough to jolt everything nearby.",
+      "mechanics": {
+        "invulnerableDurationMs": 2500,
+        "landingDamage": 6,
+        "landingRadiusTiles": 2,
+        "repositionTarget": "nearest_player_highest_hp"
+      },
+      "announceText": "THE NAME-EATER slips BETWEEN THE SHELVES — the stacks close over it!",
+      "landText": "It resurfaces at your strongest unit's shoulder, and the shelves around it slam shut."
+    },
+    "phases": [
+      {
+        "condition": {
+          "gameTimeLt": 30000
+        },
+        "priorities": [
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "mana"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_asc"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      },
+      {
+        "condition": {
+          "gameTimeGte": 30000,
+          "gameTimeLt": 75000
+        },
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "costGte": 4,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "none"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ],
+        "announceOnce": "\"The fields taught you to be gleaned. The Archive will teach you to be shelved.\""
+      },
+      {
+        "condition": null,
+        "manaOverride": 9,
+        "maxPlaysOverride": 4,
+        "announceOnce": "\"EVERY REGISTER IN THIS HALL REMEMBERS A NAME THE WORLD ERASED. YOURS WILL MAKE A FINE ADDITION.\"",
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -13590,6 +13590,291 @@
       "strengths": ["melee", "small"],
       "weaknesses": ["ranged", "flying"],
       "size": "large"
+    },
+    "stack-runner": {
+      "name": "Stack Runner",
+      "attack": 4,
+      "maxHp": 14,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 60,
+      "attackRange": 5,
+      "attackCooldownMs": 1050,
+      "flying": false,
+      "tags": ["fast", "small"],
+      "strengths": ["fast", "melee"],
+      "weaknesses": ["armored", "ranged"],
+      "size": "small"
+    },
+    "lamp-acolyte": {
+      "name": "Lamp Acolyte",
+      "attack": 5,
+      "maxHp": 19,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 36,
+      "attackRange": 70,
+      "attackCooldownMs": 1550,
+      "flying": false,
+      "tags": ["ranged", "magic"],
+      "strengths": ["melee"],
+      "weaknesses": ["fast"],
+      "size": "small"
+    },
+    "index-warden": {
+      "name": "Index Warden",
+      "attack": 6,
+      "maxHp": 24,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 30,
+      "attackRange": 5,
+      "attackCooldownMs": 1300,
+      "flying": false,
+      "tags": ["melee"],
+      "strengths": ["ranged"],
+      "weaknesses": ["fast"],
+      "size": "small"
+    },
+    "reading-lamp": {
+      "name": "Reading Lamp",
+      "attack": 5,
+      "maxHp": 25,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 130,
+      "attackCooldownMs": 1750,
+      "tags": ["ranged"]
+    },
+    "register-bearer": {
+      "name": "Register Bearer",
+      "attack": 8,
+      "maxHp": 30,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 38,
+      "attackRange": 5,
+      "attackCooldownMs": 1350,
+      "flying": false,
+      "tags": ["melee", "armored"],
+      "strengths": ["fast"],
+      "weaknesses": ["magic"],
+      "size": "medium"
+    },
+    "hollow-cataloguer": {
+      "name": "Hollow Cataloguer",
+      "attack": 7,
+      "maxHp": 34,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 36,
+      "attackRange": 5,
+      "attackCooldownMs": 1350,
+      "flying": false,
+      "tags": ["melee"],
+      "strengths": ["small"],
+      "weaknesses": ["siege"],
+      "size": "medium"
+    },
+    "lectern-archer": {
+      "name": "Lectern Archer",
+      "attack": 7,
+      "maxHp": 20,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 40,
+      "attackRange": 140,
+      "attackCooldownMs": 1550,
+      "flying": false,
+      "tags": ["ranged"],
+      "strengths": ["flying"],
+      "weaknesses": ["melee", "fast"],
+      "size": "small"
+    },
+    "sealed-courier": {
+      "name": "Sealed Courier",
+      "attack": 10,
+      "maxHp": 32,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 80,
+      "attackRange": 5,
+      "attackCooldownMs": 1250,
+      "flying": false,
+      "tags": ["fast", "melee"],
+      "strengths": ["ranged", "small"],
+      "weaknesses": ["armored"],
+      "size": "medium"
+    },
+    "index-engine": {
+      "name": "Index Engine",
+      "attack": 0,
+      "maxHp": 22,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "structureEffect": {
+        "type": "mana",
+        "amount": 1
+      },
+      "tags": ["forgotten"]
+    },
+    "cataloguer-automaton": {
+      "name": "Cataloguer Automaton",
+      "attack": 0,
+      "maxHp": 33,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "stack-runner",
+        "intervalMs": 11500
+      },
+      "tags": ["forgotten"]
+    },
+    "watch-lectern": {
+      "name": "Watch-Lectern",
+      "attack": 7,
+      "maxHp": 29,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 150,
+      "attackCooldownMs": 1650,
+      "tags": ["ranged"]
+    },
+    "shelf-barricade": {
+      "name": "Shelf Barricade",
+      "attack": 0,
+      "maxHp": 66,
+      "isWall": true,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "tags": ["melee"],
+      "size": "medium"
+    },
+    "sealed-stack": {
+      "name": "Sealed Stack",
+      "attack": 0,
+      "maxHp": 94,
+      "isWall": true,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 0,
+      "tags": ["armored"],
+      "size": "medium"
+    },
+    "archive-warden": {
+      "name": "Archive Warden",
+      "attack": 13,
+      "maxHp": 50,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 38,
+      "attackRange": 5,
+      "attackCooldownMs": 1400,
+      "flying": false,
+      "tags": ["melee", "armored"],
+      "strengths": ["melee", "fast"],
+      "weaknesses": ["magic"],
+      "size": "large",
+      "affinity": {
+        "withName": "The Name-Eater",
+        "range": 80,
+        "effectType": "damage",
+        "effectAmount": 1.25,
+        "label": "Archive Warden's Vigil"
+      }
+    },
+    "choir-of-sealed-names": {
+      "name": "Choir of Sealed Names",
+      "attack": 9,
+      "maxHp": 34,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 28,
+      "attackRange": 160,
+      "attackCooldownMs": 2000,
+      "flying": false,
+      "tags": ["ranged", "magic"],
+      "strengths": ["armored"],
+      "weaknesses": ["fast", "melee"],
+      "size": "medium"
+    },
+    "reading-room-sentry": {
+      "name": "Reading Room Sentry",
+      "attack": 0,
+      "maxHp": 50,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 0,
+      "attackRange": 0,
+      "attackCooldownMs": 99999,
+      "structureEffect": {
+        "type": "spawn",
+        "unitTemplateRef": "stack-runner",
+        "intervalMs": 9500
+      },
+      "tags": ["forgotten"]
+    },
+    "stackbound-knight": {
+      "name": "Stackbound Knight",
+      "attack": 17,
+      "maxHp": 70,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 32,
+      "attackRange": 5,
+      "attackCooldownMs": 1550,
+      "flying": false,
+      "tags": ["melee", "armored", "large"],
+      "strengths": ["melee", "small"],
+      "weaknesses": ["magic", "flying"],
+      "size": "large",
+      "unitTrait": {
+        "guardBase": true,
+        "baseGuardRange": 95,
+        "engageRange": 195
+      }
+    },
+    "the-unbound-index": {
+      "name": "The Unbound Index",
+      "attack": 12,
+      "maxHp": 47,
+      "isWall": false,
+      "bypassWall": true,
+      "moveSpeed": 60,
+      "attackRange": 65,
+      "attackCooldownMs": 1650,
+      "flying": true,
+      "tags": ["flying", "magic"],
+      "strengths": ["melee", "armored"],
+      "weaknesses": ["ranged"],
+      "size": "large"
+    },
+    "the-name-eater": {
+      "name": "The Name-Eater",
+      "attack": 20,
+      "maxHp": 98,
+      "isWall": false,
+      "bypassWall": false,
+      "moveSpeed": 30,
+      "attackRange": 5,
+      "attackCooldownMs": 1450,
+      "flying": false,
+      "tags": ["melee", "large", "magic"],
+      "strengths": ["melee", "small"],
+      "weaknesses": ["ranged", "flying"],
+      "size": "large"
     }
   },
   "cards": [
@@ -22827,6 +23112,300 @@
       "deckCount": 0,
       "tags": ["forgotten", "fields"],
       "lore": "She does not glean out of cruelty. She gleans because leaving a memory ungathered, out here, is the same as losing it twice. She has not decided yet whether yours counts as lost."
+    },
+    {
+      "name": "Stack Runner",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "stack-runner",
+      "description": "A quick-footed runner who threads the aisles faster than the shelves can close behind her.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "She has run the same aisle for three hundred years and never once lost her place in the stacks. The stacks, it must be said, have tried."
+    },
+    {
+      "name": "Lamp Acolyte",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "lamp-acolyte",
+      "description": "An acolyte who reads by a portable reading-lamp, and strikes at whatever the light finds first.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "She was taught that a name unread is a name still lost. She has not let the wick go out since her ordination."
+    },
+    {
+      "name": "Index Warden",
+      "rarity": "common",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "index-warden",
+      "description": "A ledger-sworn guard who holds an aisle the way the Archive holds every name it ever shelved.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "He does not know whose name is on the shelf behind him. He has decided, three centuries in, that it doesn't matter. It is still his to keep."
+    },
+    {
+      "name": "Reading Lamp",
+      "rarity": "common",
+      "cardType": "structure",
+      "cost": 2,
+      "unitRef": "reading-lamp",
+      "description": "A standing reading-lamp that strikes at anything crossing its light.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Lit the day the first name was shelved. It has never once been allowed to gutter — not through the dark, not through the Fracture, not through anything."
+    },
+    {
+      "name": "Parchment Poultice",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffHeal",
+        "amount": 7
+      },
+      "description": "Heals all friendly units by 7.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Ground from the endpapers of registers too damaged to shelve. Even ruined, the ink remembers how to mend."
+    },
+    {
+      "name": "Quickening Ink",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffSpeed",
+        "amount": 11
+      },
+      "description": "All friendly mobile units move faster.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "A cataloguer's trick — ink that writes itself faster than the hand holding the pen. Nobody has ever caught the shelving up."
+    },
+    {
+      "name": "Register Bearer",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "register-bearer",
+      "description": "An armoured bearer who carries sealed registers into the line rather than leave them behind.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "He has never once dropped a register, not in three hundred years of carrying them. He does not intend to start over you."
+    },
+    {
+      "name": "Hollow Cataloguer",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "hollow-cataloguer",
+      "description": "A steady cataloguer given a body and a task after its own name was shelved.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "It does not remember what it was called. It remembers exactly where it is shelved, down to the row. That is enough to keep working."
+    },
+    {
+      "name": "Lectern Archer",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "lectern-archer",
+      "description": "A long-range archer loosing arrows from atop the reading lecterns.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "She shoots at the dark between the shelves, because the dark is the only part of the Archive that has ever moved on its own."
+    },
+    {
+      "name": "Sealed Courier",
+      "rarity": "uncommon",
+      "cost": 4,
+      "cardType": "unit",
+      "unitRef": "sealed-courier",
+      "description": "A swift courier who runs sealed registers between wings faster than the stacks can shift.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "The seal on her satchel has never once been broken in transit. She takes that more personally than her own name, which she also no longer has."
+    },
+    {
+      "name": "Index Engine",
+      "rarity": "uncommon",
+      "cardType": "structure",
+      "cost": 3,
+      "unitRef": "index-engine",
+      "description": "A cataloguing engine that raises your maximum mana.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "It cross-references every shelf in the wing at once. Somewhere in that constant reckoning, it found room to spare."
+    },
+    {
+      "name": "Cataloguer Automaton",
+      "rarity": "uncommon",
+      "cardType": "structure",
+      "cost": 3,
+      "unitRef": "cataloguer-automaton",
+      "description": "Spawner. Periodically wakes Stack Runners from sealed shelving.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "It was built to shelve names, not people. It has stopped drawing the distinction. Nobody has told it to."
+    },
+    {
+      "name": "Watch-Lectern",
+      "rarity": "uncommon",
+      "cardType": "structure",
+      "cost": 3,
+      "unitRef": "watch-lectern",
+      "description": "A tall lectern-tower with long attack range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Built to watch the far stacks for the thing that moves between them. It has never once looked away."
+    },
+    {
+      "name": "Shelf Barricade",
+      "rarity": "uncommon",
+      "cardType": "structure",
+      "cost": 2,
+      "unitRef": "shelf-barricade",
+      "description": "A defensive barricade built from toppled shelving and bound ledgers.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Every plank in it once held somebody's forgetting. Stacked crosswise, it holds a line instead."
+    },
+    {
+      "name": "Sealed Stack",
+      "rarity": "uncommon",
+      "cardType": "structure",
+      "cost": 3,
+      "unitRef": "sealed-stack",
+      "description": "A dense wall of sealed registers, stacked floor to ceiling.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Sealed under the Court's own writ, on the grounds that some names are safer shelved than read. It is heavier than any wall has a right to be."
+    },
+    {
+      "name": "Marginal Notes",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffMaxHp",
+        "amount": 9
+      },
+      "description": "All friendly units gain +9 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Every margin in the Archive is written full — corrections, warnings, one word repeated so often it stopped reading like a word at all: remember."
+    },
+    {
+      "name": "Lamp-Oil Reserve",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffRange",
+        "amount": 16
+      },
+      "description": "All attacking units gain +16 attack range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Oil rationed for three centuries so the reading-lamps would never once go dark between the shelves. There is, it turns out, more of it than anyone admitted."
+    },
+    {
+      "name": "Silence Bell",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "aoe",
+        "damage": 7,
+        "range": 105
+      },
+      "description": "The silence bell tolls, damaging enemies within its ring.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Rung whenever the reading rooms need quiet enough to hear a name being read for the first time in three hundred years."
+    },
+    {
+      "name": "Archive Warden",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "archive-warden",
+      "description": "An elite warden who has guarded the deep stacks since before the Fracture ever needed guarding against.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Sworn to the Archive before sworn to any court. He has stood between the shelves and the thing that feeds on them longer than the thing has been hungry."
+    },
+    {
+      "name": "Choir of Sealed Names",
+      "rarity": "rare",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "choir-of-sealed-names",
+      "description": "A choir of sealed registers that sings the names shelved around it at long range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "They sing the same litany at the reading room's centre, one name a verse, three hundred years running. They have never once reached the end of the shelf."
+    },
+    {
+      "name": "Reading Room Sentry",
+      "rarity": "rare",
+      "cardType": "structure",
+      "cost": 5,
+      "unitRef": "reading-room-sentry",
+      "description": "Spawner. Periodically wakes Stack Runners from stone and sealed vellum.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Carved in the shape of a watching cataloguer, and just as patient. It knows exactly how much of the wing is left unshelved."
+    },
+    {
+      "name": "Writ of Erasure",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "upgrade",
+      "upgradeEffect": {
+        "type": "buffMaxHp",
+        "amount": 13
+      },
+      "description": "All friendly units gain +13 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "Signed to erase a name from the world. It erased the name from everywhere except the shelf that held it, which is, in the Archive's accounting, the only place that ever mattered."
+    },
+    {
+      "name": "Stackbound Knight",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "stackbound-knight",
+      "description": "A towering knight bound to the deep stacks, guarding them above all else.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "He has never once let a reader leave with more than they were owed. He has also never once turned away a name that came home on its own."
+    },
+    {
+      "name": "The Unbound Index",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "the-unbound-index",
+      "description": "A drifting index of unshelved pages that flies over walls, hunting for the entry it's missing.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "It was never bound into any register. Three hundred years loose in the stacks have taught it to want to be."
+    },
+    {
+      "name": "The Name-Eater",
+      "rarity": "legendary",
+      "cost": 7,
+      "cardType": "unit",
+      "unitRef": "the-name-eater",
+      "description": "The thing between the shelves — prisoner and librarian both, and hungrier than either title admits.",
+      "deckCount": 0,
+      "tags": ["forgotten", "archive"],
+      "lore": "The Court keeps it fed on names nobody will miss. It has never once, in three hundred years, agreed on which names those are."
     }
   ],
   "heroCards": [
@@ -23354,6 +23933,38 @@
       },
       "description": "HERO: Deploys the First Reaper — the harvester who cut the very first sheaf of memory-wheat in the void. All units gain +3 attack.",
       "lore": "Nobody ordained her the first. She simply refused to let the field go unharvested while there was still a hand left to hold the sickle. Three centuries on, the fields still cut the way she taught them."
+    },
+    {
+      "id": "hero-returned-archivist",
+      "name": "The Archivist Returned",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Returned Archivist",
+        "attack": 10,
+        "maxHp": 52,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 34,
+        "attackRange": 120,
+        "attackCooldownMs": 1500,
+        "flying": false,
+        "tags": ["ranged", "magic"],
+        "size": "medium",
+        "unitTrait": {
+          "guardBase": true,
+          "baseGuardRange": 90,
+          "engageRange": 185
+        }
+      },
+      "heroEffect": {
+        "type": "buffMaxHp",
+        "amount": 8
+      },
+      "description": "HERO: Deploys the Returned Archivist — a Dominion archivist whose own name was gleaned back from the Archive's stacks. All units gain +8 max HP.",
+      "lore": "Campaign 1 knew an Archivist who never left the Crystal Spire. This one is not him — only someone who once did the same work, in a kingdom that no longer had a name to file her under. The Archive gave hers back. She has not stopped reading since."
     }
   ]
 }

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -222,5 +222,19 @@
     "nodeId": "mem-c2act3-2",
     "title": "Fragment: The Gleaner's Ledger",
     "body": "A GLEANER'S PERSONAL LEDGER, RECOVERED FROM THE UNREMEMBERED FIELDS\n\n'Row 40, east furrow: gleaned a woman's wedding song, three verses, tune intact. Left it with the miller's widow — it was hers before the dark, though she does not remember losing it, only finding it again.\n\nRow 6, west furrow: gleaned the taste of a fruit that no longer grows anywhere in Amarath. Could not find its owner. Filed under: unclaimed.\n\nRow 51: gleaned a child's fear of the mist. Did not return it. Some things are kinder gleaned than kept.\n\nThe Queen asks me, some evenings, whether I have ever gleaned something that wasn't ours to take back — some scrap of the wider Dominion's own forgetting, blown into our furrows on a wind we didn't ask for. I tell her no. I have started keeping a second ledger, in a hand she does not know, in case the answer changes.'"
+  },
+  {
+    "id": "c2act4-frag-1",
+    "actId": "c2act4",
+    "nodeId": "mem-c2act4-1",
+    "title": "Fragment: The Founding Shelving",
+    "body": "FOUNDING RECORD OF THE ARCHIVE OF NAMES — FIRST SHELVING, YEAR ONE OF THE DARK\n\n'Every name the void took arrived the same way: unannounced, unattached to a face, and impossible to put down. The first archivists tried burning them, out of mercy, and found that a burned name comes back anyway, worse for the burning. So the King's order changed: nothing erased is to be destroyed. Everything erased is to be shelved.\n\nWe built the first wing in nine days, out of whatever stone the fields would spare. It was full in six. We built a second wing. It was full in four. We have not stopped building since, and we have never once caught up to what the world keeps forgetting.\n\nThe rite-keepers say a shelved name is a name that can still, someday, be read back to whoever it belonged to. I believe them, because the alternative is that we are only building a very large grave and calling it a library.\n\nEntry ends. Wing eleven opens next season. We are already behind on wing twelve.'"
+  },
+  {
+    "id": "c2act4-frag-2",
+    "actId": "c2act4",
+    "nodeId": "mem-c2act4-2",
+    "title": "Fragment: The Librarian's Note",
+    "body": "A LIBRARIAN'S PERSONAL NOTE, PINNED INSIDE THE DEEP STACKS\n\n'It appeared the day wing four sealed its last shelf — nobody built it, nobody summoned it, it was simply between the registers the next morning, reading them in an order none of us had catalogued. We called the Court. The Court came, looked at it for a long while, and then did something I did not expect: it left the thing exactly where it was, and appointed it Warden of the Deep Stacks.\n\nI asked the Court steward why. She said: because it has never once misfiled a name, and because a thing that hungers for what's already lost is safer than a thing that hungers for what isn't. I did not find that reassuring. I still don't.\n\nIt has fed on names nobody claimed for three hundred years now. It has also, in that time, returned eleven names to archivists who didn't know they were owed one. I keep a running count of both numbers. I am not certain which one is supposed to make me feel better.\n\nIt does not speak often. When it does, it only ever asks one question: whose name is next.'"
   }
 ]

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -312,5 +312,21 @@
         "amount": 2
       }
     ]
+  },
+  {
+    "name": "Index of the Lost",
+    "icon": "📇",
+    "desc": "All friendly units gain +2 attack and +4 max HP — you carry the shape of what the Archive lost, and it carries you back.",
+    "lore": "Bound from every name the Name-Eater ever catalogued and never once misplaced, cross-referenced against what came back. Holding it, you know exactly what's missing, and exactly what to do about it.",
+    "effects": [
+      {
+        "type": "unitAtk",
+        "amount": 2
+      },
+      {
+        "type": "unitHp",
+        "amount": 4
+      }
+    ]
   }
 ]

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -929,6 +929,41 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 2,
   },
 
+  // Campaign 2, Act 4 — The Archive of Names
+  {
+    id: 'campaign:c2act4:1',
+    name: 'The First Entry',
+    description: 'Complete Campaign 2 Act 4 — The Archive of Names',
+    category: 'campaign',
+    progressKey: 'campaign:c2act4',
+    target: 1,
+    reward: { type: 'crystals', crystals: 750 },
+    tier: 1,
+  },
+  {
+    id: 'campaign:c2act4:10',
+    name: 'Warden of the Deep Stacks',
+    description: 'Complete Campaign 2 Act 4 ten times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act4',
+    target: 10,
+    reward: { type: 'crystals', crystals: 3600 },
+    tier: 2,
+  },
+  {
+    id: 'campaign:c2act4:100',
+    name: 'The Archive Remembers Your Name',
+    description: 'Complete Campaign 2 Act 4 one hundred times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act4',
+    target: 100,
+    reward: {
+      type: 'item',
+      item: { id: 'name_eaters_index_card', name: "Name-Eater's Index Card", icon: '📇', desc: 'A single index card from a hundred readings. It has your name filed under a shelf you have never seen.' },
+    },
+    tier: 2,
+  },
+
   // ── Boss avatar unlocks (one per act, triggered on first act completion) ─
 
   { id: 'campaign:act1:boss',  name: 'Face of the Thornlord',       description: 'Defeat Act 1 to unlock the Thornlord avatar',       category: 'campaign', progressKey: 'campaign:act1',  target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thornlord' },       tier: 1 },
@@ -948,6 +983,7 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
   { id: 'campaign:c2act1:boss',    name: 'Face of the Pale Herald',    description: 'Defeat Campaign 2 Act 1 to unlock the Pale Herald avatar', category: 'campaign', progressKey: 'campaign:c2act1', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-paleherald' },      tier: 1 },
   { id: 'campaign:c2act2:boss',    name: 'Face of the Toll Warden',    description: 'Defeat Campaign 2 Act 2 to unlock the Toll Warden avatar', category: 'campaign', progressKey: 'campaign:c2act2', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-tollwarden' },      tier: 1 },
   { id: 'campaign:c2act3:boss',    name: 'Face of the Gleaner Queen',  description: 'Defeat Campaign 2 Act 3 to unlock the Gleaner Queen avatar', category: 'campaign', progressKey: 'campaign:c2act3', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-gleanerqueen' },    tier: 1 },
+  { id: 'campaign:c2act4:boss',    name: 'Face of the Name-Eater',     description: 'Defeat Campaign 2 Act 4 to unlock the Name-Eater avatar', category: 'campaign', progressKey: 'campaign:c2act4', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-nameeater' },       tier: 1 },
 
   // ── Boss Cards — earned by repeat boss completions (10/20/30/40 runs) ────
   // Act 1 — Thornlord

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -24,12 +24,13 @@ import actFinaleData from '../data/acts/actfinale.json'
 import c2act1Data from '../data/acts/c2act1.json'
 import c2act2Data from '../data/acts/c2act2.json'
 import c2act3Data from '../data/acts/c2act3.json'
+import c2act4Data from '../data/acts/c2act4.json'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ALL_ACTS: any[] = [
   act1Data, act2Data, act3Data, act4Data, act5Data,
   act6Data, act7Data, act8Data, act9Data, act10Data,
-  act11Data, act12Data, act13Data, actFinaleData, c2act1Data, c2act2Data, c2act3Data,
+  act11Data, act12Data, act13Data, actFinaleData, c2act1Data, c2act2Data, c2act3Data, c2act4Data,
 ]
 
 const FRAGMENT_KEY        = 'jarv_memory_fragments'

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -20,6 +20,7 @@ import actFinaleData from '../data/acts/actfinale.json'
 import c2act1Data from '../data/acts/c2act1.json'
 import c2act2Data from '../data/acts/c2act2.json'
 import c2act3Data from '../data/acts/c2act3.json'
+import c2act4Data from '../data/acts/c2act4.json'
 import worldBattlesData from '../data/acts/worldbattles.json'
 import consumablesData from '../data/consumables.json'
 
@@ -903,6 +904,7 @@ export const ACT_FINALE: Act = actFinaleData as Act
 export const C2_ACT_1: Act = c2act1Data as Act
 export const C2_ACT_2: Act = c2act2Data as Act
 export const C2_ACT_3: Act = c2act3Data as Act
+export const C2_ACT_4: Act = c2act4Data as Act
 /** Standalone battles launched from the world map — never part of campaign progression. */
 export const ACT_WORLD: Act = worldBattlesData as Act
 
@@ -924,6 +926,7 @@ export const ACTS: Record<string, Act> = {
   c2act1:    C2_ACT_1,
   c2act2:    C2_ACT_2,
   c2act3:    C2_ACT_3,
+  c2act4:    C2_ACT_4,
   world:     ACT_WORLD,
 }
 
@@ -1012,6 +1015,7 @@ export const BOSS_AVATAR_SLUGS = [
   'boss-tidal-sovereign', 'boss-cloudmarshal', 'boss-cinderwarlord', 'boss-rootqueen',
   'boss-paleengine', 'boss-dunebaron', 'boss-elderwarden', 'boss-harbormaster',
   'boss-grandautomaton', 'boss-paleherald', 'boss-tollwarden', 'boss-gleanerqueen',
+  'boss-nameeater',
 ] as const
 export const AVATAR_SLUGS = [...BASE_AVATAR_SLUGS, ...STREAK_AVATAR_SLUGS, ...BOSS_AVATAR_SLUGS] as const
 export type AvatarSlug = typeof AVATAR_SLUGS[number]
@@ -1044,6 +1048,7 @@ export const BOSS_AVATAR_LABELS: Record<string, string> = {
   'boss-paleherald':      'The Pale Herald',
   'boss-tollwarden':      'The Toll Warden',
   'boss-gleanerqueen':    'The Gleaner Queen',
+  'boss-nameeater':       'The Name-Eater',
 }
 
 export function loadUnlockedAvatars(): string[] {


### PR DESCRIPTION
Closes #1989 (part of #181 — The Forgotten Kingdom).

Implements Campaign 2, Act 4 per `docs/campaign2.md` §4 row 4, mirroring the c2act3 pattern. **Authored by a Sonnet agent session; independently reviewed — no defects found.**

## Content
- **Act map** `c2act4.json`: 15-node Archive map, `vault` environment, balanced A/B paths (3 combat each), 2 memory-fragment detours, inline events, replay intro rules, difficulty 20→30 / 238→288 HP (one step above Act 3's 18→28)
- **25 cards** tagged `forgotten`/`archive` (6c/12u/4r/2e/1l) + templates + **The Archivist Returned** hero card (+8 max HP); legendary **The Name-Eater** doubles as the boss card
- **Boss** `nameeater` — *Between the Shelves*: burrows at 66 % and 33 % HP (2.5 s untargetable), resurfacing beside the player's highest-HP unit for 6 AOE damage
- **Relic** *Index of the Lost*: all units +2 ATK and +4 max HP at battle start
- **Story**: intro picks up from the Gleaner Queen's fall; the Name-Eater is the Court's prisoner-librarian, fed on unclaimed names; outro teases Act 5 (The Candle City); fragments cover the Archive's founding and a librarian's note on the Eater's arrival
- Achievements `campaign:c2act4` (1/10/100) + `boss-nameeater` avatar unlock; registered in `questline.ts`/`codex.ts`/`CampaignAdminScreen`; **`c2act3.json` gains `nextActId: "c2act4"`**
- Sprites: 21 new sprite slugs (animated units, structures, boss avatar) — all verified against the engine's name-slug rule; 6 cutscene panels

## Review (independent of the authoring agent)
- Cross-checked every `enemyDeck` name, `bossAI`, `bossCard`, `fragmentId`, `childIds` target, relic name/desc pairing, duplicate names, path balance, reachability, and sprite-slug coverage (including the hero unit) — all clean
- Rebased onto latest `main`; `npm run build` clean; 680/680 unit tests pass (browser-runner error pre-existing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpUJqxnEEScXuYt5jkJstQ)_