### PR TITLE
Add admin-controlled town access for the hub world

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -54,6 +54,13 @@ service cloud.firestore {
       allow write: if request.auth != null;
     }
 
+    // ── Hub-world town access (admin-controlled) ────────────────────────────
+    // Anyone can read which towns are open. Only the admin account can write.
+    match /globalState/townAccess {
+      allow read: if true;
+      allow write: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
+    }
+
     // ── Minigame leaderboards ────────────────────────────────────────────────
     // Anyone can read leaderboard entries.
     // Authenticated users can only write their own entry (keyed by their uid).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -91,13 +91,15 @@ import { GiftAdminScreen }  from './components/admin/GiftAdminScreen'
 import { LoginModal }        from './components/modals/LoginModal'
 import { InventoryScreen }   from './components/screens/InventoryScreen'
 import { markDailyRewardClaimed, addToInventory, computeReward, loadInventory, RewardDef, ALL_ITEMS } from './game/dailyLogin'
-import { applyGiftRewards, GiftDef } from './game/gifts'
+import { applyGiftRewards, GiftDef, GIFT_OWNER_UID } from './game/gifts'
+import { fetchEnabledTownIds, isTownAccessible } from './game/townAccess'
 import { NewsScreen }      from './components/screens/NewsScreen'
 import { NewsAdminScreen } from './components/admin/NewsAdminScreen'
 import { CampaignAdminScreen } from './components/admin/CampaignAdminScreen'
 import { SceneryAdminScreen } from './components/admin/SceneryAdminScreen'
 import { FeedbackModal } from './components/modals/FeedbackModal'
 import { FeedbackAdminScreen } from './components/admin/FeedbackAdminScreen'
+import { TownAccessAdminScreen } from './components/admin/TownAccessAdminScreen'
 import { DeckSelectorModal } from './components/cards/DeckSelectorModal'
 import { loadDeckSlot } from './game/collection'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
@@ -240,6 +242,7 @@ type Screen =
   | 'newsAdmin'
   | 'campaignAdmin'
   | 'feedbackAdmin'
+  | 'townAccessAdmin'
   | 'minigames'
   | 'playerstats'
   | 'quickbattle'
@@ -551,6 +554,22 @@ export default function App() {
 
   // Firebase auth
   const { user, authLoading } = useAuth()
+  const isAdmin = user?.uid === GIFT_OWNER_UID
+
+  // Admin-controlled hub-world town access — locked until fetched/enabled.
+  const [enabledTownIds, setEnabledTownIds] = useState<Set<string>>(new Set())
+  useEffect(() => {
+    fetchEnabledTownIds().then(ids => setEnabledTownIds(new Set(ids)))
+  }, [])
+  const restrictedTownNodeIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const node of WORLD_MAP_NODES) {
+      if (node.locationKey && !isTownAccessible(node.locationKey, enabledTownIds, isAdmin)) {
+        ids.add(node.id)
+      }
+    }
+    return ids
+  }, [enabledTownIds, isAdmin])
 
   // Per-battle misc achievement flags
   const battleFlawlessRef    = useRef(true)
@@ -1293,11 +1312,12 @@ export default function App() {
       setCurrentLocationKey('ravenwatch')
       setScreen('hubworld')
     } else if (LOCATION_REGISTRY[id]) {
+      if (!isTownAccessible(id, enabledTownIds, isAdmin)) return
       setCurrentWorldLocation(id)
       setCurrentLocationKey(id)
       setScreen('location')
     }
-  }, [])
+  }, [enabledTownIds, isAdmin])
 
   // Re-run the current world-map battle after a loss ("Try Again").
   const handleWorldBattleRetry = useCallback(() => {
@@ -2914,6 +2934,7 @@ export default function App() {
           onNewsAdmin={() => setScreen('newsAdmin')}
           onCampaignAdmin={() => setScreen('campaignAdmin')}
           onFeedbackAdmin={() => setScreen('feedbackAdmin')}
+          onTownAccessAdmin={() => setScreen('townAccessAdmin')}
           onHubWorld={() => setScreen('hubworld')}
           onTitleScreen={() => setScreen('title')}
           onSceneryPreview={() => setScreen('sceneryPreview')}
@@ -3009,6 +3030,7 @@ export default function App() {
           onSignOut={() => { import('firebase/auth').then(({ signOut }) => signOut(auth)) }}
           onPlayerTap={() => { setReturnScreen('hubworld'); setScreen('player') }}
           onFeedback={() => setFeedbackOpen(true)}
+          restrictedNodeIds={restrictedTownNodeIds}
         />
       )}
 
@@ -3045,6 +3067,10 @@ export default function App() {
 
       {screen === 'feedbackAdmin' && (
         <FeedbackAdminScreen onBack={() => setScreen('settings')} />
+      )}
+
+      {screen === 'townAccessAdmin' && (
+        <TownAccessAdminScreen onBack={() => setScreen('settings')} />
       )}
 
       {screen === 'sceneryPreview' && (

--- a/web/src/components/admin/TownAccessAdminScreen.tsx
+++ b/web/src/components/admin/TownAccessAdminScreen.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useEffect } from 'react'
+import { OverlayScreen } from '../ui/OverlayScreen'
+import { Section } from '../ui/Section'
+import {
+  ALWAYS_OPEN_LOCATION_IDS, TOGGLEABLE_LOCATIONS,
+  fetchEnabledTownIds, saveEnabledTownIds,
+} from '../../game/townAccess'
+
+interface Props {
+  onBack: () => void
+}
+
+export function TownAccessAdminScreen({ onBack }: Props) {
+  const [enabled, setEnabled] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(true)
+  const [status, setStatus] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchEnabledTownIds().then(ids => { setEnabled(new Set(ids)); setLoading(false) })
+  }, [])
+
+  async function toggle(id: string) {
+    const next = new Set(enabled)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setEnabled(next)
+    setStatus(null)
+    try {
+      await saveEnabledTownIds(Array.from(next))
+    } catch (e) {
+      setStatus(`Error: ${String(e)}`)
+    }
+  }
+
+  return (
+    <OverlayScreen title="TOWN ACCESS" onBack={onBack}>
+      <Section title="Always Open">
+        <div className="settings-sublabel" style={{ marginBottom: '6px' }}>
+          These towns are reachable by every player and cannot be locked.
+        </div>
+        {ALWAYS_OPEN_LOCATION_IDS.map(id => (
+          <div key={id} className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+            <div className="settings-label">{id === 'ravenwatch' ? 'Ravenwatch' : id === 'millhaven' ? 'Millhaven' : id}</div>
+          </div>
+        ))}
+      </Section>
+
+      <Section bordered title="Toggleable Towns">
+        <div className="settings-sublabel" style={{ marginBottom: '6px' }}>
+          Locked towns are unreachable for regular players — on the world map and via
+          in-town exits — until enabled here. Your admin account always has full access.
+        </div>
+        {loading && <div className="settings-sublabel">Loading…</div>}
+        {!loading && TOGGLEABLE_LOCATIONS.map(({ id, label }) => {
+          const on = enabled.has(id)
+          return (
+            <div key={id} className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+              <div className="settings-label">{label}</div>
+              <div
+                className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+                onClick={() => toggle(id)}
+              >
+                <div className={`settings-toggle-track${on ? ' settings-toggle-track--on' : ''}`}>
+                  <div className="settings-toggle-thumb" />
+                </div>
+              </div>
+            </div>
+          )
+        })}
+        {status && (
+          <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+            <div className="settings-sublabel" style={{ color: '#ff5555' }}>{status}</div>
+          </div>
+        )}
+      </Section>
+    </OverlayScreen>
+  )
+}

--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -29,9 +29,10 @@ interface Props {
   onSignOut?:    () => void
   onPlayerTap?:  () => void
   onFeedback?:   () => void
+  restrictedNodeIds?: Set<string>
 }
 
-export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, onPlayerTap, onFeedback }: Props) {
+export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, onPlayerTap, onFeedback, restrictedNodeIds }: Props) {
   const [peekNode, setPeekNode] = useState<WorldNodeDef | null>(null)
   const [questsOpen, setQuestsOpen] = useState(false)
   const [wrongSave, setWrongSave]   = useState<{ cards: number; crystals: number; deck: number } | null>(null)
@@ -111,6 +112,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
           id="hub-world"
           worldMap={WORLD_MAP}
           clearedNodeIds={clearedNodeIds}
+          restrictedNodeIds={restrictedNodeIds}
           mapWidth={1600}
           mapHeight={1400}
           setPeekNode={setPeekNode}
@@ -121,7 +123,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
             node={peekNode}
             mode="world"
             isCleared={isNodeCleared(peekNode.id)}
-            isAvailable={getWorldNodeStatus(peekNode, clearedNodeIds) !== 'locked'}
+            isAvailable={getWorldNodeStatus(peekNode, clearedNodeIds, restrictedNodeIds) !== 'locked'}
             onEnter={() => { setPeekNode(null); onSelectNode(peekNode) }}
             onClose={() => setPeekNode(null)}
           />

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -26,6 +26,7 @@ interface Props {
   onNewsAdmin?: () => void
   onCampaignAdmin?: () => void
   onFeedbackAdmin?: () => void
+  onTownAccessAdmin?: () => void
   onHubWorld?: () => void
   onTitleScreen?: () => void
   onCheckForUpdates?: () => Promise<void>
@@ -162,7 +163,7 @@ function exportLocalStorage(): void {
   URL.revokeObjectURL(url)
 }
 
-export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin, onHubWorld, onTitleScreen, onCheckForUpdates, onSceneryPreview }: Props) {
+export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCrystalsChanged, onDevHandicapChanged, onGiftAdmin, onNewsAdmin, onCampaignAdmin, onFeedbackAdmin, onTownAccessAdmin, onHubWorld, onTitleScreen, onCheckForUpdates, onSceneryPreview }: Props) {
   const [soundOn,       setSoundOn]       = useState(isSoundEnabled)
   const [soundVolume,   setSoundVolumeState]   = useState(getSoundVolume)
   const [musicVolume,   setMusicVolumeState]   = useState(getMusicVolume)
@@ -684,7 +685,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </Section>
         )}
 
-        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin || onFeedbackAdmin) && (
+        {user?.uid === GIFT_OWNER_UID && (onGiftAdmin || onNewsAdmin || onFeedbackAdmin || onCampaignAdmin || onTownAccessAdmin) && (
           <Section bordered title="ADMIN">
             {onGiftAdmin && (
               <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
@@ -720,6 +721,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-sublabel">View and delete player-submitted feedback</div>
                 </div>
                 <button className="action-btn action-btn--gold" onClick={onFeedbackAdmin}>OPEN</button>
+              </div>
+            )}
+            {onTownAccessAdmin && (
+              <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+                <div>
+                  <div className="settings-label">Town access</div>
+                  <div className="settings-sublabel">Choose which hub-world towns players can enter</div>
+                </div>
+                <button className="action-btn action-btn--gold" onClick={onTownAccessAdmin}>OPEN</button>
               </div>
             )}
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -31,6 +31,7 @@ interface Props {
   worldMap: WorldMap
   run?: RunState               // campaign mode: required when clearedNodeIds absent
   clearedNodeIds?: Set<string> // world mode: required when run absent
+  restrictedNodeIds?: Set<string> // world mode: towns locked by admin town-access setting
   mapWidth?: number            // override canvas width (world map uses 700)
   mapHeight?: number           // override canvas height (world map uses 520)
   setPeekNode: (node: QuestNode | null) => void
@@ -59,7 +60,8 @@ export function getNodeStatus(nodeId: string, availableIds: string[], run: RunSt
   return 'locked'
 }
 
-export function getWorldNodeStatus(node: QuestNode, clearedNodeIds: Set<string>): NodeStatus {
+export function getWorldNodeStatus(node: QuestNode, clearedNodeIds: Set<string>, restrictedNodeIds?: Set<string>): NodeStatus {
+  if (restrictedNodeIds?.has(node.id)) return 'locked'
   if (clearedNodeIds.has(node.id)) return 'completed'
   if (!node.requiredClears?.length) return 'available'
   const cleared = node.requiredClears.every(req => {
@@ -588,7 +590,7 @@ function updateMarkerStyle(
 
 // ── Main component ─────────────────────────────────────────────────────────────
 
-export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, mapWidth: mapWidthProp, mapHeight: mapHeightProp, setPeekNode, showPaths }: Props) {
+export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNodeIds, mapWidth: mapWidthProp, mapHeight: mapHeightProp, setPeekNode, showPaths }: Props) {
   const isFreeform = useMemo(() => Object.values(worldMap.nodes).some(n => n.x !== undefined), [worldMap.nodes])
 
   const availableIds      = useMemo(() => run ? getAvailableNodeIds(worldMap.nodes, run) : [], [worldMap.nodes, run])
@@ -667,7 +669,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, mapWidth: ma
 
       for (const node of Object.values(worldMap.nodes)) {
         if (deadRef.current) return
-        const available = getWorldNodeStatus(node, clearedNodeIds ?? new Set()) !== 'locked'
+        const available = getWorldNodeStatus(node, clearedNodeIds ?? new Set(), restrictedNodeIds) !== 'locked'
         const isCurrent = node.id === currentLocation
         const container = new PIXI.Container()
         container.position.set(node.x!, node.y!)
@@ -691,7 +693,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, mapWidth: ma
           }
         }
 
-        const status = getWorldNodeStatus(node, clearedNodeIds ?? new Set())
+        const status = getWorldNodeStatus(node, clearedNodeIds ?? new Set(), restrictedNodeIds)
         if (status === 'locked') {
           container.alpha = 0.38
           const lockLabel = new PIXI.Text({ text: '🔒',

--- a/web/src/game/townAccess.ts
+++ b/web/src/game/townAccess.ts
@@ -1,0 +1,82 @@
+// ─── Town Access ────────────────────────────────────────────────────────────
+// Admin-controlled gate on which hub-world towns are reachable by regular
+// players. Ravenwatch and Millhaven are always open. Every other town is
+// locked until the admin explicitly enables it here; the admin account
+// itself is never restricted.
+//
+// Firestore rules required (see firestore.rules):
+//   match /globalState/townAccess {
+//     allow read: if true;
+//     allow write: if request.auth.uid == "pAB2tLH049PCOI73cQpFlisKpDw1";
+//   }
+
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { db } from '../firebase'
+import { logError } from '../logger'
+
+const TOWN_ACCESS_DOC = doc(db, 'globalState', 'townAccess')
+const LOCAL_KEY = 'jarv_town_access_cache'
+
+/** Location ids reachable by every player regardless of the admin setting. */
+export const ALWAYS_OPEN_LOCATION_IDS: readonly string[] = ['ravenwatch', 'millhaven']
+
+/** Every other town, in world-map order, for the admin toggle screen. */
+export const TOGGLEABLE_LOCATIONS: readonly { id: string; label: string }[] = [
+  { id: 'ironhold-keep',      label: 'Ironhold Keep' },
+  { id: 'thornwood-camp',     label: 'Thornwood Camp' },
+  { id: 'gravemoor',          label: 'Gravemoor' },
+  { id: 'hollowmere',         label: 'Hollowmere' },
+  { id: 'dreadspire-citadel', label: 'Dreadspire Citadel' },
+  { id: 'appleford',          label: 'Appleford' },
+  { id: 'saltmere-port',      label: 'Saltmere Port' },
+  { id: 'harrowfield',        label: 'Harrowfield' },
+  { id: 'capital-city',       label: 'Crownhaven' },
+  { id: 'royal-palace',       label: 'Royal Palace' },
+  { id: 'gearford',           label: 'Gearford' },
+]
+
+function loadLocalCache(): string[] {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY)
+    return raw ? JSON.parse(raw) as string[] : []
+  } catch {
+    return []
+  }
+}
+
+function saveLocalCache(ids: string[]): void {
+  try { localStorage.setItem(LOCAL_KEY, JSON.stringify(ids)) } catch { /* ignore */ }
+}
+
+/**
+ * Fetch the admin-enabled town id list. Falls back to the last-known local
+ * cache on error, and to an empty list (locked) if nothing has ever loaded —
+ * towns stay locked until the admin turns them on.
+ */
+export async function fetchEnabledTownIds(): Promise<string[]> {
+  try {
+    const snap = await getDoc(TOWN_ACCESS_DOC)
+    if (snap.exists()) {
+      const ids = (snap.data().enabled as string[] | undefined) ?? []
+      saveLocalCache(ids)
+      return ids
+    }
+    return loadLocalCache()
+  } catch (e) {
+    logError('fetchEnabledTownIds failed, using local cache', { error: String(e) })
+    return loadLocalCache()
+  }
+}
+
+/** Admin-only: persist the enabled-town list. Firestore rules reject non-admin writes. */
+export async function saveEnabledTownIds(ids: string[]): Promise<void> {
+  await setDoc(TOWN_ACCESS_DOC, { enabled: ids })
+  saveLocalCache(ids)
+}
+
+/** True if `locationId` should be reachable right now for this player. */
+export function isTownAccessible(locationId: string, enabledTownIds: Set<string>, isAdmin: boolean): boolean {
+  if (isAdmin) return true
+  if (ALWAYS_OPEN_LOCATION_IDS.includes(locationId)) return true
+  return enabledTownIds.has(locationId)
+}


### PR DESCRIPTION
## Summary
- Ravenwatch and Millhaven stay open to every player; every other hub-world town is now locked by default until the admin enables it.
- New "Town Access" admin screen (Settings → Admin, gated behind the same admin UID as the other admin tools) lets the admin toggle each remaining town on/off.
- The admin account always bypasses the restriction, so admin testing/access is unaffected.
- Enforced in two places: the world map (locked towns render with a lock icon, same as progression-locked nodes, and can't be clicked into) and `goToWorldLocation` (the shared chokepoint used both by the world map and by in-town direct-exit doors), so the gate can't be bypassed by walking through a town exit.
- Setting is stored in a new Firestore doc `globalState/townAccess` (public read, admin-only write — same pattern as the existing `gifts`/`news` collections), with a localStorage cache fallback if Firestore is unreachable.

## Implementation
- `web/src/game/townAccess.ts` — always-open list, toggleable-town list, Firestore fetch/save, `isTownAccessible()` helper.
- `web/src/components/admin/TownAccessAdminScreen.tsx` — new admin toggle screen.
- `web/src/components/ui/NodeMap/NodeMapRederer.tsx` — `getWorldNodeStatus()` accepts an optional `restrictedNodeIds` set and treats those nodes as locked.
- `web/src/components/hub/HubWorldMap.tsx` — threads `restrictedNodeIds` through to the renderer and peek modal.
- `web/src/App.tsx` — fetches enabled towns on load, computes `restrictedTownNodeIds`, gates `goToWorldLocation`, wires the new admin screen into `Screen`/routing.
- `web/src/components/screens/SettingsScreen.tsx` — adds the "Town access" button to the existing ADMIN section.
- `firestore.rules` — adds the `globalState/townAccess` rule (public read, admin-only write).

## Test plan
- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 680/680 tests pass (one unrelated Playwright headless-shell environment error during teardown, pre-existing in this sandbox, unrelated to this change)
- [ ] Manually verify in a deployed environment: non-admin sees only Ravenwatch/Millhaven open by default; admin toggles a town on in the new admin screen and confirms it becomes enterable for a non-admin account; admin account can always enter every town regardless of the setting


---
_Generated by [Claude Code](https://claude.ai/code/session_012ctFp6hoMpZj6jGRnj632P)_