### PR TITLE
Fix black screen on resume: prompt to update instead of force-reloading the SW

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -291,8 +291,10 @@ function formatTimeAgo(date: Date): string {
 }
 
 export default function App() {
-  // ── PWA auto-update ───────────────────────────────────────────────────────────
+  // ── PWA update (prompt mode) ──────────────────────────────────────────────────
   const swRegRef = useRef<ServiceWorkerRegistration | null>(null)
+  // Lets the player dismiss the update prompt for the rest of the session.
+  const [updateDismissed, setUpdateDismissed] = useState(false)
   const { needRefresh: [needRefresh], updateServiceWorker } = useRegisterSW({
     onRegisteredSW(_url, r) {
       swRegRef.current = r ?? null
@@ -305,23 +307,28 @@ export default function App() {
       }
     },
     onNeedRefresh() {
-      journal('sw-need-refresh')
-      rollbar?.info('[sw] update available — applying skipWaiting')
-      updateServiceWorker(true)
+      // Prompt mode: don't auto-apply. Surface the toast (driven by needRefresh)
+      // and let the player reload at a safe moment. Auto-reloading here is what
+      // black-screened memory-pressured devices on resume.
+      journal('sw-update-available')
+      rollbar?.info('[sw] update available — awaiting player confirmation')
     },
   })
-  // Attached at mount (synchronously, before any async SW lifecycle callbacks)
-  // so we never miss the controllerchange event when skipWaiting activates a
-  // new service worker before onRegisteredSW has run.
+  // Reload once the new SW takes control. In prompt mode the new SW only
+  // activates after the player taps UPDATE (updateServiceWorker posts
+  // SKIP_WAITING) — or when another tab accepts the update — so this no longer
+  // fires spontaneously on resume. Attached at mount so we never miss the
+  // controllerchange event.
   useEffect(() => {
     if (!navigator.serviceWorker) return
     let reloading = false
     const handler = () => {
       if (reloading) return
       reloading = true
-      // Journaled (not just logged live) because this reload typically fires
-      // right at foreground resume, when a live Rollbar event has no time to
-      // send — the journal entry survives the reload and is flushed at boot.
+      // Journaled (not just logged live) because a live Rollbar event may not
+      // have time to send before the reload — the journal entry survives it and
+      // is flushed at boot. A reload with no preceding sw-update-accepted this
+      // session means another tab accepted the update.
       journal('sw-controllerchange-reload', { visibility: document.visibilityState })
       window.location.reload()
     }
@@ -3647,6 +3654,32 @@ export default function App() {
               <span className="ach-toast-sub">Achievement unlocked!</span>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Service-worker update prompt — replaces the old force-reload-on-resume.
+          The player reloads on their terms; dismiss hides it for the session. */}
+      {needRefresh && !updateDismissed && (
+        <div className="sw-update-toast">
+          <span className="sw-update-toast-text">A new version is available.</span>
+          <div className="sw-update-toast-actions">
+            <button
+              className="action-btn action-btn--sm"
+              onClick={() => {
+                journal('sw-update-accepted')
+                updateServiceWorker(true)
+              }}
+            >
+              UPDATE
+            </button>
+            <button
+              className="sw-update-toast-dismiss"
+              aria-label="Dismiss update"
+              onClick={() => setUpdateDismissed(true)}
+            >
+              ×
+            </button>
+          </div>
         </div>
       )}
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7568,6 +7568,42 @@ body {
   to   { opacity: 1; transform: translateX(0); }
 }
 
+/* ── Service-worker update prompt ─────────────────────────── */
+
+.sw-update-toast {
+  position: fixed;
+  bottom: 80px;
+  left: 12px;
+  z-index: 9000;
+  max-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #0a1420;
+  border: 1px solid #2a5a8a;
+  color: #88ccff;
+  font-size: var(--font-sm);
+  padding: 10px 12px;
+  box-shadow: 0 2px 8px rgba(0, 120, 255, 0.12);
+  animation: ach-toast-in 0.3s ease;
+}
+
+.sw-update-toast-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sw-update-toast-dismiss {
+  background: none;
+  border: none;
+  color: #4a7aaa;
+  font-size: var(--font-md);
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
 /* ── Hall of Achievements ───────────────────────────────────────────────── */
 
 .hoa-tabs {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,10 +14,15 @@ export default defineConfig({
     __BUILD_DATE__: JSON.stringify(new Date().toISOString())
   },
   plugins: [react(), VitePWA({
-    registerType: 'autoUpdate',
+    // 'prompt' (not 'autoUpdate') so a newly-installed SW never applies itself:
+    // the app surfaces a "new version" prompt and only reloads when the player
+    // accepts. Combined with removing skipWaiting/clientsClaim below, this stops
+    // the force-reload-on-resume that black-screened memory-pressured devices.
+    registerType: 'prompt',
     workbox: {
-      skipWaiting: true,
-      clientsClaim: true,
+      // No skipWaiting/clientsClaim: the new SW waits in the background until
+      // the app calls updateServiceWorker(true) on the player's tap. Until then
+      // the old SW keeps serving a consistent asset set (no stale-chunk risk).
       // Cache all static assets with cache-first strategy
       globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
       runtimeCaching: [{


### PR DESCRIPTION
## Problem

A live player's persisted resume journal (`localStorage.jarv_resume_journal`) pinned down a distinct cause of the "black screen / reload when returning to the game":

- Two `sw-controllerchange-reload` events, **both while `visibility: visible`** — the page hard-reloaded (`window.location.reload()`) the instant the tab was foregrounded, twice in one session.
- **Zero** `webglcontextlost` / `silent-context-loss` / `init-failed` entries — so this is *not* the WebGL context-loss path fixed in #2011.

The service worker was auto-updating and force-reloading on activation. Since `main` auto-deploys on every push, returning players frequently hit a freshly-deployed SW and got a hard reload mid-resume — a visible flash on desktop, and on a memory-pressured iPhone the reload's boot is the jetsam window (#2012), so it black-screened / reload-looped.

Root driver: `workbox.skipWaiting: true` + `clientsClaim: true` with `registerType: 'autoUpdate'` made the newly-installed SW **self-activate**, firing `controllerchange` with no user action — so fixing only `App.tsx` wouldn't have stopped it.

## Changes

**`web/vite.config.ts`** — `registerType: 'autoUpdate'` → `'prompt'`, and removed `skipWaiting`/`clientsClaim`. The new SW now waits in the background until the app posts `SKIP_WAITING`; until then the old SW serves a consistent asset set (also removes stale-chunk risk, which matters for the dynamic-import work in #2012). Verified in the built `dist/sw.js`: the only `skipWaiting()` left is message-gated (`SKIP_WAITING`), and `clientsClaim` is gone.

**`web/src/App.tsx`** — `onNeedRefresh` no longer auto-applies; the existing `needRefresh` state drives a non-blocking "A new version is available" toast with an **UPDATE** button (→ `updateServiceWorker(true)` → one reload) and a session dismiss. The `controllerchange` reload handler is unchanged but now only fires after the player accepts (or another tab does). New journal breadcrumbs `sw-update-available` / `sw-update-accepted`.

**`web/src/styles.css`** — `.sw-update-toast` styling mirroring the existing achievement toast, reusing `action-btn`.

## Verification

- `npm run build` passes; inspected `dist/sw.js` to confirm no self-activation.
- `npm run test`: 1314 tests / 228 files pass.
- Behavioral: no reload now fires on plain background/foreground; an available update surfaces the toast, and UPDATE applies + reloads exactly once.

## Telemetry

With jawg.uk now filing as `production` (#2011), the journal sequence `sw-update-available` → `sw-update-accepted` → `sw-controllerchange-reload` should be the norm; a `sw-controllerchange-reload` with no preceding `sw-update-accepted` flags a remaining spontaneous reload (e.g. multi-tab) to investigate.

## Related

- #2011 (merged) — WebGL context-loss recovery + telemetry env fix
- #2012 — boot-OOM (code-split screens + act data), the amplifier that makes any reload fatal on low-memory iPhones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvSYaBaDVq67Kzd9amkP3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvSYaBaDVq67Kzd9amkP3B)_