### PR TITLE
Fix fog: hide dead-end battles into locked towns, follow real road bends

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,7 +120,7 @@ import { isNoDamageMode } from './game/debug'
 import { saveBattleState, loadBattleState, clearBattleState } from './game/battleState'
 import { loadCommander, promoteCommander, CommanderState } from './game/commander'
 
-import { WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
+import { WORLD_MAP, WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
 import { setCurrentWorldLocation, getCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
 import { CommanderScreen } from './components/screens/CommanderScreen'
 import { TrainingScreen }  from './components/screens/TrainingScreen'
@@ -565,12 +565,32 @@ export default function App() {
   // player would, by suppressing their own town-access bypass.
   const [previewAsPlayer, setPreviewAsPlayer] = useState<boolean>(loadPreviewAsPlayer)
   const bypassTownAccess = isAdmin && !previewAsPlayer
+  // Fogged nodes: locked towns themselves, plus any battle/waypoint node whose
+  // own connections only ever lead to a locked town (so it has no reachable
+  // purpose right now) — a battle node right next to Ravenwatch stays fogged
+  // if its only destination is a currently-locked town, while one that leads
+  // on to an unlocked town (however many hops away) stays revealed.
   const restrictedTownNodeIds = useMemo(() => {
     const ids = new Set<string>()
+    if (bypassTownAccess) return ids // admin bypass: nothing is fogged
+
+    const nodesById = WORLD_MAP.nodes
+    const memo = new Map<string, boolean>()
+    const leadsSomewhereOpen = (id: string): boolean => {
+      if (memo.has(id)) return memo.get(id)!
+      memo.set(id, false) // cycle guard while this id is being resolved
+      const node = nodesById[id]
+      const result = node
+        ? node.locationKey
+          ? isTownAccessible(node.locationKey, enabledTownIds, false)
+          : (node.connections ?? node.childIds).some(leadsSomewhereOpen)
+        : false
+      memo.set(id, result)
+      return result
+    }
+
     for (const node of WORLD_MAP_NODES) {
-      if (node.locationKey && !isTownAccessible(node.locationKey, enabledTownIds, bypassTownAccess)) {
-        ids.add(node.id)
-      }
+      if (!leadsSomewhereOpen(node.id)) ids.add(node.id)
     }
     return ids
   }, [enabledTownIds, bypassTownAccess])

--- a/web/src/components/hub/HubWorldMap.stories.tsx
+++ b/web/src/components/hub/HubWorldMap.stories.tsx
@@ -26,6 +26,12 @@ export const Default: Story = {
   },
 }
 
+// Only Thornwood Camp is admin-enabled (plus the always-open Ravenwatch and
+// Millhaven). Matches what App.tsx's restrictedTownNodeIds would compute for
+// that config: every other town is fogged, and so is every battle node whose
+// only destination is one of those locked towns (Forest Path / Bridge Battle,
+// which solely gate the locked Ironhold Keep) — while River Crossing stays
+// open since it leads on to the unlocked Millhaven.
 export const FoggedTowns: Story = {
   args: {
     onSelectNode: fn(),
@@ -33,9 +39,15 @@ export const FoggedTowns: Story = {
     onFeedback:   fn(),
     user:         null,
     restrictedNodeIds: new Set([
-      'gravemoor', 'hollowmere', 'appleford', 'harrowfield', 'capital-city',
-      'gearford', 'ironhold-keep', 'thornwood-camp', 'saltmere-port',
-      'royal-palace', 'dreadspire-citadel',
+      'forest-path', 'bridge-battle', 'ironhold-keep', 'b-blight-fields',
+      'gravemoor', 'b-grave-mists', 'b-crypt-road', 'hollowmere',
+      'b-howling-dark', 'b-dread-gate', 'dreadspire-citadel', 'b-east-road',
+      'appleford', 'b-orchard-raid', 'b-salt-marsh', 'saltmere-port',
+      'b-pirate-cove', 'b-smugglers-landing', 'b-south-road', 'harrowfield',
+      'b-scarecrow-fields', 'b-river-ford', 'b-royal-checkpoint',
+      'capital-city', 'royal-palace', 'b-tournament', 'b-west-road',
+      'b-mine-trouble', 'gearford', 'b-smoke-fields', 'b-foundry-gate',
+      'b-bandit-toll',
     ]),
   },
 }

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -749,7 +749,8 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
         fogCtx.fillStyle = 'rgba(195,200,210,0.94)'
         fogCtx.fillRect(0, 0, mapWidth, mapHeight)
         fogCtx.globalCompositeOperation = 'destination-out'
-        fogCtx.lineCap = 'round'
+        fogCtx.lineCap  = 'round'
+        fogCtx.lineJoin = 'round'
 
         const seenEdges = new Set<string>()
         for (const node of Object.values(worldMap.nodes)) {
@@ -773,8 +774,15 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
             const target = worldMap.nodes[connId]
             if (!target || target.x === undefined || target.y === undefined) continue
 
+            // Follow the same elbow route (horizontal → vertical → horizontal via
+            // the midpoint column) that buildWorldPathTiles draws the road tiles
+            // along, so the reveal swath fully covers the actual bent road art
+            // instead of just a straight line between the two node centers.
+            const midX = (node.x + target.x) / 2
             const path = new Path2D()
             path.moveTo(node.x, node.y)
+            path.lineTo(midX, node.y)
+            path.lineTo(midX, target.y)
             path.lineTo(target.x, target.y)
             fogCtx.strokeStyle = 'rgba(0,0,0,1)'
             fogCtx.globalAlpha = 0.45


### PR DESCRIPTION
## Summary

Follow-up to #2010, fixing two issues found from field testing the fog:

1. **Battles beyond a locked town stayed visible.** A battle node (no `locationKey`) was never itself admin-restricted, so it stayed revealed even when its only destination was a locked town — e.g. Forest Path and Bridge Battle, which exist solely to gate Ironhold Keep, remained visible even with Ironhold Keep locked. `restrictedTownNodeIds` (in `App.tsx`) now walks each node's own `connections` recursively and fogs it unless that chain eventually reaches an accessible town. Town nodes still get their own independent `isTownAccessible` check, so an always-open or admin-enabled town (e.g. Millhaven) stays revealed even if everything between it and Ravenwatch is locked — it just won't have a connecting road drawn to Ravenwatch's fog bubble if the only route between them is cut by a locked town.
2. **Fog remnants on roads between two unlocked places.** The reveal swath was a straight line between node centers, but the actual road tiles (`buildWorldPathTiles`) bend through a horizontal → vertical → horizontal elbow via the midpoint column. The fog swath (`NodeMapRederer.tsx`) now follows that same elbow, so a fully-unlocked route is completely clear instead of leaving a sliver of fog where the road bends.

## Verification

Updated the `FoggedTowns` Storybook story to the exact scenario reported: only Thornwood Camp admin-enabled (plus always-open Ravenwatch/Millhaven), everything else locked. Screenshot confirms:
- Ravenwatch now sits in its own isolated fog bubble — Forest Path and Bridge Battle are fogged since they only ever led to the still-locked Ironhold Keep.
- Millhaven, River Crossing, and Thornwood Camp form one clear, unbroken connected zone (River Crossing stays open because it leads on to the unlocked Millhaven).
- A solid, gap-free fog band now separates the two zones where Ironhold Keep sits, instead of the old behavior where the intervening battle nodes leaked through as revealed "islands."

## Test plan
- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 680/680 tests pass (one unrelated Playwright headless-shell teardown error, pre-existing in this sandbox)
- [x] Visually verified via the updated `FoggedTowns` story + headless screenshot
- [ ] Manual check in a deployed environment against the live map at full size/zoom


---
_Generated by [Claude Code](https://claude.ai/code/session_012ctFp6hoMpZj6jGRnj632P)_