### PR TITLE
Fog battles by requiredClears reachability, not connections adjacency

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,7 +120,7 @@ import { isNoDamageMode } from './game/debug'
 import { saveBattleState, loadBattleState, clearBattleState } from './game/battleState'
 import { loadCommander, promoteCommander, CommanderState } from './game/commander'
 
-import { WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
+import { WORLD_MAP, WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
 import { setCurrentWorldLocation, getCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
 import { CommanderScreen } from './components/screens/CommanderScreen'
 import { TrainingScreen }  from './components/screens/TrainingScreen'
@@ -572,18 +572,40 @@ export default function App() {
   // player would, by suppressing their own town-access bypass.
   const [previewAsPlayer, setPreviewAsPlayer] = useState<boolean>(loadPreviewAsPlayer)
   const bypassTownAccess = isAdmin && !previewAsPlayer
-  // Fogged nodes: only actual locations (towns/castles/camps/ports — anything
-  // with a locationKey) that the admin hasn't enabled. Battle/waypoint nodes
-  // are never admin-fogged — connections is a road-drawing convenience, not a
-  // proxy for requiredClears gating, so treating "leads to a locked town" as
-  // fog-worthy could hide a battle a player still needs to clear a further-
-  // along, already-enabled town's requiredClears, softlocking it. Battle
-  // availability stays governed only by the pre-existing progression system.
+  // Fogged nodes: locations (towns/castles/camps/ports) the admin hasn't
+  // enabled, plus any battle/waypoint node that isn't a requiredClears
+  // prerequisite (directly, or transitively through an OR-alternative) for
+  // reaching a currently-open town. Deliberately based on requiredClears —
+  // the real gameplay gate — rather than `connections` (a road-drawing
+  // convenience graph that mostly but doesn't always match it: e.g. Forest
+  // Path/Bridge Battle gate Ironhold Keep, Thornwood Camp, and River
+  // Crossing independently, not chained through Ironhold Keep, even though
+  // `connections` draws them as one line). Using `connections` instead
+  // could fog a battle a player still needs to satisfy a further-along,
+  // already-enabled town's requiredClears — softlocking it.
   const restrictedTownNodeIds = useMemo(() => {
     const ids = new Set<string>()
     if (bypassTownAccess) return ids // admin bypass: nothing is fogged
+
+    const nodesById = WORLD_MAP.nodes
+    const openTownIds = WORLD_MAP_NODES
+      .filter(n => n.locationKey && isTownAccessible(n.locationKey, enabledTownIds, false))
+      .map(n => n.id)
+
+    const neededIds = new Set<string>()
+    const markNeeded = (id: string): void => {
+      if (neededIds.has(id)) return
+      neededIds.add(id)
+      for (const group of nodesById[id]?.requiredClears ?? []) {
+        for (const altId of group.split('|')) markNeeded(altId)
+      }
+    }
+    openTownIds.forEach(markNeeded)
+
     for (const node of WORLD_MAP_NODES) {
-      if (node.locationKey && !isTownAccessible(node.locationKey, enabledTownIds, false)) {
+      if (node.locationKey) {
+        if (!isTownAccessible(node.locationKey, enabledTownIds, false)) ids.add(node.id)
+      } else if (!neededIds.has(node.id)) {
         ids.add(node.id)
       }
     }

--- a/web/src/components/hub/HubWorldMap.stories.tsx
+++ b/web/src/components/hub/HubWorldMap.stories.tsx
@@ -28,13 +28,15 @@ export const Default: Story = {
 
 // Only Thornwood Camp is admin-enabled (plus the always-open Ravenwatch and
 // Millhaven). Matches what App.tsx's restrictedTownNodeIds actually computes
-// for that config: fog only ever covers locations (towns/castles/camps/
-// ports), never battle nodes — so Forest Path and Bridge Battle stay fully
-// visible and clickable (they have no locationKey and no requiredClears, so
-// hiding them would strand Thornwood Camp's own requiredClears — which only
-// needs one of those two battles cleared — behind fog with no way to satisfy
-// it). Only Ironhold Keep itself (and every other non-enabled location) is
-// fogged; the road into it fades into the fog since one endpoint is hidden.
+// for that config: locations are fogged unless admin-enabled; battle nodes
+// are fogged unless they're a requiredClears prerequisite (directly, or
+// through an OR-alternative) for reaching an open town. Forest Path, Bridge
+// Battle, and River Crossing stay visible/clickable — clearing one of the
+// first two is Thornwood Camp's (and River Crossing's, and Millhaven's,
+// independently) only requirement, not "reach Ironhold Keep" — while every
+// other battle (Collapsed Mine, Salt Marsh Crossing, Bandit Toll, etc.),
+// which serves only locked content, stays fogged along with the towns
+// themselves.
 export const FoggedTowns: Story = {
   args: {
     onSelectNode: fn(),
@@ -42,9 +44,14 @@ export const FoggedTowns: Story = {
     onFeedback:   fn(),
     user:         null,
     restrictedNodeIds: new Set([
-      'ironhold-keep', 'gravemoor', 'hollowmere', 'dreadspire-citadel',
-      'appleford', 'saltmere-port', 'harrowfield', 'capital-city',
-      'royal-palace', 'gearford',
+      'appleford', 'b-bandit-toll', 'b-blight-fields', 'b-crypt-road',
+      'b-dread-gate', 'b-east-road', 'b-foundry-gate', 'b-grave-mists',
+      'b-howling-dark', 'b-mine-trouble', 'b-orchard-raid', 'b-pirate-cove',
+      'b-river-ford', 'b-royal-checkpoint', 'b-salt-marsh',
+      'b-scarecrow-fields', 'b-smoke-fields', 'b-smugglers-landing',
+      'b-south-road', 'b-tournament', 'b-west-road', 'capital-city',
+      'dreadspire-citadel', 'gearford', 'gravemoor', 'harrowfield',
+      'hollowmere', 'ironhold-keep', 'royal-palace', 'saltmere-port',
     ]),
   },
 }


### PR DESCRIPTION
## Summary

Follow-up to #2018, which fixed a real softlock but over-corrected: making battle nodes never admin-fogged also revealed every battle serving only permanently-locked content (Collapsed Mine, Salt Marsh Crossing, Bandit Toll, etc. all became visible even though nothing they gate is open) — the opposite problem from what the fog feature was built for.

**Root cause:** `connections` (the road-*drawing* graph) and `requiredClears` (the actual gameplay gate) are different graphs that mostly, but don't always, overlap. Forest Path and Bridge Battle gate Ironhold Keep, Thornwood Camp, and River Crossing *independently* — all three only need one of the two battles cleared, not "reach Ironhold Keep" — but `connections` draws them as a single chain through Ironhold Keep. Read every `requiredClears` entry in `worldMap.json` to confirm this is safe to rely on: each is a single OR-group string, never multiple AND'd entries, and never references a location id — a clean, walkable dependency graph on its own.

**The fix** (`web/src/App.tsx`): `restrictedTownNodeIds` now walks `requiredClears` from every currently-open town (directly, and transitively through any OR-alternative) to build the set of battle ids that actually matter right now, and only fogs a battle node if it's outside that set. This satisfies both #2018's softlock concern and the original "hide undeveloped content" ask simultaneously — nothing needed for an open town can ever be fogged, and nothing serving only locked content stays visible. Locations keep their existing independent `isTownAccessible` check, unchanged.

Also updates `HubWorldMap.stories.tsx`'s `FoggedTowns` story to the corrected fogged-id set for the same "only Thornwood Camp enabled" scenario.

## Verification
- [x] `npm run build` (typecheck + Vite build) passes
- [x] `npm run test` — 688/688 tests pass (one unrelated Playwright headless-shell teardown error, pre-existing in this sandbox)
- [x] Verified the exact fogged-id set by walking the algorithm over `worldMap.json` with a script before updating the story, then screenshot-confirmed all three properties hold together: Forest Path/Bridge Battle/River Crossing visible and clickable, Ironhold Keep fully hidden, and every unrelated battle (Collapsed Mine, Quarry Road, Salt Marsh Crossing, Bandit Toll, Old King's Road, Southford Crossing, Royal Checkpoint, Scarecrow Fields, etc.) fogged again
- [ ] Manual check in a deployed environment: enable a "deep" town, confirm its prerequisite battles are reachable and clearing them unlocks it, and confirm unrelated locked-content battles stay hidden

## Test plan
Same as above — build, tests, and visual verification are done; only the live-environment spot check remains.


---
_Generated by [Claude Code](https://claude.ai/code/session_012ctFp6hoMpZj6jGRnj632P)_