### PR TITLE
Hide admin-locked towns behind fog on the world map

### DIFF
--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -36,6 +36,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
   const [peekNode, setPeekNode] = useState<WorldNodeDef | null>(null)
   const [questsOpen, setQuestsOpen] = useState(false)
   const [wrongSave, setWrongSave]   = useState<{ cards: number; crystals: number; deck: number } | null>(null)
+  const [fogTapped, setFogTapped]   = useState(false)
 
   const { isNight: isGameNight } = useHubClock()
   const playerName = loadPlayerName()
@@ -113,6 +114,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
           worldMap={WORLD_MAP}
           clearedNodeIds={clearedNodeIds}
           restrictedNodeIds={restrictedNodeIds}
+          onFoggedTap={() => setFogTapped(true)}
           mapWidth={1600}
           mapHeight={1400}
           setPeekNode={setPeekNode}
@@ -127,6 +129,21 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
             onEnter={() => { setPeekNode(null); onSelectNode(peekNode) }}
             onClose={() => setPeekNode(null)}
           />
+        )}
+        {fogTapped && (
+          <div className="nm-peek-backdrop" onClick={() => setFogTapped(false)}>
+            <div className="nm-peek-panel" onClick={e => e.stopPropagation()}>
+              <div className="nm-peek-header u-col u-items-c u-gap-1">
+                <span className="nm-peek-icon">🌫</span>
+              </div>
+              <div className="nm-peek-desc" style={{ textAlign: 'center' }}>
+                The fog is too thick to proceed.
+              </div>
+              <div className="nm-peek-actions u-flex u-gap-4">
+                <button className="action-btn nm-peek-back-btn u-grow" onClick={() => setFogTapped(false)}>BACK</button>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </OverlayScreen>

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -32,6 +32,7 @@ interface Props {
   run?: RunState               // campaign mode: required when clearedNodeIds absent
   clearedNodeIds?: Set<string> // world mode: required when run absent
   restrictedNodeIds?: Set<string> // world mode: towns locked by admin town-access setting
+  onFoggedTap?: (node: QuestNode) => void // world mode: tapped a restrictedNodeIds town
   mapWidth?: number            // override canvas width (world map uses 700)
   mapHeight?: number           // override canvas height (world map uses 520)
   setPeekNode: (node: QuestNode | null) => void
@@ -590,7 +591,7 @@ function updateMarkerStyle(
 
 // ── Main component ─────────────────────────────────────────────────────────────
 
-export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNodeIds, mapWidth: mapWidthProp, mapHeight: mapHeightProp, setPeekNode, showPaths }: Props) {
+export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNodeIds, onFoggedTap, mapWidth: mapWidthProp, mapHeight: mapHeightProp, setPeekNode, showPaths }: Props) {
   const isFreeform = useMemo(() => Object.values(worldMap.nodes).some(n => n.x !== undefined), [worldMap.nodes])
 
   const availableIds      = useMemo(() => run ? getAvailableNodeIds(worldMap.nodes, run) : [], [worldMap.nodes, run])
@@ -669,6 +670,33 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
 
       for (const node of Object.values(worldMap.nodes)) {
         if (deadRef.current) return
+
+        // Admin-disabled town: hidden under fog instead of the usual lock icon.
+        // Still tappable so a curious player learns why, but never walked to or peeked.
+        if (restrictedNodeIds?.has(node.id)) {
+          const fogContainer = new PIXI.Container()
+          fogContainer.position.set(node.x!, node.y!)
+
+          const fog = new PIXI.Graphics()
+          for (const [ox, oy, r] of [[0, 0, 22], [-13, 5, 14], [13, 5, 14], [0, -11, 15]] as const) {
+            fog.circle(ox, oy, r).fill({ color: 0xaaaaaa, alpha: 0.5 })
+          }
+          fogContainer.addChild(fog)
+
+          const fogIcon = new PIXI.Text({ text: '🌫',
+            style: { fontSize: 16, fontFamily: 'monospace' } })
+          fogIcon.anchor.set(0.5)
+          fogContainer.addChild(fogIcon)
+
+          makeClickable(fogContainer, () => {
+            if (isWalkingRef.current) return
+            onFoggedTap?.(node)
+          })
+
+          worldLayer.addChild(fogContainer)
+          continue
+        }
+
         const available = getWorldNodeStatus(node, clearedNodeIds ?? new Set(), restrictedNodeIds) !== 'locked'
         const isCurrent = node.id === currentLocation
         const container = new PIXI.Container()


### PR DESCRIPTION
## Summary
- Follow-up to #2007 (Town Access admin setting). Towns disabled by the admin now render on the world map as an obscured fog cloud (no decor, no name label) instead of the previous dim-with-lock-icon treatment, so their identity stays hidden until the admin enables them.
- Tapping a fogged town shows a short "The fog is too thick to proceed." message instead of walking the avatar there or opening the normal town peek panel.
- The admin account is unaffected — `restrictedNodeIds` is already empty for admin (from the existing `isTownAccessible` bypass), so admin sees every town normally and can walk to any of them.
- Progression-locked nodes (e.g. a battle node not yet unlocked by clearing prerequisites) keep their existing dim/🔒 treatment — this change only affects towns locked via the admin Town Access setting.

## Implementation
- `web/src/components/ui/NodeMap/NodeMapRederer.tsx` — new `onFoggedTap` prop; the world-map node-render loop now special-cases `restrictedNodeIds` membership before the normal decor/label/lock rendering, drawing a small cluster of translucent grey circles + a 🌫 glyph and wiring the tap handler to `onFoggedTap` instead of the normal walk-and-peek flow.
- `web/src/components/hub/HubWorldMap.tsx` — passes `onFoggedTap`, tracks a `fogTapped` state, and renders a small modal (reusing the existing `nm-peek-*` styling) with the fog message and a BACK button.

## Test plan
- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 680/680 tests pass (one unrelated Playwright headless-shell teardown error, pre-existing in this sandbox)
- [ ] Manually verify in a deployed environment: a non-admin sees fog over an admin-disabled town on the world map, tapping it shows the fog message and doesn't navigate; enabling the town in the admin screen makes it appear normally; the admin account never sees fog


---
_Generated by [Claude Code](https://claude.ai/code/session_012ctFp6hoMpZj6jGRnj632P)_