### PR TITLE
Gate the Shelf DECORATE tab behind an owned house + curated Shelter Keeper pet adoption

### DIFF
--- a/web/src/components/hub/HomeShelf.stories.tsx
+++ b/web/src/components/hub/HomeShelf.stories.tsx
@@ -9,9 +9,14 @@ function seedItemStore(items: ItemEntry[]): void {
   localStorage.setItem('jarv_item_store', JSON.stringify(items))
 }
 
+// DECORATE only renders for a real owned-house key (not the 'default' bucket)
+// — see HomeShelf.tsx's houseKey !== 'default' gating — so these stories use
+// a stand-in house key, matching how the in-house 🛋 DECORATE button invokes it.
+const HOUSE_KEY = 'ravenwatch:building-1'
+
 // Seed the decorate-tab stores: placed furniture, owned furniture ids, crystals.
 function seedDecorate(opts: { placed?: unknown[]; owned?: string[]; crystals?: number } = {}): void {
-  localStorage.setItem('jarv_hub_home_layout', JSON.stringify({ placed: opts.placed ?? [] }))
+  localStorage.setItem(`jarv_hub_home_layout:${HOUSE_KEY}`, JSON.stringify({ placed: opts.placed ?? [] }))
   localStorage.setItem('jarv_hub_furniture_owned', JSON.stringify(opts.owned ?? []))
   saveCrystals(opts.crystals ?? 100)
 }
@@ -97,7 +102,7 @@ export const Populated: Story = {
 }
 
 export const DecorateEmpty: Story = {
-  args: { onBack: fn() },
+  args: { onBack: fn(), houseKey: HOUSE_KEY },
   decorators: [
     (Story) => { seedItemStore([]); seedDecorate(); return <Story /> },
   ],
@@ -105,7 +110,7 @@ export const DecorateEmpty: Story = {
 }
 
 export const DecoratePopulated: Story = {
-  args: { onBack: fn() },
+  args: { onBack: fn(), houseKey: HOUSE_KEY },
   decorators: [
     (Story) => {
       seedItemStore([])

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -90,6 +90,10 @@ type PendingStyleBuy = { kind: 'floor'; tileId: string } | { kind: 'wall'; mater
 
 export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }: Props) {
   const [tab, setTab] = useState<'shelf' | 'decorate' | 'rooms'>(initialTab)
+  // DECORATE (like ROOMS) only makes sense tied to a real owned house — a
+  // stray 'decorate' tab with no house context would edit an orphaned
+  // 'default' bucket that isn't shown anywhere in the world.
+  const effectiveTab = tab === 'decorate' && houseKey === 'default' ? 'shelf' : tab
 
   // ── Shelf tab (existing, unchanged) ──
   const items  = loadInventory()
@@ -331,17 +335,19 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
     <OverlayScreen
       title="HOME"
       onBack={onBack}
-      right={tab !== 'shelf' ? <span className="crystal-count">💎 {crystals.toLocaleString()}</span> : undefined}
+      right={effectiveTab !== 'shelf' ? <span className="crystal-count">💎 {crystals.toLocaleString()}</span> : undefined}
     >
       <div className="hoa-tabs">
-        <button className={`hoa-tab${tab === 'shelf' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('shelf')}>SHELF</button>
-        <button className={`hoa-tab${tab === 'decorate' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('decorate')}>DECORATE</button>
+        <button className={`hoa-tab${effectiveTab === 'shelf' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('shelf')}>SHELF</button>
         {houseKey !== 'default' && (
-          <button className={`hoa-tab${tab === 'rooms' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('rooms')}>ROOMS</button>
+          <button className={`hoa-tab${effectiveTab === 'decorate' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('decorate')}>DECORATE</button>
+        )}
+        {houseKey !== 'default' && (
+          <button className={`hoa-tab${effectiveTab === 'rooms' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('rooms')}>ROOMS</button>
         )}
       </div>
 
-      {tab === 'shelf' && (
+      {effectiveTab === 'shelf' && (
         <div className="shelf-room">
           {isEmpty && (
             <div className="shelf-empty-msg">Your shelves are bare. Collect items to fill them.</div>
@@ -383,7 +389,7 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
         </div>
       )}
 
-      {tab === 'decorate' && (
+      {effectiveTab === 'decorate' && (
         <div className="shelf-room">
           {houseKey !== 'default' && purchasedSlotIds.length > 0 && (
             <div className="hoa-tabs">
@@ -493,7 +499,7 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
         </div>
       )}
 
-      {tab === 'rooms' && (
+      {effectiveTab === 'rooms' && (
         <div className="shelf-room">
           <div className="town-directory__list">
             {getAllRoomSlotDefs().map(slot => {

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -34,6 +34,7 @@ import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem, getHubItemCatalogEntry, getHubItems, spendTickets } from '../../game/itemStore'
 import { questItemId } from '../../game/hub/questItems'
 import { HubTabbedModal, type HubTabId } from './HubTabbedModal'
+import { PetShelterModal } from './PetShelterModal'
 import { BountyBoardModal } from './BountyBoardModal'
 import { hasUnclaimedBounties, getPendingBountyReport, getPendingBountyCollect, advanceBountyStep, getActiveBountyStep, isBountyCollectPickup, reconcileBountyPickups } from '../../game/hub/bounties'
 import { getActivePet, getTreatsRemainingToday, canGiveTreat, recordAffection, recordTreatGiven, getAffectionRemaining, grantAccessory } from '../../game/hub/pet'
@@ -251,6 +252,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   const [tabbedModalOpen,     setTabbedModalOpen]     = useState(false)
   const [activeHubTab,        setActiveHubTab]        = useState<HubTabId>('quests')
   const [bountyBoardOpen,     setBountyBoardOpen]     = useState(false)
+  const [petShelterOpen,      setPetShelterOpen]      = useState(false)
   function openHubTab(tab: HubTabId) { setActiveHubTab(tab); setTabbedModalOpen(true) }
   // buildingId → purchased upgrade level; read each frame by the canvas to
   // reveal unlocked decor live, and updated on purchase.
@@ -636,7 +638,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     }
     if (screen === 'town-upgrades') { openHubTab('upgrades'); return }
     if (screen === 'bounty-board') { setBountyBoardOpen(true); return }
-    if (screen === 'adopt-pet') { openHubTab('pet'); return }
+    if (screen === 'adopt-pet') { setPetShelterOpen(true); return }
     if (screen === 'worldmap') { onWorldMap?.(); return }
     if (screen.startsWith('town:')) { onNavigateTown?.(screen.slice(5)); return }
     if (screen === 'campaign') { onCampaign?.(); return }
@@ -2147,6 +2149,7 @@ function hasOfferableQuest(giverId: string): boolean {
           />
         )}
         {bountyBoardOpen && <BountyBoardModal onClose={() => setBountyBoardOpen(false)} resolveNpcName={getNpcDisplayName} townNpcs={locationData.HUB_NPCS}/>}
+        {petShelterOpen && <PetShelterModal onClose={() => setPetShelterOpen(false)} onAdopted={() => setPetShelterOpen(false)} />}
         {relationshipNpcId && <RelationshipView npcName={getNpcDisplayName(relationshipNpcId)} entry={getRelationship(relationshipNpcId)} onClose={() => setRelationshipNpcId(null)} />}
         {openTreasure && <TreasureModal treasure={openTreasure} onClose={() => setOpenTreasure(null)} />}
 

--- a/web/src/components/hub/PetModal.tsx
+++ b/web/src/components/hub/PetModal.tsx
@@ -2,83 +2,15 @@ import React, { useState } from 'react'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { ConfirmModal } from '../modals/ConfirmModal'
 import {
-  getActivePet, adoptPet, renamePet, dismissPet,
+  getActivePet, renamePet, dismissPet,
   ownsAccessory, getEquippedAccessoryId, equipAccessory, unequipAccessory,
 } from '../../game/hub/pet'
 import { ANIMAL_SPECS, type AnimalType } from '../../game/hub/animals'
 import { PET_ACCESSORIES } from '../../data/petAccessories'
-import { getPatternsForSpecies } from '../../data/petPatterns'
 
 interface Props {
   onClose: () => void
   petActionRef?: React.MutableRefObject<{ setPetAccessory: (assetId: string | null) => void } | null>
-}
-
-const PET_SPECIES: ('dog' | 'cat')[] = ['dog', 'cat']
-const SPECIES_LABEL: Record<string, string> = { dog: 'Dog', cat: 'Cat' }
-const SPECIES_NAME_PLACEHOLDER: Record<string, string> = { dog: 'Name your pup', cat: 'Name your cat' }
-
-function PickerBody({ onAdopt, submitLabel }: { onAdopt: (type: string, variant: string, name: string, pattern: string) => void; submitLabel: string }) {
-  const [species, setSpecies] = useState<'dog' | 'cat'>('dog')
-  const variants = Object.keys(ANIMAL_SPECS[species].palette)
-  const [variant, setVariant] = useState(variants[0])
-  const patterns = getPatternsForSpecies(species)
-  const [pattern, setPattern] = useState<string>('none')
-  const [name, setName] = useState('')
-
-  const chooseSpecies = (s: 'dog' | 'cat') => {
-    setSpecies(s)
-    setVariant(Object.keys(ANIMAL_SPECS[s].palette)[0])
-    setPattern('none')  // dog/cat pattern lists differ — never carry a stale selection across species
-  }
-
-  return (
-    <>
-      <div className="pet-modal__section-label">Choose a companion</div>
-      <div className="hoa-tabs">
-        {PET_SPECIES.map(s => (
-          <button
-            key={s}
-            className={`hoa-tab${species === s ? ' hoa-tab--active' : ''}`}
-            onClick={() => chooseSpecies(s)}
-          >{SPECIES_LABEL[s]}</button>
-        ))}
-      </div>
-      <div className="pet-modal__swatches">
-        {variants.map(v => (
-          <button
-            key={v}
-            className={`pet-modal__swatch${v === variant ? ' pet-modal__swatch--selected' : ''}`}
-            style={{ backgroundColor: `#${ANIMAL_SPECS[species].palette[v].toString(16).padStart(6, '0')}` }}
-            title={v}
-            onClick={() => setVariant(v)}
-          />
-        ))}
-      </div>
-      <div className="pet-modal__section-label">Coat pattern</div>
-      <div className="hoa-tabs">
-        <button
-          className={`hoa-tab${pattern === 'none' ? ' hoa-tab--active' : ''}`}
-          onClick={() => setPattern('none')}
-        >None</button>
-        {patterns.map(p => (
-          <button
-            key={p.id}
-            className={`hoa-tab${pattern === p.id ? ' hoa-tab--active' : ''}`}
-            onClick={() => setPattern(p.id)}
-          >{p.label}</button>
-        ))}
-      </div>
-      <input
-        className="pet-modal__name-input"
-        placeholder={SPECIES_NAME_PLACEHOLDER[species]}
-        value={name}
-        maxLength={24}
-        onChange={e => setName(e.target.value)}
-      />
-      <button className="action-btn action-btn--gold" onClick={() => onAdopt(species, variant, name, pattern)}>{submitLabel}</button>
-    </>
-  )
 }
 
 function AccessoriesTab({ petActionRef, refresh }: {
@@ -139,24 +71,10 @@ export function PetContent({ onClose, petActionRef }: Props) {
   const [, setTick] = useState(0)
   const refresh = () => setTick(t => t + 1)
   const [renameValue, setRenameValue] = useState<string | null>(null)
-  const [swapping, setSwapping] = useState(false)
-  const [confirmSwap, setConfirmSwap] = useState<{ type: string; variant: string; name: string; pattern: string } | null>(null)
   const [confirmDismiss, setConfirmDismiss] = useState(false)
   const [tab, setTab] = useState<'info' | 'accessories'>('info')
 
   const pet = getActivePet()
-
-  if (confirmSwap) {
-    return (
-      <ConfirmModal
-        title="Adopt a new companion?"
-        body={`Adopting ${confirmSwap.name} will mean saying goodbye to ${pet?.name ?? 'your current pet'}.`}
-        confirmLabel="Adopt"
-        onConfirm={() => { adoptPet(confirmSwap.type, confirmSwap.variant, confirmSwap.name, confirmSwap.pattern); setConfirmSwap(null); setSwapping(false); refresh() }}
-        onCancel={() => setConfirmSwap(null)}
-      />
-    )
-  }
 
   if (confirmDismiss) {
     return (
@@ -173,15 +91,17 @@ export function PetContent({ onClose, petActionRef }: Props) {
   return (
       <div className="pet-modal">
         <div className="pet-modal__header">
-          <span>🐾 {pet ? 'My Pet' : 'Pet Shelter'}</span>
+          <span>🐾 My Pet</span>
           <button className="pet-modal__close" onClick={onClose}>✕</button>
         </div>
 
         {!pet && (
-          <PickerBody submitLabel="Adopt" onAdopt={(type, variant, name, pattern) => { adoptPet(type, variant, name, pattern); refresh() }} />
+          <div className="pet-modal__section-label">
+            No pet yet — visit the Shelter Keeper in Ravenwatch to adopt one.
+          </div>
         )}
 
-        {pet && !swapping && (
+        {pet && (
           <>
             <div className="hoa-tabs">
               <button className={`hoa-tab${tab === 'info' ? ' hoa-tab--active' : ''}`} onClick={() => setTab('info')}>Info</button>
@@ -208,8 +128,10 @@ export function PetContent({ onClose, petActionRef }: Props) {
                   className="action-btn"
                   onClick={() => { if (renameValue != null) renamePet(renameValue); setRenameValue(null); refresh() }}
                 >Save Name</button>
+                <div className="pet-modal__section-label">
+                  Want a different companion? Visit the Shelter Keeper in Ravenwatch.
+                </div>
                 <div className="pet-modal__actions-row">
-                  <button className="action-btn" onClick={() => setSwapping(true)}>Adopt a Different Companion</button>
                   <button className="action-btn action-btn--danger" onClick={() => setConfirmDismiss(true)}>Dismiss Pet</button>
                 </div>
               </>
@@ -217,13 +139,6 @@ export function PetContent({ onClose, petActionRef }: Props) {
 
             {tab === 'accessories' && <AccessoriesTab petActionRef={petActionRef} refresh={refresh} />}
           </>
-        )}
-
-        {pet && swapping && (
-          <PickerBody
-            submitLabel="Adopt"
-            onAdopt={(type, variant, name, pattern) => setConfirmSwap({ type, variant, name, pattern })}
-          />
         )}
       </div>
   )

--- a/web/src/components/hub/PetShelterModal.stories.tsx
+++ b/web/src/components/hub/PetShelterModal.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PetShelterModal } from './PetShelterModal'
+import { adoptPet } from '../../game/hub/pet'
+
+const meta = {
+  component: PetShelterModal,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="game-container">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PetShelterModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FirstVisit: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_pet')
+      return <Story />
+    },
+  ],
+}
+
+export const AlreadyHasPet: Story = {
+  args: {
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => {
+      localStorage.removeItem('jarv_hub_pet')
+      adoptPet('dog', 'golden', 'Rex')
+      return <Story />
+    },
+  ],
+}

--- a/web/src/components/hub/PetShelterModal.tsx
+++ b/web/src/components/hub/PetShelterModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
+import { ConfirmModal } from '../modals/ConfirmModal'
+import { getActivePet, adoptPet } from '../../game/hub/pet'
+import { ANIMAL_SPECS, type AnimalType } from '../../game/hub/animals'
+import { getTodaysShelterPets, type ShelterPet } from '../../game/hub/petShelter'
+
+interface Props {
+  onClose: () => void
+  onAdopted?: () => void
+}
+
+const SPECIES_ICON: Record<string, string> = { dog: '🐶', cat: '🐱' }
+
+function swatchColor(pet: ShelterPet): string {
+  const hex = ANIMAL_SPECS[pet.type as AnimalType]?.palette[pet.variant] ?? 0x8b5a2b
+  return `#${hex.toString(16).padStart(6, '0')}`
+}
+
+export function PetShelterContent({ onClose, onAdopted }: Props) {
+  const [confirmPet, setConfirmPet] = useState<ShelterPet | null>(null)
+  const roster = getTodaysShelterPets()
+  const currentPet = getActivePet()
+
+  function handleConfirm() {
+    if (!confirmPet) return
+    adoptPet(confirmPet.type, confirmPet.variant, confirmPet.name, confirmPet.pattern)
+    setConfirmPet(null)
+    onAdopted?.()
+  }
+
+  if (confirmPet) {
+    return (
+      <ConfirmModal
+        title="Adopt a new companion?"
+        body={
+          currentPet
+            ? `Adopting ${confirmPet.name} will mean saying goodbye to ${currentPet.name}.`
+            : `${confirmPet.name} will follow you around town. Adopt them?`
+        }
+        confirmLabel="Adopt"
+        onConfirm={handleConfirm}
+        onCancel={() => setConfirmPet(null)}
+      />
+    )
+  }
+
+  return (
+    <div className="pet-modal">
+      <div className="pet-modal__header">
+        <span>🏚️ Ravenwatch Shelter</span>
+        <button className="pet-modal__close" onClick={onClose}>✕</button>
+      </div>
+
+      <div className="pet-modal__section-label">I have these pets to adopt</div>
+
+      <div className="pet-modal__accessories">
+        <div className="pet-modal__accessory-colors">
+          {roster.map(pet => (
+            <button
+              key={`${pet.type}-${pet.name}`}
+              className="pet-modal__accessory"
+              onClick={() => setConfirmPet(pet)}
+            >
+              <span className="pet-modal__current-swatch" style={{ backgroundColor: swatchColor(pet) }} />
+              <span className="pet-modal__accessory-name">{SPECIES_ICON[pet.type]} {pet.name}</span>
+              <span className="pet-modal__accessory-status">Tap to adopt</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PetShelterModal(props: Props) {
+  return (
+    <ModalBackdrop onClose={props.onClose}>
+      <PetShelterContent {...props} />
+    </ModalBackdrop>
+  )
+}

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -10306,7 +10306,7 @@
       "tx": 23,
       "ty": 10,
       "dialogue": [
-        "Looking for a companion? We've got a few dogs here who'd love a home."
+        "I have these pets to adopt — dogs and cats, all looking for a home."
       ],
       "screen": "adopt-pet"
     }

--- a/web/src/game/hub/petShelter.test.ts
+++ b/web/src/game/hub/petShelter.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { getTodaysShelterPets } from './petShelter'
+
+const DAY_A = new Date('2026-06-30T12:00:00Z')
+const DAY_B = new Date('2026-07-01T12:00:00Z')
+
+describe('petShelter', () => {
+  it('always returns 2 dogs and 2 cats', () => {
+    const roster = getTodaysShelterPets(DAY_A)
+    expect(roster).toHaveLength(4)
+    expect(roster.filter(p => p.type === 'dog')).toHaveLength(2)
+    expect(roster.filter(p => p.type === 'cat')).toHaveLength(2)
+  })
+
+  it('gives each species distinct variants', () => {
+    const roster = getTodaysShelterPets(DAY_A)
+    const dogVariants = roster.filter(p => p.type === 'dog').map(p => p.variant)
+    const catVariants = roster.filter(p => p.type === 'cat').map(p => p.variant)
+    expect(new Set(dogVariants).size).toBe(dogVariants.length)
+    expect(new Set(catVariants).size).toBe(catVariants.length)
+  })
+
+  it('is deterministic for the same day', () => {
+    expect(getTodaysShelterPets(DAY_A)).toEqual(getTodaysShelterPets(DAY_A))
+  })
+
+  it('varies across different days', () => {
+    expect(getTodaysShelterPets(DAY_A)).not.toEqual(getTodaysShelterPets(DAY_B))
+  })
+
+  it('never uses the literal pattern id "none"', () => {
+    const roster = getTodaysShelterPets(DAY_A)
+    for (const pet of roster) expect(pet.pattern).not.toBe('none')
+  })
+})

--- a/web/src/game/hub/petShelter.ts
+++ b/web/src/game/hub/petShelter.ts
@@ -1,0 +1,55 @@
+// ─── Ravenwatch Pet Shelter ─────────────────────────────────────────────────
+//
+// The Shelter Keeper's daily roster: 2 dogs + 2 cats, deterministically
+// re-rolled once per real day (same for every player that day), following
+// the same date-seeded pool idiom as getDailyBounties (bounties.ts) /
+// getTodaysShopItems (shopStock.ts) — hashStr/makeSeededRng/seededShuffle
+// from seededRandom.ts, keyed off a "YYYY-MM-DD" string.
+
+import { hashStr, makeSeededRng, seededShuffle } from '../seededRandom'
+import { ANIMAL_SPECS } from './animals'
+import { getPatternsForSpecies, type PatternSpecies } from '../../data/petPatterns'
+
+export type ShelterSpecies = 'dog' | 'cat'
+
+export interface ShelterPet {
+  type:    ShelterSpecies
+  variant: string
+  pattern?: string
+  name:    string
+}
+
+const PETS_PER_SPECIES = 2
+
+const DOG_NAMES = ['Rex', 'Biscuit', 'Duke', 'Willow', 'Scout', 'Peanut', 'Ranger', 'Maple']
+const CAT_NAMES = ['Whiskers', 'Mochi', 'Shadow', 'Clementine', 'Smokey', 'Pepper', 'Luna', 'Tumble']
+
+function nameListFor(species: ShelterSpecies): string[] {
+  return species === 'dog' ? DOG_NAMES : CAT_NAMES
+}
+
+function speciesRoster(species: ShelterSpecies, rng: () => number): ShelterPet[] {
+  const variants = seededShuffle(Object.keys(ANIMAL_SPECS[species].palette), rng)
+  const patternIds = seededShuffle(
+    ['none', ...getPatternsForSpecies(species as PatternSpecies).map(p => p.id)],
+    rng,
+  )
+  const names = seededShuffle(nameListFor(species), rng)
+
+  return Array.from({ length: PETS_PER_SPECIES }, (_, i) => {
+    const pattern = patternIds[i % patternIds.length]
+    return {
+      type: species,
+      variant: variants[i % variants.length],
+      ...(pattern !== 'none' ? { pattern } : {}),
+      name: names[i % names.length],
+    }
+  })
+}
+
+/** Today's shelter roster: 2 dogs + 2 cats, the same for every player on a given real day. */
+export function getTodaysShelterPets(at?: Date): ShelterPet[] {
+  const dayKey = (at ?? new Date()).toISOString().slice(0, 10)
+  const rng = makeSeededRng(hashStr(dayKey) ^ 0x5eed9e7)
+  return [...speciesRoster('dog', rng), ...speciesRoster('cat', rng)]
+}


### PR DESCRIPTION
## Summary

**Shelf screen** — the `DECORATE` tab now only appears when `HomeShelf` has a real owned-house `houseKey`, the same gating `ROOMS` already had. Previously it showed up even on the generic 'default'-bucket Shelf screen (e.g. Ravenwatch's Steward Maren, who has no house context), letting players edit a furniture layout that isn't tied to anywhere in the world. A defensive fallback keeps a stray `initialTab='decorate'` from ever rendering an orphaned, buttonless pane.

**Shelter Keeper (Ravenwatch)** — replaced the free-form "build your own pet" picker with a curated daily shelter roster:
- `getTodaysShelterPets()` (`web/src/game/hub/petShelter.ts`) deterministically rolls 2 dogs + 2 cats per real day, the same for every player, reusing the existing `hashStr`/`makeSeededRng`/`seededShuffle` daily-seeded idiom already used by `getDailyBounties`/`getTodaysShopItems`.
- New `PetShelterModal` shows "I have these pets to adopt" plus the day's four candidates; tapping one confirms and adopts.
- "My Pet" (`PetModal.tsx`) drops the free species/color/pattern picker and the "Adopt a Different Companion" swap button — rename, accessorize, and dismiss stay there, but re-adopting now means going back to the Shelter Keeper.
- This also fixes a latent gap where opening the pet tab with no active pet silently fell back to the Quests tab, so a first-time visitor never actually saw an adoption screen.

## Test plan
- [x] `npm run build` (typecheck + Vite build) — passes clean
- [x] `npm run test` — 693 tests pass across 51 files (new `petShelter.test.ts` covers determinism, the 2-dog/2-cat shape, and distinct variants per species)
- [ ] Manual: Steward Maren's Shelf screen has no DECORATE tab; the in-house 🛋 DECORATE button still works; the Shelter Keeper shows today's 4-pet roster and adoption works; "My Pet" has no swap button

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWawCfC6Ri6mwB5qDZi2g)_