### PR TITLE
Fix inn rumours never appearing for Innkeeper Rosie

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -10,10 +10,10 @@
 
 | File | Owns | TypeScript exports |
 |---|---|---|
-| `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs, exterior decor, interiors, windows, interactables | parsed by `loader.ts` |
-| `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, inn rumours, friendship dialogue, dialogue trees, relationship dialogue | parsed by `loader.ts` and `questDefs.ts` |
+| `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs (incl. each NPC's own `innRumours`), exterior decor, interiors, windows, interactables | parsed by `loader.ts` |
+| `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, friendship dialogue, dialogue trees, relationship dialogue | parsed by `loader.ts` and `questDefs.ts` |
 | `web/src/data/hub/loader.ts` | Parses both JSON files; exports all map/NPC/item/path data | `MAP_W`, `MAP_H`, `AVATAR_START`, `HUB_AREAS`, `HUB_STREET_TILES`, `HUB_BUILDINGS`, `HUB_DOORS`, `HUB_INTERIORS`, `EXTERIOR_DECOR`, `HUB_NPCS`, `EXTERIOR_NPCS`, `INTERIOR_NPCS`, `HUB_PICKUP_ITEMS`, `HUB_BLOCKED_PATHS`, `HUB_LOCKED_DOORS`, … |
-| `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `INN_RUMOURS`, `FRIENDSHIP_DIALOGUE` |
+| `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `FRIENDSHIP_DIALOGUE` |
 | `web/src/game/hub/quests.ts` | Quest progress/status persistence (localStorage) | `getQuestState`, `setQuestStatus`, `incrementQuestProgress`, `getQuestProgress`, `resetQuest` |
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
 | `web/src/game/hub/friendship.ts` | NPC friendship XP/level persistence (localStorage) — signed ladder, see §7f | `getFriendshipLevel`, `addFriendshipXp`, `getFriendshipData`, `MAX_FRIENDSHIP_LEVEL` |
@@ -21,7 +21,7 @@
 | `web/src/data/hub/buildingUpgrades.json` / `.ts` | Shared upgrade tracks keyed by building *kind* (costs, benefits, services, decor) — see §10 | `getUpgradeTrack`, `getReputationTier`, `REPUTATION_TIERS` |
 | `web/src/game/hub/relationships.ts` | NPC relationship-track (ally/rival/romance) persistence (localStorage) — see §7c | `getRelationship`, `getRelationshipTrack`, `getRelationshipLevel`, `addRelationshipPoints`, `grantRelationshipWithRivalry`, `relationshipProgress` |
 | `web/src/game/hub/dialogueFlags.ts` | Branching-dialogue flag + "seen" branch persistence (localStorage) — see §7b | `setDialogueFlag`, `hasDialogueFlag`, `getDialogueFlags`, `markNodeSeen`, `hasNodeSeen` |
-| `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard` |
+| `web/src/game/hub/innConvos.ts` | Inn conversation tracking (localStorage) | `getHeardConvoIds`, `markConvoHeard`, `isConvoHeard`, `resetHeardConvoIds` |
 | `web/src/game/hub/interactables.ts` | Interactable grant + moved-position persistence (localStorage) | `interactableStoreKey`, `isInteractableGranted`, `markInteractableGranted`, `getInteractableMoves`, `setInteractableMove` |
 | `web/src/game/hub/animals.ts` | Pure animal logic — `ANIMAL_SPECS` registry (per-type data), spawn maths, tint resolution | `ANIMAL_SPECS`, `computeProceduralCounts`, `resolveVariantTint`, `ANIMAL_CAPS`, `TINT_PALETTES` |
 | `web/src/components/hub/hubAnimals.ts` | PixiJS animal manager — spawns & ticks all animal types | `createAnimalSystem` |
@@ -1516,13 +1516,13 @@ or unedited keys are preserved).
 | mapW/H, townName, environment (config) | Town panel (no selection) |
 | avatarStart, exitTiles, weather, ambientNpcSprites, npcSpawnTiles, pondTiles, chickenZones (config) | Town panel → extra sections |
 | buildings, exteriorDecor, interiors, streets, areas, doors (config) | Canvas tools + Building/Interior/Street/Area inspectors |
-| npcs, animals (config) | NPC drawer (NPCs tab) + canvas |
+| npcs, animals, innRumours (config, per-NPC) | NPC drawer (NPCs tab) + canvas |
 | treasures (config) | "+ Add Treasure" + Treasure inspector; quest-items overlay |
 | interactables (config) | Interactables overlay toggle + Interactable inspector (incl. reactions) |
 | lockedDoors (config) | Building inspector → locked door |
 | quests, pickupItems (questDefs) | NPC drawer (Quests tab) |
 | blockedPaths (questDefs) | "+ Add Road Block" + Blocked Path inspector; blocked-paths overlay |
-| innRumours, friendshipDialogue, relationshipDialogue, dialogues (questDefs) | NPC drawer (Dialogue tab) |
+| friendshipDialogue, relationshipDialogue, dialogues (questDefs) | NPC drawer (Dialogue tab) |
 
 **Pick-on-map:** NPCs, animals, treasures, interactables, exit tiles, avatar
 spawn, and blocked-path tiles all support a "📍 Pick on map" button that sets

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -175,7 +175,7 @@ export function HubTownCanvas({
     EXIT_TILES: exitTilesData,
     HUB_TOWN_NAME: locationKey,
   } = locationData
-  const {HUB_QUEST_DEFS,INN_RUMOURS,FRIENDSHIP_DIALOGUE,HUB_PICKUP_ITEMS,HUB_BLOCKED_PATHS} = questData
+  const {HUB_QUEST_DEFS,FRIENDSHIP_DIALOGUE,HUB_PICKUP_ITEMS,HUB_BLOCKED_PATHS} = questData
   const HUB_ENV = locationData?.ENVIRONMENT || 'camp'
   const HUB_WEATHER = locationData?.WEATHER
   const COURTYARD_PX = { x: AVATAR_START.tx * T + T / 2, y: AVATAR_START.ty * T + T }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -16,7 +16,7 @@ import { canTalkToday, recordTalk } from '../../game/hub/talkCooldown'
 import { canGiftToday, recordGift } from '../../game/hub/giftCooldown'
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
-import { getHeardConvoIds, markConvoHeard } from '../../game/hub/innConvos'
+import { getHeardConvoIds, markConvoHeard, resetHeardConvoIds } from '../../game/hub/innConvos'
 import { loadDeck, loadCollection, loadCrystals, saveCrystals, addCardsToCollection, addAugmentInstance, CRYSTAL_PACK_COST } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
 import { CommanderState } from '../../game/commander'
@@ -1253,13 +1253,15 @@ function hasOfferableQuest(giverId: string): boolean {
     // ── Inn rumour handling (Innkeeper Rosie) ───────────────────────────────
     if (npcId === 'innkeeper-rosie' && npcDef?.innRumours) {
       const heard = getHeardConvoIds()
-      const unheard = npcDef.innRumours.filter(r => !heard.has(r.id))
-      if (unheard.length > 0) {
-        const rumour = unheard[0]
-        markConvoHeard(rumour.id)
-        setDialogueEvent({ speakerName, text: rumour.text })
-        return
+      let unheard = npcDef.innRumours.filter(r => !heard.has(r.id))
+      if (unheard.length === 0) {
+        resetHeardConvoIds(npcDef.innRumours.map(r => r.id))
+        unheard = npcDef.innRumours
       }
+      const rumour = unheard[0]
+      markConvoHeard(rumour.id)
+      setDialogueEvent({ speakerName, text: rumour.text })
+      return
     }
 
     // ── Screen NPCs: open dialogue (don't navigate on tap) ──────────────────

--- a/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
@@ -103,22 +103,6 @@ function RelationshipEditor({ data, onChange, npcOptions }: { data: Record<strin
   )
 }
 
-// innRumours: [{ id, text }]
-function RumoursEditor({ data, onChange }: { data: Array<{ id: string; text: string }>; onChange: (d: Array<{ id: string; text: string }>) => void }) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {data.map((r, i) => (
-        <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
-          <input style={{ ...INPUT, width: 90, flex: '0 0 90px', fontFamily: 'monospace' }} value={r.id} onChange={e => onChange(data.map((x, j) => j === i ? { ...x, id: e.target.value } : x))} />
-          <textarea style={{ ...INPUT, resize: 'vertical', fontFamily: 'inherit' }} rows={2} value={r.text} onChange={e => onChange(data.map((x, j) => j === i ? { ...x, text: e.target.value } : x))} />
-          <button style={BTN_X} onClick={() => onChange(data.filter((_, j) => j !== i))}>✕</button>
-        </div>
-      ))}
-      <button style={BTN_ADD} onClick={() => onChange([...data, { id: '', text: '' }])}>+ Add rumour</button>
-    </div>
-  )
-}
-
 // dialogues: [{ id, npcId, start, nodes }] — fields + JSON node editor.
 function DialogueTreeRow({ dlg, onChange, onDelete, npcOptions }: { dlg: Record<string, unknown>; onChange: (d: Record<string, unknown>) => void; onDelete: () => void; npcOptions: RefOption[] }) {
   const [nodesText, setNodesText] = useState(() => JSON.stringify(dlg.nodes ?? {}, null, 1))
@@ -153,16 +137,12 @@ export function DialogueEditor({ mapId, configData, questDefsData, onQuestDefsCh
   const q = questDefsData as unknown as Record<string, unknown>
   const friendship = (q.friendshipDialogue as Record<string, Record<string, string>>) ?? {}
   const relationship = (q.relationshipDialogue as Record<string, Record<string, Record<string, string>>>) ?? {}
-  const rumours = (q.innRumours as Array<{ id: string; text: string }>) ?? []
   const dialogues = (q.dialogues as Array<Record<string, unknown>>) ?? []
   const npcOptions = npcRefOptions(mapId, configData.npcs ?? [], false)
   const patch = (key: string, value: unknown) => onQuestDefsChange(prev => ({ ...(prev as object), [key]: value }) as QuestDefsJson)
 
   return (
     <div style={{ flex: 1, overflowY: 'auto', padding: 8, color: '#ccc' }}>
-      <Section title={`Inn Rumours (${rumours.length})`} color="#f0c040">
-        <RumoursEditor data={rumours} onChange={d => patch('innRumours', d)} />
-      </Section>
       <Section title={`Friendship Dialogue (${Object.keys(friendship).length})`} color="#88ffaa">
         <FriendshipEditor data={friendship} npcOptions={npcOptions} onChange={d => patch('friendshipDialogue', d)} />
       </Section>

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -164,7 +164,6 @@ const ALL_QUEST_BUNDLES: HubQuestBundle[] = [
 
 export const ALL_QUESTS : HubQuestBundle = {
   HUB_QUEST_DEFS:    ALL_QUEST_BUNDLES.flatMap(b => b.HUB_QUEST_DEFS),
-  INN_RUMOURS:       ALL_QUEST_BUNDLES.flatMap(b => b.INN_RUMOURS ?? []),
   FRIENDSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.FRIENDSHIP_DIALOGUE)),
   RELATIONSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.RELATIONSHIP_DIALOGUE)),
   HUB_PICKUP_ITEMS:  ALL_QUEST_BUNDLES.flatMap(b => b.HUB_PICKUP_ITEMS),

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -2,7 +2,7 @@ import { BASE_CHIP_TILES } from '../tiles/baseChipIndex'
 import { WALL_TILES, ROOF_TILES } from '../tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../tiles/buildingMaterials'
 import { expandBundleDecor, expandBundleWindows, expandBundleDoors } from '../bundles/bundleLoader'
-import { DialogueTree, FriendshipDialogue, HubQuestDef, QuestInnRumour, RawQuestConfig, RelationshipDialogue } from './questDefs'
+import { DialogueTree, FriendshipDialogue, HubQuestDef, RawQuestConfig, RelationshipDialogue } from './questDefs'
 import { RawAnimal, RawConfig, RawInteractable } from './config'
 import rollbar from '../../rollbar'
 
@@ -396,7 +396,6 @@ export interface HubLocationBundle {
 
 export interface HubQuestBundle {
   HUB_QUEST_DEFS: HubQuestDef[]
-  INN_RUMOURS?: QuestInnRumour[]
   FRIENDSHIP_DIALOGUE: FriendshipDialogue
   RELATIONSHIP_DIALOGUE: RelationshipDialogue
   HUB_PICKUP_ITEMS: HubPickupItem[]
@@ -806,8 +805,6 @@ export function createHubQuestData(
 
 const HUB_QUEST_DEFS: HubQuestDef[] = rawQuestConfig.quests as unknown as HubQuestDef[] || {}
 
-const INN_RUMOURS = rawQuestConfig.innRumours || []
-
 const FRIENDSHIP_DIALOGUE = rawQuestConfig.friendshipDialogue || {}
 
 const RELATIONSHIP_DIALOGUE: RelationshipDialogue = rawQuestConfig.relationshipDialogue || {}
@@ -865,7 +862,6 @@ const HUB_DIALOGUES: Record<string, DialogueTree> = Object.fromEntries(
 
 
     HUB_QUEST_DEFS,
-    INN_RUMOURS,
     FRIENDSHIP_DIALOGUE,
     RELATIONSHIP_DIALOGUE,
     HUB_BLOCKED_PATHS,

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -157,11 +157,6 @@ export interface QuestPickupItem {
   chain?: string
 }
 
-export interface QuestInnRumour{
-  id: string
-  text: string
-}
-
 export type FriendshipDialogue = Record<
   string,                  // npc id
   Record<string, string>   // friendship level -> dialogue
@@ -272,7 +267,6 @@ export interface DialogueTree {
 export interface RawQuestConfig {
   quests: QuestDefinition[]
   pickupItems?: QuestPickupItem[]
-  innRumours?: QuestInnRumour[]
   friendshipDialogue?: FriendshipDialogue
   relationshipDialogue?: RelationshipDialogue
   blockedPaths?: QuestBlockedPaths[]

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9885,6 +9885,14 @@
       ],
       "innRumours": [
         {
+          "id": "rumour-bram",
+          "text": "Cartographer Bram has been charting every street twice. Something about the maps not matching what he remembers."
+        },
+        {
+          "id": "rumour-fisherman",
+          "text": "Old Greyfish has been sleeping at the pond lately. Says he doesn't trust what's happening under the water."
+        },
+        {
           "id": "rumour-barracks",
           "text": "The south barracks wing has been sealed for years. Captain Thorin keeps to himself about it…"
         },

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -5621,36 +5621,6 @@
       "questId": "midsummer-lanterns"
     }
   ],
-  "innRumours": [
-    {
-      "id": "rumour-bram",
-      "text": "Cartographer Bram has been charting every street twice. Something about the maps not matching what he remembers."
-    },
-    {
-      "id": "rumour-fisherman",
-      "text": "Old Greyfish has been sleeping at the pond lately. Says he doesn't trust what's happening under the water."
-    },
-    {
-      "id": "rumour-barracks",
-      "text": "The south barracks wing has been sealed for years. Captain Thorin keeps to himself about it…"
-    },
-    {
-      "id": "rumour-elder",
-      "text": "The Elder was pacing the courtyard today, muttering about lost things."
-    },
-    {
-      "id": "rumour-vex",
-      "text": "Vex keeps badgering every traveller about rare herbs. If you find some, he pays well."
-    },
-    {
-      "id": "rumour-naia",
-      "text": "That archivist Naia never leaves the scholars' hall. Something about old books she cannot find."
-    },
-    {
-      "id": "rumour-pond",
-      "text": "Old Greyfish says the pond shimmers at night. Strange glimmers beneath the water, he says…"
-    }
-  ],
   "friendshipDialogue": {
     "elder": {
       "2": "Ah, I remember you. You found my pendants. Come and sit a moment.",

--- a/web/src/game/hub/innConvos.ts
+++ b/web/src/game/hub/innConvos.ts
@@ -28,3 +28,9 @@ export function markConvoHeard(id: string): void {
 export function isConvoHeard(id: string): boolean {
   return load().has(id)
 }
+
+export function resetHeardConvoIds(ids: string[]): void {
+  const heard = load()
+  ids.forEach(id => heard.delete(id))
+  save(heard)
+}


### PR DESCRIPTION
## Summary

Tapping Innkeeper Rosie always showed the generic "give gift" / "make conversation" options and never a rumour. Root cause:

- The heard-rumour set (`localStorage`, `web/src/game/hub/innConvos.ts`) never clears, expires, or rotates.
- Ravenwatch's live rumour list — `web/src/data/hub/ravenwatch/config.json`'s `innkeeper-rosie` npc, the only field `HubWorld.tsx` actually reads — only had 5 entries. Once a player heard all 5 (easy after a few visits), every future tap fell straight through to Give/Talk, permanently.
- Separately, `questDefs.json` had a "documented" 7-rumour list (2 extra, never-recovered rumours) that fed a dead `INN_RUMOURS` export nothing ever consumed — a content-authoring trap where editing the "documented" file silently did nothing in-game.

## Changes

- Recovered the 2 missing rumours (`rumour-bram`, `rumour-fisherman`) into `config.json`'s live list; removed the orphaned duplicate from `questDefs.json`.
- Removed the now-fully-dead `INN_RUMOURS` plumbing (`loader.ts`, `hubWorldFactory.ts`, `HubTownCanvas.tsx`) and the map editor's dead "Inn Rumours" quest-def-level UI (`DialogueEditor.tsx`), which edited that same orphaned field.
- Added `resetHeardConvoIds()` to `innConvos.ts` and wired it into `HubWorld.tsx`'s tap handler so exhausting the pool now loops back to the first rumour instead of falling through to Give/Talk.
- Updated `docs/hubworld.md` to describe `config.json`'s per-npc `innRumours` field as canonical.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 688 tests pass (unrelated Playwright browser-launch warning only)
- [x] Verified `config.json` now has all 7 `rumour-*` ids for Ravenwatch's innkeeper
- [ ] Manual: tap Rosie repeatedly in-game to confirm all 7 rumours surface once each, then loop back on the 8th tap, with Give/Talk never appearing while a rumour is unheard


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hd3GCzmfhqWES5nw3oKxAT)_