### PR TITLE
Reduce boot memory: code-split act data, screens, and hub town data

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -166,7 +166,7 @@ import rollbar, { updateRollbarPerson } from './rollbar'
 import { useAuth } from './hooks/useAuth'
 import { auth } from './firebase'
 import { uploadSave, applySave } from './game/cloudSave'
-import { ALL_QUEST_DEFS, LOCATION_REGISTRY } from './data/hub/hubWorldFactory'
+import { getHubWorldData, type HubWorldData } from './data/hub/hubWorldFactory'
 
 // Apply saved display settings on load
 applyTextSettings()
@@ -423,12 +423,25 @@ export default function App() {
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
   const [shopBuildingId, setShopBuildingId] = useState<string | undefined>(undefined)
   // Restore the town the player was last in (persisted in worldState). The saved
-  // value is a world-map node id; for town nodes that id equals the LOCATION_REGISTRY
-  // key. Fall back to ravenwatch if the saved id isn't a known town (e.g. a battle node).
-  const [currentLocationKey, setCurrentLocationKey] = useState<string>(() => {
-    const saved = getCurrentWorldLocation()
-    return LOCATION_REGISTRY[saved] ? saved : 'ravenwatch'
-  })
+  // value is a world-map node id; for town nodes that id equals the hub data's
+  // locationRegistry key. Hub data is lazy-loaded (see hubData below), so this
+  // can't validate against it synchronously — an effect corrects an invalid
+  // saved id back to ravenwatch once hub data has loaded.
+  const [currentLocationKey, setCurrentLocationKey] = useState<string>(() => getCurrentWorldLocation() || 'ravenwatch')
+
+  // ── Hub town data (lazy-loaded) ──────────────────────────────────────────────
+  // All 13 towns' config/quest data (~1.5MB) is only fetched once the player
+  // actually heads toward the hub — never at boot.
+  const [hubData, setHubData] = useState<HubWorldData | null>(null)
+  useEffect(() => {
+    if (hubData) return
+    if (screen === 'hubworld' || screen === 'location' || screen === 'worldmap') {
+      getHubWorldData().then(setHubData)
+    }
+  }, [screen, hubData])
+  useEffect(() => {
+    if (hubData && !hubData.locationRegistry[currentLocationKey]) setCurrentLocationKey('ravenwatch')
+  }, [hubData, currentLocationKey])
   const [miniGamesEntry, setMiniGamesEntry] = useState<'menu' | 'citybuilder'>('menu')
   const [hubMiniGameEntry, setHubMiniGameEntry] = useState<SubScreen>('menu')
   const [showTitleLoginModal, setShowTitleLoginModal] = useState(false)
@@ -1461,13 +1474,13 @@ export default function App() {
       setCurrentWorldLocation(id)
       setCurrentLocationKey('ravenwatch')
       setScreen('hubworld')
-    } else if (LOCATION_REGISTRY[id]) {
+    } else if (hubData?.locationRegistry[id]) {
       if (!isTownAccessible(id, enabledTownIds, bypassTownAccess)) return
       setCurrentWorldLocation(id)
       setCurrentLocationKey(id)
       setScreen('location')
     }
-  }, [enabledTownIds, bypassTownAccess])
+  }, [enabledTownIds, bypassTownAccess, hubData])
 
   // Re-run the current world-map battle after a loss ("Try Again").
   const handleWorldBattleRetry = useCallback(() => {
@@ -3101,22 +3114,7 @@ export default function App() {
       )}
 
 
-      {/* {screen === 'location' && LOCATION_REGISTRY[currentLocationKey] && (
-        <HubLocationWorld
-          locationData={LOCATION_REGISTRY[currentLocationKey].locationData}
-          locationQuests={LOCATION_REGISTRY[currentLocationKey].locationQuests}
-          questDefs={LOCATION_REGISTRY[currentLocationKey].questDefs}
-          allQuestDefs={ ALL_QUEST_DEFS}
-          user={user}
-          crystals={crystals}
-          commander={commander ?? undefined}
-          onBack={() => setScreen('worldmap')}
-          onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
-          onFeedback={() => setFeedbackOpen(true)}
-        />
-      )} */}
-
-      {(screen === 'hubworld' || screen === 'location') && (
+      {(screen === 'hubworld' || screen === 'location') && hubData && (
         <HubWorld
           onBack={() => setScreen('settings')}
           onNavigate={(s, buildingId) => {
@@ -3141,11 +3139,14 @@ export default function App() {
           user={user}
           commander={commander ?? undefined}
 
-          locationData={LOCATION_REGISTRY[currentLocationKey].locationData}
-          locationQuests={LOCATION_REGISTRY[currentLocationKey].locationQuests}
-          questDefs={LOCATION_REGISTRY[currentLocationKey].questDefs}
-          allQuestDefs={ ALL_QUEST_DEFS}
-
+          locationData={hubData.locationRegistry[currentLocationKey].locationData}
+          locationQuests={hubData.locationRegistry[currentLocationKey].locationQuests}
+          questDefs={hubData.locationRegistry[currentLocationKey].questDefs}
+          allQuestDefs={hubData.allQuestDefs}
+          locationRegistry={hubData.locationRegistry}
+          allQuests={hubData.allQuests}
+          friendshipDialogue={hubData.friendshipDialogue}
+          relationshipDialogue={hubData.relationshipDialogue}
 
           isSignedIn={user != null && !user.isAnonymous}
           onSignIn={() => setShowTitleLoginModal(true)}
@@ -3164,11 +3165,11 @@ export default function App() {
         />
       )}
 
-      {screen === 'worldmap' && (
+      {screen === 'worldmap' && hubData && (
         <HubWorldMap
           key={worldMapKey}
           onSelectNode={(node) => {
-            if (node.id === 'ravenwatch' || (node.locationKey && LOCATION_REGISTRY[node.locationKey])) {
+            if (node.id === 'ravenwatch' || (node.locationKey && hubData.locationRegistry[node.locationKey])) {
               goToWorldLocation(node.id === 'ravenwatch' ? node.id : node.locationKey!)
             } else if (node.type === 'battle') {
               if (!isNodeCleared(node.id)) {
@@ -3184,23 +3185,9 @@ export default function App() {
           onFeedback={() => setFeedbackOpen(true)}
           restrictedNodeIds={restrictedTownNodeIds}
           previewingAsPlayer={isAdmin && previewAsPlayer}
+          allQuestDefs={hubData.allQuestDefs}
         />
       )}
-
-      {/* {screen === 'location' && LOCATION_REGISTRY[currentLocationKey] && (
-        <HubLocationWorld
-          locationData={LOCATION_REGISTRY[currentLocationKey].locationData}
-          locationQuests={LOCATION_REGISTRY[currentLocationKey].locationQuests}
-          questDefs={LOCATION_REGISTRY[currentLocationKey].questDefs}
-          allQuestDefs={ ALL_QUEST_DEFS}
-          user={user}
-          crystals={crystals}
-          commander={commander ?? undefined}
-          onBack={() => setScreen('worldmap')}
-          onCrystalsChange={(n) => { saveCrystals(n); setCrystals(n) }}
-          onFeedback={() => setFeedbackOpen(true)}
-        />
-      )} */}
 
       {screen === 'giftAdmin' && (
         <GiftAdminScreen onBack={() => setScreen('settings')} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,9 +24,10 @@ import {
 import { getCardCatalog } from './game/cards'
 import { applyStatUpgrade } from './game/playerStats'
 import {
-  loadRun, saveRun, clearRun, newRun, LIVES_START, LIVES_MAX,
+  loadRun, loadRunRaw, saveRun, clearRun, newRun, LIVES_START, LIVES_MAX,
   getAvailableNodeIds, skipSiblings, isActComplete,
-  generateRewardChoices, generateEndlessRewardChoices, generateMerchantCards, MERCHANT_PRICES, ACTS, getNextAct, getCampaignForAct,
+  generateRewardChoices, generateEndlessRewardChoices, generateMerchantCards, MERCHANT_PRICES,
+  loadAct, getCachedAct, getCampaignForAct,
   loadFatigued, saveFatigued, clearFatigued, getTopPlayedCards,
   hasSeenIntro, markIntroSeen,
   loadRunCount, incrementRunCount, getAct1Intro,
@@ -339,8 +340,18 @@ export default function App() {
   // ── Startup: auto-resume a pending campaign battle on page refresh ──────────
   // If the player refreshed mid-battle, pendingNodeId is still set. We build the
   // game state immediately so they land straight back in the battle.
+  //
+  // Act data is now lazy-loaded (see questline.ts loadAct), so it is never
+  // available synchronously this early at boot — getCachedAct always misses
+  // here, so the two branches below that need it (pendingNodeId battle-resume,
+  // and the isActComplete check) fall through exactly like they would if the
+  // act had failed to load, showing a provisional screen. The resume effect
+  // further down finishes the job once the act has actually loaded, correcting
+  // the screen/gameState if a resume was warranted. Every other branch here
+  // (0-lives, pendingActComplete/pendingRelicSelect, hubworld-default,
+  // endless-restore, plain intro/title) needs no act data and is unaffected.
   const [_startup] = useState(() => {
-    const savedRun = loadRun()
+    const savedRun = loadRunRaw()
     // Guard: a run drained to 0 lives is unplayable. Normally hitting 0 lives clears
     // the run via the campaign-failed flow, so a *persisted* 0-life run is a corrupted
     // /zombie state (e.g. from the pre-#1702 bug where losing a non-campaign battle
@@ -354,7 +365,7 @@ export default function App() {
       return { screen: 'campaignfailed' as Screen, gameState: null as GameState | null, run: null as RunState | null, isCampaign: false }
     }
     if (savedRun?.pendingNodeId) {
-      const act  = ACTS[savedRun.actId]
+      const act  = getCachedAct(savedRun.actId)
       const node = act?.nodes[savedRun.pendingNodeId]
       if (node && (node.type === 'battle' || node.type === 'boss' || node.type === 'elite')) {
         // If a mid-battle save exists, restore it exactly — no fresh start for cheaters
@@ -389,7 +400,7 @@ export default function App() {
       return { screen: 'actcomplete' as Screen, gameState: null as GameState | null, run: savedRun, isCampaign: false }
     }
     // If the act is complete but pendingActComplete was cleared, also restore to actcomplete.
-    const savedAct = savedRun ? ACTS[savedRun.actId] : null
+    const savedAct = savedRun ? getCachedAct(savedRun.actId) : null
     if (savedRun && savedAct && isActComplete(savedAct, savedRun)) {
       return { screen: 'actcomplete' as Screen, gameState: null as GameState | null, run: savedRun, isCampaign: false }
     }
@@ -474,6 +485,100 @@ export default function App() {
   const isDraftModeRef      = useRef(false)                  // true while playing a Card Draft battle
    const quickBattleModeRef = useRef<QuickBattleMode>('easy')                //  Quick Battle Mode
   const worldBattleNodeIdRef = useRef<string | null>(null)
+
+  // ── Current run's act data (lazy-loaded) ────────────────────────────────────
+  // Loaded async whenever run.actId changes; actDataFailed distinguishes "still
+  // loading" from "genuinely invalid actId" for the data-guard effect below.
+  const [actData, setActData]             = useState<Act | null>(() => run ? getCachedAct(run.actId) ?? null : null)
+  const [actDataFailed, setActDataFailed] = useState(false)
+  const [hasNextAct, setHasNextAct]       = useState(false)
+
+  useEffect(() => {
+    if (!run) { setActData(null); setActDataFailed(false); return }
+    const cached = getCachedAct(run.actId)
+    if (cached) { setActData(cached); setActDataFailed(false); return }
+    setActData(null)
+    setActDataFailed(false)
+    let cancelled = false
+    loadAct(run.actId)
+      .then(act => { if (!cancelled) { setActData(act); setActDataFailed(false) } })
+      .catch(() => { if (!cancelled) { setActData(null); setActDataFailed(true) } })
+    return () => { cancelled = true }
+  }, [run?.actId])
+
+  // Whether a next act exists after the current one — used by the ActComplete screen.
+  useEffect(() => {
+    const nextActId = actData?.nextActId
+    if (!nextActId) { setHasNextAct(false); return }
+    let cancelled = false
+    loadAct(nextActId)
+      .then(() => { if (!cancelled) setHasNextAct(true) })
+      .catch(() => { if (!cancelled) setHasNextAct(false) })
+    return () => { cancelled = true }
+  }, [actData?.nextActId])
+
+  // ── Startup resume, part 2 ───────────────────────────────────────────────────
+  // Finishes what the synchronous _startup initializer above couldn't: the
+  // pendingNodeId battle-resume and the isActComplete check both need act data,
+  // which is never available synchronously at boot. Runs once on mount; every
+  // other startup branch (0-lives, pendingActComplete/pendingRelicSelect,
+  // hubworld-default, endless-restore, plain intro/title) needed no act data
+  // and was already decided correctly by the synchronous initializer.
+  useEffect(() => {
+    const savedRun = _startup.run
+    if (!savedRun) return
+    let cancelled = false
+    ;(async () => {
+      if (savedRun.pendingNodeId) {
+        const act  = await loadAct(savedRun.actId).catch(() => undefined)
+        const node = act?.nodes[savedRun.pendingNodeId]
+        if (node && (node.type === 'battle' || node.type === 'boss' || node.type === 'elite')) {
+          if (cancelled) return
+          const startupArch = loadPlayerArchetype()
+          const savedBattle = loadBattleState()
+          isCampaignRef.current = true
+          if (savedBattle) {
+            incrementAchievementProgress('misc:refresh_cheat')
+            if (startupArch) savedBattle.archetypePassive = startupArch
+            dispatch({ type: 'START', gameState: savedBattle })
+            setRun(savedRun)
+            setScreen('playing')
+            return
+          }
+          const collection  = loadCollection()
+          const fatigued    = loadFatigued()
+          const deckEntries = loadDeck().filter(e => !fatigued.includes(e.cardName))
+          const playerCards = buildDeckCards(deckEntries, collection)
+          const earnedEntries = (savedRun.earnedCards ?? []).map(n => ({ cardName: n, count: 1 }))
+          if (earnedEntries.length > 0) playerCards.push(...buildDeckCards(earnedEntries, collection))
+          const mods = act ? getModifiersByCount(act, savedRun.activeModifierCount) : []
+          const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
+          state.playerBase = { hp: savedRun.playerHp, maxHp: savedRun.maxHp }
+          if (savedRun.activeRelic) getRelicDef(savedRun.activeRelic)?.applyToGame(state)
+          if (startupArch) state.archetypePassive = startupArch
+          dispatch({ type: 'START', gameState: state })
+          setRun(savedRun)
+          setScreen('playing')
+          return
+        }
+        // Act missing or node not a battle node — fall through, exactly like the
+        // synchronous initializer's fallthrough when act data was unavailable.
+      }
+      if (savedRun.pendingActComplete || savedRun.pendingRelicSelect) return // already resolved synchronously
+      const act = getCachedAct(savedRun.actId) ?? (await loadAct(savedRun.actId).catch(() => undefined))
+      if (cancelled) return
+      if (act && isActComplete(act, savedRun)) {
+        setRun(savedRun)
+        setScreen('actcomplete')
+      }
+      // hubworld-default / endless-restore / plain intro-title fallback need no
+      // act data and were already decided correctly by the sync initializer.
+    })()
+    return () => { cancelled = true }
+    // Intentionally runs once on mount only — _startup is captured from the
+    // initial render and never changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Cutscenes & boss dialogue
   const [cutscenePanels, setCutscenePanels]   = useState<CutscenePanel[]>([])
@@ -743,7 +848,7 @@ export default function App() {
     } else if (screen === 'bossEpilogue' && epiloguePanels.length === 0) {
       rollbar.error('bossEpilogue screen reached with no panels', { runActId: run?.actId })
       setScreen(run?.pendingActComplete ? 'actcomplete' : fallback)
-    } else if (screen === 'actcomplete' && (!run || !ACTS[run.actId])) {
+    } else if (screen === 'actcomplete' && (!run || actDataFailed)) {
       rollbar.error('actcomplete screen reached without valid run/actData', { runActId: run?.actId })
       clearRun()
       setRun(null)
@@ -763,13 +868,13 @@ export default function App() {
     } else if (screen === 'itemfound' && !foundItem) {
       rollbar.error('itemfound screen reached without foundItem', { runActId: run?.actId })
       setScreen(fallback)
-    } else if (screen === 'nodemap' && (!run || !ACTS[run.actId])) {
+    } else if (screen === 'nodemap' && (!run || actDataFailed)) {
       rollbar.error('nodemap screen reached without valid run/actData', { runActId: run?.actId })
       clearRun()
       setRun(null)
       setScreen('title')
     }
-  }, [screen, cutscenePanels, epiloguePanels, run, bossDialogueNode, activeEvent, merchantItems, mysteryReward, foundItem])
+  }, [screen, cutscenePanels, epiloguePanels, run, bossDialogueNode, activeEvent, merchantItems, mysteryReward, foundItem, actDataFailed])
 
   // Show boss fight splash when phase 2 triggers.
   useEffect(() => {
@@ -909,7 +1014,7 @@ export default function App() {
     if (screen === 'title') swRegRef.current?.update().catch(() => {})
   }, [screen])
 
-  useMusic(screen, gameState, run)
+  useMusic(screen, gameState, run, actData)
 
   // ── Free play ────────────────────────────────────────────
 
@@ -1149,8 +1254,8 @@ export default function App() {
   // ── Campaign ─────────────────────────────────────────────
 
   const launchCampaign = useCallback((startActId: string) => {
-    const doLaunch = () => {
-    const existing = loadRun()
+    const doLaunch = async () => {
+    const existing = await loadRun()
 
     const goToNodemap = () => {
       const fat = loadFatigued()
@@ -1165,7 +1270,7 @@ export default function App() {
       const activeRun = existing
       saveRun(activeRun)  // Persist any stash drain so a page refresh doesn't lose bought consumables
       setRun(activeRun)
-      const act = ACTS[activeRun.actId]
+      const act = await loadAct(activeRun.actId)
 
       if (activeRun.pendingNodeId) {
         const node = act.nodes[activeRun.pendingNodeId]
@@ -1226,23 +1331,23 @@ export default function App() {
 
     // ── Fresh run ─────────────────────────────────────────────────────────────
     const actId = startActId
-    const act = ACTS[actId]
+    const act = await loadAct(actId)
     const completionCount = loadActCount(actId)
 
-    const proceedWithModifiers = (chosenModifierCount: number) => {
+    const proceedWithModifiers = async (chosenModifierCount: number) => {
       let activeRun = newRun(actId, chosenModifierCount)
       const earned = loadEarnedRelics()
       saveRun(activeRun)
       setRun(activeRun)
 
-      const proceedAfterRelicSelect = (chosenRelic: string | null) => {
+      const proceedAfterRelicSelect = async (chosenRelic: string | null) => {
         rollbar.info('proceedAfterRelicSelect: relic chosen', { actId, chosenRelic, earnedCount: earned.length })
         const runWithRelic = { ...activeRun, activeRelic: chosenRelic }
         saveRun(runWithRelic)
         setRun(runWithRelic)
         const runCount = incrementRunCount()
         const introToShow = actId === 'act1'
-          ? getAct1Intro(runCount)
+          ? await getAct1Intro(runCount)
           : (act.intro ?? [])
         markIntroSeen(actId)
         rollbar.info('proceedAfterRelicSelect: showing intro or nodemap', {
@@ -1257,7 +1362,7 @@ export default function App() {
               actId,
               runRefActId: runRef.current?.actId,
               hasRun: !!runRef.current,
-              hasActData: !!(runRef.current && ACTS[runRef.current.actId]),
+              hasActData: !!(runRef.current && getCachedAct(runRef.current.actId)),
             })
             setCutscenePanels([])
             goToNodemap()
@@ -1309,8 +1414,8 @@ export default function App() {
   // Campaign 2 is launched from Cartographer Elsben in Ironhold Keep. If a
   // campaign-1 run is in progress it must be explicitly abandoned first —
   // both campaigns share the single active-run slot.
-  const handleCampaign2 = useCallback(() => {
-    const existing = loadRun()
+  const handleCampaign2 = useCallback(async () => {
+    const existing = await loadRun()
     if (existing && getCampaignForAct(existing.actId).id !== 'c2') {
       setCampaign2AbandonConfirm(true)
       return
@@ -1318,10 +1423,10 @@ export default function App() {
     launchCampaign('c2act1')
   }, [launchCampaign])
 
-  const handleWorldBattle = useCallback((worldNode: WorldNodeDef) => {
+  const handleWorldBattle = useCallback(async (worldNode: WorldNodeDef) => {
     if (!worldNode.battleConfig) return
     const { actId, nodeId } = worldNode.battleConfig
-    const act = ACTS[actId]
+    const act = await loadAct(actId).catch(() => undefined)
     if (!act) return
     const node = act.nodes[nodeId]
     if (!node) return
@@ -1372,8 +1477,8 @@ export default function App() {
 
   const handleSelectNode = useCallback((node: QuestNode) => {
     const currentRun = run
-    if (!currentRun) return
-    const act = ACTS[currentRun.actId]
+    if (!currentRun || !actData) return
+    const act = actData
 
     // Mark siblings as skipped (branch choice)
     const afterSkip = skipSiblings(act.nodes, node.id, currentRun)
@@ -1483,7 +1588,7 @@ export default function App() {
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
-  }, [run])
+  }, [run, actData])
 
   const handleBossDialogueDone = useCallback(() => {
     const node = bossDialogueNode
@@ -1505,7 +1610,7 @@ export default function App() {
     const earnedEntries = (run.earnedCards ?? []).map(n => ({ cardName: n, count: 1 }))
     if (earnedEntries.length > 0) playerCards.push(...buildDeckCards(earnedEntries, collection))
     battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
-    const act = ACTS[run.actId]
+    const act = actData ?? undefined
     const mods761 = act ? getModifiersByCount(act, run.activeModifierCount) : []
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods761) })
     state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
@@ -1513,7 +1618,7 @@ export default function App() {
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
-  }, [bossDialogueNode, run])
+  }, [bossDialogueNode, run, actData])
 
   const handleEventChoice = useCallback((choice: EventChoice) => {
     const currentRun = run
@@ -1674,7 +1779,7 @@ export default function App() {
   const handleCharacterDone = useCallback((choice?: CharacterChoice) => {
     const currentRun = run
     if (!currentRun || !activeCharacterEncounter) { setScreen('nodemap'); return }
-    const act = ACTS[currentRun.actId]
+    const act = actData
     if (!act) { setScreen('nodemap'); return }
 
     recordCharacterEncounter(activeCharacterEncounter.characterId, choice?.label)
@@ -1714,7 +1819,7 @@ export default function App() {
     } else {
       setScreen('nodemap')
     }
-  }, [run, activeCharacterEncounter])
+  }, [run, activeCharacterEncounter, actData])
 
   const handleMemoryCollect = useCallback(() => {
     const currentRun = run
@@ -1762,8 +1867,8 @@ export default function App() {
 
   const handleCampaignWin = useCallback(() => {
     const currentRun = run
-    if (!currentRun || !gameState) return
-    const act = ACTS[currentRun.actId]
+    if (!currentRun || !gameState || !actData) return
+    const act = actData
     const nodeId = currentRun.pendingNodeId!
     const node = act.nodes[nodeId]
 
@@ -1860,7 +1965,7 @@ export default function App() {
     setRewardChoices(choices)
     setRewardCrystals(crystalReward)
     setScreen('reward')
-  }, [run, gameState])
+  }, [run, gameState, actData])
 
   const handleRewardPick = useCallback((cardName: string) => {
     addCardsToCollection([{ cardName, count: 1 }])
@@ -1954,13 +2059,13 @@ export default function App() {
     dispatch({ type: 'SET_SPEED', multiplier: next })
   }, [battle.speedMultiplier])
 
-  const handleActComplete = useCallback(() => {
+  const handleActComplete = useCallback(async () => {
     const currentRun = run
     if (!currentRun) {
       rollbar.error('handleActComplete called with null run', { screen })
       return
     }
-    const act = ACTS[currentRun.actId]
+    const act = actData
     rollbar.info('Act complete: beginning transition', {
       actId: currentRun.actId,
       equippedRelic: currentRun.activeRelic,
@@ -1975,7 +2080,7 @@ export default function App() {
     // Guard: never break the relic just earned this act
     const equippedRelic = currentRun.activeRelic
 
-    const proceedFromSpin = (willBreak: boolean) => {
+    const proceedFromSpin = async (willBreak: boolean) => {
       rollbar.info('proceedFromSpin called', { actId: currentRun.actId, willBreak, equippedRelic, rewardRelic: act?.rewardRelic })
       if (willBreak && equippedRelic && equippedRelic !== act?.rewardRelic) {
         removeEarnedRelic(equippedRelic)
@@ -1992,7 +2097,8 @@ export default function App() {
         })
       }
 
-      const nextAct = getNextAct(currentRun.actId)
+      const nextActId = act?.nextActId
+      const nextAct = nextActId ? await loadAct(nextActId).catch(() => null) : null
 
       if (nextAct) {
         // ── Progress to next act ──────────────────────────────
@@ -2041,7 +2147,7 @@ export default function App() {
                 toActId: nextAct.id,
                 runRefActId: runRef.current?.actId,
                 hasRun: !!runRef.current,
-                hasActData: !!(runRef.current && ACTS[runRef.current.actId]),
+                hasActData: !!(runRef.current && getCachedAct(runRef.current.actId)),
               })
               setCutscenePanels([])
               setScreen('nodemap')
@@ -2126,7 +2232,7 @@ export default function App() {
     }
 
     proceedFromSpin(false)
-  }, [run])
+  }, [run, actData])
 
 
   const handleCardRestConfirm = useCallback((resting: string[]) => {
@@ -2175,7 +2281,8 @@ export default function App() {
   const handleCampaignRetry = useCallback(() => {
     const currentRun = run
     if (!currentRun) { setScreen('title'); return }
-    const act = ACTS[currentRun.actId]
+    if (!actData) { setScreen('nodemap'); return }
+    const act = actData
     const nodeId = currentRun.pendingNodeId
     if (!nodeId) { setScreen('nodemap'); return }
     const node = act.nodes[nodeId]
@@ -2234,7 +2341,7 @@ export default function App() {
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
-  }, [run])
+  }, [run, actData])
 
   const handleAbandonRun = useCallback(() => {
     clearRun()
@@ -2889,7 +2996,6 @@ export default function App() {
 
   // ── Render ───────────────────────────────────────────────
 
-  const actData = run ? ACTS[run.actId] ?? null : null
   const actTheme = run?.actId
 
   return (
@@ -3151,7 +3257,7 @@ export default function App() {
         <PostBattleReward
           choices={rewardChoices}
           crystals={rewardCrystals}
-          nodeType={run ? ACTS[run.actId].nodes[run.completedNodeIds[run.completedNodeIds.length - 1]]?.type ?? 'battle' : 'battle'}
+          nodeType={run && actData ? actData.nodes[run.completedNodeIds[run.completedNodeIds.length - 1]]?.type ?? 'battle' : 'battle'}
           onPick={handleRewardPick}
           onSkip={handleRewardSkip}
           battleSummary={summaryStats ?? undefined}
@@ -3165,7 +3271,7 @@ export default function App() {
           relicName={actData.rewardRelic}
           relicDesc={actData.rewardRelicDesc}
           onContinue={handleActComplete}
-          hasNextAct={!!getNextAct(actData.id)}
+          hasNextAct={hasNextAct}
         />
       )}
 
@@ -3326,7 +3432,10 @@ export default function App() {
 
       {screen === 'replayBriefing' && replayBriefingRef.current && (() => {
         const { actId, completionCount, lastRunFailed, proceed } = replayBriefingRef.current!
-        const act = ACTS[actId]
+        // launchCampaign() already awaited loadAct(actId) before setting this ref,
+        // so the act is guaranteed to be in cache by the time this renders.
+        const act = getCachedAct(actId)
+        if (!act) return null
         return (
           <ReplayBriefingScreen
             act={act}
@@ -3707,7 +3816,7 @@ export default function App() {
         if (gameState.phase.type === 'celebration') {
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
               <VictoryPanel
                 playerScore={gameState.playerScore}
                 opponentScore={gameState.opponentScore}
@@ -3724,7 +3833,7 @@ export default function App() {
           const fp = gameState.phase as { type: 'fingerSmash'; wave: number; smashedNames: string[]; rewardDue: boolean }
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
               <FingerSmash
                 smashedNames={fingerSmashNames}
                 onDone={() => {
@@ -3786,7 +3895,7 @@ export default function App() {
           />
         ) : (
           <>
-            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run ? getModifiersByCount(ACTS[run.actId], run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
+            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
             {showBossShockwave && <BossShockwave onDone={() => dispatch({ type: 'HIDE_BOSS_SHOCKWAVE' })} />}
             {activeRareEvent === 'fakeCrash'   && <FakeCrashEvent   onDone={handleRareEventDone} />}
             {activeRareEvent === 'blackjack'   && <BlackjackEvent   onDone={handleRareEventDone} />}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useCallback, useEffect, useRef, useMemo, useReducer } from 'react'
+import React, { useState, useCallback, useEffect, useRef, useMemo, useReducer, lazy, Suspense } from 'react'
+import { ScreenLoadingFallback } from './components/ScreenLoadingFallback'
 import { resolvedNodeOpts, loadHandicap, HANDICAP_KEY, buildQuickBattleOpts, loadCurrentDeckInfo } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
@@ -41,76 +42,78 @@ import {
   setLastRunFailed, loadLastRunFailed, clearLastRunFailed,
   ARCHETYPE_STARTER_PACK, loadPlayerArchetype,
 } from './game/questline'
-import { CardRestSelect }       from './components/cards/CardRestSelect'
-import { CampScreen, CampChoice } from './components/campaign/CampScreen'
-import { EventScreen }          from './components/campaign/EventScreen'
+const CardRestSelect = lazy(() => import('./components/cards/CardRestSelect').then(m => ({ default: m.CardRestSelect })))
+import type { CampChoice } from './components/campaign/CampScreen'
+const CampScreen = lazy(() => import('./components/campaign/CampScreen').then(m => ({ default: m.CampScreen })))
+const EventScreen = lazy(() => import('./components/campaign/EventScreen').then(m => ({ default: m.EventScreen })))
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/campaign/MerchantScreen'
-import { MysteryScreen } from './components/campaign/MysteryScreen'
-import { MemoryFragmentScreen } from './components/campaign/MemoryFragmentScreen'
+const MysteryScreen = lazy(() => import('./components/campaign/MysteryScreen').then(m => ({ default: m.MysteryScreen })))
+const MemoryFragmentScreen = lazy(() => import('./components/campaign/MemoryFragmentScreen').then(m => ({ default: m.MemoryFragmentScreen })))
 import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault, saveHubDefault } from './game/codex'
-import { CharacterEncounterScreen } from './components/campaign/CharacterEncounterScreen'
-import { NarratorJournalScreen } from './components/hub/NarratorJournalScreen'
+const CharacterEncounterScreen = lazy(() => import('./components/campaign/CharacterEncounterScreen').then(m => ({ default: m.CharacterEncounterScreen })))
+const NarratorJournalScreen = lazy(() => import('./components/hub/NarratorJournalScreen').then(m => ({ default: m.NarratorJournalScreen })))
 import { CharacterChoice, recordCharacterEncounter, getCharacterEncounterChance, resolveCharacterEncounterId } from './game/characters'
 import memoryFragmentsData from './data/memoryFragments.json'
 import { ItemFoundScreen }    from './components/modals/ItemFoundScreen'
-import { CharacterScreen }    from './components/screens/CharacterScreen'
-import { CutsceneScreen }       from './components/campaign/CutsceneScreen'
-import { BossDialogueScreen }   from './components/battle/BossDialogueScreen'
-import { Battlefield }        from './components/battle/Battlefield'
-import { GameOver }           from './components/battle/GameOver'
+const CharacterScreen = lazy(() => import('./components/screens/CharacterScreen').then(m => ({ default: m.CharacterScreen })))
+const CutsceneScreen = lazy(() => import('./components/campaign/CutsceneScreen').then(m => ({ default: m.CutsceneScreen })))
+const BossDialogueScreen = lazy(() => import('./components/battle/BossDialogueScreen').then(m => ({ default: m.BossDialogueScreen })))
+const Battlefield = lazy(() => import('./components/battle/Battlefield').then(m => ({ default: m.Battlefield })))
+const GameOver = lazy(() => import('./components/battle/GameOver').then(m => ({ default: m.GameOver })))
 import { TitleScreen }        from './components/title/TitleScreen'
-import { QuickBattleMode, QuickBattleScreen }  from './components/screens/QuickBattleScreen'
-import { CardDraftScreen }    from './components/screens/CardDraftScreen'
-import { CollectionScreen }   from './components/screens/CollectionScreen'
-import { DeckBuilder }        from './components/cards/DeckBuilder'
-import { PackOpening }        from './components/cards/PackOpening'
+import type { QuickBattleMode } from './components/screens/QuickBattleScreen'
+const QuickBattleScreen = lazy(() => import('./components/screens/QuickBattleScreen').then(m => ({ default: m.QuickBattleScreen })))
+const CardDraftScreen = lazy(() => import('./components/screens/CardDraftScreen').then(m => ({ default: m.CardDraftScreen })))
+const CollectionScreen = lazy(() => import('./components/screens/CollectionScreen').then(m => ({ default: m.CollectionScreen })))
+const DeckBuilder = lazy(() => import('./components/cards/DeckBuilder').then(m => ({ default: m.DeckBuilder })))
+const PackOpening = lazy(() => import('./components/cards/PackOpening').then(m => ({ default: m.PackOpening })))
 import { NodeMap }            from './components/campaign/NodeMap'
-import { HubWorld }           from './components/hub/HubWorld'
-import { HubWorldMap }        from './components/hub/HubWorldMap'
-import { CasinoScreen }       from './components/hub/CasinoScreen'
-import { TheatreScreen }      from './components/hub/TheatreScreen'
-import { PostBattleReward }   from './components/battle/PostBattleReward'
-import { ActComplete }        from './components/battle/ActComplete'
-import { RelicSelectScreen }  from './components/campaign/RelicSelectScreen'
-import { ReplayBriefingScreen } from './components/campaign/ReplayBriefingScreen'
-import { StarterPackSelect }  from './components/cards/StarterPackSelect'
+const HubWorld = lazy(() => import('./components/hub/HubWorld').then(m => ({ default: m.HubWorld })))
+const HubWorldMap = lazy(() => import('./components/hub/HubWorldMap').then(m => ({ default: m.HubWorldMap })))
+const CasinoScreen = lazy(() => import('./components/hub/CasinoScreen').then(m => ({ default: m.CasinoScreen })))
+const TheatreScreen = lazy(() => import('./components/hub/TheatreScreen').then(m => ({ default: m.TheatreScreen })))
+const PostBattleReward = lazy(() => import('./components/battle/PostBattleReward').then(m => ({ default: m.PostBattleReward })))
+const ActComplete = lazy(() => import('./components/battle/ActComplete').then(m => ({ default: m.ActComplete })))
+const RelicSelectScreen = lazy(() => import('./components/campaign/RelicSelectScreen').then(m => ({ default: m.RelicSelectScreen })))
+const ReplayBriefingScreen = lazy(() => import('./components/campaign/ReplayBriefingScreen').then(m => ({ default: m.ReplayBriefingScreen })))
+const StarterPackSelect = lazy(() => import('./components/cards/StarterPackSelect').then(m => ({ default: m.StarterPackSelect })))
 import { SettingsScreen, applyTextSettings, loadSkipIntro, load8bitEnabled, apply8bitMode, applyLightMode, loadLightMode } from './components/screens/SettingsScreen'
 import { IntroScreen } from './components/title/IntroScreen'
-import { FakeCrashEvent }     from './components/rare-events/FakeCrashEvent'
-import { BlackjackEvent }     from './components/rare-events/BlackjackEvent'
-import { WrongNumberEvent }   from './components/rare-events/WrongNumberEvent'
-import { NarratorEvent }      from './components/rare-events/NarratorEvent'
-import { LiarsDiceEvent }     from './components/rare-events/LiarsDiceEvent'
-import { GamblerEvent }       from './components/rare-events/GamblerEvent'
-import { DevBuildEvent }        from './components/rare-events/DevBuildEvent'
-import { GlitchedCardEvent }    from './components/rare-events/GlitchedCardEvent'
-import { ConfusedTouristEvent } from './components/rare-events/ConfusedTouristEvent'
+const FakeCrashEvent = lazy(() => import('./components/rare-events/FakeCrashEvent').then(m => ({ default: m.FakeCrashEvent })))
+const BlackjackEvent = lazy(() => import('./components/rare-events/BlackjackEvent').then(m => ({ default: m.BlackjackEvent })))
+const WrongNumberEvent = lazy(() => import('./components/rare-events/WrongNumberEvent').then(m => ({ default: m.WrongNumberEvent })))
+const NarratorEvent = lazy(() => import('./components/rare-events/NarratorEvent').then(m => ({ default: m.NarratorEvent })))
+const LiarsDiceEvent = lazy(() => import('./components/rare-events/LiarsDiceEvent').then(m => ({ default: m.LiarsDiceEvent })))
+const GamblerEvent = lazy(() => import('./components/rare-events/GamblerEvent').then(m => ({ default: m.GamblerEvent })))
+const DevBuildEvent = lazy(() => import('./components/rare-events/DevBuildEvent').then(m => ({ default: m.DevBuildEvent })))
+const GlitchedCardEvent = lazy(() => import('./components/rare-events/GlitchedCardEvent').then(m => ({ default: m.GlitchedCardEvent })))
+const ConfusedTouristEvent = lazy(() => import('./components/rare-events/ConfusedTouristEvent').then(m => ({ default: m.ConfusedTouristEvent })))
 import { CardTile }           from './components/cards/CardTile'
 import { DailyLoginModal }   from './components/screens/DailyLoginModal'
 import { GiftClaimModal }    from './components/admin/GiftClaimModal'
-import { GiftAdminScreen }  from './components/admin/GiftAdminScreen'
+const GiftAdminScreen = lazy(() => import('./components/admin/GiftAdminScreen').then(m => ({ default: m.GiftAdminScreen })))
 import { LoginModal }        from './components/modals/LoginModal'
-import { InventoryScreen }   from './components/screens/InventoryScreen'
+const InventoryScreen = lazy(() => import('./components/screens/InventoryScreen').then(m => ({ default: m.InventoryScreen })))
 import { markDailyRewardClaimed, addToInventory, computeReward, loadInventory, RewardDef, ALL_ITEMS } from './game/dailyLogin'
 import { applyGiftRewards, GiftDef, GIFT_OWNER_UID } from './game/gifts'
 import { fetchEnabledTownIds, isTownAccessible, loadPreviewAsPlayer, savePreviewAsPlayer } from './game/townAccess'
-import { NewsScreen }      from './components/screens/NewsScreen'
-import { NewsAdminScreen } from './components/admin/NewsAdminScreen'
-import { CampaignAdminScreen } from './components/admin/CampaignAdminScreen'
-import { SceneryAdminScreen } from './components/admin/SceneryAdminScreen'
+const NewsScreen = lazy(() => import('./components/screens/NewsScreen').then(m => ({ default: m.NewsScreen })))
+const NewsAdminScreen = lazy(() => import('./components/admin/NewsAdminScreen').then(m => ({ default: m.NewsAdminScreen })))
+const CampaignAdminScreen = lazy(() => import('./components/admin/CampaignAdminScreen').then(m => ({ default: m.CampaignAdminScreen })))
+const SceneryAdminScreen = lazy(() => import('./components/admin/SceneryAdminScreen').then(m => ({ default: m.SceneryAdminScreen })))
 import { FeedbackModal } from './components/modals/FeedbackModal'
-import { FeedbackAdminScreen } from './components/admin/FeedbackAdminScreen'
-import { TownAccessAdminScreen } from './components/admin/TownAccessAdminScreen'
+const FeedbackAdminScreen = lazy(() => import('./components/admin/FeedbackAdminScreen').then(m => ({ default: m.FeedbackAdminScreen })))
+const TownAccessAdminScreen = lazy(() => import('./components/admin/TownAccessAdminScreen').then(m => ({ default: m.TownAccessAdminScreen })))
 import { DeckSelectorModal } from './components/cards/DeckSelectorModal'
 import { loadDeckSlot } from './game/collection'
 import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
 import { getWeeklyChallenge, getWeeklyPlayerDeck, getWeeklyOpponentDeck, getWeeklyChallengeState, saveWeeklyChallengeResult, grantWeeklyReward, publishWeeklyResult, WeeklyRewardResult } from './game/weeklyChallenge'
-import { WeeklyChallengeScreen } from './components/screens/WeeklyChallengeScreen'
+const WeeklyChallengeScreen = lazy(() => import('./components/screens/WeeklyChallengeScreen').then(m => ({ default: m.WeeklyChallengeScreen })))
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic, rollExoticDrop } from './game/relics'
 import { recordQuestKills, recordQuestWin, recordQuestCardPlayed, recordQuestBossDefeat, QuestChainDef } from './game/quests'
 import { recordChronicleWin, describeReward, ChronicleChapterDef } from './game/chronicle'
-import { ChronicleScreen } from './components/screens/ChronicleScreen'
-import { BossEpilogueScreen } from './components/campaign/BossEpilogueScreen'
+const ChronicleScreen = lazy(() => import('./components/screens/ChronicleScreen').then(m => ({ default: m.ChronicleScreen })))
+const BossEpilogueScreen = lazy(() => import('./components/campaign/BossEpilogueScreen').then(m => ({ default: m.BossEpilogueScreen })))
 import bossEpiloguesData from './data/bossEpilogues.json'
 import { playCardPlay, playButtonClick, playBattleEvent, playCardFlip, playRestHeal, playBattleStart, playVictory, playDefeat, stopBattleMusic, stopGameOverMusic } from './game/sound'
 import { useMusic } from './hooks/useMusic'
@@ -123,38 +126,39 @@ import { loadCommander, promoteCommander, CommanderState } from './game/commande
 
 import { WORLD_MAP, WORLD_MAP_NODES, type WorldNodeDef } from './data/world/worldMapDef'
 import { setCurrentWorldLocation, getCurrentWorldLocation, markNodeCleared, isNodeCleared } from './game/world/worldState'
-import { CommanderScreen } from './components/screens/CommanderScreen'
-import { TrainingScreen }  from './components/screens/TrainingScreen'
+const CommanderScreen = lazy(() => import('./components/screens/CommanderScreen').then(m => ({ default: m.CommanderScreen })))
+const TrainingScreen = lazy(() => import('./components/screens/TrainingScreen').then(m => ({ default: m.TrainingScreen })))
 import {
   incrementAchievementProgress, setAchievementProgress, AchievementDef,
 } from './game/achievements'
 import { incrementAugmentSouls } from './game/collection'
-import { AchievementsScreen }  from './components/screens/AchievementsScreen'
-import { HallOfAchievements }   from './components/hub/HallOfAchievements'
-import { HomeShelf }             from './components/hub/HomeShelf'
-import { HeroCardsScreen }   from './components/screens/HeroCardsScreen'
-import FingerSmash from './components/battle/FingerSmash'
-import BossShockwave from './components/battle/BossShockwave'
-import { ShopScreen }        from './components/screens/ShopScreen'
-import { BattleSummary }    from './components/battle/BattleSummary'
-import { VictoryPanel }     from './components/battle/VictoryPanel'
-import { RelicSpinScreen }  from './components/campaign/RelicSpinScreen'
-import { CampaignVictoryScreen } from './components/battle/CampaignVictoryScreen'
-import { ToBeContinuedScreen } from './components/battle/ToBeContinuedScreen'
-import { CampaignFailedScreen }  from './components/battle/CampaignFailedScreen'
-import { StatUpgradeScreen }     from './components/campaign/StatUpgradeScreen'
-import { PlayerStatsScreen }     from './components/screens/PlayerStatsScreen'
-import { CodexScreen }          from './components/screens/CodexScreen'
-import { DailyChallengeScreen } from './components/screens/DailyChallengeScreen'
+const AchievementsScreen = lazy(() => import('./components/screens/AchievementsScreen').then(m => ({ default: m.AchievementsScreen })))
+const HallOfAchievements = lazy(() => import('./components/hub/HallOfAchievements').then(m => ({ default: m.HallOfAchievements })))
+const HomeShelf = lazy(() => import('./components/hub/HomeShelf').then(m => ({ default: m.HomeShelf })))
+const HeroCardsScreen = lazy(() => import('./components/screens/HeroCardsScreen').then(m => ({ default: m.HeroCardsScreen })))
+const FingerSmash = lazy(() => import('./components/battle/FingerSmash'))
+const BossShockwave = lazy(() => import('./components/battle/BossShockwave'))
+const ShopScreen = lazy(() => import('./components/screens/ShopScreen').then(m => ({ default: m.ShopScreen })))
+const BattleSummary = lazy(() => import('./components/battle/BattleSummary').then(m => ({ default: m.BattleSummary })))
+const VictoryPanel = lazy(() => import('./components/battle/VictoryPanel').then(m => ({ default: m.VictoryPanel })))
+const RelicSpinScreen = lazy(() => import('./components/campaign/RelicSpinScreen').then(m => ({ default: m.RelicSpinScreen })))
+const CampaignVictoryScreen = lazy(() => import('./components/battle/CampaignVictoryScreen').then(m => ({ default: m.CampaignVictoryScreen })))
+const ToBeContinuedScreen = lazy(() => import('./components/battle/ToBeContinuedScreen').then(m => ({ default: m.ToBeContinuedScreen })))
+const CampaignFailedScreen = lazy(() => import('./components/battle/CampaignFailedScreen').then(m => ({ default: m.CampaignFailedScreen })))
+const StatUpgradeScreen = lazy(() => import('./components/campaign/StatUpgradeScreen').then(m => ({ default: m.StatUpgradeScreen })))
+const PlayerStatsScreen = lazy(() => import('./components/screens/PlayerStatsScreen').then(m => ({ default: m.PlayerStatsScreen })))
+const CodexScreen = lazy(() => import('./components/screens/CodexScreen').then(m => ({ default: m.CodexScreen })))
+const DailyChallengeScreen = lazy(() => import('./components/screens/DailyChallengeScreen').then(m => ({ default: m.DailyChallengeScreen })))
 import { ConfirmModal }          from './components/modals/ConfirmModal'
 import { StreakBrokenModal }     from './components/modals/StreakBrokenModal'
-import { EndlessLeaderboardScreen } from './components/screens/EndlessLeaderboardScreen'
-import { MiniGamesMenu, SubScreen } from './components/screens/MiniGamesMenu'
-import { Fishing } from './components/minigames/Fishing'
+const EndlessLeaderboardScreen = lazy(() => import('./components/screens/EndlessLeaderboardScreen').then(m => ({ default: m.EndlessLeaderboardScreen })))
+import type { SubScreen } from './components/screens/MiniGamesMenu'
+const MiniGamesMenu = lazy(() => import('./components/screens/MiniGamesMenu').then(m => ({ default: m.MiniGamesMenu })))
+const Fishing = lazy(() => import('./components/minigames/Fishing').then(m => ({ default: m.Fishing })))
 import { OverlayScreen } from './components/ui/OverlayScreen'
-import { AugmentCollectionScreen } from './components/screens/AugmentCollectionScreen'
-import { PlayerScreen }            from './components/screens/PlayerScreen'
-import { CollectionTabScreen }     from './components/screens/CollectionTabScreen'
+const AugmentCollectionScreen = lazy(() => import('./components/screens/AugmentCollectionScreen').then(m => ({ default: m.AugmentCollectionScreen })))
+const PlayerScreen = lazy(() => import('./components/screens/PlayerScreen').then(m => ({ default: m.PlayerScreen })))
+const CollectionTabScreen = lazy(() => import('./components/screens/CollectionTabScreen').then(m => ({ default: m.CollectionTabScreen })))
 import './styles.css'
 import { publishSecretRareWin, type SecretRarityType } from './game/secretRareNews'
 import brokenRelicsData from './data/broken-relics.json'
@@ -3002,6 +3006,7 @@ export default function App() {
     <div className="game-container">
       <div className="game-title">JARV'S AMAZING WEB GAME</div>
 
+      <Suspense fallback={<ScreenLoadingFallback />}>
       {/* Event card reveal overlay */}
       {pendingEventCard && (() => {
         const catalog = getCardCatalog()
@@ -4158,6 +4163,7 @@ export default function App() {
           }}
         />
       )}
+      </Suspense>
     </div>
   )
 }

--- a/web/src/components/ScreenLoadingFallback.tsx
+++ b/web/src/components/ScreenLoadingFallback.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+/**
+ * Suspense fallback shown briefly while a lazy-loaded screen's chunk fetches.
+ * Styled to match ErrorBoundary's fallback so loading and error states feel
+ * like the same system.
+ */
+export function ScreenLoadingFallback(): React.ReactElement {
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      justifyContent: 'center', height: '100vh', gap: 16, textAlign: 'center',
+    }}>
+      <div className="title-logo">JARV'S</div>
+    </div>
+  )
+}

--- a/web/src/components/admin/CampaignAdminScreen.tsx
+++ b/web/src/components/admin/CampaignAdminScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Section } from '../ui/Section'
-import { ACTS, Act, QuestNode, NodeType, RunState } from '../../game/questline'
+import { loadAct, ACT_IDS, Act, QuestNode, NodeType, RunState } from '../../game/questline'
 import { getCardCatalog } from '../../game/cards'
 import battlefieldData from '../../data/battlefield.json'
 import { TerrainEditorPanel, TerrainItemDef, RiverDef } from './TerrainEditorPanel'
@@ -11,10 +11,6 @@ interface Props {
   onBack: () => void
 }
 
-const ACT_IDS = [
-  'act1','act2','act3','act4','act5','act6','act7',
-  'act8','act9','act10','act11','act12','act13','actfinale','c2act1','c2act2','c2act3','c2act4','c2act5',
-]
 const NODE_TYPES: NodeType[] = ['battle', 'elite', 'boss', 'rest', 'event', 'merchant']
 
 const PREV_COL = 90  // px per row slot (rows run left-to-right)
@@ -278,11 +274,36 @@ function NodeIdPicker({
 }
 
 // ─── Main component ───────────────────────────────────────────────────────────
+//
+// Act JSON is lazy-loaded (see questline.ts loadAct); this admin screen is
+// rarely opened, so it preloads every act's data on mount rather than needing
+// full async plumbing throughout the editor below.
 
 export function CampaignAdminScreen({ onBack }: Props) {
+  const [loadedActs, setLoadedActs] = useState<Record<string, Act> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all(ACT_IDS.map(id => loadAct(id).then(act => [id, act] as const)))
+      .then(entries => { if (!cancelled) setLoadedActs(Object.fromEntries(entries)) })
+    return () => { cancelled = true }
+  }, [])
+
+  if (!loadedActs) {
+    return (
+      <OverlayScreen title="CAMPAIGN EDITOR" onBack={onBack} className="settings-screen u-col u-grow">
+        <div className="settings-sublabel">Loading acts…</div>
+      </OverlayScreen>
+    )
+  }
+
+  return <CampaignAdminScreenLoaded onBack={onBack} acts={loadedActs} />
+}
+
+function CampaignAdminScreenLoaded({ onBack, acts }: Props & { acts: Record<string, Act> }) {
   const [tab, setTab] = useState<'nodes' | 'terrain'>('nodes')
   const [actId, setActId] = useState('act1')
-  const [act, setAct] = useState<Act>(() => JSON.parse(JSON.stringify(ACTS['act1'])))
+  const [act, setAct] = useState<Act>(() => JSON.parse(JSON.stringify(acts['act1'])))
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [nodeIdInput, setNodeIdInput] = useState('')
   const [deckSearch, setDeckSearch] = useState('')
@@ -341,7 +362,7 @@ export function CampaignAdminScreen({ onBack }: Props) {
 
   function handleActChange(newId: string) {
     setActId(newId)
-    setAct(JSON.parse(JSON.stringify(ACTS[newId])))
+    setAct(JSON.parse(JSON.stringify(acts[newId])))
     setSelectedNodeId(null)
     setDeckSearch('')
   }
@@ -521,7 +542,7 @@ export function CampaignAdminScreen({ onBack }: Props) {
             onChange={e => handleActChange(e.target.value)}
           >
             {ACT_IDS.map(id => (
-              <option key={id} value={id}>{id} — {ACTS[id]?.title ?? id}</option>
+              <option key={id} value={id}>{id} — {acts[id]?.title ?? id}</option>
             ))}
           </select>
         </div>

--- a/web/src/components/admin/DevMenu.tsx
+++ b/web/src/components/admin/DevMenu.tsx
@@ -5,7 +5,7 @@ import { loadDevConfig, patchDevConfig, clearDevConfig } from '../../game/devSto
 import { getCardCatalog } from '../../game/cards'
 import { addCardsToCollection, loadCollection, CollectionEntry } from '../../game/collection'
 import { MAX_HANDICAP } from '../../game/engine'
-import { ACTS } from '../../game/questline'
+import { Act, ACT_IDS, loadAct } from '../../game/questline'
 import { logError } from '../../logger'
 import { getAllGifts, loadClaimedGiftIds, resetClaimedGifts, GiftDef } from '../../game/gifts'
 import { isChronicleDevUnlocked, setChronicleDevUnlocked } from '../../game/chronicle'
@@ -37,6 +37,16 @@ export function DevMenu({ onCrystalsChanged, onHandicapChanged, onSceneryPreview
   const [handicapVal, setHandicapVal] = useState(0)
   const [msg,         setMsg]         = useState<string | null>(null)
   const [chronicleUnlocked, setChronicleUnlocked] = useState(isChronicleDevUnlocked)
+  // Act data is lazy-loaded; this dev menu's "skip to act" dropdown needs every
+  // act's title, so it preloads all of them (rarely opened, admin-only screen).
+  const [acts, setActs] = useState<Record<string, Act> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all(ACT_IDS.map(id => loadAct(id).then(act => [id, act] as const)))
+      .then(entries => { if (!cancelled) setActs(Object.fromEntries(entries)) })
+    return () => { cancelled = true }
+  }, [])
 
   function flash(text: string) {
     setMsg(text)
@@ -88,10 +98,10 @@ export function DevMenu({ onCrystalsChanged, onHandicapChanged, onSceneryPreview
     }
   }
 
-  function handleSkipToAct(actId: string) {
+  async function handleSkipToAct(actId: string) {
     if (!actId) return
     try {
-      const act       = ACTS[actId]
+      const act       = await loadAct(actId)
       const firstNode = Object.keys(act.nodes)[0]
       const run = {
         actId,
@@ -201,8 +211,8 @@ export function DevMenu({ onCrystalsChanged, onHandicapChanged, onSceneryPreview
           defaultValue=""
           onChange={e => handleSkipToAct(e.target.value)}
         >
-          <option value="">— choose —</option>
-          {Object.entries(ACTS).filter(([id]) => id !== 'world').map(([id, act]) => (
+          <option value="">{acts ? '— choose —' : 'Loading…'}</option>
+          {acts && Object.entries(acts).map(([id, act]) => (
             <option key={id} value={id}>{act.title ?? id}</option>
           ))}
         </select>

--- a/web/src/components/hub/HubInteriorViewer.stories.tsx
+++ b/web/src/components/hub/HubInteriorViewer.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HubInteriorViewer } from './HubInteriorViewer'
-import { IRONHOLDKEEP, MILLHAVE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import { IRONHOLDKEEP, MILLHAVE, RAVENWATCH } from '../../data/hub/hubTownStoryFixtures'
 
 const meta = {
   component: HubInteriorViewer,

--- a/web/src/components/hub/HubMinimap.stories.tsx
+++ b/web/src/components/hub/HubMinimap.stories.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HubMinimap, MinimapObjective } from './HubMinimap'
-import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import { RAVENWATCH } from '../../data/hub/hubTownStoryFixtures'
 
 // Story-friendly wrapper: HubMinimap reads the player position and viewport
 // imperatively via refs, so we set those up here and feed it static demo data.

--- a/web/src/components/hub/HubTabbedModal.stories.tsx
+++ b/web/src/components/hub/HubTabbedModal.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HubTabbedModal, type HubTabId } from './HubTabbedModal'
-import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import { RAVENWATCH } from '../../data/hub/hubTownStoryFixtures'
 import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
 import type { UpgradeRow } from './HubTownUpgrades'
 

--- a/web/src/components/hub/HubTownCanvas.stories.tsx
+++ b/web/src/components/hub/HubTownCanvas.stories.tsx
@@ -16,7 +16,7 @@ import {
   GRAVEMOOR, GRAVEMOOR_QUESTS,
   HOLLOWMERE, HOLLOWMERE_QUESTS,
   DREADSPIRECITADEL, DREADSPIRECITADEL_QUESTS,
-} from '../../data/hub/hubWorldFactory'
+} from '../../data/hub/hubTownStoryFixtures'
 
 const PAN_STEP = 64
 

--- a/web/src/components/hub/HubWorld.stories.tsx
+++ b/web/src/components/hub/HubWorld.stories.tsx
@@ -17,7 +17,8 @@ import {
   GRAVEMOOR, GRAVEMOOR_QUESTS,
   HOLLOWMERE, HOLLOWMERE_QUESTS,
   DREADSPIRECITADEL, DREADSPIRECITADEL_QUESTS,
-} from '../../data/hub/hubWorldFactory'
+  LOCATION_REGISTRY, ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE,
+} from '../../data/hub/hubTownStoryFixtures'
 
 const meta = {
   component: HubWorld,
@@ -45,8 +46,8 @@ export const Default: Story = {
     locationData:    RAVENWATCH,
     locationQuests: RAVENWATCH_QUESTS,
     questDefs:       RAVENWATCH_QUESTS.HUB_QUEST_DEFS,
-    allQuestDefs:    ALL_QUEST_DEFS   
-  },
+    allQuestDefs: ALL_QUEST_DEFS,
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 function tileInspector (args: Props){
@@ -91,8 +92,8 @@ export const TileInspector: Story = {
         locationData:    RAVENWATCH,
     locationQuests: RAVENWATCH_QUESTS,
     questDefs:       RAVENWATCH_QUESTS.HUB_QUEST_DEFS,
-    allQuestDefs:    ALL_QUEST_DEFS   
-  },
+    allQuestDefs: ALL_QUEST_DEFS,
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const MillhavenTileInspector: Story = {
@@ -105,8 +106,8 @@ export const MillhavenTileInspector: Story = {
     locationData:    MILLHAVE,
     locationQuests: MILLHAVE_QUESTS,
     questDefs:       MILLHAVE_QUESTS.HUB_QUEST_DEFS,
-    allQuestDefs:    ALL_QUEST_DEFS   
-  },
+    allQuestDefs: ALL_QUEST_DEFS,
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const IronholdKeepTileInspector: Story = {
@@ -116,7 +117,7 @@ export const IronholdKeepTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: IRONHOLDKEEP, locationQuests: IRONHOLDKEEP_QUESTS,
     questDefs: IRONHOLDKEEP_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const ThornwoodCampTileInspector: Story = {
@@ -126,7 +127,7 @@ export const ThornwoodCampTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: THORNWOODCAMP, locationQuests: THORNWOODCAMP_QUESTS,
     questDefs: THORNWOODCAMP_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const CapitalCityTileInspector: Story = {
@@ -136,7 +137,7 @@ export const CapitalCityTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: CAPITALCITY, locationQuests: CAPITALCITY_QUESTS,
     questDefs: CAPITALCITY_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const RoyalPalaceTileInspector: Story = {
@@ -146,7 +147,7 @@ export const RoyalPalaceTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: ROYALPALACE, locationQuests: ROYALPALACE_QUESTS,
     questDefs: ROYALPALACE_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const SaltmerePortTileInspector: Story = {
@@ -156,7 +157,7 @@ export const SaltmerePortTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: SALTMEREPORT, locationQuests: SALTMEREPORT_QUESTS,
     questDefs: SALTMEREPORT_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const GearfordTileInspector: Story = {
@@ -166,7 +167,7 @@ export const GearfordTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: GEARFORD, locationQuests: GEARFORD_QUESTS,
     questDefs: GEARFORD_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const HarrowfieldTileInspector: Story = {
@@ -176,7 +177,7 @@ export const HarrowfieldTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: HARROWFIELD, locationQuests: HARROWFIELD_QUESTS,
     questDefs: HARROWFIELD_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const ApplefordTileInspector: Story = {
@@ -186,7 +187,7 @@ export const ApplefordTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: APPLEFORD, locationQuests: APPLEFORD_QUESTS,
     questDefs: APPLEFORD_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const GravemoorTileInspector: Story = {
@@ -196,7 +197,7 @@ export const GravemoorTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: GRAVEMOOR, locationQuests: GRAVEMOOR_QUESTS,
     questDefs: GRAVEMOOR_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const HollowmereTileInspector: Story = {
@@ -206,7 +207,7 @@ export const HollowmereTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: HOLLOWMERE, locationQuests: HOLLOWMERE_QUESTS,
     questDefs: HOLLOWMERE_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }
 
 export const DreadspirecCitadelTileInspector: Story = {
@@ -216,5 +217,5 @@ export const DreadspirecCitadelTileInspector: Story = {
     onBack: fn(), onFeedback: fn(), user: null,
     locationData: DREADSPIRECITADEL, locationQuests: DREADSPIRECITADEL_QUESTS,
     questDefs: DREADSPIRECITADEL_QUESTS.HUB_QUEST_DEFS, allQuestDefs: ALL_QUEST_DEFS,
-  },
+    locationRegistry: LOCATION_REGISTRY, allQuests: ALL_QUESTS, friendshipDialogue: FRIENDSHIP_DIALOGUE, relationshipDialogue: RELATIONSHIP_DIALOGUE},
 }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -50,7 +50,7 @@ import { formatGameTime, hourInRange, getGameHour, getTimeOfDay } from '../../ga
 import { isNpcAsleep, getNpcActivity } from '../../game/hub/hubNpcSchedule'
 import { Festival, getActiveFestival } from '../../game/hub/hubCalendar'
 import { getDailyChallengeNPCDialogue, getMiniGameChallengeNPCDialogue } from '../../game/hub/npcDialogue'
-import {  ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import type { LocationEntry } from '../../data/hub/hubWorldFactory'
 import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure, HubNpc } from '../../data/hub/loader'
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
@@ -229,6 +229,12 @@ export interface Props {
     locationQuests: HubQuestBundle
     questDefs:       HubQuestDef[]
     allQuestDefs:    HubQuestDef[]
+    /** All towns' hub data, keyed by locationKey — needed for cross-town
+     *  reputation pricing (countOwnedPlayerHouses). Lazy-loaded by App.tsx. */
+    locationRegistry: Record<string, LocationEntry>
+    allQuests:            HubQuestBundle
+    friendshipDialogue:   HubQuestBundle['FRIENDSHIP_DIALOGUE']
+    relationshipDialogue: HubQuestBundle['RELATIONSHIP_DIALOGUE']
 
   onSignIn?:   () => void
   onSignOut?:         () => void
@@ -239,7 +245,7 @@ export interface Props {
 }
 
 export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndless, onWorldMap, onNavigateTown, onPlayerTap, onNarratorLog,
-  locationData, locationQuests, questDefs, allQuestDefs,
+  locationData, locationQuests, questDefs, allQuestDefs, locationRegistry, allQuests, friendshipDialogue, relationshipDialogue,
   crystals = 0, isSignedIn = false, commander, user, onSignIn: onLoginToggle, onSignOut, onFeedback, onCrystalsChange, onTileTap, onBuyCrystalPack }: Props) {
   const [splashVisible, setSplashVisible] = useState(() => !_hubSplashShown && !loadSkipIntro())
   const [splashFading,  setSplashFading]  = useState(false)
@@ -298,13 +304,13 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
       const id = b.id as string
       const name = locationData.HUB_INTERIORS[id]?.name
         ?? id.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
-      const next = nextUpgrade(town, id, b.upgradeKind)
+      const next = nextUpgrade(town, id, b.upgradeKind, locationRegistry)
       return { buildingId: id, name, kind: b.upgradeKind as string, level: next.level, total: next.total, next }
     })
 
   const handleUpgrade = useCallback((buildingId: string) => {
     const b = locationData.HUB_BUILDINGS.find(x => x.id === buildingId)
-    const res = purchaseUpgrade(town, buildingId, b?.upgradeKind)
+    const res = purchaseUpgrade(town, buildingId, b?.upgradeKind, locationRegistry)
     if (res.ok) {
       onCrystalsChange?.(loadCrystals())
       buildingUpgradeLevelsRef.current[buildingId] = res.newLevel
@@ -317,7 +323,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
           : 'That building is already fully upgraded.'
       setDialogueEvent({ speakerName: 'Town Steward', text: msg })
     }
-  }, [locationData, town, onCrystalsChange, refreshState])
+  }, [locationData, town, onCrystalsChange, refreshState, locationRegistry])
 
   const handleCollectTribute = useCallback(() => {
     const amount = collectTribute(town)
@@ -1369,7 +1375,7 @@ function hasOfferableQuest(giverId: string): boolean {
     // active, it flavours the greeting at the matching level. NPCs steered via a
     // dialogue tree should not author relationshipDialogue (the tree below is how
     // the player steers — a greeting here would shadow it).
-    const relTracks = RELATIONSHIP_DIALOGUE[npcId]
+    const relTracks = relationshipDialogue[npcId]
     const rel = getRelationship(npcId)
     if (!npcDef?.dialogueTree && relTracks && rel.track && relTracks[rel.track]) {
       const lines = Object.entries(relTracks[rel.track]!)
@@ -1383,7 +1389,7 @@ function hasOfferableQuest(giverId: string): boolean {
     }
 
     // ── Friendship tier dialogue override ───────────────────────────────────
-    const friendTiers = FRIENDSHIP_DIALOGUE[npcId]
+    const friendTiers = friendshipDialogue[npcId]
     if (friendTiers) {
       const level = getFriendshipLevel(npcId)
       const tiers = Object.entries(friendTiers)
@@ -1399,7 +1405,7 @@ function hasOfferableQuest(giverId: string): boolean {
     // ── Branching dialogue tree (ordinary chat) ─────────────────────────────
     const treeId = npcDef?.dialogueTree
     if (treeId) {
-      const tree = ALL_QUESTS.HUB_DIALOGUES[treeId]
+      const tree = allQuests.HUB_DIALOGUES[treeId]
       if (tree) {
         runDialogueNode(tree, tree.start, npcId, speakerName, npcDef, true)
         return

--- a/web/src/components/hub/HubWorldMap.stories.tsx
+++ b/web/src/components/hub/HubWorldMap.stories.tsx
@@ -1,6 +1,7 @@
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HubWorldMap } from './HubWorldMap'
+import { ALL_QUEST_DEFS } from '../../data/hub/hubTownStoryFixtures'
 
 const meta = {
   component: HubWorldMap,
@@ -23,6 +24,7 @@ export const Default: Story = {
     onBack:       fn(),
     onFeedback:   fn(),
     user:         null,
+    allQuestDefs: ALL_QUEST_DEFS,
   },
 }
 
@@ -43,6 +45,7 @@ export const FoggedTowns: Story = {
     onBack:       fn(),
     onFeedback:   fn(),
     user:         null,
+    allQuestDefs: ALL_QUEST_DEFS,
     restrictedNodeIds: new Set([
       'appleford', 'b-bandit-toll', 'b-blight-fields', 'b-crypt-road',
       'b-dread-gate', 'b-east-road', 'b-foundry-gate', 'b-grave-mists',

--- a/web/src/components/hub/HubWorldMap.tsx
+++ b/web/src/components/hub/HubWorldMap.tsx
@@ -19,7 +19,7 @@ import { LoginButton } from '../ui/LoginButton'
 import type { User } from 'firebase/auth'
 import { NodeMapRederer, getWorldNodeStatus } from '../ui/NodeMap/NodeMapRederer'
 import { NodePeekModal } from '../ui/NodeMap/NodePeekModal'
-import { ALL_QUEST_DEFS } from '../../data/hub/hubWorldFactory'
+import type { HubQuestDef } from '../../data/hub/questDefs'
 
 interface Props {
   onSelectNode:  (node: WorldNodeDef) => void
@@ -31,9 +31,11 @@ interface Props {
   onFeedback?:   () => void
   restrictedNodeIds?: Set<string>
   previewingAsPlayer?: boolean
+  /** Every town's quest defs — lazy-loaded by App.tsx. */
+  allQuestDefs: HubQuestDef[]
 }
 
-export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, onPlayerTap, onFeedback, restrictedNodeIds, previewingAsPlayer }: Props) {
+export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, onPlayerTap, onFeedback, restrictedNodeIds, previewingAsPlayer, allQuestDefs }: Props) {
   const [peekNode, setPeekNode] = useState<WorldNodeDef | null>(null)
   const [questsOpen, setQuestsOpen] = useState(false)
   const [wrongSave, setWrongSave]   = useState<{ cards: number; crystals: number; deck: number } | null>(null)
@@ -58,7 +60,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
   }, [])
 
   const handleQuestAbandon = (questId: string) => {
-    const quest = ALL_QUEST_DEFS.find(q => q.id === questId)
+    const quest = allQuestDefs.find(q => q.id === questId)
     if (!quest) return
     unmarkPickedUp(quest.steps.flatMap(s => s.pickupIds ?? []))
     resetQuest(questId)
@@ -114,7 +116,7 @@ export function HubWorldMap({ onSelectNode, onBack, user, onSignIn, onSignOut, o
         </div>
       </Toolbar>
 
-      {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={ALL_QUEST_DEFS} />}
+      {questsOpen && <QuestsModal onClose={() => setQuestsOpen(false)} onAbandon={handleQuestAbandon} questDefs={allQuestDefs} />}
 
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
         <NodeMapRederer

--- a/web/src/components/hub/HubWorldQuests.stories.tsx
+++ b/web/src/components/hub/HubWorldQuests.stories.tsx
@@ -3,7 +3,7 @@ import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HubWorld } from './HubWorld'
 import { setQuestStatus, getQuestProgress } from '../../game/hub/quests'
-import { ALL_QUEST_DEFS, RAVENWATCH, RAVENWATCH_QUESTS } from '../../data/hub/hubWorldFactory'
+import { ALL_QUEST_DEFS, ALL_QUESTS, FRIENDSHIP_DIALOGUE, RELATIONSHIP_DIALOGUE, LOCATION_REGISTRY, RAVENWATCH, RAVENWATCH_QUESTS } from '../../data/hub/hubTownStoryFixtures'
 import { HubLocationBundle, HubQuestBundle } from '../../data/hub/loader'
 
 const meta = {
@@ -105,6 +105,10 @@ function makeQuestStory(questId: string, locationData: HubLocationBundle, locati
       locationQuests: locationQuests,
       questDefs: ALL_QUEST_DEFS,
       allQuestDefs: ALL_QUEST_DEFS,
+      locationRegistry: LOCATION_REGISTRY,
+      allQuests: ALL_QUESTS,
+      friendshipDialogue: FRIENDSHIP_DIALOGUE,
+      relationshipDialogue: RELATIONSHIP_DIALOGUE,
     },
   }
 }

--- a/web/src/components/hub/TownDirectory.stories.tsx
+++ b/web/src/components/hub/TownDirectory.stories.tsx
@@ -1,7 +1,7 @@
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { TownDirectory } from './TownDirectory'
-import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import { RAVENWATCH } from '../../data/hub/hubTownStoryFixtures'
 
 const meta = {
   component: TownDirectory,

--- a/web/src/components/hub/TownJournal.stories.tsx
+++ b/web/src/components/hub/TownJournal.stories.tsx
@@ -1,7 +1,7 @@
 import { fn } from 'storybook/test'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { TownJournal } from './TownJournal'
-import { RAVENWATCH } from '../../data/hub/hubWorldFactory'
+import { RAVENWATCH } from '../../data/hub/hubTownStoryFixtures'
 
 const meta = {
   component: TownJournal,

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -5,7 +5,7 @@ import { EntityInspector } from './EntityInspector'
 import { MapEditorCanvas } from './MapEditorCanvas'
 import { useMapEditorState } from './useMapEditorState'
 import type { MapId,  QuestDefsJson } from '../../data/hub/hubWorldFactory'
-import  {  QUEST_DEFS_BY_MAP } from '../../data/hub/hubWorldFactory'
+import  {  QUEST_DEFS_BY_MAP } from '../../data/hub/hubTownRawQuestConfigs'
 
 import { SelectedEntity } from './mapEditorTypes'
 import type { RawBlockedPath, RawInteractable, PickKind } from './mapEditorTypes'

--- a/web/src/components/mapEditor/entityRefs.ts
+++ b/web/src/components/mapEditor/entityRefs.ts
@@ -7,7 +7,7 @@
 // interior/pickup) only include other towns when `crossTown` is set.
 
 import type { MapId, QuestDefsJson } from '../../data/hub/hubWorldFactory'
-import { QUEST_DEFS_BY_MAP } from '../../data/hub/hubWorldFactory'
+import { QUEST_DEFS_BY_MAP } from '../../data/hub/hubTownRawQuestConfigs'
 import type { RawMapConfig } from './mapEditorTypes'
 import { RAW_CONFIGS } from './useMapEditorState'
 import hubItems from '../../data/hubItems.json'

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import {
   getCodexCards, getCodexRelics, getCodexWorld, getCodexFragments, getCodexConversations, getCodexChronicle,
@@ -194,10 +194,18 @@ export function CodexScreen({ onDone }: Props) {
 
   const cards         = useMemo(() => getCodexCards(),         [])
   const relics        = useMemo(() => getCodexRelics(),        [])
-  const world         = useMemo(() => getCodexWorld(),         [])
   const fragments     = useMemo(() => getCodexFragments(),     [])
   const conversations = useMemo(() => getCodexConversations(), [])
   const chronicle     = useMemo(() => getCodexChronicle(),     [])
+
+  // World lore spans every act, so it's loaded on demand (this screen is
+  // navigated to, not part of boot) rather than kept eagerly in memory.
+  const [world, setWorld] = useState<CodexWorldEntry[]>([])
+  useEffect(() => {
+    let cancelled = false
+    getCodexWorld().then(entries => { if (!cancelled) setWorld(entries) })
+    return () => { cancelled = true }
+  }, [])
 
   const filteredCards = useMemo<CodexCardEntry[]>(() => {
     let list = cards

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react'
 import { type User } from 'firebase/auth'
 import { loadDeck, loadCollection, deckTotalCards, isDeckValid, COPIES_MAX, loadWinStreak, loadBestStreak } from '../../game/collection'
-import { loadPlayerName, loadRun } from '../../game/questline'
+import { loadPlayerName, loadRunRaw } from '../../game/questline'
 import { getCardCatalog } from '../../game/cards'
 import { hasUnclaimedAchievements } from '../../game/achievements'
 import { getDailyShopSellSlots } from '../../game/shopSchedule'
@@ -64,7 +64,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
   const deck             = loadDeck()
   const count            = deckTotalCards(deck)
   const valid            = isDeckValid(deck)
-  const savedRun         = loadRun()
+  const savedRun         = loadRunRaw()
   const collection       = loadCollection()
   const totalOwned       = collection.reduce((s, e) => s + e.count, 0)
   const campaignUnlocked = savedRun !== null || totalOwned >= CAMPAIGN_UNLOCK_CARDS

--- a/web/src/data/hub/hubTownRawQuestConfigs.ts
+++ b/web/src/data/hub/hubTownRawQuestConfigs.ts
@@ -1,0 +1,38 @@
+import rawQuestConfig from './ravenwatch/questDefs.json'
+import ironholdkeep_quests from './ironholdkeep/questDefs.json'
+import millhaven_quests from './millhaven/questDefs.json'
+import thornwoodcamp_quests from './thornwoodcamp/questDefs.json'
+import capitalcity_quests from './capitalcity/questDefs.json'
+import royalpalace_quests from './royalpalace/questDefs.json'
+import saltmereport_quests from './saltmereport/questDefs.json'
+import gearford_quests from './gearford/questDefs.json'
+import harrowfield_quests from './harrowfield/questDefs.json'
+import appleford_quests from './appleford/questDefs.json'
+import gravemoor_quests from './gravemoor/questDefs.json'
+import hollowmere_quests from './hollowmere/questDefs.json'
+import dreadspirecitadel_quests from './dreadspirecitadel/questDefs.json'
+import { MapId, QuestDefsJson } from './hubWorldFactory'
+
+/**
+ * Statically imports every town's raw questDefs.json — only for the map
+ * editor (Storybook-only, unreachable from the running game). Keep this the
+ * *one* place that still eagerly imports these files: hubWorldFactory.ts
+ * loads them dynamically for the production app (see getHubWorldData), and
+ * mixing a static import of the same file back in would make Vite bundle it
+ * back into the eager graph, undoing that split.
+ */
+export const QUEST_DEFS_BY_MAP: Record<MapId, QuestDefsJson> = {
+  ravenwatch: rawQuestConfig as QuestDefsJson,
+  millhaven: millhaven_quests as QuestDefsJson,
+  ironholdkeep: ironholdkeep_quests as QuestDefsJson,
+  thornwoodcamp: thornwoodcamp_quests as QuestDefsJson,
+  capitalcity: capitalcity_quests as QuestDefsJson,
+  royalpalace: royalpalace_quests as QuestDefsJson,
+  saltmereport: saltmereport_quests as QuestDefsJson,
+  gearford: gearford_quests as QuestDefsJson,
+  harrowfield: harrowfield_quests as QuestDefsJson,
+  appleford: appleford_quests as QuestDefsJson,
+  gravemoor: gravemoor_quests as QuestDefsJson,
+  hollowmere: hollowmere_quests as QuestDefsJson,
+  dreadspirecitadel: dreadspirecitadel_quests as QuestDefsJson,
+}

--- a/web/src/data/hub/hubTownStoryFixtures.ts
+++ b/web/src/data/hub/hubTownStoryFixtures.ts
@@ -1,0 +1,100 @@
+// Eagerly-built hub town fixtures for Storybook stories and tests only.
+//
+// hubWorldFactory.ts loads every town's data dynamically (see getHubWorldData)
+// so the production app doesn't pay for all 13 towns' JSON at boot. Stories
+// need synchronous, already-resolved data at module-eval time, which the async
+// API can't provide — so this file keeps the old eager-import-and-build
+// approach, isolated here where it can't leak into the app's boot bundle
+// (nothing under src/components or src/App.tsx imports this file).
+import { createHubLocationData, createHubQuestData, HubQuestBundle } from './loader'
+import ravenwatch_config from './ravenwatch/config.json'
+import ravenwatch_quests from './ravenwatch/questDefs.json'
+import ironholdkeep_config from './ironholdkeep/config.json'
+import ironholdkeep_quests from './ironholdkeep/questDefs.json'
+import millhaven_config from './millhaven/config.json'
+import millhaven_quests from './millhaven/questDefs.json'
+import thornwoodcamp_config from './thornwoodcamp/config.json'
+import thornwoodcamp_quests from './thornwoodcamp/questDefs.json'
+import capitalcity_config from './capitalcity/config.json'
+import capitalcity_quests from './capitalcity/questDefs.json'
+import royalpalace_config from './royalpalace/config.json'
+import royalpalace_quests from './royalpalace/questDefs.json'
+import saltmereport_config from './saltmereport/config.json'
+import saltmereport_quests from './saltmereport/questDefs.json'
+import gearford_config from './gearford/config.json'
+import gearford_quests from './gearford/questDefs.json'
+import harrowfield_config from './harrowfield/config.json'
+import harrowfield_quests from './harrowfield/questDefs.json'
+import appleford_config from './appleford/config.json'
+import appleford_quests from './appleford/questDefs.json'
+import gravemoor_config from './gravemoor/config.json'
+import gravemoor_quests from './gravemoor/questDefs.json'
+import hollowmere_config from './hollowmere/config.json'
+import hollowmere_quests from './hollowmere/questDefs.json'
+import dreadspirecitadel_config from './dreadspirecitadel/config.json'
+import dreadspirecitadel_quests from './dreadspirecitadel/questDefs.json'
+import { LocationEntry } from './hubWorldFactory'
+
+export const RAVENWATCH = createHubLocationData(ravenwatch_config)
+export const IRONHOLDKEEP = createHubLocationData(ironholdkeep_config)
+export const MILLHAVE = createHubLocationData(millhaven_config)
+export const THORNWOODCAMP = createHubLocationData(thornwoodcamp_config)
+export const CAPITALCITY = createHubLocationData(capitalcity_config)
+export const ROYALPALACE = createHubLocationData(royalpalace_config)
+export const SALTMEREPORT = createHubLocationData(saltmereport_config)
+export const GEARFORD = createHubLocationData(gearford_config)
+export const HARROWFIELD = createHubLocationData(harrowfield_config)
+export const APPLEFORD = createHubLocationData(appleford_config)
+export const GRAVEMOOR = createHubLocationData(gravemoor_config)
+export const HOLLOWMERE = createHubLocationData(hollowmere_config)
+export const DREADSPIRECITADEL = createHubLocationData(dreadspirecitadel_config)
+
+export const RAVENWATCH_QUESTS = createHubQuestData(ravenwatch_quests)
+export const IRONHOLDKEEP_QUESTS = createHubQuestData(ironholdkeep_quests)
+export const MILLHAVE_QUESTS = createHubQuestData(millhaven_quests)
+export const THORNWOODCAMP_QUESTS = createHubQuestData(thornwoodcamp_quests)
+export const CAPITALCITY_QUESTS = createHubQuestData(capitalcity_quests)
+export const ROYALPALACE_QUESTS = createHubQuestData(royalpalace_quests)
+export const SALTMEREPORT_QUESTS = createHubQuestData(saltmereport_quests)
+export const GEARFORD_QUESTS = createHubQuestData(gearford_quests)
+export const HARROWFIELD_QUESTS = createHubQuestData(harrowfield_quests)
+export const APPLEFORD_QUESTS = createHubQuestData(appleford_quests)
+export const GRAVEMOOR_QUESTS = createHubQuestData(gravemoor_quests)
+export const HOLLOWMERE_QUESTS = createHubQuestData(hollowmere_quests)
+export const DREADSPIRECITADEL_QUESTS = createHubQuestData(dreadspirecitadel_quests)
+
+const ALL_QUEST_BUNDLES: HubQuestBundle[] = [
+  RAVENWATCH_QUESTS, IRONHOLDKEEP_QUESTS, MILLHAVE_QUESTS, THORNWOODCAMP_QUESTS,
+  CAPITALCITY_QUESTS, ROYALPALACE_QUESTS, SALTMEREPORT_QUESTS, GEARFORD_QUESTS,
+  HARROWFIELD_QUESTS, APPLEFORD_QUESTS, GRAVEMOOR_QUESTS, HOLLOWMERE_QUESTS,
+  DREADSPIRECITADEL_QUESTS,
+]
+
+export const ALL_QUESTS: HubQuestBundle = {
+  HUB_QUEST_DEFS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_QUEST_DEFS),
+  FRIENDSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.FRIENDSHIP_DIALOGUE)),
+  RELATIONSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.RELATIONSHIP_DIALOGUE)),
+  HUB_PICKUP_ITEMS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_PICKUP_ITEMS),
+  HUB_BLOCKED_PATHS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_BLOCKED_PATHS),
+  HUB_DIALOGUES: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.HUB_DIALOGUES)),
+}
+
+export const ALL_QUEST_DEFS = [...ALL_QUESTS.HUB_QUEST_DEFS]
+export const FRIENDSHIP_DIALOGUE = { ...ALL_QUESTS.FRIENDSHIP_DIALOGUE }
+export const RELATIONSHIP_DIALOGUE = { ...ALL_QUESTS.RELATIONSHIP_DIALOGUE }
+
+export const LOCATION_REGISTRY: Record<string, LocationEntry> = {
+  'ravenwatch':         { locationData: RAVENWATCH,          locationQuests: RAVENWATCH_QUESTS,          questDefs: RAVENWATCH_QUESTS.HUB_QUEST_DEFS },
+  'ironhold-keep':      { locationData: IRONHOLDKEEP,        locationQuests: IRONHOLDKEEP_QUESTS,        questDefs: IRONHOLDKEEP_QUESTS.HUB_QUEST_DEFS },
+  'millhaven':          { locationData: MILLHAVE,            locationQuests: MILLHAVE_QUESTS,            questDefs: MILLHAVE_QUESTS.HUB_QUEST_DEFS },
+  'thornwood-camp':     { locationData: THORNWOODCAMP,       locationQuests: THORNWOODCAMP_QUESTS,       questDefs: THORNWOODCAMP_QUESTS.HUB_QUEST_DEFS },
+  'capital-city':       { locationData: CAPITALCITY,         locationQuests: CAPITALCITY_QUESTS,         questDefs: CAPITALCITY_QUESTS.HUB_QUEST_DEFS },
+  'royal-palace':       { locationData: ROYALPALACE,         locationQuests: ROYALPALACE_QUESTS,         questDefs: ROYALPALACE_QUESTS.HUB_QUEST_DEFS },
+  'saltmere-port':      { locationData: SALTMEREPORT,        locationQuests: SALTMEREPORT_QUESTS,        questDefs: SALTMEREPORT_QUESTS.HUB_QUEST_DEFS },
+  'gearford':           { locationData: GEARFORD,            locationQuests: GEARFORD_QUESTS,            questDefs: GEARFORD_QUESTS.HUB_QUEST_DEFS },
+  'harrowfield':        { locationData: HARROWFIELD,         locationQuests: HARROWFIELD_QUESTS,         questDefs: HARROWFIELD_QUESTS.HUB_QUEST_DEFS },
+  'appleford':          { locationData: APPLEFORD,           locationQuests: APPLEFORD_QUESTS,           questDefs: APPLEFORD_QUESTS.HUB_QUEST_DEFS },
+  'gravemoor':          { locationData: GRAVEMOOR,           locationQuests: GRAVEMOOR_QUESTS,           questDefs: GRAVEMOOR_QUESTS.HUB_QUEST_DEFS },
+  'hollowmere':         { locationData: HOLLOWMERE,          locationQuests: HOLLOWMERE_QUESTS,          questDefs: HOLLOWMERE_QUESTS.HUB_QUEST_DEFS },
+  'dreadspire-citadel': { locationData: DREADSPIRECITADEL,   locationQuests: DREADSPIRECITADEL_QUESTS,   questDefs: DREADSPIRECITADEL_QUESTS.HUB_QUEST_DEFS },
+}

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -1,74 +1,6 @@
 import { createHubLocationData, createHubQuestData, HubLocationBundle, HubQuestBundle } from "./loader";
-import ravenwatch_config from './ravenwatch/config.json'
-import rawQuestConfig from './ravenwatch/questDefs.json'
-
-import ironholdkeep_config from './ironholdkeep/config.json'
-import ironholdkeep_quests from './ironholdkeep/questDefs.json'
-
-import millhaven_config from './millhaven/config.json'
-import millhaven_quests from './millhaven/questDefs.json'
-
-import thornwoodcamp_config from './thornwoodcamp/config.json'
-import thornwoodcamp_quests from './thornwoodcamp/questDefs.json'
-
-import capitalcity_config from './capitalcity/config.json'
-import capitalcity_quests from './capitalcity/questDefs.json'
-
-import royalpalace_config from './royalpalace/config.json'
-import royalpalace_quests from './royalpalace/questDefs.json'
-
-import saltmereport_config from './saltmereport/config.json'
-import saltmereport_quests from './saltmereport/questDefs.json'
-
-import gearford_config from './gearford/config.json'
-import gearford_quests from './gearford/questDefs.json'
-
-import harrowfield_config from './harrowfield/config.json'
-import harrowfield_quests from './harrowfield/questDefs.json'
-
-import appleford_config from './appleford/config.json'
-import appleford_quests from './appleford/questDefs.json'
-
-import gravemoor_config from './gravemoor/config.json'
-import gravemoor_quests from './gravemoor/questDefs.json'
-
-import hollowmere_config from './hollowmere/config.json'
-import hollowmere_quests from './hollowmere/questDefs.json'
-
-import dreadspirecitadel_config from './dreadspirecitadel/config.json'
-import dreadspirecitadel_quests from './dreadspirecitadel/questDefs.json'
-
-import { HubQuestDef } from "./questDefs";
-import { isSelfSave } from '../../utils/hotReloadGuard'
-
-// Map-editor / bundle-editor saves write straight onto these same config.json
-// / questDefs.json files, which are also statically imported here — a second,
-// independent import chain from the one accepted in
-// web/src/components/mapEditor/useMapEditorState.ts. Vite needs an accept
-// boundary in every import chain from a changed file up to the app root, or
-// it falls back to a full page reload. See hotReloadGuard.ts for details.
-if (import.meta.hot) {
-  import.meta.hot.accept([
-    './ravenwatch/config.json', './ravenwatch/questDefs.json',
-    './ironholdkeep/config.json', './ironholdkeep/questDefs.json',
-    './millhaven/config.json', './millhaven/questDefs.json',
-    './thornwoodcamp/config.json', './thornwoodcamp/questDefs.json',
-    './capitalcity/config.json', './capitalcity/questDefs.json',
-    './royalpalace/config.json', './royalpalace/questDefs.json',
-    './saltmereport/config.json', './saltmereport/questDefs.json',
-    './gearford/config.json', './gearford/questDefs.json',
-    './harrowfield/config.json', './harrowfield/questDefs.json',
-    './appleford/config.json', './appleford/questDefs.json',
-    './gravemoor/config.json', './gravemoor/questDefs.json',
-    './hollowmere/config.json', './hollowmere/questDefs.json',
-    './dreadspirecitadel/config.json', './dreadspirecitadel/questDefs.json',
-  ], () => {
-    if (!isSelfSave()) {
-      console.warn('[hub data] A hub config.json/questDefs.json changed on disk outside this tab. Refresh to pick it up — unsaved changes here were left alone.')
-    }
-  })
-}
-
+import type { RawConfig } from './config'
+import { HubQuestDef, RawQuestConfig } from "./questDefs";
 
 export interface RawQuestPickupItem {
   id: string
@@ -101,110 +33,131 @@ export type MapId =
   | 'hollowmere'
   | 'dreadspirecitadel'
 export type QuestDefsJson = { pickupItems?: RawQuestPickupItem[]; [key: string]: unknown }
-export const QUEST_DEFS_BY_MAP: Record<MapId, QuestDefsJson> = {
-  ravenwatch: rawQuestConfig as QuestDefsJson,
-  millhaven: millhaven_quests as  QuestDefsJson,
-  ironholdkeep: ironholdkeep_quests as QuestDefsJson,
-  thornwoodcamp: thornwoodcamp_quests as QuestDefsJson,
-  capitalcity: capitalcity_quests as QuestDefsJson,
-  royalpalace: royalpalace_quests as QuestDefsJson,
-  saltmereport: saltmereport_quests as QuestDefsJson,
-  gearford: gearford_quests as QuestDefsJson,
-  harrowfield: harrowfield_quests as QuestDefsJson,
-  appleford: appleford_quests as QuestDefsJson,
-  gravemoor: gravemoor_quests as QuestDefsJson,
-  hollowmere: hollowmere_quests as QuestDefsJson,
-  dreadspirecitadel: dreadspirecitadel_quests as QuestDefsJson,
-}
-
-
-export const RAVENWATCH = createHubLocationData(ravenwatch_config)
-export const IRONHOLDKEEP = createHubLocationData(ironholdkeep_config)
-export const MILLHAVE = createHubLocationData(millhaven_config)
-export const THORNWOODCAMP = createHubLocationData(thornwoodcamp_config)
-export const CAPITALCITY = createHubLocationData(capitalcity_config)
-export const ROYALPALACE = createHubLocationData(royalpalace_config)
-export const SALTMEREPORT = createHubLocationData(saltmereport_config)
-export const GEARFORD = createHubLocationData(gearford_config)
-export const HARROWFIELD = createHubLocationData(harrowfield_config)
-export const APPLEFORD = createHubLocationData(appleford_config)
-export const GRAVEMOOR = createHubLocationData(gravemoor_config)
-export const HOLLOWMERE = createHubLocationData(hollowmere_config)
-export const DREADSPIRECITADEL = createHubLocationData(dreadspirecitadel_config)
-
-export const RAVENWATCH_QUESTS = createHubQuestData(rawQuestConfig)
-export const IRONHOLDKEEP_QUESTS  = createHubQuestData(ironholdkeep_quests)
-export const MILLHAVE_QUESTS  = createHubQuestData(millhaven_quests)
-export const THORNWOODCAMP_QUESTS = createHubQuestData(thornwoodcamp_quests)
-export const CAPITALCITY_QUESTS = createHubQuestData(capitalcity_quests)
-export const ROYALPALACE_QUESTS = createHubQuestData(royalpalace_quests)
-export const SALTMEREPORT_QUESTS = createHubQuestData(saltmereport_quests)
-export const GEARFORD_QUESTS = createHubQuestData(gearford_quests)
-export const HARROWFIELD_QUESTS = createHubQuestData(harrowfield_quests)
-export const APPLEFORD_QUESTS = createHubQuestData(appleford_quests)
-export const GRAVEMOOR_QUESTS = createHubQuestData(gravemoor_quests)
-export const HOLLOWMERE_QUESTS = createHubQuestData(hollowmere_quests)
-export const DREADSPIRECITADEL_QUESTS = createHubQuestData(dreadspirecitadel_quests)
-
-const ALL_QUEST_BUNDLES: HubQuestBundle[] = [
-  RAVENWATCH_QUESTS,
-  IRONHOLDKEEP_QUESTS,
-  MILLHAVE_QUESTS,
-  THORNWOODCAMP_QUESTS,
-  CAPITALCITY_QUESTS,
-  ROYALPALACE_QUESTS,
-  SALTMEREPORT_QUESTS,
-  GEARFORD_QUESTS,
-  HARROWFIELD_QUESTS,
-  APPLEFORD_QUESTS,
-  GRAVEMOOR_QUESTS,
-  HOLLOWMERE_QUESTS,
-  DREADSPIRECITADEL_QUESTS,
-]
-
-export const ALL_QUESTS : HubQuestBundle = {
-  HUB_QUEST_DEFS:    ALL_QUEST_BUNDLES.flatMap(b => b.HUB_QUEST_DEFS),
-  FRIENDSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.FRIENDSHIP_DIALOGUE)),
-  RELATIONSHIP_DIALOGUE: Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.RELATIONSHIP_DIALOGUE)),
-  HUB_PICKUP_ITEMS:  ALL_QUEST_BUNDLES.flatMap(b => b.HUB_PICKUP_ITEMS),
-  HUB_BLOCKED_PATHS: ALL_QUEST_BUNDLES.flatMap(b => b.HUB_BLOCKED_PATHS),
-  HUB_DIALOGUES:     Object.assign({}, ...ALL_QUEST_BUNDLES.map(b => b.HUB_DIALOGUES)),
-}
-
-export const ALL_QUEST_DEFS = [
-  ...Object.values(ALL_QUESTS.HUB_QUEST_DEFS).flat(),
-]
-
-
-export const FRIENDSHIP_DIALOGUE = {
-  ...ALL_QUESTS.FRIENDSHIP_DIALOGUE,
-}
-
-export const RELATIONSHIP_DIALOGUE = {
-  ...ALL_QUESTS.RELATIONSHIP_DIALOGUE,
-}
 
 export interface LocationEntry {
   locationData: HubLocationBundle
   locationQuests: HubQuestBundle
-  questDefs:    HubQuestDef[]
+  questDefs: HubQuestDef[]
 }
 
-// Maps locationKey → data bundle.
-// To add a new location: create web/src/data/<key>/ with config.json + questDefs.json + loader.ts,
-// then add one entry here.
-export const LOCATION_REGISTRY: Record<string, LocationEntry> = {
-  'ravenwatch':    { locationData: RAVENWATCH,  locationQuests: RAVENWATCH_QUESTS,  questDefs: RAVENWATCH_QUESTS.HUB_QUEST_DEFS },
-  'ironhold-keep': { locationData: IRONHOLDKEEP, locationQuests:IRONHOLDKEEP_QUESTS, questDefs: IRONHOLDKEEP_QUESTS.HUB_QUEST_DEFS },
-  'millhaven':     { locationData: MILLHAVE, locationQuests:MILLHAVE_QUESTS, questDefs: MILLHAVE_QUESTS.HUB_QUEST_DEFS },
-  'thornwood-camp':     { locationData: THORNWOODCAMP, locationQuests: THORNWOODCAMP_QUESTS, questDefs: THORNWOODCAMP_QUESTS.HUB_QUEST_DEFS },
-  'capital-city':       { locationData: CAPITALCITY, locationQuests: CAPITALCITY_QUESTS, questDefs: CAPITALCITY_QUESTS.HUB_QUEST_DEFS },
-  'royal-palace':       { locationData: ROYALPALACE, locationQuests: ROYALPALACE_QUESTS, questDefs: ROYALPALACE_QUESTS.HUB_QUEST_DEFS },
-  'saltmere-port':      { locationData: SALTMEREPORT, locationQuests: SALTMEREPORT_QUESTS, questDefs: SALTMEREPORT_QUESTS.HUB_QUEST_DEFS },
-  'gearford':           { locationData: GEARFORD, locationQuests: GEARFORD_QUESTS, questDefs: GEARFORD_QUESTS.HUB_QUEST_DEFS },
-  'harrowfield':        { locationData: HARROWFIELD, locationQuests: HARROWFIELD_QUESTS, questDefs: HARROWFIELD_QUESTS.HUB_QUEST_DEFS },
-  'appleford':          { locationData: APPLEFORD, locationQuests: APPLEFORD_QUESTS, questDefs: APPLEFORD_QUESTS.HUB_QUEST_DEFS },
-  'gravemoor':          { locationData: GRAVEMOOR, locationQuests: GRAVEMOOR_QUESTS, questDefs: GRAVEMOOR_QUESTS.HUB_QUEST_DEFS },
-  'hollowmere':         { locationData: HOLLOWMERE, locationQuests: HOLLOWMERE_QUESTS, questDefs: HOLLOWMERE_QUESTS.HUB_QUEST_DEFS },
-  'dreadspire-citadel': { locationData: DREADSPIRECITADEL, locationQuests: DREADSPIRECITADEL_QUESTS, questDefs: DREADSPIRECITADEL_QUESTS.HUB_QUEST_DEFS },
+export interface HubWorldData {
+  /** Maps locationKey (used by App.tsx/world-map nodes) → data bundle. */
+  locationRegistry: Record<string, LocationEntry>
+  allQuests: HubQuestBundle
+  allQuestDefs: HubQuestDef[]
+  friendshipDialogue: HubQuestBundle['FRIENDSHIP_DIALOGUE']
+  relationshipDialogue: HubQuestBundle['RELATIONSHIP_DIALOGUE']
+}
+
+// Every town's config.json/questDefs.json is dynamically imported and
+// aggregated on first use (see getHubWorldData) rather than statically
+// imported up front — this data (~1.5MB combined across 13 towns) is only
+// needed once a player actually opens the hub world, not at app boot.
+// To add a new location: create web/src/data/<key>/ with config.json +
+// questDefs.json + loader.ts, then add one entry to CONFIG_LOADERS,
+// QUEST_LOADERS, and LOCATION_KEY_BY_MAP_ID below.
+
+const CONFIG_LOADERS: Record<MapId, () => Promise<{ default: RawConfig }>> = {
+  ravenwatch:        () => import('./ravenwatch/config.json'),
+  ironholdkeep:      () => import('./ironholdkeep/config.json'),
+  millhaven:         () => import('./millhaven/config.json'),
+  thornwoodcamp:     () => import('./thornwoodcamp/config.json'),
+  capitalcity:       () => import('./capitalcity/config.json'),
+  royalpalace:       () => import('./royalpalace/config.json'),
+  saltmereport:      () => import('./saltmereport/config.json'),
+  gearford:          () => import('./gearford/config.json'),
+  harrowfield:       () => import('./harrowfield/config.json'),
+  appleford:         () => import('./appleford/config.json'),
+  gravemoor:         () => import('./gravemoor/config.json'),
+  hollowmere:        () => import('./hollowmere/config.json'),
+  dreadspirecitadel: () => import('./dreadspirecitadel/config.json'),
+}
+
+const QUEST_LOADERS: Record<MapId, () => Promise<{ default: RawQuestConfig }>> = {
+  ravenwatch:        () => import('./ravenwatch/questDefs.json'),
+  ironholdkeep:      () => import('./ironholdkeep/questDefs.json'),
+  millhaven:         () => import('./millhaven/questDefs.json'),
+  thornwoodcamp:     () => import('./thornwoodcamp/questDefs.json'),
+  capitalcity:       () => import('./capitalcity/questDefs.json'),
+  royalpalace:       () => import('./royalpalace/questDefs.json'),
+  saltmereport:      () => import('./saltmereport/questDefs.json'),
+  gearford:          () => import('./gearford/questDefs.json'),
+  harrowfield:       () => import('./harrowfield/questDefs.json'),
+  appleford:         () => import('./appleford/questDefs.json'),
+  gravemoor:         () => import('./gravemoor/questDefs.json'),
+  hollowmere:        () => import('./hollowmere/questDefs.json'),
+  dreadspirecitadel: () => import('./dreadspirecitadel/questDefs.json'),
+}
+
+/** locationKey (App.tsx/world-map convention) for each MapId. */
+const LOCATION_KEY_BY_MAP_ID: Record<MapId, string> = {
+  ravenwatch:        'ravenwatch',
+  ironholdkeep:      'ironhold-keep',
+  millhaven:         'millhaven',
+  thornwoodcamp:     'thornwood-camp',
+  capitalcity:       'capital-city',
+  royalpalace:       'royal-palace',
+  saltmereport:      'saltmere-port',
+  gearford:          'gearford',
+  harrowfield:       'harrowfield',
+  appleford:         'appleford',
+  gravemoor:         'gravemoor',
+  hollowmere:        'hollowmere',
+  dreadspirecitadel: 'dreadspire-citadel',
+}
+
+const MAP_IDS = Object.keys(CONFIG_LOADERS) as MapId[]
+
+let cachedData: HubWorldData | undefined
+let pendingData: Promise<HubWorldData> | undefined
+
+/** Loads (and caches) every town's hub data, aggregated. Cheap on repeat calls. */
+export function getHubWorldData(): Promise<HubWorldData> {
+  if (cachedData) return Promise.resolve(cachedData)
+  if (!pendingData) {
+    pendingData = Promise.all(
+      MAP_IDS.map(async mapId => {
+        const [configModule, questModule] = await Promise.all([CONFIG_LOADERS[mapId](), QUEST_LOADERS[mapId]()])
+        return {
+          mapId,
+          locationData: createHubLocationData(configModule.default),
+          locationQuests: createHubQuestData(questModule.default),
+        }
+      }),
+    ).then(results => {
+      const locationRegistry: Record<string, LocationEntry> = {}
+      const bundles: HubQuestBundle[] = []
+      for (const { mapId, locationData, locationQuests } of results) {
+        bundles.push(locationQuests)
+        locationRegistry[LOCATION_KEY_BY_MAP_ID[mapId]] = {
+          locationData, locationQuests, questDefs: locationQuests.HUB_QUEST_DEFS,
+        }
+      }
+
+      const allQuests: HubQuestBundle = {
+        HUB_QUEST_DEFS:        bundles.flatMap(b => b.HUB_QUEST_DEFS),
+        FRIENDSHIP_DIALOGUE:   Object.assign({}, ...bundles.map(b => b.FRIENDSHIP_DIALOGUE)),
+        RELATIONSHIP_DIALOGUE: Object.assign({}, ...bundles.map(b => b.RELATIONSHIP_DIALOGUE)),
+        HUB_PICKUP_ITEMS:      bundles.flatMap(b => b.HUB_PICKUP_ITEMS),
+        HUB_BLOCKED_PATHS:     bundles.flatMap(b => b.HUB_BLOCKED_PATHS),
+        HUB_DIALOGUES:         Object.assign({}, ...bundles.map(b => b.HUB_DIALOGUES)),
+      }
+
+      const data: HubWorldData = {
+        locationRegistry,
+        allQuests,
+        allQuestDefs: [...allQuests.HUB_QUEST_DEFS],
+        friendshipDialogue: { ...allQuests.FRIENDSHIP_DIALOGUE },
+        relationshipDialogue: { ...allQuests.RELATIONSHIP_DIALOGUE },
+      }
+      cachedData = data
+      return data
+    })
+  }
+  return pendingData
+}
+
+/** Synchronous, no-fetch read of already-loaded hub data. Undefined if not loaded yet. */
+export function peekHubWorldData(): HubWorldData | undefined {
+  return cachedData
 }

--- a/web/src/data/hub/npcDialogueCoverage.test.ts
+++ b/web/src/data/hub/npcDialogueCoverage.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { LOCATION_REGISTRY } from './hubWorldFactory'
+import { getHubWorldData } from './hubWorldFactory'
+
+const { locationRegistry: LOCATION_REGISTRY } = await getHubWorldData()
 
 // Guard for the activity-aware dialogue content pass (#1960): every scheduled
 // NPC whose schedule includes a `sleep` entry must have both a non-empty

--- a/web/src/data/hub/playerHouseConsistency.test.ts
+++ b/web/src/data/hub/playerHouseConsistency.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { LOCATION_REGISTRY } from './hubWorldFactory'
+import { getHubWorldData } from './hubWorldFactory'
+
+const { locationRegistry: LOCATION_REGISTRY } = await getHubWorldData()
 
 // Regression sentinel for the player-house authoring trap (see docs/hubworld.md
 // §10/§13): a building can be tagged `requiresOwnership`/`upgradeKind` without

--- a/web/src/game/codex.ts
+++ b/web/src/game/codex.ts
@@ -1,38 +1,11 @@
 import { getCardCatalog } from './cards'
 import { loadCollection } from './collection'
 import { getEverAcquiredRelics } from './itemStore'
-import { loadActCount } from './questline'
+import { loadActCount, loadAct, ACT_IDS } from './questline'
 import { getCharacterDef, getCharacterState, getCharacterIds } from './characters'
 import { getChronicleStatus } from './chronicle'
 import relicsData from '../data/relics.json'
 import memoryFragmentsData from '../data/memoryFragments.json'
-
-import act1Data from '../data/acts/act1.json'
-import act2Data from '../data/acts/act2.json'
-import act3Data from '../data/acts/act3.json'
-import act4Data from '../data/acts/act4.json'
-import act5Data from '../data/acts/act5.json'
-import act6Data from '../data/acts/act6.json'
-import act7Data from '../data/acts/act7.json'
-import act8Data from '../data/acts/act8.json'
-import act9Data from '../data/acts/act9.json'
-import act10Data from '../data/acts/act10.json'
-import act11Data from '../data/acts/act11.json'
-import act12Data from '../data/acts/act12.json'
-import act13Data from '../data/acts/act13.json'
-import actFinaleData from '../data/acts/actfinale.json'
-import c2act1Data from '../data/acts/c2act1.json'
-import c2act2Data from '../data/acts/c2act2.json'
-import c2act3Data from '../data/acts/c2act3.json'
-import c2act4Data from '../data/acts/c2act4.json'
-import c2act5Data from '../data/acts/c2act5.json'
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ALL_ACTS: any[] = [
-  act1Data, act2Data, act3Data, act4Data, act5Data,
-  act6Data, act7Data, act8Data, act9Data, act10Data,
-  act11Data, act12Data, act13Data, actFinaleData, c2act1Data, c2act2Data, c2act3Data, c2act4Data, c2act5Data,
-]
 
 const FRAGMENT_KEY        = 'jarv_memory_fragments'
 const HUB_WORLD_UNLOCK_KEY = 'jarv_hub_world_unlocked'
@@ -233,8 +206,11 @@ export function getCodexChronicle(): CodexChronicleEntry[] {
   }))
 }
 
-export function getCodexWorld(): CodexWorldEntry[] {
-  return ALL_ACTS.map(act => {
+/** Cross-act lore aggregate for the Codex screen. Loads every act's data on
+ *  demand (Codex is a screen the player navigates to, not part of boot). */
+export async function getCodexWorld(): Promise<CodexWorldEntry[]> {
+  const acts = await Promise.all(ACT_IDS.map(id => loadAct(id)))
+  return acts.map(act => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const bossNode = Object.values(act.nodes as Record<string, any>).find((n: any) => n.type === 'boss') as any
     const actCompleted = loadActCount(act.id) > 0

--- a/web/src/game/collectiblesCatalog.ts
+++ b/web/src/game/collectiblesCatalog.ts
@@ -12,7 +12,7 @@
 // "The Hearthstone" would keep seeing the old broken icon forever, because the
 // display fields are captured inline into the player's save at grant time.
 
-import { ALL_QUEST_DEFS, ALL_QUESTS, LOCATION_REGISTRY } from '../data/hub/hubWorldFactory'
+import { peekHubWorldData, HubWorldData } from '../data/hub/hubWorldFactory'
 import chronicleData from '../data/chronicle.json'
 
 export interface KnownCollectible {
@@ -22,16 +22,16 @@ export interface KnownCollectible {
   lore?: string
 }
 
-function buildKnownCollectibles(): Record<string, KnownCollectible> {
+function buildKnownCollectibles(hubData: HubWorldData): Record<string, KnownCollectible> {
   const known: Record<string, KnownCollectible> = {}
 
   // Quest-completion rewards (HubWorld.tsx grantQuestReward)
-  for (const quest of ALL_QUEST_DEFS) {
+  for (const quest of hubData.allQuestDefs) {
     const c = quest.reward.collectible
     if (c) known[c.id] = { name: c.name, icon: c.icon, desc: c.desc }
   }
 
-  for (const { locationData } of Object.values(LOCATION_REGISTRY)) {
+  for (const { locationData } of Object.values(hubData.locationRegistry)) {
     // World-exploration finds (HubWorld.tsx giveItem reaction)
     for (const interactable of locationData.HUB_INTERACTABLES) {
       for (const reaction of interactable.reactions) {
@@ -49,7 +49,7 @@ function buildKnownCollectibles(): Record<string, KnownCollectible> {
   }
 
   // Barter-trade rewards (HubWorld.tsx tradeHubItem dialogue effect)
-  for (const tree of Object.values(ALL_QUESTS.HUB_DIALOGUES)) {
+  for (const tree of Object.values(hubData.allQuests.HUB_DIALOGUES)) {
     for (const node of Object.values(tree.nodes)) {
       for (const choice of node.choices ?? []) {
         for (const effect of choice.effects ?? []) {
@@ -75,9 +75,22 @@ function buildKnownCollectibles(): Record<string, KnownCollectible> {
   return known
 }
 
-const KNOWN_COLLECTIBLES = buildKnownCollectibles()
+// Hub town data is lazy-loaded (see hubWorldFactory.ts) and may not have
+// loaded yet — e.g. loadInventory() can run before the player has ever opened
+// the hub. Rather than trigger a fetch here (which would pull ~1.5MB of town
+// JSON into memory at whatever moment this first runs, defeating the point of
+// making it lazy), this only builds the catalog once hub data has already
+// been loaded by something else (normally opening the hub world). Until then,
+// getKnownCollectible() returns undefined and callers fall back to the
+// item's own stored display fields — see loadInventory() in dailyLogin.ts.
+let cachedCatalog: Record<string, KnownCollectible> | undefined
 
 /** Look up the current authoritative definition for a narrative-reward collectible id. */
 export function getKnownCollectible(id: string): KnownCollectible | undefined {
-  return KNOWN_COLLECTIBLES[id]
+  if (!cachedCatalog) {
+    const hubData = peekHubWorldData()
+    if (!hubData) return undefined
+    cachedCatalog = buildKnownCollectibles(hubData)
+  }
+  return cachedCatalog[id]
 }

--- a/web/src/game/hub/reputation.test.ts
+++ b/web/src/game/hub/reputation.test.ts
@@ -15,6 +15,7 @@ import {
 } from './reputation'
 import { saveCrystals, loadCrystals } from '../collection'
 import { getUpgradeTrack } from '../../data/hub/buildingUpgrades'
+import { getHubWorldData } from '../../data/hub/hubWorldFactory'
 
 // In-memory localStorage mock (tests run in node environment)
 const store = new Map<string, string>()
@@ -33,6 +34,7 @@ beforeEach(() => {
 
 const TOWN = 'Appleford'
 const shop = getUpgradeTrack('shop')
+const { locationRegistry } = await getHubWorldData()
 
 describe('reputation default state', () => {
   it('returns zero reputation and level for an unknown town/building', () => {
@@ -42,7 +44,7 @@ describe('reputation default state', () => {
   })
 
   it('reports the first level as the next upgrade', () => {
-    const n = nextUpgrade(TOWN, 'cider-house', 'shop')
+    const n = nextUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     expect(n.level).toBe(0)
     expect(n.total).toBe(shop.length)
     expect(n.cost).toBe(shop[0].cost)
@@ -54,7 +56,7 @@ describe('reputation default state', () => {
 describe('purchaseUpgrade', () => {
   it('spends crystals, raises the level and grants reputation', () => {
     saveCrystals(1000)
-    const res = purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    const res = purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     expect(res.ok).toBe(true)
     expect(loadCrystals()).toBe(1000 - shop[0].cost)
     expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(1)
@@ -63,7 +65,7 @@ describe('purchaseUpgrade', () => {
 
   it('refuses when the player cannot afford it', () => {
     saveCrystals(shop[0].cost - 1)
-    const res = purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    const res = purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     expect(res).toEqual({ ok: false, reason: 'insufficient-crystals' })
     expect(loadCrystals()).toBe(shop[0].cost - 1)
     expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(0)
@@ -72,11 +74,11 @@ describe('purchaseUpgrade', () => {
   it('blocks higher tiers behind a town reputation gate', () => {
     saveCrystals(100000)
     // Level 1 is ungated.
-    expect(purchaseUpgrade(TOWN, 'cider-house', 'shop').ok).toBe(true)
+    expect(purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry).ok).toBe(true)
     // Level 2 requires more reputation than a single building can provide.
-    const gated = nextUpgrade(TOWN, 'cider-house', 'shop')
+    const gated = nextUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     if (gated.repRequired > getTownReputation(TOWN)) {
-      const res = purchaseUpgrade(TOWN, 'cider-house', 'shop')
+      const res = purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
       expect(res).toEqual({ ok: false, reason: 'rep-locked' })
       expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(1)
     }
@@ -85,14 +87,14 @@ describe('purchaseUpgrade', () => {
   it('unlocks gated tiers once enough reputation is earned town-wide', () => {
     saveCrystals(100000)
     // Invest across several buildings to accumulate town reputation.
-    purchaseUpgrade(TOWN, 'b1', 'shop')
-    purchaseUpgrade(TOWN, 'b2', 'shop')
-    purchaseUpgrade(TOWN, 'b3', 'shop')
-    purchaseUpgrade(TOWN, 'b4', 'shop')
+    purchaseUpgrade(TOWN, 'b1', 'shop', locationRegistry)
+    purchaseUpgrade(TOWN, 'b2', 'shop', locationRegistry)
+    purchaseUpgrade(TOWN, 'b3', 'shop', locationRegistry)
+    purchaseUpgrade(TOWN, 'b4', 'shop', locationRegistry)
     // With enough rep, b1 can now reach level 2.
-    const n = nextUpgrade(TOWN, 'b1', 'shop')
+    const n = nextUpgrade(TOWN, 'b1', 'shop', locationRegistry)
     if (getTownReputation(TOWN) >= n.repRequired) {
-      expect(purchaseUpgrade(TOWN, 'b1', 'shop').ok).toBe(true)
+      expect(purchaseUpgrade(TOWN, 'b1', 'shop', locationRegistry).ok).toBe(true)
       expect(getUpgradeLevel(TOWN, 'b1')).toBe(2)
     }
   })
@@ -100,17 +102,17 @@ describe('purchaseUpgrade', () => {
   it('reports maxed once every level is purchased', () => {
     saveCrystals(1000000)
     // Build up enough town reputation (via other buildings) to clear the gates.
-    for (let i = 0; i < 12; i++) purchaseUpgrade(TOWN, `dummy-${i}`, 'shop')
-    for (let i = 0; i < shop.length; i++) purchaseUpgrade(TOWN, 'cider-house', 'shop')
-    const n = nextUpgrade(TOWN, 'cider-house', 'shop')
+    for (let i = 0; i < 12; i++) purchaseUpgrade(TOWN, `dummy-${i}`, 'shop', locationRegistry)
+    for (let i = 0; i < shop.length; i++) purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
+    const n = nextUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     expect(n.maxed).toBe(true)
     expect(n.def).toBeNull()
-    expect(purchaseUpgrade(TOWN, 'cider-house', 'shop')).toEqual({ ok: false, reason: 'maxed' })
+    expect(purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)).toEqual({ ok: false, reason: 'maxed' })
   })
 
   it('persists across reloads', () => {
     saveCrystals(1000)
-    purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     // A fresh read goes through localStorage again.
     expect(getUpgradeLevel(TOWN, 'cider-house')).toBe(1)
     expect(getTownReputation(TOWN)).toBe(shop[0].repReward)
@@ -122,13 +124,13 @@ describe('unlocked services', () => {
     saveCrystals(100000)
     setUpgradeKindResolver((_town, id) => (id === 'cider-house' ? 'shop' : undefined))
     expect(getUnlockedServices(TOWN)).toEqual([])
-    purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     expect(hasTownService(TOWN, shop[0].service!)).toBe(true)
   })
 
   it('returns nothing when no resolver is registered', () => {
     saveCrystals(1000)
-    purchaseUpgrade(TOWN, 'cider-house', 'shop')
+    purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)
     expect(getUnlockedServices(TOWN)).toEqual([])
   })
 })
@@ -143,33 +145,33 @@ describe('playerHouse building track', () => {
 
   it('purchasing it raises the level to 1 and maxes the track', () => {
     saveCrystals(playerHouse[0].cost)
-    const res = purchaseUpgrade(TOWN, 'player-house', 'playerHouse')
+    const res = purchaseUpgrade(TOWN, 'player-house', 'playerHouse', locationRegistry)
     expect(res.ok).toBe(true)
     expect(getUpgradeLevel(TOWN, 'player-house')).toBe(1)
     expect(loadCrystals()).toBe(0)
-    expect(nextUpgrade(TOWN, 'player-house', 'playerHouse').maxed).toBe(true)
+    expect(nextUpgrade(TOWN, 'player-house', 'playerHouse', locationRegistry).maxed).toBe(true)
   })
 
   it('prices scale with how many player houses are already owned across all towns', () => {
-    expect(nextUpgrade('Millhaven', 'building-1', 'playerHouse').cost).toBe(2500)
+    expect(nextUpgrade('Millhaven', 'building-1', 'playerHouse', locationRegistry).cost).toBe(2500)
     saveCrystals(2500)
-    expect(purchaseUpgrade('Millhaven', 'building-1', 'playerHouse').ok).toBe(true)
+    expect(purchaseUpgrade('Millhaven', 'building-1', 'playerHouse', locationRegistry).ok).toBe(true)
 
-    expect(nextUpgrade('Ravenwatch', 'building-1', 'playerHouse').cost).toBe(10000)
+    expect(nextUpgrade('Ravenwatch', 'building-1', 'playerHouse', locationRegistry).cost).toBe(10000)
     saveCrystals(10000)
-    expect(purchaseUpgrade('Ravenwatch', 'building-1', 'playerHouse').ok).toBe(true)
+    expect(purchaseUpgrade('Ravenwatch', 'building-1', 'playerHouse', locationRegistry).ok).toBe(true)
 
-    expect(nextUpgrade('Crownhaven', 'building-1', 'playerHouse').cost).toBe(25000)
+    expect(nextUpgrade('Crownhaven', 'building-1', 'playerHouse', locationRegistry).cost).toBe(25000)
   })
 
   it('formula extrapolates past the third house by continuing to double', () => {
-    expect(countOwnedPlayerHouses()).toBe(0) // sanity: fresh store
+    expect(countOwnedPlayerHouses(locationRegistry)).toBe(0) // sanity: fresh store
     for (const t of ['Millhaven', 'Ravenwatch', 'Crownhaven']) {
-      saveCrystals(nextUpgrade(t, 'building-1', 'playerHouse').cost)
-      purchaseUpgrade(t, 'building-1', 'playerHouse')
+      saveCrystals(nextUpgrade(t, 'building-1', 'playerHouse', locationRegistry).cost)
+      purchaseUpgrade(t, 'building-1', 'playerHouse', locationRegistry)
     }
-    expect(countOwnedPlayerHouses()).toBe(3)
-    expect(nextUpgrade('SomeFourthTown', 'building-1', 'playerHouse').cost).toBe(55000)
+    expect(countOwnedPlayerHouses(locationRegistry)).toBe(3)
+    expect(nextUpgrade('SomeFourthTown', 'building-1', 'playerHouse', locationRegistry).cost).toBe(55000)
   })
 })
 
@@ -183,7 +185,7 @@ describe('daily tribute', () => {
   it('scales with unlocked services and credits crystals once per day', () => {
     setUpgradeKindResolver((_t, id) => (id === 'cider-house' ? 'shop' : undefined))
     saveCrystals(100000)
-    purchaseUpgrade(TOWN, 'cider-house', 'shop')   // unlocks 1 service
+    purchaseUpgrade(TOWN, 'cider-house', 'shop', locationRegistry)   // unlocks 1 service
     const amount = tributeAmount(TOWN)
     expect(amount).toBeGreaterThan(0)
 

--- a/web/src/game/hub/reputation.ts
+++ b/web/src/game/hub/reputation.ts
@@ -15,7 +15,7 @@ import {
   getReputationTier,
   type BuildingUpgradeLevel,
 } from '../../data/hub/buildingUpgrades'
-import { LOCATION_REGISTRY } from '../../data/hub/hubWorldFactory'
+import type { LocationEntry } from '../../data/hub/hubWorldFactory'
 
 const KEY = 'jarv_hub_reputation'
 
@@ -87,10 +87,13 @@ function playerHousePrice(ownedCount: number): number {
   return 7500 * 2 ** (n - 1) - 5000
 }
 
-/** Count of player-house buildings currently owned (purchased) across every town. */
-export function countOwnedPlayerHouses(): number {
+/** Count of player-house buildings currently owned (purchased) across every town.
+ *  Takes the caller's already-loaded location registry — hub town data is
+ *  lazy-loaded, and by the time this is called (from the hub UI) it's already
+ *  in hand, so there's no need for this module to load it independently. */
+export function countOwnedPlayerHouses(locationRegistry: Record<string, LocationEntry>): number {
   let count = 0
-  for (const { locationData } of Object.values(LOCATION_REGISTRY)) {
+  for (const { locationData } of Object.values(locationRegistry)) {
     const t = locationData.HUB_TOWN_NAME
     for (const b of locationData.HUB_BUILDINGS) {
       if (b.id && b.upgradeKind === 'playerHouse' && getUpgradeLevel(t, b.id) >= 1) count++
@@ -118,7 +121,7 @@ export interface NextUpgrade {
   maxed: boolean
 }
 
-export function nextUpgrade(town: string, buildingId: string, kind: string | undefined): NextUpgrade {
+export function nextUpgrade(town: string, buildingId: string, kind: string | undefined, locationRegistry: Record<string, LocationEntry>): NextUpgrade {
   const track = getUpgradeTrack(kind)
   const data = load()
   const state = townState(data, town)
@@ -133,7 +136,7 @@ export function nextUpgrade(town: string, buildingId: string, kind: string | und
   // Dynamic pricing only applies to the first tier (buying the house itself) —
   // any future higher tier would be a per-house upgrade, priced statically
   // from the catalog like every other kind's higher tiers.
-  const cost = kind === 'playerHouse' && level === 0 ? playerHousePrice(countOwnedPlayerHouses()) : def.cost
+  const cost = kind === 'playerHouse' && level === 0 ? playerHousePrice(countOwnedPlayerHouses(locationRegistry)) : def.cost
   return {
     def: { ...def, cost },
     level,
@@ -156,8 +159,8 @@ export type PurchaseResult =
  * reputation gate and the crystal balance, then deducts crystals, increments
  * the level, and grants reputation. All-or-nothing.
  */
-export function purchaseUpgrade(town: string, buildingId: string, kind: string | undefined): PurchaseResult {
-  const next = nextUpgrade(town, buildingId, kind)
+export function purchaseUpgrade(town: string, buildingId: string, kind: string | undefined, locationRegistry: Record<string, LocationEntry>): PurchaseResult {
+  const next = nextUpgrade(town, buildingId, kind, locationRegistry)
   if (next.maxed || !next.def) return { ok: false, reason: 'maxed' }
   if (next.repLocked) return { ok: false, reason: 'rep-locked' }
 

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -3,26 +3,6 @@ import { loadPlayerStats } from './playerStats'
 import { logError } from '../logger'
 import { getCardCatalog } from './cards'
 import { addConsumable, removeConsumable, getConsumables } from './itemStore'
-import act1Data from '../data/acts/act1.json'
-import act2Data from '../data/acts/act2.json'
-import act3Data from '../data/acts/act3.json'
-import act4Data from '../data/acts/act4.json'
-import act5Data from '../data/acts/act5.json'
-import act6Data from '../data/acts/act6.json'
-import act7Data from '../data/acts/act7.json'
-import act8Data  from '../data/acts/act8.json'
-import act9Data  from '../data/acts/act9.json'
-import act10Data from '../data/acts/act10.json'
-import act11Data from '../data/acts/act11.json'
-import act12Data from '../data/acts/act12.json'
-import act13Data    from '../data/acts/act13.json'
-import actFinaleData from '../data/acts/actfinale.json'
-import c2act1Data from '../data/acts/c2act1.json'
-import c2act2Data from '../data/acts/c2act2.json'
-import c2act3Data from '../data/acts/c2act3.json'
-import c2act4Data from '../data/acts/c2act4.json'
-import c2act5Data from '../data/acts/c2act5.json'
-import worldBattlesData from '../data/acts/worldbattles.json'
 import consumablesData from '../data/consumables.json'
 
 // ─── Consumables ──────────────────────────────────────────
@@ -518,8 +498,9 @@ export function resolveActIntro(act: Act, n: number): CutscenePanel[] {
 }
 
 /** Thin wrapper for backward compatibility — new code should call resolveActIntro directly. */
-export function getAct1Intro(runCount: number): CutscenePanel[] {
-  return resolveActIntro(ACT_1, runCount)
+export async function getAct1Intro(runCount: number): Promise<CutscenePanel[]> {
+  const act1 = await loadAct('act1')
+  return resolveActIntro(act1, runCount)
 }
 
 // ─── Ordinal helper ───────────────────────────────────────────────────────────
@@ -566,7 +547,13 @@ export interface RunState {
 
 const RUN_KEY = 'jarv_run'
 
-export function loadRun(): RunState | null {
+/**
+ * Parses the saved run and migrates/repairs fields that don't need act data.
+ * Does NOT validate actId/node ids against the act's node map — callers that
+ * need the fully act-validated run should use loadRun() instead. Safe to call
+ * synchronously (e.g. from a render body or a useState initializer).
+ */
+export function loadRunRaw(): RunState | null {
   try {
     const raw = localStorage.getItem(RUN_KEY)
     if (!raw) return null
@@ -595,51 +582,6 @@ export function loadRun(): RunState | null {
     if (typeof parsed.livesRemaining !== 'number') parsed.livesRemaining = parsed.maxLives
     parsed.livesRemaining = Math.max(0, Math.min(parsed.maxLives, parsed.livesRemaining))
 
-    // Ensure actId is valid
-    const act = ACTS[parsed.actId]
-    if (!act) {
-      console.warn('[run] Invalid actId — clearing run')
-      localStorage.removeItem(RUN_KEY)
-      return null
-    }
-
-    // Remove any node IDs that don't exist in the act
-    const validIds = new Set(Object.keys(act.nodes))
-    parsed.completedNodeIds = parsed.completedNodeIds.filter(id => validIds.has(id))
-    parsed.skippedNodeIds   = parsed.skippedNodeIds.filter(id => validIds.has(id))
-    if (parsed.pendingNodeId && !validIds.has(parsed.pendingNodeId)) {
-      parsed.pendingNodeId = null
-    }
-
-    // Repair saves corrupted by the convergence-node skip bug (fixed in skipSiblings):
-    // A node Y was incorrectly skipped if any of its completed parents has no other completed child.
-    // Such a node is still reachable and must be un-skipped so the map isn't deadlocked.
-    {
-      const completedSet = new Set(parsed.completedNodeIds)
-      const parentMap = buildParentMap(act.nodes)
-      const toUnSkip = parsed.skippedNodeIds.filter(nodeId => {
-        const parents = parentMap[nodeId] ?? []
-        return parents.some(pid => {
-          if (!completedSet.has(pid)) return false
-          return !act.nodes[pid].childIds.some(cid => cid !== nodeId && completedSet.has(cid))
-        })
-      })
-      if (toUnSkip.length > 0) {
-        const unSkipSet = new Set(toUnSkip)
-        parsed.skippedNodeIds = parsed.skippedNodeIds.filter(id => !unSkipSet.has(id))
-        saveRun(parsed)
-      }
-    }
-
-    // If act is already complete with no pendingNode, clear run so a fresh one starts —
-    // unless pendingActComplete is set (player is on the act-complete screen) or
-    // pendingRelicSelect is set (player exited mid relic-select between acts).
-    if (isActComplete(act, parsed) && !parsed.pendingNodeId && !parsed.pendingActComplete && !parsed.pendingRelicSelect) {
-      console.warn('[run] Act already complete — clearing stale run')
-      localStorage.removeItem(RUN_KEY)
-      return null
-    }
-
     return parsed
   } catch (e) {
     // Corrupt JSON — clear and start fresh
@@ -647,6 +589,64 @@ export function loadRun(): RunState | null {
     try { localStorage.removeItem(RUN_KEY) } catch { /* ignore */ }
     return null
   }
+}
+
+/**
+ * Full act-validated load: loadRunRaw() plus the repairs that need the act's
+ * node map (dropping stale node ids, un-skipping convergence-bug victims,
+ * clearing a stale already-complete run). Async because the act may need to
+ * be fetched.
+ */
+export async function loadRun(): Promise<RunState | null> {
+  const parsed = loadRunRaw()
+  if (!parsed) return null
+
+  // Ensure actId is valid
+  const act = await loadAct(parsed.actId).catch(() => undefined)
+  if (!act) {
+    console.warn('[run] Invalid actId — clearing run')
+    localStorage.removeItem(RUN_KEY)
+    return null
+  }
+
+  // Remove any node IDs that don't exist in the act
+  const validIds = new Set(Object.keys(act.nodes))
+  parsed.completedNodeIds = parsed.completedNodeIds.filter(id => validIds.has(id))
+  parsed.skippedNodeIds   = parsed.skippedNodeIds.filter(id => validIds.has(id))
+  if (parsed.pendingNodeId && !validIds.has(parsed.pendingNodeId)) {
+    parsed.pendingNodeId = null
+  }
+
+  // Repair saves corrupted by the convergence-node skip bug (fixed in skipSiblings):
+  // A node Y was incorrectly skipped if any of its completed parents has no other completed child.
+  // Such a node is still reachable and must be un-skipped so the map isn't deadlocked.
+  {
+    const completedSet = new Set(parsed.completedNodeIds)
+    const parentMap = buildParentMap(act.nodes)
+    const toUnSkip = parsed.skippedNodeIds.filter(nodeId => {
+      const parents = parentMap[nodeId] ?? []
+      return parents.some(pid => {
+        if (!completedSet.has(pid)) return false
+        return !act.nodes[pid].childIds.some(cid => cid !== nodeId && completedSet.has(cid))
+      })
+    })
+    if (toUnSkip.length > 0) {
+      const unSkipSet = new Set(toUnSkip)
+      parsed.skippedNodeIds = parsed.skippedNodeIds.filter(id => !unSkipSet.has(id))
+      saveRun(parsed)
+    }
+  }
+
+  // If act is already complete with no pendingNode, clear run so a fresh one starts —
+  // unless pendingActComplete is set (player is on the act-complete screen) or
+  // pendingRelicSelect is set (player exited mid relic-select between acts).
+  if (isActComplete(act, parsed) && !parsed.pendingNodeId && !parsed.pendingActComplete && !parsed.pendingRelicSelect) {
+    console.warn('[run] Act already complete — clearing stale run')
+    localStorage.removeItem(RUN_KEY)
+    return null
+  }
+
+  return parsed
 }
 
 export function saveRun(run: RunState): void {
@@ -895,50 +895,66 @@ export function generateEndlessRewardChoices(wave: number): string[] {
 }
 
 // ─── Acts ─────────────────────────────────────────────────
+//
+// Act JSON is heavy (~30-50KB each, ~582KB combined) and only one act is ever
+// in play at a time, so each act is dynamically imported on first use and
+// cached rather than statically imported up front. See loadAct/getCachedAct.
+// New acts: add a loader entry here — no other wiring needed.
 
-export const ACT_1: Act = act1Data as Act
-export const ACT_2: Act = act2Data as Act
-export const ACT_3: Act = act3Data as Act
-export const ACT_4: Act = act4Data as Act
-export const ACT_5: Act = act5Data as Act
-export const ACT_6: Act = act6Data as Act
-export const ACT_7: Act = act7Data as Act
-export const ACT_8:  Act = act8Data  as Act
-export const ACT_9:  Act = act9Data  as Act
-export const ACT_10: Act = act10Data as Act
-export const ACT_11: Act = act11Data as Act
-export const ACT_12: Act = act12Data as Act
-export const ACT_13:     Act = act13Data    as Act
-export const ACT_FINALE: Act = actFinaleData as Act
-export const C2_ACT_1: Act = c2act1Data as Act
-export const C2_ACT_2: Act = c2act2Data as Act
-export const C2_ACT_3: Act = c2act3Data as Act
-export const C2_ACT_4: Act = c2act4Data as Act
-export const C2_ACT_5: Act = c2act5Data as Act
-/** Standalone battles launched from the world map — never part of campaign progression. */
-export const ACT_WORLD: Act = worldBattlesData as Act
+const ACT_LOADERS: Record<string, () => Promise<{ default: unknown }>> = {
+  act1:      () => import('../data/acts/act1.json'),
+  act2:      () => import('../data/acts/act2.json'),
+  act3:      () => import('../data/acts/act3.json'),
+  act4:      () => import('../data/acts/act4.json'),
+  act5:      () => import('../data/acts/act5.json'),
+  act6:      () => import('../data/acts/act6.json'),
+  act7:      () => import('../data/acts/act7.json'),
+  act8:      () => import('../data/acts/act8.json'),
+  act9:      () => import('../data/acts/act9.json'),
+  act10:     () => import('../data/acts/act10.json'),
+  act11:     () => import('../data/acts/act11.json'),
+  act12:     () => import('../data/acts/act12.json'),
+  act13:     () => import('../data/acts/act13.json'),
+  actfinale: () => import('../data/acts/actfinale.json'),
+  c2act1:    () => import('../data/acts/c2act1.json'),
+  c2act2:    () => import('../data/acts/c2act2.json'),
+  c2act3:    () => import('../data/acts/c2act3.json'),
+  c2act4:    () => import('../data/acts/c2act4.json'),
+  c2act5:    () => import('../data/acts/c2act5.json'),
+  /** Standalone battles launched from the world map — never part of campaign progression. */
+  world:     () => import('../data/acts/worldbattles.json'),
+}
 
-export const ACTS: Record<string, Act> = {
-  act1:  ACT_1,
-  act2:  ACT_2,
-  act3:  ACT_3,
-  act4:  ACT_4,
-  act5:  ACT_5,
-  act6:  ACT_6,
-  act7:  ACT_7,
-  act8:  ACT_8,
-  act9:  ACT_9,
-  act10: ACT_10,
-  act11: ACT_11,
-  act12: ACT_12,
-  act13:     ACT_13,
-  actfinale: ACT_FINALE,
-  c2act1:    C2_ACT_1,
-  c2act2:    C2_ACT_2,
-  c2act3:    C2_ACT_3,
-  c2act4:    C2_ACT_4,
-  c2act5:    C2_ACT_5,
-  world:     ACT_WORLD,
+/** All campaign act ids, in authored order (excludes the standalone 'world' battles map). */
+export const ACT_IDS: string[] = Object.keys(ACT_LOADERS).filter(id => id !== 'world')
+
+const actPromiseCache  = new Map<string, Promise<Act>>()
+const resolvedActCache = new Map<string, Act>()
+
+/** Loads (and caches) an act's data by id. Rejects if actId is unknown. */
+export function loadAct(actId: string): Promise<Act> {
+  const cached = actPromiseCache.get(actId)
+  if (cached) return cached
+
+  const loader = ACT_LOADERS[actId]
+  if (!loader) {
+    const rejected = Promise.reject(new Error(`Unknown actId: ${actId}`))
+    actPromiseCache.set(actId, rejected)
+    return rejected
+  }
+
+  const promise = loader().then(m => {
+    const act = m.default as Act
+    resolvedActCache.set(actId, act)
+    return act
+  })
+  actPromiseCache.set(actId, promise)
+  return promise
+}
+
+/** Synchronous, no-fetch read of an already-loaded act. Undefined if not loaded yet. */
+export function getCachedAct(actId: string): Act | undefined {
+  return resolvedActCache.get(actId)
 }
 
 // ─── Campaigns ────────────────────────────────────────────
@@ -1003,10 +1019,11 @@ export function recordNodeComplete(actId: string, nodeId: string): void {
 }
 
 /** Returns the act that follows this one in the campaign, or null if it's the last. */
-export function getNextAct(actId: string): Act | null {
-  const nextId = ACTS[actId]?.nextActId
+export async function getNextAct(actId: string): Promise<Act | null> {
+  const cur = await loadAct(actId).catch(() => undefined)
+  const nextId = cur?.nextActId
   if (!nextId) return null
-  return ACTS[nextId] ?? null
+  return loadAct(nextId).catch(() => null)
 }
 
 // ─── Player character ─────────────────────────────────────────────────────────

--- a/web/src/hooks/useMusic.ts
+++ b/web/src/hooks/useMusic.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { GameState } from '../game/types'
-import { RunState, ACTS } from '../game/questline'
+import { RunState, Act } from '../game/questline'
 import {
   startBattleMusic, stopBattleMusic,
   startTitleMusic, stopTitleMusic,
@@ -13,7 +13,7 @@ import {
 
 type Screen = string
 
-export function useMusic(screen: Screen, gameState: GameState | null, run: RunState | null): void {
+export function useMusic(screen: Screen, gameState: GameState | null, run: RunState | null, act: Act | null): void {
   // Music router: exactly one track plays at a time; switching screen stops all others.
   // Acts can specify per-context music IDs in their JSON (mapMusicId, battleMusicId, bossMusicId).
   useEffect(() => {
@@ -24,8 +24,6 @@ export function useMusic(screen: Screen, gameState: GameState | null, run: RunSt
     stopMapMusic()
     stopHubMusic()
     if (screen !== 'hubworld' && screen !== 'location') setNightAmbiance(false)  // crickets are hub-only
-
-    const act = run ? ACTS[run.actId] : undefined
 
     if (screen === 'title' || screen === 'settings' || screen === 'deckbuilder' || screen === 'collection') {
       startTitleMusic()


### PR DESCRIPTION
## Summary

Fixes #2012. Three independent workstreams (one commit each) to shrink the JS/data loaded at app boot, which was the root cause of iOS jetsam killing the tab under memory pressure a few seconds after boot, before any WebGL context exists.

- **Lazy-load act JSON data** (`questline.ts`): the 20 act JSONs (~582KB) were statically imported and always in memory. `loadAct()`/`getCachedAct()` now dynamically import each act on first use, cached thereafter. `loadRun()` splits into a sync `loadRunRaw()` (no act dependency) and an async act-validated version; App.tsx's startup resume flow was restructured so the one synchronous decision point (a `useState` initializer, which can't `await`) makes its provisional choice using only data that doesn't need an act, and a mount effect finishes the two act-dependent resume checks once the act has loaded. Also fixed `codex.ts`, which separately statically imported every act JSON for the Codex screen's world-lore tab — that import alone would have kept all 20 acts bundled regardless of the `questline.ts` change.
- **Code-split screens via `React.lazy`** (`App.tsx`): ~70 screen components (admin tools, battle/hub/post-battle screens, minigames, rare-event overlays) converted from static imports to `React.lazy()`, wrapped in a single `Suspense` boundary. `IntroScreen`, `TitleScreen`, and `SettingsScreen` stay eager for first paint.
- **Lazy-load hub town data** (`hubWorldFactory.ts`): all 13 towns' `config.json`/`questDefs.json` (~1.5MB) are now dynamically imported and aggregated on first use via `getHubWorldData()`, instead of built eagerly at module load. This also required fixing two other static-import paths that would have kept the whole thing eager regardless (App.tsx's own `LOCATION_REGISTRY` import, and `dailyLogin.ts → collectiblesCatalog.ts`, which is imported eagerly by App.tsx).

Measured in a production build:
- `index` chunk (App.tsx + eager screens): **~937KB → ~259KB**
- `game-logic` chunk (`/src/game/*`, including hub town data): **~2.37MB → ~1.02MB**
- Per-act, per-screen, and per-town-config chunks now appear and load on demand.

## Test plan

- [x] `npm run build` (tsc + vite build) — clean, no type errors
- [x] `npm run test` (vitest) — 693/693 passing
- [x] Browser-verified in a real Chromium instance (production build, test Firebase config):
  - Fresh boot → intro → title screen renders correctly
  - Quick Battle flow → lazy-loaded `Battlefield` renders and plays correctly, no console errors
  - Hub world (Ravenwatch) renders correctly with NPCs, buildings, minimap, no console errors
- [x] Confirmed via `git worktree` comparison against the pre-change baseline that an unrelated black-screen artifact seen early in testing was a pre-existing sandbox limitation (no real Firebase backend reachable), not a regression from these changes

## Notes / follow-ups

- The hub-town workstream keeps two intentionally-eager fallback modules, both isolated from the app's boot path (neither is reachable from `App.tsx`): `hubTownRawQuestConfigs.ts` (map editor, Storybook-only) and `hubTownStoryFixtures.ts` (Storybook stories needing synchronous fixture data).
- `collectiblesCatalog.ts`'s "self-healing" collectible-display-name correction now only becomes active once hub data has loaded at least once in the session (i.e., after the player opens the hub); before that it falls back to the item's own stored display fields, which is the existing fallback behavior in `loadInventory()` for unrecognized ids.
- `game-logic` (~1.02MB) is still sizeable — the remainder is other `/src/game/*` logic (engine, card catalog, etc.) not in scope for this issue's three workstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCSRVQ85FwDkscQx7MefZ4)_