### PR TITLE
Stop admin town-fog from softlocking progression to further-along towns

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,7 +120,7 @@ import { isNoDamageMode } from './game/debug'
 import { saveBattleState, loadBattleState, clearBattleState } from './game/battleState'
 import { loadCommander, promoteCommander, CommanderState } from './game/commander'
 
-import { WORLD_MAP, WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
+import { WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
 import { setCurrentWorldLocation, getCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
 import { CommanderScreen } from './components/screens/CommanderScreen'
 import { TrainingScreen }  from './components/screens/TrainingScreen'
@@ -572,32 +572,20 @@ export default function App() {
   // player would, by suppressing their own town-access bypass.
   const [previewAsPlayer, setPreviewAsPlayer] = useState<boolean>(loadPreviewAsPlayer)
   const bypassTownAccess = isAdmin && !previewAsPlayer
-  // Fogged nodes: locked towns themselves, plus any battle/waypoint node whose
-  // own connections only ever lead to a locked town (so it has no reachable
-  // purpose right now) — a battle node right next to Ravenwatch stays fogged
-  // if its only destination is a currently-locked town, while one that leads
-  // on to an unlocked town (however many hops away) stays revealed.
+  // Fogged nodes: only actual locations (towns/castles/camps/ports — anything
+  // with a locationKey) that the admin hasn't enabled. Battle/waypoint nodes
+  // are never admin-fogged — connections is a road-drawing convenience, not a
+  // proxy for requiredClears gating, so treating "leads to a locked town" as
+  // fog-worthy could hide a battle a player still needs to clear a further-
+  // along, already-enabled town's requiredClears, softlocking it. Battle
+  // availability stays governed only by the pre-existing progression system.
   const restrictedTownNodeIds = useMemo(() => {
     const ids = new Set<string>()
     if (bypassTownAccess) return ids // admin bypass: nothing is fogged
-
-    const nodesById = WORLD_MAP.nodes
-    const memo = new Map<string, boolean>()
-    const leadsSomewhereOpen = (id: string): boolean => {
-      if (memo.has(id)) return memo.get(id)!
-      memo.set(id, false) // cycle guard while this id is being resolved
-      const node = nodesById[id]
-      const result = node
-        ? node.locationKey
-          ? isTownAccessible(node.locationKey, enabledTownIds, false)
-          : (node.connections ?? node.childIds).some(leadsSomewhereOpen)
-        : false
-      memo.set(id, result)
-      return result
-    }
-
     for (const node of WORLD_MAP_NODES) {
-      if (!leadsSomewhereOpen(node.id)) ids.add(node.id)
+      if (node.locationKey && !isTownAccessible(node.locationKey, enabledTownIds, false)) {
+        ids.add(node.id)
+      }
     }
     return ids
   }, [enabledTownIds, bypassTownAccess])

--- a/web/src/components/hub/HubWorldMap.stories.tsx
+++ b/web/src/components/hub/HubWorldMap.stories.tsx
@@ -27,11 +27,14 @@ export const Default: Story = {
 }
 
 // Only Thornwood Camp is admin-enabled (plus the always-open Ravenwatch and
-// Millhaven). Matches what App.tsx's restrictedTownNodeIds would compute for
-// that config: every other town is fogged, and so is every battle node whose
-// only destination is one of those locked towns (Forest Path / Bridge Battle,
-// which solely gate the locked Ironhold Keep) — while River Crossing stays
-// open since it leads on to the unlocked Millhaven.
+// Millhaven). Matches what App.tsx's restrictedTownNodeIds actually computes
+// for that config: fog only ever covers locations (towns/castles/camps/
+// ports), never battle nodes — so Forest Path and Bridge Battle stay fully
+// visible and clickable (they have no locationKey and no requiredClears, so
+// hiding them would strand Thornwood Camp's own requiredClears — which only
+// needs one of those two battles cleared — behind fog with no way to satisfy
+// it). Only Ironhold Keep itself (and every other non-enabled location) is
+// fogged; the road into it fades into the fog since one endpoint is hidden.
 export const FoggedTowns: Story = {
   args: {
     onSelectNode: fn(),
@@ -39,15 +42,9 @@ export const FoggedTowns: Story = {
     onFeedback:   fn(),
     user:         null,
     restrictedNodeIds: new Set([
-      'forest-path', 'bridge-battle', 'ironhold-keep', 'b-blight-fields',
-      'gravemoor', 'b-grave-mists', 'b-crypt-road', 'hollowmere',
-      'b-howling-dark', 'b-dread-gate', 'dreadspire-citadel', 'b-east-road',
-      'appleford', 'b-orchard-raid', 'b-salt-marsh', 'saltmere-port',
-      'b-pirate-cove', 'b-smugglers-landing', 'b-south-road', 'harrowfield',
-      'b-scarecrow-fields', 'b-river-ford', 'b-royal-checkpoint',
-      'capital-city', 'royal-palace', 'b-tournament', 'b-west-road',
-      'b-mine-trouble', 'gearford', 'b-smoke-fields', 'b-foundry-gate',
-      'b-bandit-toll',
+      'ironhold-keep', 'gravemoor', 'hollowmere', 'dreadspire-citadel',
+      'appleford', 'saltmere-port', 'harrowfield', 'capital-city',
+      'royal-palace', 'gearford',
     ]),
   },
 }


### PR DESCRIPTION
## Summary

Fixes a real softlock bug in the admin town-access fog, found while testing #2017.

**The bug:** `restrictedTownNodeIds` fogged a battle node whenever its road eventually led (via `connections`, the road-*drawing* graph) to an admin-locked town — but `connections` isn't a proxy for `requiredClears` (the actual gameplay gate). Forest Path and Bridge Battle both have `requiredClears: []` and are the only way to satisfy Thornwood Camp's `requiredClears: ["forest-path|bridge-battle"]`. If the admin enables Thornwood Camp but leaves Ironhold Keep (the next town in the `connections` chain) disabled, the old logic hid *and tap-blocked* Forest Path/Bridge Battle too, since their only `connections` target (Ironhold Keep) was still locked — softlocking Thornwood Camp forever even though the admin turned it on, since the player could never clear the prerequisite battles.

**The fix** (`web/src/App.tsx`): fog now only ever applies to nodes with a `locationKey` (towns/castles/camps/ports), based purely on that node's own `isTownAccessible` result. Battle/waypoint nodes are never admin-fogged — their availability stays exactly what it's always been, governed only by the pre-existing, unrelated `requiredClears`/`clearedNodeIds` progression system. Nothing admin-controlled can hide a node the existing progression system says is currently available, so this can't softlock anything, for this town or any future admin configuration.

This doesn't touch the Ironhold Keep junction/arch fix from #2017 — when Ironhold Keep *is* admin-open, both approach edges still get revealed together and the `connectionWaypoints` routing still applies. What changes is only the case where Ironhold Keep stays closed: previously that also hid Forest Path/Bridge Battle entirely; now they stay visible and clickable, and only the edge into Ironhold Keep (and Ironhold Keep itself) stays fogged.

Also updates `HubWorldMap.stories.tsx`'s `FoggedTowns` story to the corrected fogged-id set for the same "only Thornwood Camp enabled" scenario.

## Verification
- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 688/688 tests pass (one unrelated Playwright headless-shell teardown error, pre-existing in this sandbox)
- [x] Screenshot-verified the softlock scenario (only Thornwood Camp admin-enabled): Forest Path and Bridge Battle now render fully visible with their halos, Ironhold Keep itself stays completely hidden (no icon/label, just fog with faint road bleed-through), and every other battle node across the map is likewise always visible
- [ ] Manual check in a deployed environment: enable only a "deep" town and confirm the prerequisite battles are reachable and clearing them actually unlocks it

## Test plan
Same as above — build, tests, and visual verification are done; only the live-environment spot check remains.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ctFp6hoMpZj6jGRnj632P)_