### PR TITLE
Add a road-waypoint mechanism to fix junctions that fuse into a flat bar

### DIFF
--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -72,6 +72,44 @@ export function getWorldNodeStatus(node: QuestNode, clearedNodeIds: Set<string>,
   return cleared ? 'available' : 'locked'
 }
 
+interface PixelPoint { x: number; y: number }
+interface TileCorner { tx: number; ty: number }
+
+// The single-bend elbow between two points: horizontal at a's row, vertical
+// at the midpoint column, horizontal at b's row — as 4 corner tile coords.
+function elbowCorners(a: PixelPoint, b: PixelPoint, T: number): TileCorner[] {
+  const aTx = Math.floor(a.x / T), aTy = Math.floor(a.y / T)
+  const bTx = Math.floor(b.x / T), bTy = Math.floor(b.y / T)
+  const midTx = Math.floor((a.x + b.x) / 2 / T)
+  return [{ tx: aTx, ty: aTy }, { tx: midTx, ty: aTy }, { tx: midTx, ty: bTy }, { tx: bTx, ty: bTy }]
+}
+
+// Full corner-tile list for an edge, optionally steered through hand-authored
+// waypoints (see QuestNode.connectionWaypoints). With no waypoints this is
+// exactly elbowCorners(node, target, T) — a single bend, unchanged from before.
+function edgeCorners(node: PixelPoint, target: PixelPoint, waypoints: PixelPoint[] | undefined, T: number): TileCorner[] {
+  const pts = [node, ...(waypoints ?? []), target]
+  const corners: TileCorner[] = []
+  for (let i = 0; i < pts.length - 1; i++) {
+    const seg = elbowCorners(pts[i], pts[i + 1], T)
+    corners.push(...(i === 0 ? seg : seg.slice(1))) // dedupe the shared join corner
+  }
+  return corners
+}
+
+// Fills every tile along a corner-to-corner path, where each consecutive
+// pair shares either a row (ty) or a column (tx) — guaranteed by elbowCorners.
+function fillCornerPath(pathSet: Set<string>, key: (tx: number, ty: number) => string, corners: TileCorner[]): void {
+  for (let i = 0; i < corners.length - 1; i++) {
+    const a = corners[i], b = corners[i + 1]
+    if (a.ty === b.ty) {
+      for (let tx = Math.min(a.tx, b.tx); tx <= Math.max(a.tx, b.tx); tx++) pathSet.add(key(tx, a.ty))
+    } else {
+      for (let ty = Math.min(a.ty, b.ty); ty <= Math.max(a.ty, b.ty); ty++) pathSet.add(key(a.tx, ty))
+    }
+  }
+}
+
 async function buildWorldPathTiles(
   container: PIXI.Container,
   nodes: QuestNode[],
@@ -91,16 +129,11 @@ async function buildWorldPathTiles(
       const target = nodes.find(n => n.id === connId)
       if (!target || target.x === undefined || node.x === undefined) continue
 
-      const aTx = Math.floor(node.x   / T), aTy = Math.floor(node.y!  / T)
-      const bTx = Math.floor(target.x / T), bTy = Math.floor(target.y! / T)
-      const midTx = Math.floor((node.x + target.x) / 2 / T)
-
-      for (let tx = Math.min(aTx, midTx); tx <= Math.max(aTx, midTx); tx++)
-        pathSet.add(key(tx, aTy))
-      for (let ty = Math.min(aTy, bTy); ty <= Math.max(aTy, bTy); ty++)
-        pathSet.add(key(midTx, ty))
-      for (let tx = Math.min(midTx, bTx); tx <= Math.max(midTx, bTx); tx++)
-        pathSet.add(key(tx, bTy))
+      const corners = edgeCorners(
+        { x: node.x, y: node.y! }, { x: target.x, y: target.y! },
+        node.connectionWaypoints?.[connId], T,
+      )
+      fillCornerPath(pathSet, key, corners)
     }
   }
 
@@ -773,17 +806,28 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
             seenEdges.add(edgeKey)
             const target = worldMap.nodes[connId]
             if (!target || target.x === undefined || target.y === undefined) continue
+            const nodeX = node.x, nodeY = node.y, targetX = target.x, targetY = target.y
 
-            // Follow the same elbow route (horizontal → vertical → horizontal via
-            // the midpoint column) that buildWorldPathTiles draws the road tiles
-            // along, so the reveal swath fully covers the actual bent road art
-            // instead of just a straight line between the two node centers.
-            const midX = (node.x + target.x) / 2
+            // Follow the exact same corner list buildWorldPathTiles draws the
+            // road tiles along (including any hand-authored connectionWaypoints),
+            // so the reveal swath fully covers the actual bent road art instead
+            // of a straight line — and can never drift out of sync with it,
+            // since both come from the same edgeCorners() call. Interior bends
+            // snap to their tile center (matching the drawn tile); the two
+            // endpoints stay at the real node/target pixel position so halos
+            // still center correctly.
+            const corners = edgeCorners(
+              { x: nodeX, y: nodeY }, { x: targetX, y: targetY },
+              node.connectionWaypoints?.[connId], TILE_SIZE,
+            )
             const path = new Path2D()
-            path.moveTo(node.x, node.y)
-            path.lineTo(midX, node.y)
-            path.lineTo(midX, target.y)
-            path.lineTo(target.x, target.y)
+            corners.forEach((c, i) => {
+              const last = corners.length - 1
+              const px = i === 0 ? nodeX : i === last ? targetX : c.tx * TILE_SIZE + TILE_SIZE / 2
+              const py = i === 0 ? nodeY : i === last ? targetY : c.ty * TILE_SIZE + TILE_SIZE / 2
+              if (i === 0) path.moveTo(px, py)
+              else path.lineTo(px, py)
+            })
             fogCtx.strokeStyle = 'rgba(0,0,0,1)'
             fogCtx.globalAlpha = 0.45
             fogCtx.lineWidth = 130

--- a/web/src/data/world/worldMap.json
+++ b/web/src/data/world/worldMap.json
@@ -17,6 +17,7 @@
       "row": 1, "col": 0, "rowCols": 1, "childIds": [],
       "x": 728, "y": 612,
       "connections": ["ironhold-keep"],
+      "connectionWaypoints": { "ironhold-keep": [{ "x": 728, "y": 550 }] },
       "requiredClears": [],
       "battleConfig": { "actId": "act1", "nodeId": "goblin-raid" },
       "decorTiles": [9]
@@ -26,6 +27,7 @@
       "row": 1, "col": 1, "rowCols": 1, "childIds": [],
       "x": 872, "y": 612,
       "connections": ["ironhold-keep"],
+      "connectionWaypoints": { "ironhold-keep": [{ "x": 872, "y": 550 }] },
       "requiredClears": [],
       "battleConfig": { "actId": "act1", "nodeId": "shrine" },
       "decorTiles": [18]

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -151,6 +151,14 @@ export interface QuestNode {
   y?: number
   // Bidirectional connections for world maps (supersedes childIds when present)
   connections?: string[]
+  // World map (freeform) only: hand-authored bend points for a specific
+  // outgoing edge, keyed by the target id (must be present in `connections`).
+  // The route is steered through these pixel points, in order, before
+  // reaching the target, using the same elbow (H/V/H) logic as an edge with
+  // no waypoints. Purely cosmetic — never affects gating/traversal (still
+  // driven by `connections`/`requiredClears`). Consumed only by the freeform
+  // world-map renderer in NodeMapRederer.tsx.
+  connectionWaypoints?: Record<string, { x: number; y: number }[]>
   // World map status: locked until these node IDs are cleared
   requiredClears?: string[]
   // Hub location key — reference into LOCATION_REGISTRY


### PR DESCRIPTION
## Summary

Follow-up to #2016 — a proper structural fix for the Ironhold Keep "T junction," this time as a general, reusable mechanism rather than another coordinate nudge.

**Root cause:** the world-map road renderer and the admin-fog reveal swath both routed every edge through a single hard-coded elbow (horizontal → vertical → horizontal via the midpoint column). Wherever two edges converge on the same target from the same broad side — Forest Path and Bridge Battle both feeding into Ironhold Keep is the worst case — their elbows land flat on the target's exact row and fuse into a meaningless crossbar, especially once the target and both approaches are hidden by fog.

**Fix:** `QuestNode.connectionWaypoints` — an optional, per-edge list of hand-authored bend points a route can be steered through before reaching its target (`web/src/game/questline.ts`). New shared `elbowCorners`/`edgeCorners`/`fillCornerPath` helpers in `NodeMapRederer.tsx` generalize the old single-bend logic to a chain of bends; with no waypoints the output is byte-for-byte identical to today's behavior, so the ~30 other edges on the map can't regress (verified — see below). Both the road-tile renderer and the fog reveal swath now consume the exact same corner list, which also fixes a real, independent bug: the fog's bend point wasn't tile-snapped the way the road tile's was, letting the two drift out of alignment by up to a tile.

**Applied to Ironhold Keep** (`web/src/data/world/worldMap.json`): Forest Path and Bridge Battle each now hold a straight run up their own side (west/east) before curving in, so the junction reads as two distinct approaches plus the exit north to Thornwood Camp — instead of a flat bar. Neither path is demoted relative to the other (both get identical, mirrored treatment), since clearing either one satisfies the same `requiredClears: ["forest-path|bridge-battle"]` OR-gate. The mechanism is generic — any other lopsided junction (e.g. Ravenwatch's 5-way hub) can get the same treatment later as a pure data change, no more code needed. Left that out of scope here since Ravenwatch is never fogged and nobody's flagged it as broken.

## Verification
- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 688/688 tests pass (one unrelated Playwright headless-shell teardown error, pre-existing in this sandbox)
- [x] Before/after Storybook screenshots (`Default` and `FoggedTowns` stories): confirmed a full-canvas pixel diff is isolated to the Ravenwatch↔ForestPath↔IronholdKeep↔BridgeBattle region (all other diffs traced to unrelated dynamic elements — wall-clock display, a pulsing location-ring animation — not this change)
- [x] Visually confirmed both fogged and unfogged views now show a clear two-direction "arch" into Ironhold Keep instead of a flat bar, and the fog swath hugs the road art tightly (no more visible offset)
- [ ] Manual check in a deployed environment against the live map at full size/zoom

## Test plan
Same as above — build, tests, and visual verification are all done; only the live-environment spot check remains.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ctFp6hoMpZj6jGRnj632P)_