### PR TITLE
Only show the SW update toast on the title screen or a hub town

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3668,8 +3668,12 @@ export default function App() {
       )}
 
       {/* Service-worker update prompt — replaces the old force-reload-on-resume.
-          The player reloads on their terms; dismiss hides it for the session. */}
-      {needRefresh && !updateDismissed && (
+          The player reloads on their terms; dismiss hides it for the session.
+          Only surfaced on the title screen or a hub town (screen 'hubworld' /
+          'location', both rendered by HubWorld) — safe, non-disruptive spots to
+          reload from, never mid-battle or in a menu. */}
+      {needRefresh && !updateDismissed
+        && (screen === 'title' || screen === 'hubworld' || screen === 'location') && (
         <div className="sw-update-toast">
           <span className="sw-update-toast-text">A new version is available.</span>
           <div className="sw-update-toast-actions">


### PR DESCRIPTION
## What

Follow-up to #2015. Gate the "A new version is available" update toast so it only appears when `screen` is `title`, `hubworld`, or `location` (the latter two both render `HubWorld`'s town canvas). Previously it could surface on any screen — including mid-battle or in a menu, where reloading is disruptive. The title screen and hub towns are safe, natural points to reload from.

## Change

One conditional in `web/src/App.tsx` on the toast's render guard:

```jsx
{needRefresh && !updateDismissed
  && (screen === 'title' || screen === 'hubworld' || screen === 'location') && ( … )}
```

No behavioral change to the SW update mechanism itself — the update still applies only on the player's tap; this just controls *where* the prompt is offered.

## Verification

- `npm run build` passes (typecheck + build).
- `npm run test`: 1314 tests / 228 files pass.

## Related
- #2015 (merged) — prompt-to-update instead of force-reloading the SW on resume
- #2012 — boot-OOM (code-split screens + act data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvSYaBaDVq67Kzd9amkP3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvSYaBaDVq67Kzd9amkP3B)_