### PR TITLE
Make inn rumours a menu choice instead of a tap side-effect

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -638,11 +638,13 @@ other content in the same modal. Follow-up dialogueEvents reached by tapping
 an earlier choice — a dialogue tree's later nodes, the gift-item picker, a
 quest offer's Accept/Not-now decision reached mid-tree, or the reward text
 shown after a quest completes — do **not** get Talk/Give re-appended, since
-the player already made their choice for this interaction. Two exceptions
-keep the old plain-text/auto-dismiss behavior and never gain Talk/Give: a
-bounty-report tick (§7e) and Innkeeper Rosie's inn-rumour reveal, since both
-are automatic incidental side effects of a tap rather than a real
-conversation turn.
+the player already made their choice for this interaction. One exception
+keeps the old plain-text/auto-dismiss behavior and never gains Talk/Give: a
+bounty-report tick (§7e), an automatic incidental side effect of a tap rather
+than a real conversation turn. Innkeeper Rosie's inn-rumour reveal is *not*
+such an exception — "🗞️ Ask about news" is one of the Talk/Give-family
+choices (`buildTalkGiveOptions`), so it always appears alongside Make
+Conversation/Give a Gift rather than preempting them.
 
 The dialogue always ends with **exactly one** trailing exit choice. Where the
 NPC's own flow already supplies a decline/exit — a quest offer's "Not now",
@@ -668,6 +670,14 @@ wrapper around `buildTalkGiveOptions` that appends Farewell).
   per real day per NPC (`canGiftToday`/`recordGift`,
   `web/src/game/hub/giftCooldown.ts`, mirroring `talkCooldown.ts`) so
   friendship/relationship can't be farmed by repeatedly gifting the same NPC.
+- **🗞️ Ask about news** — only shown for NPCs with an authored `innRumours`
+  list on their `config.json` entry (currently just Innkeeper Rosie). Reveals
+  one rumour, cycling through the list in order and looping back to the start
+  once all have been heard (`getHeardConvoIds`/`markConvoHeard`/
+  `resetHeardConvoIds`, `web/src/game/hub/innConvos.ts`). Limited to once per
+  real day per NPC (`canHearRumourToday`/`recordRumourHeard`,
+  `web/src/game/hub/rumourCooldown.ts`, mirroring `talkCooldown.ts`) so it
+  coexists with Make Conversation/Give a Gift instead of preempting them.
 
 ### Favorite gift (`HubNpc.favoriteGiftItemId` / `favoriteGiftTrack`)
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -14,6 +14,7 @@ import { getFriendshipLevel, addFriendshipXp, getFriendshipData } from '../../ga
 import { getRelationship, grantRelationshipWithRivalry, RELATIONSHIP_TRACKS, type RelationshipTrack } from '../../game/hub/relationships'
 import { canTalkToday, recordTalk } from '../../game/hub/talkCooldown'
 import { canGiftToday, recordGift } from '../../game/hub/giftCooldown'
+import { canHearRumourToday, recordRumourHeard } from '../../game/hub/rumourCooldown'
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
 import { getHeardConvoIds, markConvoHeard, resetHeardConvoIds } from '../../game/hub/innConvos'
@@ -949,6 +950,27 @@ function buildTalkGiveOptions(
       },
     })
   }
+  if (npcDef?.innRumours && npcDef.innRumours.length > 0) {
+    const rumours = npcDef.innRumours
+    const rumourableToday = canHearRumourToday(npcId)
+    choices.push({
+      label: rumourableToday ? '🗞️ Ask about news' : '🗞️ Ask about news (already caught up today)',
+      disabled: !rumourableToday,
+      onClick: () => {
+        if (!rumourableToday) return
+        recordRumourHeard(npcId)
+        const heard = getHeardConvoIds()
+        let unheard = rumours.filter(r => !heard.has(r.id))
+        if (unheard.length === 0) {
+          resetHeardConvoIds(rumours.map(r => r.id))
+          unheard = rumours
+        }
+        const rumour = unheard[0]
+        markConvoHeard(rumour.id)
+        setDialogueEvent({ speakerName, text: rumour.text })
+      },
+    })
+  }
   return choices
 }
 
@@ -1248,20 +1270,6 @@ function hasOfferableQuest(giverId: string): boolean {
         if (q.receiverNpcId === npcId && isQuestReadyToComplete(q)) return q
       }
       return null
-    }
-
-    // ── Inn rumour handling (Innkeeper Rosie) ───────────────────────────────
-    if (npcId === 'innkeeper-rosie' && npcDef?.innRumours) {
-      const heard = getHeardConvoIds()
-      let unheard = npcDef.innRumours.filter(r => !heard.has(r.id))
-      if (unheard.length === 0) {
-        resetHeardConvoIds(npcDef.innRumours.map(r => r.id))
-        unheard = npcDef.innRumours
-      }
-      const rumour = unheard[0]
-      markConvoHeard(rumour.id)
-      setDialogueEvent({ speakerName, text: rumour.text })
-      return
     }
 
     // ── Screen NPCs: open dialogue (don't navigate on tap) ──────────────────

--- a/web/src/game/hub/rumourCooldown.ts
+++ b/web/src/game/hub/rumourCooldown.ts
@@ -1,0 +1,45 @@
+// ─── Rumour cooldown ──────────────────────────────────────────────────────────
+//
+// Persistence for the "Ask about news" NPC interaction: an NPC with authored
+// `innRumours` can only reveal one rumour per real day. Keyed by bare npcId,
+// same convention as talkCooldown.ts/giftCooldown.ts, mapping to the
+// YYYY-MM-DD the NPC last shared a rumour.
+
+import { logError } from '../../logger'
+
+const KEY = 'jarv_hub_rumour_cooldown'
+
+type RumourCooldownStore = Record<string, string>
+
+function load(): RumourCooldownStore {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as RumourCooldownStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(store: RumourCooldownStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store))
+  } catch (e) {
+    logError('rumourCooldown save failed', { error: String(e) })
+  }
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Whether this NPC can still reveal a rumour today. */
+export function canHearRumourToday(npcId: string): boolean {
+  return load()[npcId] !== todayKey()
+}
+
+/** Record that this NPC revealed a rumour today. */
+export function recordRumourHeard(npcId: string): void {
+  const store = load()
+  store[npcId] = todayKey()
+  save(store)
+}


### PR DESCRIPTION
## Summary

Follow-up to #2022. That fix made Rosie's rumour reveal loop back to the start once the pool was exhausted — but since the reveal short-circuited the tap handler with an early `return` before it could reach the Give/Talk code, this meant every tap on Rosie showed a rumour forever, and Make Conversation / Give a Gift became permanently unreachable.

## Changes

- Moved the rumour reveal out of the tap handler and into `buildTalkGiveOptions` (`web/src/components/hub/HubWorld.tsx`) as a third choice, "🗞️ Ask about news," alongside the existing "🗣️ Make conversation" and "🎁 Give a gift" — so all three now always coexist in the same menu.
- Gated it to once per real day per NPC via a new `web/src/game/hub/rumourCooldown.ts` (`canHearRumourToday`/`recordRumourHeard`), mirroring the existing `talkCooldown.ts`/`giftCooldown.ts` pattern.
- The rumour still cycles through the list in order and loops back once all have been heard, reusing `innConvos.ts`'s `getHeardConvoIds`/`markConvoHeard`/`resetHeardConvoIds`.
- Removed the old automatic tap-handler short-circuit entirely.
- Updated `docs/hubworld.md` to describe the rumour reveal as a Talk/Give-family menu choice rather than an automatic incidental side effect.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 688 tests pass (unrelated pre-existing Playwright browser-launch warning only)
- [ ] Manual: tap Rosie and confirm all three options (Make conversation, Give a gift, Ask about news) appear together; confirm "Ask about news" becomes disabled after use today and re-enables the next day; confirm rumours still cycle through all 7 and loop back once exhausted


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hd3GCzmfhqWES5nw3oKxAT)_