### PR TITLE
Gate deeper topics by friendship, randomize choice order, add editor support

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -973,6 +973,7 @@ Then on the NPC (in `config.json`): `"conversationTopics": ["elder-topic-pendant
 | `npcId` | string? | Documentation only — which NPC this belongs to. |
 | `label` | string | Topic-picker button text (icon + short prompt). |
 | `treeId` | string | Id of the `DialogueTree` (in this town's `dialogues` array) this topic walks. Conventionally the same string as `id`, but kept as a separate field in case a future topic wants to reuse a tree. |
+| `requireFriendshipLevel` | number? | Only offered once `getFriendshipLevel(npcId) >= this`. Omit for a topic available from the very first conversation. See "Friendship-gated topics" below. |
 
 The tree itself uses the exact `DialogueTree`/`DialogueNode`/`DialogueChoiceDef`/
 `DialogueEffect` schema documented in §7b — nothing new there.
@@ -997,12 +998,15 @@ too:
 
 - The "🗣️ Make conversation" choice resolves `npcDef.conversationTopics` to
   `ConversationTopicDef`s via `allQuests.HUB_CONVERSATION_TOPICS`, keeping
-  only entries whose `treeId` also resolves in `allQuests.HUB_DIALOGUES` — a
-  stale/typo'd id just drops that topic instead of breaking the menu (the
-  coverage test below is the real authoring guard).
-- If zero topics resolve, behavior is **byte-for-byte** the old flat line:
-  `addFriendshipXp(npcId, 2)` + `grantRelationshipWithRivalry(npcId, 'ally', 1, ...)`
-  + "Always good to catch up."
+  only entries whose `treeId` also resolves in `allQuests.HUB_DIALOGUES` **and**
+  whose `requireFriendshipLevel` (if set) is met — a stale/typo'd id or a
+  not-yet-unlocked deeper topic both just drop out of the list instead of
+  breaking the menu (the coverage test below is the real authoring guard for
+  the former).
+- If zero topics resolve (no authored topics, or all of them still gated),
+  behavior is **byte-for-byte** the old flat line: `grantFriendship(npcId, 2)`
+  + `grantRelationshipWithRivalry(npcId, 'ally', 1, ...)` + "Always good to
+  catch up."
 - Otherwise, a topic-picker `dialogueEvent` is shown ("What would you like to
   talk about?") with one button per topic plus "Never mind". This mirrors the
   "🎁 Give a gift" nested-picker pattern (§7d): opening the menu does **not**
@@ -1013,6 +1017,55 @@ too:
   — `topLevel = false` because this is a nested follow-up screen, so
   Talk/Give is **not** re-appended mid-conversation (same rule as any other
   follow-up dialogueEvent, §7d).
+
+### Friendship-gated topics (deeper conversations unlock over time)
+
+A topic's `requireFriendshipLevel` gates it out of the picker until the
+player's friendship with that NPC reaches that level — so a first-time chat
+only offers a shallow topic, and more open up as the friendship grows,
+instead of dumping every topic in the menu from the very first conversation.
+
+Every existing NPC (pilot and auto-generated alike) already follows a
+graduated convention worth reusing for new content: **the first topic in an
+NPC's `conversationTopics` list has no gate** (always offered), **the second
+requires level 1**, **the third requires level 2**, and so on — i.e. the
+topic's index in that NPC's list becomes its `requireFriendshipLevel`. This
+needs no new engine support (`requireFriendshipLevel` is just another
+optional field checked alongside the id/treeId resolution above) and applies
+uniformly whether the topics are hand-authored or auto-generated.
+
+### Randomized choice order (no "always pick the top option")
+
+`runDialogueNode`'s visible choices (both a topic's tone/follow-up choices and
+any other `dialogueTree` node's choices) are shuffled (`shuffled()`,
+`web/src/game/hub/shuffle.ts` — a plain Fisher-Yates copy, unit-tested there)
+before being rendered, so the good/neutral/bad outcome isn't reliably in the
+same list position — a player has to read the choices instead of learning
+"top button is always the safe/best one". This applies to every `DialogueTree`
+node's choices, not just conversation topics. Exit-style choices (an authored
+`end`-effect "leave" choice, or the generic trailing Farewell/Talk-Give block
+appended at the top level) are unaffected — they're already handled
+separately from `visible` and keep their conventional trailing position.
+
+### Map editor support
+
+Both the topic list on an NPC and the topic definitions themselves are
+editable in the visual map editor (Storybook `MapEditor` story; requires the
+dev server for file saves — see §13):
+- **`NpcEditor.tsx`** — a "Conversation Topics" field (right below "Dialogue
+  Tree") on the NPC form manages `HubNpc.conversationTopics` as a reorderable,
+  searchable list of topic ids (`EntityRefMultiPicker` with `reorderable`,
+  `web/src/components/mapEditor/EntityRefPicker.tsx`) — add/remove/reorder via
+  ↑/↓ buttons, since order determines both display order and (per the
+  graduated convention above) the implicit friendship-level gate.
+- **`DialogueEditor.tsx`** — a "Conversation Topics" section (alongside
+  Friendship/Relationship Dialogue and Dialogue Trees) manages the
+  `conversationTopics` array itself: `id`, `npcId`, `label`, a `treeId` picker
+  sourced from the same tree list as `dialogueTree`, and an optional
+  `requireFriendshipLevel` number field. The tree's own nodes/choices/effects
+  are still edited as raw JSON via the existing Dialogue Trees section (§7b) —
+  authoring a topic's underlying branching content isn't yet a structured
+  form, just like any other `dialogueTree`.
 
 ### Persistence
 
@@ -1026,9 +1079,11 @@ the existing friendship/relationship stores exactly as-is.
    good ending (`friendship` +, best one paired with `relationship: ally`),
    one neutral ending (no `friendship` effect), and one bad ending
    (`friendship` −).
-2. Add a matching entry to `conversationTopics` (`id`, `label`, `treeId`).
+2. Add a matching entry to `conversationTopics` (`id`, `label`, `treeId`,
+   optional `requireFriendshipLevel`).
 3. Attach the ordered topic ids to the NPC via `conversationTopics: string[]`
-   in `config.json`.
+   in `config.json` — following the graduated convention above, only the
+   first id should be ungated.
 4. Run `npm run test` (loader parsing + `npcDialogueCoverage.test.ts`'s
    `conversation topic coverage` / `conversation topic trees terminate`
    guards) and `npm run build`.

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -55,6 +55,7 @@ import { HubInteractable, HubLocationBundle, HubQuestBundle, HubTreasure, HubNpc
 import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { canDigToday, recordDig } from '../../game/hub/digs'
+import { shuffled } from '../../game/hub/shuffle'
 import { canForageToday, recordForage } from '../../game/hub/forages'
 import { getReputationTier } from '../../data/hub/buildingUpgrades'
 import { resolveWeather } from '../../game/hub/weather'
@@ -952,9 +953,13 @@ function buildTalkGiveOptions(
       // Per-NPC authored topics (questDefs.json `conversationTopics`, §7g) —
       // each points at an ordinary DialogueTree, both must resolve or the
       // topic is silently dropped (a stale/typo'd id shouldn't break the menu).
+      // A topic's own requireFriendshipLevel (if set) gates it behind that
+      // friendship level, so deeper topics unlock as the player gets closer
+      // to the NPC instead of every topic being available from the first talk.
       const topics = (npcDef?.conversationTopics ?? [])
         .map(id => allQuests.HUB_CONVERSATION_TOPICS[id])
-        .filter((t): t is ConversationTopicDef => !!t && !!allQuests.HUB_DIALOGUES[t.treeId])
+        .filter((t): t is ConversationTopicDef => !!t && !!allQuests.HUB_DIALOGUES[t.treeId] &&
+          (!t.requireFriendshipLevel || getFriendshipLevel(npcId) >= t.requireFriendshipLevel))
 
       if (topics.length === 0) {
         // No authored topics for this NPC — exact legacy behavior.
@@ -1128,7 +1133,10 @@ function hasOfferableQuest(giverId: string): boolean {
     const node = tree.nodes[nodeId]
     if (!node) { setDialogueEvent(null); return }
     markNodeSeen(tree.id, nodeId)
-    const visible = (node.choices ?? []).filter(c =>
+    // Shuffled so a good/neutral/bad outcome isn't always in the same list
+    // position (see `shuffled` above) — order among exit-style choices (e.g.
+    // an authored "leave" choice) is separated back out below regardless.
+    const visible = shuffled((node.choices ?? []).filter(c =>
       (!c.requireFlag  || hasDialogueFlag(c.requireFlag)) &&
       (!c.hideIfFlag   || !hasDialogueFlag(c.hideIfFlag)) &&
       (!c.requireCampaignComplete || isCampaignComplete(c.requireCampaignComplete)) &&
@@ -1139,7 +1147,7 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireTimeOfDay || c.requireTimeOfDay === getTimeOfDay(gameHour)) &&
       (!c.requireActivity  || (!!npcDef && 'schedule' in npcDef &&
           getNpcActivity(npcDef as HubNpc, gameHour) === c.requireActivity))
-    )
+    ))
     const speaker = node.speakerName ?? speakerName
 
     let finalChoices: DialogueChoice[]

--- a/web/src/components/mapEditor/EntityRefPicker.tsx
+++ b/web/src/components/mapEditor/EntityRefPicker.tsx
@@ -87,19 +87,36 @@ function optStyle(active: boolean): React.CSSProperties {
   }
 }
 
-/** Multi-select variant — manages a list of ids (used for pickupIds). */
+function swapItems<T>(arr: T[], i: number, j: number): T[] {
+  const next = [...arr]
+  ;[next[i], next[j]] = [next[j], next[i]]
+  return next
+}
+
+/** Multi-select variant — manages an ordered list of ids (used for pickupIds,
+ *  and for an NPC's conversationTopics where display order is meaningful).
+ *  `reorderable` adds ↑/↓ buttons that swap adjacent entries in place. */
 export function EntityRefMultiPicker({
-  values, onChange, options, placeholder = 'Add id…',
+  values, onChange, options, placeholder = 'Add id…', reorderable = false,
 }: {
   values: string[]
   onChange: (values: string[]) => void
   options: RefOption[]
   placeholder?: string
+  reorderable?: boolean
 }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       {values.map((v, i) => (
         <div key={i} style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+          {reorderable && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <button disabled={i === 0} onClick={() => onChange(swapItems(values, i, i - 1))} title="Move up"
+                style={{ ...reorderBtnStyle, opacity: i === 0 ? 0.3 : 1, cursor: i === 0 ? 'default' : 'pointer' }}>↑</button>
+              <button disabled={i === values.length - 1} onClick={() => onChange(swapItems(values, i, i + 1))} title="Move down"
+                style={{ ...reorderBtnStyle, opacity: i === values.length - 1 ? 0.3 : 1, cursor: i === values.length - 1 ? 'default' : 'pointer' }}>↓</button>
+            </div>
+          )}
           <div style={{ flex: 1 }}>
             <EntityRefPicker value={v} options={options} onChange={nv => onChange(values.map((x, j) => j === i ? nv : x))} placeholder={placeholder} />
           </div>
@@ -111,4 +128,8 @@ export function EntityRefMultiPicker({
         style={{ padding: '2px 8px', background: '#1e2e1e', border: '1px solid #3a5a3a', color: '#6d6', borderRadius: 3, fontSize: 10, cursor: 'pointer', alignSelf: 'flex-start' }}>+ Add</button>
     </div>
   )
+}
+
+const reorderBtnStyle: React.CSSProperties = {
+  padding: '0 4px', background: '#1a1a2a', border: '1px solid #444', color: '#aaa', borderRadius: 2, fontSize: 9, lineHeight: '14px',
 }

--- a/web/src/components/mapEditor/entityRefs.ts
+++ b/web/src/components/mapEditor/entityRefs.ts
@@ -62,11 +62,13 @@ type NpcLite = { id: string; name?: string }
 type QuestLite = { id: string; title?: string }
 type PickupLite = { id: string }
 type BuildingLite = { id?: string }
+type TopicLite = { id: string; label?: string }
 
 function npcsOf(cfg: RawMapConfig | undefined): NpcLite[] { return (cfg?.npcs ?? []) as NpcLite[] }
 function questsOf(q: QuestDefsJson | undefined): QuestLite[] { return ((q?.quests as QuestLite[] | undefined) ?? []) }
 function pickupsOf(q: QuestDefsJson | undefined): PickupLite[] { return (q?.pickupItems ?? []) as PickupLite[] }
 function dialoguesOf(q: QuestDefsJson | undefined): QuestLite[] { return ((q?.dialogues as QuestLite[] | undefined) ?? []) }
+function conversationTopicsOf(q: QuestDefsJson | undefined): TopicLite[] { return ((q?.conversationTopics as TopicLite[] | undefined) ?? []) }
 
 export function npcRefOptions(currentMap: MapId, currentNpcs: NpcLite[], crossTown = false): RefOption[] {
   const out: RefOption[] = []
@@ -112,6 +114,17 @@ export function dialogueTreeRefOptions(currentMap: MapId, currentDialogues: Ques
   const out: RefOption[] = []
   eachTown<QuestLite[], QuestLite[]>(currentMap, currentDialogues, m => dialoguesOf(QUEST_DEFS_BY_MAP[m]), crossTown, (ds, group) => {
     for (const d of ds) if (d.id) out.push({ value: d.id, label: d.id, group })
+  })
+  return out
+}
+
+// "Make Conversation" topics (questDefs.json `conversationTopics`) — used both
+// as the picker options for HubNpc.conversationTopics (an ordered id list) and
+// to resolve a topic's own label when showing that list.
+export function conversationTopicRefOptions(currentMap: MapId, currentTopics: TopicLite[], crossTown = false): RefOption[] {
+  const out: RefOption[] = []
+  eachTown<TopicLite[], TopicLite[]>(currentMap, currentTopics, m => conversationTopicsOf(QUEST_DEFS_BY_MAP[m]), crossTown, (ts, group) => {
+    for (const t of ts) if (t.id) out.push({ value: t.id, label: t.label ?? t.id, group })
   })
   return out
 }

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -100,6 +100,7 @@ export interface RawNpc {
   questReceive?: string | string[]
   isGhost?: boolean
   dialogueTree?: string   // id of a branching dialogue tree (questDefs.json `dialogues`)
+  conversationTopics?: string[]   // ordered ids of "Make Conversation" topics (questDefs.json `conversationTopics`)
   screen?: string   // opens a screen/modal (e.g. 'adopt-pet') via a dialogue choice, in addition to dialogue
   minLevel?: number   // building upgrade level at which this NPC first appears (0/undefined = always)
   hideAtLevel?: number // building upgrade level at which this NPC disappears (undefined = never)

--- a/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/DialogueEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import type { MapId, QuestDefsJson } from '../../../data/hub/hubWorldFactory'
 import type { RawMapConfig } from '../mapEditorTypes'
 import { EntityRefPicker } from '../EntityRefPicker'
-import { npcRefOptions, type RefOption } from '../entityRefs'
+import { npcRefOptions, dialogueTreeRefOptions, type RefOption } from '../entityRefs'
 
 interface Props {
   mapId: MapId
@@ -133,12 +133,57 @@ function DialogueTreeRow({ dlg, onChange, onDelete, npcOptions }: { dlg: Record<
   )
 }
 
+// conversationTopics: [{ id, npcId, label, treeId, requireFriendshipLevel? }] —
+// the "Make Conversation" menu entries; each points at a tree above by treeId.
+function ConversationTopicRow({ topic, onChange, onDelete, npcOptions, treeOptions }: {
+  topic: Record<string, unknown>
+  onChange: (t: Record<string, unknown>) => void
+  onDelete: () => void
+  npcOptions: RefOption[]
+  treeOptions: RefOption[]
+}) {
+  return (
+    <div style={{ background: '#16161e', border: '1px solid #2a2a3a', borderRadius: 3, padding: 6, marginBottom: 6 }}>
+      <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+        <input style={INPUT} placeholder="id" value={String(topic.id ?? '')} onChange={e => onChange({ ...topic, id: e.target.value })} />
+        <div style={{ flex: 1 }}>
+          <EntityRefPicker value={String(topic.npcId ?? '')} options={npcOptions} placeholder="npcId…" onChange={v => onChange({ ...topic, npcId: v })} />
+        </div>
+        <button style={BTN_X} onClick={onDelete}>✕</button>
+      </div>
+      <input style={{ ...INPUT, marginBottom: 4 }} placeholder="label, e.g. 🕯️ Ask about the missing pendant"
+        value={String(topic.label ?? '')} onChange={e => onChange({ ...topic, label: e.target.value })} />
+      <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+        <div style={{ flex: 1 }}>
+          <EntityRefPicker value={String(topic.treeId ?? '')} options={treeOptions} placeholder="treeId (dialogues array)…" onChange={v => onChange({ ...topic, treeId: v })} />
+        </div>
+        <input
+          style={{ ...INPUT, width: 90, flex: '0 0 90px' }}
+          type="number" min={0}
+          placeholder="min friendship"
+          title="Only offered once the NPC's friendship level is at least this — leave blank to always offer it"
+          value={topic.requireFriendshipLevel == null ? '' : String(topic.requireFriendshipLevel)}
+          onChange={e => {
+            const v = e.target.value
+            const next = { ...topic }
+            if (v === '') delete next.requireFriendshipLevel
+            else next.requireFriendshipLevel = Number(v)
+            onChange(next)
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
 export function DialogueEditor({ mapId, configData, questDefsData, onQuestDefsChange }: Props) {
   const q = questDefsData as unknown as Record<string, unknown>
   const friendship = (q.friendshipDialogue as Record<string, Record<string, string>>) ?? {}
   const relationship = (q.relationshipDialogue as Record<string, Record<string, Record<string, string>>>) ?? {}
   const dialogues = (q.dialogues as Array<Record<string, unknown>>) ?? []
+  const conversationTopics = (q.conversationTopics as Array<Record<string, unknown>>) ?? []
   const npcOptions = npcRefOptions(mapId, configData.npcs ?? [], false)
+  const treeOptions = dialogueTreeRefOptions(mapId, dialogues as Array<{ id: string }>)
   const patch = (key: string, value: unknown) => onQuestDefsChange(prev => ({ ...(prev as object), [key]: value }) as QuestDefsJson)
 
   return (
@@ -160,6 +205,19 @@ export function DialogueEditor({ mapId, configData, questDefsData, onQuestDefsCh
           />
         ))}
         <button style={BTN_ADD} onClick={() => patch('dialogues', [...dialogues, { id: '', npcId: '', start: 'greet', nodes: { greet: { text: '' } } }])}>+ Add dialogue tree</button>
+      </Section>
+      <Section title={`Conversation Topics (${conversationTopics.length})`} color="#ffcc66">
+        {conversationTopics.map((t, i) => (
+          <ConversationTopicRow
+            key={i}
+            topic={t}
+            npcOptions={npcOptions}
+            treeOptions={treeOptions}
+            onChange={d => patch('conversationTopics', conversationTopics.map((x, j) => j === i ? d : x))}
+            onDelete={() => patch('conversationTopics', conversationTopics.filter((_, j) => j !== i))}
+          />
+        ))}
+        <button style={BTN_ADD} onClick={() => patch('conversationTopics', [...conversationTopics, { id: '', npcId: '', label: '', treeId: '' }])}>+ Add conversation topic</button>
       </Section>
     </div>
   )

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -5,8 +5,8 @@ import { NPC_ACTIVITIES } from '../../../game/hub/hubNpcSchedule'
 import { SpriteSearchPicker } from '../SpritePicker'
 import { AnimalEditor } from './AnimalEditor'
 import type { MapId } from '../../../data/hub/hubWorldFactory'
-import { EntityRefPicker } from '../EntityRefPicker'
-import { buildingRefOptions, interiorRefOptions, questRefOptions, dialogueTreeRefOptions, type RefOption } from '../entityRefs'
+import { EntityRefPicker, EntityRefMultiPicker } from '../EntityRefPicker'
+import { buildingRefOptions, interiorRefOptions, questRefOptions, dialogueTreeRefOptions, conversationTopicRefOptions, type RefOption } from '../entityRefs'
 import { SCREEN_IDS } from '../EntityInspector'
 
 // Screens reachable from an NPC's dialogue: the standard SCREEN_IDS list, plus
@@ -38,6 +38,7 @@ interface NpcRefOpts {
   questGive: RefOption[]
   questReceive: RefOption[]
   dialogueTrees: RefOption[]
+  conversationTopics: RefOption[]
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
@@ -263,6 +264,10 @@ function NpcFullEditor({ npc, opts, onUpdate, onPickLocation }: {
         <EntityRefPicker value={npc.dialogueTree ?? ''} options={opts.dialogueTrees} placeholder="Search dialogue trees…"
           onChange={v => onUpdate({ dialogueTree: v || undefined })} />
       </Field>
+      <Field label="Conversation Topics (Make Conversation menu, in display order)">
+        <EntityRefMultiPicker values={npc.conversationTopics ?? []} options={opts.conversationTopics} reorderable
+          placeholder="Search conversation topics…" onChange={v => onUpdate({ conversationTopics: v.length ? v : undefined })} />
+      </Field>
       <Field label="Screen (optional)">
         <input
           style={INPUT} list={`npc-screen-options-${npc.id}`}
@@ -347,6 +352,7 @@ export function NpcEditor({
     questGive: questRefOptions(mapId, localQuests, false),     // this NPC gives quests from its own town
     questReceive: questRefOptions(mapId, localQuests, true),   // may receive cross-town deliveries
     dialogueTrees: dialogueTreeRefOptions(mapId, (questDefsData.dialogues as Array<{ id: string }> | undefined) ?? []),
+    conversationTopics: conversationTopicRefOptions(mapId, (questDefsData.conversationTopics as Array<{ id: string; label?: string }> | undefined) ?? []),
   }
 
   // Scroll to a newly added row after the render that includes it

--- a/web/src/data/hub/appleford/questDefs.json
+++ b/web/src/data/hub/appleford/questDefs.json
@@ -3381,13 +3381,15 @@
       "id": "appleford-orchard-keeper-bess-topic-auto-2",
       "npcId": "orchard-keeper-bess",
       "label": "💬 \"Raiders hit the east rows last week.\"",
-      "treeId": "appleford-orchard-keeper-bess-topic-auto-2"
+      "treeId": "appleford-orchard-keeper-bess-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-orchard-keeper-bess-topic-auto-3",
       "npcId": "orchard-keeper-bess",
       "label": "💬 \"An orchard is patience you can eat.\"",
-      "treeId": "appleford-orchard-keeper-bess-topic-auto-3"
+      "treeId": "appleford-orchard-keeper-bess-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-cider-brewer-tom-topic-auto-1",
@@ -3399,13 +3401,15 @@
       "id": "appleford-cider-brewer-tom-topic-auto-2",
       "npcId": "cider-brewer-tom",
       "label": "💬 \"The toll road's made deliveries a nightmare.\"",
-      "treeId": "appleford-cider-brewer-tom-topic-auto-2"
+      "treeId": "appleford-cider-brewer-tom-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-cider-brewer-tom-topic-auto-3",
       "npcId": "cider-brewer-tom",
       "label": "💬 \"First mug's full price.\"",
-      "treeId": "appleford-cider-brewer-tom-topic-auto-3"
+      "treeId": "appleford-cider-brewer-tom-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-beekeeper-mabe-topic-auto-1",
@@ -3417,13 +3421,15 @@
       "id": "appleford-beekeeper-mabe-topic-auto-2",
       "npcId": "beekeeper-mabe",
       "label": "💬 \"Honey, wax, mead — one little bee gives you all…\"",
-      "treeId": "appleford-beekeeper-mabe-topic-auto-2"
+      "treeId": "appleford-beekeeper-mabe-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-beekeeper-mabe-topic-auto-3",
       "npcId": "beekeeper-mabe",
       "label": "💬 \"Bess grows the blossom, I keep the bees.\"",
-      "treeId": "appleford-beekeeper-mabe-topic-auto-3"
+      "treeId": "appleford-beekeeper-mabe-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-cooper-wend-topic-auto-1",
@@ -3435,13 +3441,15 @@
       "id": "appleford-cooper-wend-topic-auto-2",
       "npcId": "cooper-wend",
       "label": "💬 \"A good cask is watertight, sweet-grained, and…\"",
-      "treeId": "appleford-cooper-wend-topic-auto-2"
+      "treeId": "appleford-cooper-wend-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-cooper-wend-topic-auto-3",
       "npcId": "cooper-wend",
       "label": "💬 \"Staves, hoops, and patience — that's a barrel.\"",
-      "treeId": "appleford-cooper-wend-topic-auto-3"
+      "treeId": "appleford-cooper-wend-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-market-trader-posy-topic-auto-1",
@@ -3453,13 +3461,15 @@
       "id": "appleford-market-trader-posy-topic-auto-2",
       "npcId": "market-trader-posy",
       "label": "💬 \"Ravenwatch pays double for our cider.\"",
-      "treeId": "appleford-market-trader-posy-topic-auto-2"
+      "treeId": "appleford-market-trader-posy-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-market-trader-posy-topic-auto-3",
       "npcId": "market-trader-posy",
       "label": "💬 \"Buy low, sell ripe.\"",
-      "treeId": "appleford-market-trader-posy-topic-auto-3"
+      "treeId": "appleford-market-trader-posy-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-chaplain-hale-topic-auto-1",
@@ -3471,13 +3481,15 @@
       "id": "appleford-chaplain-hale-topic-auto-2",
       "npcId": "chaplain-hale",
       "label": "💬 \"We bless the first pressing every year.\"",
-      "treeId": "appleford-chaplain-hale-topic-auto-2"
+      "treeId": "appleford-chaplain-hale-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-chaplain-hale-topic-auto-3",
       "npcId": "chaplain-hale",
       "label": "💬 \"Quiet hands, full baskets, grateful hearts.\"",
-      "treeId": "appleford-chaplain-hale-topic-auto-3"
+      "treeId": "appleford-chaplain-hale-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-scrumping-wren-topic-auto-1",
@@ -3489,13 +3501,15 @@
       "id": "appleford-scrumping-wren-topic-auto-2",
       "npcId": "scrumping-wren",
       "label": "💬 \"I dropped my things running from Keeper Bess.\"",
-      "treeId": "appleford-scrumping-wren-topic-auto-2"
+      "treeId": "appleford-scrumping-wren-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-scrumping-wren-topic-auto-3",
       "npcId": "scrumping-wren",
       "label": "💬 \"When I grow up I'm going to own the whole…\"",
-      "treeId": "appleford-scrumping-wren-topic-auto-3"
+      "treeId": "appleford-scrumping-wren-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "appleford-orchard-hand-hob-topic-auto-1",
@@ -3507,13 +3521,15 @@
       "id": "appleford-orchard-hand-hob-topic-auto-2",
       "npcId": "orchard-hand-hob",
       "label": "💬 \"Best apples are always the ones just out of…\"",
-      "treeId": "appleford-orchard-hand-hob-topic-auto-2"
+      "treeId": "appleford-orchard-hand-hob-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "appleford-orchard-hand-hob-topic-auto-3",
       "npcId": "orchard-hand-hob",
       "label": "💬 \"Fill a crate, haul it to Posy, start again.\"",
-      "treeId": "appleford-orchard-hand-hob-topic-auto-3"
+      "treeId": "appleford-orchard-hand-hob-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/capitalcity/questDefs.json
+++ b/web/src/data/hub/capitalcity/questDefs.json
@@ -11477,7 +11477,8 @@
       "id": "capitalcity-mira-archive-topic-auto-2",
       "npcId": "mira-archive",
       "label": "💬 \"You've seen things out there I can only read…\"",
-      "treeId": "capitalcity-mira-archive-topic-auto-2"
+      "treeId": "capitalcity-mira-archive-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-innkeeper-crownhaven-topic-auto-1",
@@ -11489,13 +11490,15 @@
       "id": "capitalcity-innkeeper-crownhaven-topic-auto-2",
       "npcId": "innkeeper-crownhaven",
       "label": "💬 \"Half my guests are here for the coronation.\"",
-      "treeId": "capitalcity-innkeeper-crownhaven-topic-auto-2"
+      "treeId": "capitalcity-innkeeper-crownhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-innkeeper-crownhaven-topic-auto-3",
       "npcId": "innkeeper-crownhaven",
       "label": "💬 \"If Captain Hale sends you with anything, I'll…\"",
-      "treeId": "capitalcity-innkeeper-crownhaven-topic-auto-3"
+      "treeId": "capitalcity-innkeeper-crownhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-watch-captain-hale-topic-auto-1",
@@ -11507,13 +11510,15 @@
       "id": "capitalcity-watch-captain-hale-topic-auto-2",
       "npcId": "watch-captain-hale",
       "label": "💬 \"The old postern gate key went missing on patrol.\"",
-      "treeId": "capitalcity-watch-captain-hale-topic-auto-2"
+      "treeId": "capitalcity-watch-captain-hale-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-watch-captain-hale-topic-auto-3",
       "npcId": "watch-captain-hale",
       "label": "💬 \"Keep your nose clean in my city, traveller.\"",
-      "treeId": "capitalcity-watch-captain-hale-topic-auto-3"
+      "treeId": "capitalcity-watch-captain-hale-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-royal-archivist-topic-auto-1",
@@ -11525,13 +11530,15 @@
       "id": "capitalcity-royal-archivist-topic-auto-2",
       "npcId": "royal-archivist",
       "label": "💬 \"The couriers dropped them somewhere between…\"",
-      "treeId": "capitalcity-royal-archivist-topic-auto-2"
+      "treeId": "capitalcity-royal-archivist-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-royal-archivist-topic-auto-3",
       "npcId": "royal-archivist",
       "label": "💬 \"History is just paperwork that survived, you…\"",
-      "treeId": "capitalcity-royal-archivist-topic-auto-3"
+      "treeId": "capitalcity-royal-archivist-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-market-matron-topic-auto-1",
@@ -11543,13 +11550,15 @@
       "id": "capitalcity-market-matron-topic-auto-2",
       "npcId": "market-matron",
       "label": "💬 \"You want gossip, try the inn.\"",
-      "treeId": "capitalcity-market-matron-topic-auto-2"
+      "treeId": "capitalcity-market-matron-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-market-matron-topic-auto-3",
       "npcId": "market-matron",
       "label": "💬 \"Mind the fountain — the pigeons have opinions.\"",
-      "treeId": "capitalcity-market-matron-topic-auto-3"
+      "treeId": "capitalcity-market-matron-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-chancellor-topic-auto-1",
@@ -11561,13 +11570,15 @@
       "id": "capitalcity-chancellor-topic-auto-2",
       "npcId": "chancellor",
       "label": "💬 \"Crownhaven looks to Ravenwatch for the old…\"",
-      "treeId": "capitalcity-chancellor-topic-auto-2"
+      "treeId": "capitalcity-chancellor-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-chancellor-topic-auto-3",
       "npcId": "chancellor",
       "label": "💬 \"Serve the crown well and the crown remembers.\"",
-      "treeId": "capitalcity-chancellor-topic-auto-3"
+      "treeId": "capitalcity-chancellor-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-high-priest-topic-auto-1",
@@ -11579,13 +11590,15 @@
       "id": "capitalcity-high-priest-topic-auto-2",
       "npcId": "high-priest",
       "label": "💬 \"The cathedral's relics were scattered in the…\"",
-      "treeId": "capitalcity-high-priest-topic-auto-2"
+      "treeId": "capitalcity-high-priest-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-high-priest-topic-auto-3",
       "npcId": "high-priest",
       "label": "💬 \"The bell has been silent too long.\"",
-      "treeId": "capitalcity-high-priest-topic-auto-3"
+      "treeId": "capitalcity-high-priest-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-mint-master-topic-auto-1",
@@ -11597,13 +11610,15 @@
       "id": "capitalcity-mint-master-topic-auto-2",
       "npcId": "mint-master",
       "label": "💬 \"Lose a mint die and you may as well hand a…\"",
-      "treeId": "capitalcity-mint-master-topic-auto-2"
+      "treeId": "capitalcity-mint-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-mint-master-topic-auto-3",
       "npcId": "mint-master",
       "label": "💬 \"Gold is heavy for a reason — it keeps honest…\"",
-      "treeId": "capitalcity-mint-master-topic-auto-3"
+      "treeId": "capitalcity-mint-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-banker-topic-auto-1",
@@ -11615,13 +11630,15 @@
       "id": "capitalcity-banker-topic-auto-2",
       "npcId": "banker",
       "label": "💬 \"A noble's debt is a delicate thing.\"",
-      "treeId": "capitalcity-banker-topic-auto-2"
+      "treeId": "capitalcity-banker-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-banker-topic-auto-3",
       "npcId": "banker",
       "label": "💬 \"Vault's sealed tight — only the watch and I…\"",
-      "treeId": "capitalcity-banker-topic-auto-3"
+      "treeId": "capitalcity-banker-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-tailor-pell-topic-auto-1",
@@ -11633,13 +11650,15 @@
       "id": "capitalcity-tailor-pell-topic-auto-2",
       "npcId": "tailor-pell",
       "label": "💬 \"A good seam is invisible.\"",
-      "treeId": "capitalcity-tailor-pell-topic-auto-2"
+      "treeId": "capitalcity-tailor-pell-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-tailor-pell-topic-auto-3",
       "npcId": "tailor-pell",
       "label": "💬 \"Bring me bolts of silk and I'll dress you fit…\"",
-      "treeId": "capitalcity-tailor-pell-topic-auto-3"
+      "treeId": "capitalcity-tailor-pell-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-jeweller-isolde-topic-auto-1",
@@ -11651,13 +11670,15 @@
       "id": "capitalcity-jeweller-isolde-topic-auto-2",
       "npcId": "jeweller-isolde",
       "label": "💬 \"Raw gems are dull little pebbles until I coax…\"",
-      "treeId": "capitalcity-jeweller-isolde-topic-auto-2"
+      "treeId": "capitalcity-jeweller-isolde-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-jeweller-isolde-topic-auto-3",
       "npcId": "jeweller-isolde",
       "label": "💬 \"Careful where you tread; I've dropped stones…\"",
-      "treeId": "capitalcity-jeweller-isolde-topic-auto-3"
+      "treeId": "capitalcity-jeweller-isolde-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-apothecary-mads-topic-auto-1",
@@ -11669,13 +11690,15 @@
       "id": "capitalcity-apothecary-mads-topic-auto-2",
       "npcId": "apothecary-mads",
       "label": "💬 \"Half of healing is herbs; the other half is…\"",
-      "treeId": "capitalcity-apothecary-mads-topic-auto-2"
+      "treeId": "capitalcity-apothecary-mads-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-apothecary-mads-topic-auto-3",
       "npcId": "apothecary-mads",
       "label": "💬 \"The academy sends me their wildest experiments.\"",
-      "treeId": "capitalcity-apothecary-mads-topic-auto-3"
+      "treeId": "capitalcity-apothecary-mads-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-baker-otto-topic-auto-1",
@@ -11687,13 +11710,15 @@
       "id": "capitalcity-baker-otto-topic-auto-2",
       "npcId": "baker-otto",
       "label": "💬 \"Coronation feast's coming.\"",
-      "treeId": "capitalcity-baker-otto-topic-auto-2"
+      "treeId": "capitalcity-baker-otto-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-baker-otto-topic-auto-3",
       "npcId": "baker-otto",
       "label": "💬 \"Grain's dear this season.\"",
-      "treeId": "capitalcity-baker-otto-topic-auto-3"
+      "treeId": "capitalcity-baker-otto-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-blacksmith-dunn-topic-auto-1",
@@ -11705,13 +11730,15 @@
       "id": "capitalcity-blacksmith-dunn-topic-auto-2",
       "npcId": "blacksmith-dunn",
       "label": "💬 \"A blade's only as honest as the hand that…\"",
-      "treeId": "capitalcity-blacksmith-dunn-topic-auto-2"
+      "treeId": "capitalcity-blacksmith-dunn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-blacksmith-dunn-topic-auto-3",
       "npcId": "blacksmith-dunn",
       "label": "💬 \"Bring me steel and I'll give the watch the edge…\"",
-      "treeId": "capitalcity-blacksmith-dunn-topic-auto-3"
+      "treeId": "capitalcity-blacksmith-dunn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-noble-lady-cora-topic-auto-1",
@@ -11723,13 +11750,15 @@
       "id": "capitalcity-noble-lady-cora-topic-auto-2",
       "npcId": "noble-lady-cora",
       "label": "💬 \"My family's locket was lost in the gardens.\"",
-      "treeId": "capitalcity-noble-lady-cora-topic-auto-2"
+      "treeId": "capitalcity-noble-lady-cora-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-noble-lady-cora-topic-auto-3",
       "npcId": "noble-lady-cora",
       "label": "💬 \"Debts and lockets — a noblewoman's life is…\"",
-      "treeId": "capitalcity-noble-lady-cora-topic-auto-3"
+      "treeId": "capitalcity-noble-lady-cora-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-academy-master-topic-auto-1",
@@ -11741,13 +11770,15 @@
       "id": "capitalcity-academy-master-topic-auto-2",
       "npcId": "academy-master",
       "label": "💬 \"My lecture notes have scattered to the four…\"",
-      "treeId": "capitalcity-academy-master-topic-auto-2"
+      "treeId": "capitalcity-academy-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-academy-master-topic-auto-3",
       "npcId": "academy-master",
       "label": "💬 \"Knowledge, like coin, is only useful in…\"",
-      "treeId": "capitalcity-academy-master-topic-auto-3"
+      "treeId": "capitalcity-academy-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-busker-lyle-topic-auto-1",
@@ -11759,13 +11790,15 @@
       "id": "capitalcity-busker-lyle-topic-auto-2",
       "npcId": "busker-lyle",
       "label": "💬 \"Snapped three lute strings practising for the…\"",
-      "treeId": "capitalcity-busker-lyle-topic-auto-2"
+      "treeId": "capitalcity-busker-lyle-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-busker-lyle-topic-auto-3",
       "npcId": "busker-lyle",
       "label": "💬 \"Every great city deserves a great song.\"",
-      "treeId": "capitalcity-busker-lyle-topic-auto-3"
+      "treeId": "capitalcity-busker-lyle-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-herald-jana-topic-auto-1",
@@ -11777,13 +11810,15 @@
       "id": "capitalcity-herald-jana-topic-auto-2",
       "npcId": "herald-jana",
       "label": "💬 \"Lost half my scrolls to the wind.\"",
-      "treeId": "capitalcity-herald-jana-topic-auto-2"
+      "treeId": "capitalcity-herald-jana-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-herald-jana-topic-auto-3",
       "npcId": "herald-jana",
       "label": "💬 \"Stand for the crown, traveller.\"",
-      "treeId": "capitalcity-herald-jana-topic-auto-3"
+      "treeId": "capitalcity-herald-jana-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-guard-bryn-topic-auto-1",
@@ -11795,13 +11830,15 @@
       "id": "capitalcity-guard-bryn-topic-auto-2",
       "npcId": "guard-bryn",
       "label": "💬 \"See anything suspicious, you tell me first, the…\"",
-      "treeId": "capitalcity-guard-bryn-topic-auto-2"
+      "treeId": "capitalcity-guard-bryn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-guard-bryn-topic-auto-3",
       "npcId": "guard-bryn",
       "label": "💬 \"Quiet night.\"",
-      "treeId": "capitalcity-guard-bryn-topic-auto-3"
+      "treeId": "capitalcity-guard-bryn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-card-vendor-crownhaven-topic-auto-1",
@@ -11813,13 +11850,15 @@
       "id": "capitalcity-card-vendor-crownhaven-topic-auto-2",
       "npcId": "card-vendor-crownhaven",
       "label": "💬 \"Every deck tells a story.\"",
-      "treeId": "capitalcity-card-vendor-crownhaven-topic-auto-2"
+      "treeId": "capitalcity-card-vendor-crownhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-card-vendor-crownhaven-topic-auto-3",
       "npcId": "card-vendor-crownhaven",
       "label": "💬 \"The court plays for crowns; you can play for…\"",
-      "treeId": "capitalcity-card-vendor-crownhaven-topic-auto-3"
+      "treeId": "capitalcity-card-vendor-crownhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-supplies-vendor-crownhaven-topic-auto-1",
@@ -11831,13 +11870,15 @@
       "id": "capitalcity-supplies-vendor-crownhaven-topic-auto-2",
       "npcId": "supplies-vendor-crownhaven",
       "label": "💬 \"Stock up before you head back out past the walls.\"",
-      "treeId": "capitalcity-supplies-vendor-crownhaven-topic-auto-2"
+      "treeId": "capitalcity-supplies-vendor-crownhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-supplies-vendor-crownhaven-topic-auto-3",
       "npcId": "supplies-vendor-crownhaven",
       "label": "💬 \"A well-supplied traveller is a living traveller.\"",
-      "treeId": "capitalcity-supplies-vendor-crownhaven-topic-auto-3"
+      "treeId": "capitalcity-supplies-vendor-crownhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-augment-vendor-crownhaven-topic-auto-1",
@@ -11849,13 +11890,15 @@
       "id": "capitalcity-augment-vendor-crownhaven-topic-auto-2",
       "npcId": "augment-vendor-crownhaven",
       "label": "💬 \"The jewellers cut stones; I cut destinies.\"",
-      "treeId": "capitalcity-augment-vendor-crownhaven-topic-auto-2"
+      "treeId": "capitalcity-augment-vendor-crownhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-augment-vendor-crownhaven-topic-auto-3",
       "npcId": "augment-vendor-crownhaven",
       "label": "💬 \"Bring me crystals and I'll bring out your…\"",
-      "treeId": "capitalcity-augment-vendor-crownhaven-topic-auto-3"
+      "treeId": "capitalcity-augment-vendor-crownhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-academy-tactician-topic-auto-1",
@@ -11867,13 +11910,15 @@
       "id": "capitalcity-academy-tactician-topic-auto-2",
       "npcId": "academy-tactician",
       "label": "💬 \"A clever deck wins more wars than a sharp sword.\"",
-      "treeId": "capitalcity-academy-tactician-topic-auto-2"
+      "treeId": "capitalcity-academy-tactician-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-academy-tactician-topic-auto-3",
       "npcId": "academy-tactician",
       "label": "💬 \"Theory here, practice in the field.\"",
-      "treeId": "capitalcity-academy-tactician-topic-auto-3"
+      "treeId": "capitalcity-academy-tactician-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-reliquary-keeper-topic-auto-1",
@@ -11885,13 +11930,15 @@
       "id": "capitalcity-reliquary-keeper-topic-auto-2",
       "npcId": "reliquary-keeper",
       "label": "💬 \"Every hero's feats are inscribed here, in gold…\"",
-      "treeId": "capitalcity-reliquary-keeper-topic-auto-2"
+      "treeId": "capitalcity-reliquary-keeper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-reliquary-keeper-topic-auto-3",
       "npcId": "reliquary-keeper",
       "label": "💬 \"Add your name to the hall, traveller.\"",
-      "treeId": "capitalcity-reliquary-keeper-topic-auto-3"
+      "treeId": "capitalcity-reliquary-keeper-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-crownhaven-dealer-topic-auto-1",
@@ -11903,13 +11950,15 @@
       "id": "capitalcity-crownhaven-dealer-topic-auto-2",
       "npcId": "crownhaven-dealer",
       "label": "💬 \"Fortune favours the bold — and occasionally the…\"",
-      "treeId": "capitalcity-crownhaven-dealer-topic-auto-2"
+      "treeId": "capitalcity-crownhaven-dealer-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-crownhaven-dealer-topic-auto-3",
       "npcId": "crownhaven-dealer",
       "label": "💬 \"Crowns won, crowns lost.\"",
-      "treeId": "capitalcity-crownhaven-dealer-topic-auto-3"
+      "treeId": "capitalcity-crownhaven-dealer-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-mint-coinwright-topic-auto-1",
@@ -11921,13 +11970,15 @@
       "id": "capitalcity-mint-coinwright-topic-auto-2",
       "npcId": "mint-coinwright",
       "label": "💬 \"Every coin starts as a tumble of raw crystal.\"",
-      "treeId": "capitalcity-mint-coinwright-topic-auto-2"
+      "treeId": "capitalcity-mint-coinwright-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-mint-coinwright-topic-auto-3",
       "npcId": "mint-coinwright",
       "label": "💬 \"Sharp eyes, sharp reflexes, full purse.\"",
-      "treeId": "capitalcity-mint-coinwright-topic-auto-3"
+      "treeId": "capitalcity-mint-coinwright-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-guard-arena-master-topic-auto-1",
@@ -11939,13 +11990,15 @@
       "id": "capitalcity-guard-arena-master-topic-auto-2",
       "npcId": "guard-arena-master",
       "label": "💬 \"A quick battle to prove your mettle — no excuses.\"",
-      "treeId": "capitalcity-guard-arena-master-topic-auto-2"
+      "treeId": "capitalcity-guard-arena-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-guard-arena-master-topic-auto-3",
       "npcId": "guard-arena-master",
       "label": "💬 \"Win in the arena and the whole capital hears…\"",
-      "treeId": "capitalcity-guard-arena-master-topic-auto-3"
+      "treeId": "capitalcity-guard-arena-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-draft-master-crownhaven-topic-auto-1",
@@ -11957,13 +12010,15 @@
       "id": "capitalcity-draft-master-crownhaven-topic-auto-2",
       "npcId": "draft-master-crownhaven",
       "label": "💬 \"Pick your cards, traveller — eight choices…\"",
-      "treeId": "capitalcity-draft-master-crownhaven-topic-auto-2"
+      "treeId": "capitalcity-draft-master-crownhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-draft-master-crownhaven-topic-auto-3",
       "npcId": "draft-master-crownhaven",
       "label": "💬 \"Every draft is a new deck.\"",
-      "treeId": "capitalcity-draft-master-crownhaven-topic-auto-3"
+      "treeId": "capitalcity-draft-master-crownhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-riverside-angler-topic-auto-1",
@@ -11975,13 +12030,15 @@
       "id": "capitalcity-riverside-angler-topic-auto-2",
       "npcId": "riverside-angler",
       "label": "💬 \"Quiet water, quick catch.\"",
-      "treeId": "capitalcity-riverside-angler-topic-auto-2"
+      "treeId": "capitalcity-riverside-angler-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-riverside-angler-topic-auto-3",
       "npcId": "riverside-angler",
       "label": "💬 \"Catch enough and even the palace kitchens will…\"",
-      "treeId": "capitalcity-riverside-angler-topic-auto-3"
+      "treeId": "capitalcity-riverside-angler-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "capitalcity-theatre-impresario-topic-auto-1",
@@ -11993,13 +12050,15 @@
       "id": "capitalcity-theatre-impresario-topic-auto-2",
       "npcId": "theatre-impresario",
       "label": "💬 \"Step onto the stage and time your cues — the…\"",
-      "treeId": "capitalcity-theatre-impresario-topic-auto-2"
+      "treeId": "capitalcity-theatre-impresario-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "capitalcity-theatre-impresario-topic-auto-3",
       "npcId": "theatre-impresario",
       "label": "💬 \"Rehearsals, ropes, a thousand candles...\"",
-      "treeId": "capitalcity-theatre-impresario-topic-auto-3"
+      "treeId": "capitalcity-theatre-impresario-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/dreadspirecitadel/questDefs.json
+++ b/web/src/data/hub/dreadspirecitadel/questDefs.json
@@ -5176,7 +5176,8 @@
       "id": "dreadspirecitadel-vask-ward-topic-auto-2",
       "npcId": "vask-ward",
       "label": "💬 \"You keep coming back here.\"",
-      "treeId": "dreadspirecitadel-vask-ward-topic-auto-2"
+      "treeId": "dreadspirecitadel-vask-ward-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-the-castellan-topic-auto-1",
@@ -5188,13 +5189,15 @@
       "id": "dreadspirecitadel-the-castellan-topic-auto-2",
       "npcId": "the-castellan",
       "label": "💬 \"I maintain the citadel.\"",
-      "treeId": "dreadspirecitadel-the-castellan-topic-auto-2"
+      "treeId": "dreadspirecitadel-the-castellan-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-the-castellan-topic-auto-3",
       "npcId": "the-castellan",
       "label": "💬 \"The dark crystals that anchor these walls have…\"",
-      "treeId": "dreadspirecitadel-the-castellan-topic-auto-3"
+      "treeId": "dreadspirecitadel-the-castellan-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-bound-knight-topic-auto-1",
@@ -5206,13 +5209,15 @@
       "id": "dreadspirecitadel-bound-knight-topic-auto-2",
       "npcId": "bound-knight",
       "label": "💬 \"Death is a poor excuse for missing a shift here.\"",
-      "treeId": "dreadspirecitadel-bound-knight-topic-auto-2"
+      "treeId": "dreadspirecitadel-bound-knight-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-bound-knight-topic-auto-3",
       "npcId": "bound-knight",
       "label": "💬 \"If you mean the citadel harm, I must stop you.\"",
-      "treeId": "dreadspirecitadel-bound-knight-topic-auto-3"
+      "treeId": "dreadspirecitadel-bound-knight-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-warlock-vesska-topic-auto-1",
@@ -5224,13 +5229,15 @@
       "id": "dreadspirecitadel-warlock-vesska-topic-auto-2",
       "npcId": "warlock-vesska",
       "label": "💬 \"Four centuries of research and I have proven,…\"",
-      "treeId": "dreadspirecitadel-warlock-vesska-topic-auto-2"
+      "treeId": "dreadspirecitadel-warlock-vesska-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-warlock-vesska-topic-auto-3",
       "npcId": "warlock-vesska",
       "label": "💬 \"If Ordrin asks, I did NOT borrow his shadow-oil.\"",
-      "treeId": "dreadspirecitadel-warlock-vesska-topic-auto-3"
+      "treeId": "dreadspirecitadel-warlock-vesska-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-cultist-ordrin-topic-auto-1",
@@ -5242,13 +5249,15 @@
       "id": "dreadspirecitadel-cultist-ordrin-topic-auto-2",
       "npcId": "cultist-ordrin",
       "label": "💬 \"One bone dust, one measure of shadow-oil, one…\"",
-      "treeId": "dreadspirecitadel-cultist-ordrin-topic-auto-2"
+      "treeId": "dreadspirecitadel-cultist-ordrin-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-cultist-ordrin-topic-auto-3",
       "npcId": "cultist-ordrin",
       "label": "💬 \"Vesska took my shadow-oil.\"",
-      "treeId": "dreadspirecitadel-cultist-ordrin-topic-auto-3"
+      "treeId": "dreadspirecitadel-cultist-ordrin-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-bone-keeper-mald-topic-auto-1",
@@ -5260,13 +5269,15 @@
       "id": "dreadspirecitadel-bone-keeper-mald-topic-auto-2",
       "npcId": "bone-keeper-mald",
       "label": "💬 \"We had a thief.\"",
-      "treeId": "dreadspirecitadel-bone-keeper-mald-topic-auto-2"
+      "treeId": "dreadspirecitadel-bone-keeper-mald-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-bone-keeper-mald-topic-auto-3",
       "npcId": "bone-keeper-mald",
       "label": "💬 \"You want the deep ossuary?\"",
-      "treeId": "dreadspirecitadel-bone-keeper-mald-topic-auto-3"
+      "treeId": "dreadspirecitadel-bone-keeper-mald-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-shrine-tender-topic-auto-1",
@@ -5278,13 +5289,15 @@
       "id": "dreadspirecitadel-shrine-tender-topic-auto-2",
       "npcId": "shrine-tender",
       "label": "💬 \"Light no honest candles here.\"",
-      "treeId": "dreadspirecitadel-shrine-tender-topic-auto-2"
+      "treeId": "dreadspirecitadel-shrine-tender-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-shrine-tender-topic-auto-3",
       "npcId": "shrine-tender",
       "label": "💬 \"Pray if you like.\"",
-      "treeId": "dreadspirecitadel-shrine-tender-topic-auto-3"
+      "treeId": "dreadspirecitadel-shrine-tender-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-alchemist-sythe-topic-auto-1",
@@ -5296,13 +5309,15 @@
       "id": "dreadspirecitadel-alchemist-sythe-topic-auto-2",
       "npcId": "alchemist-sythe",
       "label": "💬 \"I need moon-herbs — proper ones, from…\"",
-      "treeId": "dreadspirecitadel-alchemist-sythe-topic-auto-2"
+      "treeId": "dreadspirecitadel-alchemist-sythe-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-alchemist-sythe-topic-auto-3",
       "npcId": "alchemist-sythe",
       "label": "💬 \"Touch nothing green.\"",
-      "treeId": "dreadspirecitadel-alchemist-sythe-topic-auto-3"
+      "treeId": "dreadspirecitadel-alchemist-sythe-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-raven-keeper-corvane-topic-auto-1",
@@ -5314,13 +5329,15 @@
       "id": "dreadspirecitadel-raven-keeper-corvane-topic-auto-2",
       "npcId": "raven-keeper-corvane",
       "label": "💬 \"Six ravens I keep, and six I count each dusk.\"",
-      "treeId": "dreadspirecitadel-raven-keeper-corvane-topic-auto-2"
+      "treeId": "dreadspirecitadel-raven-keeper-corvane-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-raven-keeper-corvane-topic-auto-3",
       "npcId": "raven-keeper-corvane",
       "label": "💬 \"They fly the whole citadel, my birds.\"",
-      "treeId": "dreadspirecitadel-raven-keeper-corvane-topic-auto-3"
+      "treeId": "dreadspirecitadel-raven-keeper-corvane-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-1",
@@ -5332,13 +5349,15 @@
       "id": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-2",
       "npcId": "dungeon-warden-gholl",
       "label": "💬 \"The lower vault stays sealed.\"",
-      "treeId": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-2"
+      "treeId": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-3",
       "npcId": "dungeon-warden-gholl",
       "label": "💬 \"If you've business in the deep cells, bring me…\"",
-      "treeId": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-3"
+      "treeId": "dreadspirecitadel-dungeon-warden-gholl-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-the-defector-topic-auto-1",
@@ -5350,13 +5369,15 @@
       "id": "dreadspirecitadel-the-defector-topic-auto-2",
       "npcId": "the-defector",
       "label": "💬 \"I served the master once.\"",
-      "treeId": "dreadspirecitadel-the-defector-topic-auto-2"
+      "treeId": "dreadspirecitadel-the-defector-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-the-defector-topic-auto-3",
       "npcId": "the-defector",
       "label": "💬 \"Get me out and I'll tell you what sleeps under…\"",
-      "treeId": "dreadspirecitadel-the-defector-topic-auto-3"
+      "treeId": "dreadspirecitadel-the-defector-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-ghost-servant-isolde-topic-auto-1",
@@ -5368,13 +5389,15 @@
       "id": "dreadspirecitadel-ghost-servant-isolde-topic-auto-2",
       "npcId": "ghost-servant-isolde",
       "label": "💬 \"I dropped the master's old keys somewhere on my…\"",
-      "treeId": "dreadspirecitadel-ghost-servant-isolde-topic-auto-2"
+      "treeId": "dreadspirecitadel-ghost-servant-isolde-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-ghost-servant-isolde-topic-auto-3",
       "npcId": "ghost-servant-isolde",
       "label": "💬 \"Mind the crypt door.\"",
-      "treeId": "dreadspirecitadel-ghost-servant-isolde-topic-auto-3"
+      "treeId": "dreadspirecitadel-ghost-servant-isolde-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-1",
@@ -5386,13 +5409,15 @@
       "id": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-2",
       "npcId": "grimoire-peddler-ashka",
       "label": "💬 \"The towers hoard their secrets.\"",
-      "treeId": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-2"
+      "treeId": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-3",
       "npcId": "grimoire-peddler-ashka",
       "label": "💬 \"One spell, properly cast, is worth a hundred…\"",
-      "treeId": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-3"
+      "treeId": "dreadspirecitadel-grimoire-peddler-ashka-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/gearford/questDefs.json
+++ b/web/src/data/hub/gearford/questDefs.json
@@ -4690,13 +4690,15 @@
       "id": "gearford-forgemaster-brunn-topic-auto-2",
       "npcId": "forgemaster-brunn",
       "label": "💬 \"Somebody's been lifting tools from the yard.\"",
-      "treeId": "gearford-forgemaster-brunn-topic-auto-2"
+      "treeId": "gearford-forgemaster-brunn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-forgemaster-brunn-topic-auto-3",
       "npcId": "forgemaster-brunn",
       "label": "💬 \"Hear that hammering?\"",
-      "treeId": "gearford-forgemaster-brunn-topic-auto-3"
+      "treeId": "gearford-forgemaster-brunn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-engineer-vela-topic-auto-1",
@@ -4708,13 +4710,15 @@
       "id": "gearford-engineer-vela-topic-auto-2",
       "npcId": "engineer-vela",
       "label": "💬 \"Every machine wants to work.\"",
-      "treeId": "gearford-engineer-vela-topic-auto-2"
+      "treeId": "gearford-engineer-vela-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-engineer-vela-topic-auto-3",
       "npcId": "engineer-vela",
       "label": "💬 \"The forge eats coal like a dragon eats...\"",
-      "treeId": "gearford-engineer-vela-topic-auto-3"
+      "treeId": "gearford-engineer-vela-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-foreman-dask-topic-auto-1",
@@ -4726,13 +4730,15 @@
       "id": "gearford-foreman-dask-topic-auto-2",
       "npcId": "foreman-dask",
       "label": "💬 \"Between the bandits on the toll road and the…\"",
-      "treeId": "gearford-foreman-dask-topic-auto-2"
+      "treeId": "gearford-foreman-dask-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-foreman-dask-topic-auto-3",
       "npcId": "foreman-dask",
       "label": "💬 \"You look sturdy.\"",
-      "treeId": "gearford-foreman-dask-topic-auto-3"
+      "treeId": "gearford-foreman-dask-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-apprentice-tila-topic-auto-1",
@@ -4744,13 +4750,15 @@
       "id": "gearford-apprentice-tila-topic-auto-2",
       "npcId": "apprentice-tila",
       "label": "💬 \"I dropped a whole tray of parts in the yard…\"",
-      "treeId": "gearford-apprentice-tila-topic-auto-2"
+      "treeId": "gearford-apprentice-tila-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-apprentice-tila-topic-auto-3",
       "npcId": "apprentice-tila",
       "label": "💬 \"One day I'll forge a blade so fine they'll sing…\"",
-      "treeId": "gearford-apprentice-tila-topic-auto-3"
+      "treeId": "gearford-apprentice-tila-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-gearwright-orin-topic-auto-1",
@@ -4762,13 +4770,15 @@
       "id": "gearford-gearwright-orin-topic-auto-2",
       "npcId": "gearwright-orin",
       "label": "💬 \"Ravenwatch sent word: their gaol lock's jammed…\"",
-      "treeId": "gearford-gearwright-orin-topic-auto-2"
+      "treeId": "gearford-gearwright-orin-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-gearwright-orin-topic-auto-3",
       "npcId": "gearwright-orin",
       "label": "💬 \"Bring me good iron and I'll cut you a key…\"",
-      "treeId": "gearford-gearwright-orin-topic-auto-3"
+      "treeId": "gearford-gearwright-orin-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-coal-hauler-bram-topic-auto-1",
@@ -4780,13 +4790,15 @@
       "id": "gearford-coal-hauler-bram-topic-auto-2",
       "npcId": "coal-hauler-bram",
       "label": "💬 \"The old depot south of town's still half-full.\"",
-      "treeId": "gearford-coal-hauler-bram-topic-auto-2"
+      "treeId": "gearford-coal-hauler-bram-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-coal-hauler-bram-topic-auto-3",
       "npcId": "coal-hauler-bram",
       "label": "💬 \"A full barrow and an empty road.\"",
-      "treeId": "gearford-coal-hauler-bram-topic-auto-3"
+      "treeId": "gearford-coal-hauler-bram-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-innkeep-mags-topic-auto-1",
@@ -4798,13 +4810,15 @@
       "id": "gearford-innkeep-mags-topic-auto-2",
       "npcId": "innkeep-mags",
       "label": "💬 \"Miners drink like the mine's about to close.\"",
-      "treeId": "gearford-innkeep-mags-topic-auto-2"
+      "treeId": "gearford-innkeep-mags-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-innkeep-mags-topic-auto-3",
       "npcId": "innkeep-mags",
       "label": "💬 \"Rats in my store again.\"",
-      "treeId": "gearford-innkeep-mags-topic-auto-3"
+      "treeId": "gearford-innkeep-mags-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-miner-jole-topic-auto-1",
@@ -4816,13 +4830,15 @@
       "id": "gearford-miner-jole-topic-auto-2",
       "npcId": "miner-jole",
       "label": "💬 \"Lost my good lamp in the west drift.\"",
-      "treeId": "gearford-miner-jole-topic-auto-2"
+      "treeId": "gearford-miner-jole-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-miner-jole-topic-auto-3",
       "npcId": "miner-jole",
       "label": "💬 \"The ore's rich this season.\"",
-      "treeId": "gearford-miner-jole-topic-auto-3"
+      "treeId": "gearford-miner-jole-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-quartermaster-rell-topic-auto-1",
@@ -4834,13 +4850,15 @@
       "id": "gearford-quartermaster-rell-topic-auto-2",
       "npcId": "quartermaster-rell",
       "label": "💬 \"Half the stores went walkabout in the last…\"",
-      "treeId": "gearford-quartermaster-rell-topic-auto-2"
+      "treeId": "gearford-quartermaster-rell-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-quartermaster-rell-topic-auto-3",
       "npcId": "quartermaster-rell",
       "label": "💬 \"Order is the only ore that never runs dry.\"",
-      "treeId": "gearford-quartermaster-rell-topic-auto-3"
+      "treeId": "gearford-quartermaster-rell-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-pumpwright-edda-topic-auto-1",
@@ -4852,13 +4870,15 @@
       "id": "gearford-pumpwright-edda-topic-auto-2",
       "npcId": "pumpwright-edda",
       "label": "💬 \"A valve's seized and a flywheel's cracked.\"",
-      "treeId": "gearford-pumpwright-edda-topic-auto-2"
+      "treeId": "gearford-pumpwright-edda-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-pumpwright-edda-topic-auto-3",
       "npcId": "pumpwright-edda",
       "label": "💬 \"Keep her turning and Gearford breathes.\"",
-      "treeId": "gearford-pumpwright-edda-topic-auto-3"
+      "treeId": "gearford-pumpwright-edda-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-engineer-torvald-topic-auto-1",
@@ -4870,13 +4890,15 @@
       "id": "gearford-engineer-torvald-topic-auto-2",
       "npcId": "engineer-torvald",
       "label": "💬 \"Half of Gearford's collapsed twice over.\"",
-      "treeId": "gearford-engineer-torvald-topic-auto-2"
+      "treeId": "gearford-engineer-torvald-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-engineer-torvald-topic-auto-3",
       "npcId": "engineer-torvald",
       "label": "💬 \"You don't build a keep in a day.\"",
-      "treeId": "gearford-engineer-torvald-topic-auto-3"
+      "treeId": "gearford-engineer-torvald-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gearford-sergeant-coldiron-topic-auto-1",
@@ -4888,13 +4910,15 @@
       "id": "gearford-sergeant-coldiron-topic-auto-2",
       "npcId": "sergeant-coldiron",
       "label": "💬 \"A war's won by whoever counts their troops…\"",
-      "treeId": "gearford-sergeant-coldiron-topic-auto-2"
+      "treeId": "gearford-sergeant-coldiron-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gearford-sergeant-coldiron-topic-auto-3",
       "npcId": "sergeant-coldiron",
       "label": "💬 \"Gear's cheap.\"",
-      "treeId": "gearford-sergeant-coldiron-topic-auto-3"
+      "treeId": "gearford-sergeant-coldiron-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/gravemoor/questDefs.json
+++ b/web/src/data/hub/gravemoor/questDefs.json
@@ -3695,13 +3695,15 @@
       "id": "gravemoor-ghost-mayor-aldous-topic-auto-2",
       "npcId": "ghost-mayor-aldous",
       "label": "💬 \"I was mayor when I died and nobody's run…\"",
-      "treeId": "gravemoor-ghost-mayor-aldous-topic-auto-2"
+      "treeId": "gravemoor-ghost-mayor-aldous-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-ghost-mayor-aldous-topic-auto-3",
       "npcId": "ghost-mayor-aldous",
       "label": "💬 \"We're dead, not rude.\"",
-      "treeId": "gravemoor-ghost-mayor-aldous-topic-auto-3"
+      "treeId": "gravemoor-ghost-mayor-aldous-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-restless-merchant-mora-topic-auto-1",
@@ -3713,13 +3715,15 @@
       "id": "gravemoor-restless-merchant-mora-topic-auto-2",
       "npcId": "restless-merchant-mora",
       "label": "💬 \"Money means little to the dead, but haggling?\"",
-      "treeId": "gravemoor-restless-merchant-mora-topic-auto-2"
+      "treeId": "gravemoor-restless-merchant-mora-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-restless-merchant-mora-topic-auto-3",
       "npcId": "restless-merchant-mora",
       "label": "💬 \"The blight took the town, but it couldn't take…\"",
-      "treeId": "gravemoor-restless-merchant-mora-topic-auto-3"
+      "treeId": "gravemoor-restless-merchant-mora-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-grave-keeper-finch-topic-auto-1",
@@ -3731,13 +3735,15 @@
       "id": "gravemoor-grave-keeper-finch-topic-auto-2",
       "npcId": "grave-keeper-finch",
       "label": "💬 \"Some of my neighbours' remains have been...\"",
-      "treeId": "gravemoor-grave-keeper-finch-topic-auto-2"
+      "treeId": "gravemoor-grave-keeper-finch-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-grave-keeper-finch-topic-auto-3",
       "npcId": "grave-keeper-finch",
       "label": "💬 \"The dead sleep better when everything's where…\"",
-      "treeId": "gravemoor-grave-keeper-finch-topic-auto-3"
+      "treeId": "gravemoor-grave-keeper-finch-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-gravedigger-hollis-topic-auto-1",
@@ -3749,13 +3755,15 @@
       "id": "gravemoor-gravedigger-hollis-topic-auto-2",
       "npcId": "gravedigger-hollis",
       "label": "💬 \"The dead are good company.\"",
-      "treeId": "gravemoor-gravedigger-hollis-topic-auto-2"
+      "treeId": "gravemoor-gravedigger-hollis-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-gravedigger-hollis-topic-auto-3",
       "npcId": "gravedigger-hollis",
       "label": "💬 \"Mind the soft ground by the new plots.\"",
-      "treeId": "gravemoor-gravedigger-hollis-topic-auto-3"
+      "treeId": "gravemoor-gravedigger-hollis-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-weeping-widow-topic-auto-1",
@@ -3767,13 +3775,15 @@
       "id": "gravemoor-weeping-widow-topic-auto-2",
       "npcId": "weeping-widow",
       "label": "💬 \"I drift these woods every night.\"",
-      "treeId": "gravemoor-weeping-widow-topic-auto-2"
+      "treeId": "gravemoor-weeping-widow-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-weeping-widow-topic-auto-3",
       "npcId": "weeping-widow",
       "label": "💬 \"Kindness to the dead is never wasted.\"",
-      "treeId": "gravemoor-weeping-widow-topic-auto-3"
+      "treeId": "gravemoor-weeping-widow-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-restless-soldier-topic-auto-1",
@@ -3785,13 +3795,15 @@
       "id": "gravemoor-restless-soldier-topic-auto-2",
       "npcId": "restless-soldier",
       "label": "💬 \"Lost my orders in the rout.\"",
-      "treeId": "gravemoor-restless-soldier-topic-auto-2"
+      "treeId": "gravemoor-restless-soldier-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-restless-soldier-topic-auto-3",
       "npcId": "restless-soldier",
       "label": "💬 \"Find my commission papers and maybe — maybe — I…\"",
-      "treeId": "gravemoor-restless-soldier-topic-auto-3"
+      "treeId": "gravemoor-restless-soldier-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-spectral-pedlar-topic-auto-1",
@@ -3803,13 +3815,15 @@
       "id": "gravemoor-spectral-pedlar-topic-auto-2",
       "npcId": "spectral-pedlar",
       "label": "💬 \"I sold trinkets in life and I sell them still.\"",
-      "treeId": "gravemoor-spectral-pedlar-topic-auto-2"
+      "treeId": "gravemoor-spectral-pedlar-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-spectral-pedlar-topic-auto-3",
       "npcId": "spectral-pedlar",
       "label": "💬 \"My stock's gone walkabout among the graves.\"",
-      "treeId": "gravemoor-spectral-pedlar-topic-auto-3"
+      "treeId": "gravemoor-spectral-pedlar-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-little-pip-topic-auto-1",
@@ -3821,13 +3835,15 @@
       "id": "gravemoor-little-pip-topic-auto-2",
       "npcId": "little-pip",
       "label": "💬 \"I'm not scared.\"",
-      "treeId": "gravemoor-little-pip-topic-auto-2"
+      "treeId": "gravemoor-little-pip-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-little-pip-topic-auto-3",
       "npcId": "little-pip",
       "label": "💬 \"She had a sad face and a long grey dress.\"",
-      "treeId": "gravemoor-little-pip-topic-auto-3"
+      "treeId": "gravemoor-little-pip-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "gravemoor-brother-mortis-topic-auto-1",
@@ -3839,13 +3855,15 @@
       "id": "gravemoor-brother-mortis-topic-auto-2",
       "npcId": "brother-mortis",
       "label": "💬 \"The bell tolls at midnight.\"",
-      "treeId": "gravemoor-brother-mortis-topic-auto-2"
+      "treeId": "gravemoor-brother-mortis-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "gravemoor-brother-mortis-topic-auto-3",
       "npcId": "brother-mortis",
       "label": "💬 \"If you would unravel the mystery of the…\"",
-      "treeId": "gravemoor-brother-mortis-topic-auto-3"
+      "treeId": "gravemoor-brother-mortis-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/harrowfield/questDefs.json
+++ b/web/src/data/hub/harrowfield/questDefs.json
@@ -3767,13 +3767,15 @@
       "id": "harrowfield-elder-maeve-topic-auto-2",
       "npcId": "elder-maeve",
       "label": "💬 \"The scarecrows have been...\"",
-      "treeId": "harrowfield-elder-maeve-topic-auto-2"
+      "treeId": "harrowfield-elder-maeve-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-elder-maeve-topic-auto-3",
       "npcId": "elder-maeve",
       "label": "💬 \"Stay for the harvest supper if you can.\"",
-      "treeId": "harrowfield-elder-maeve-topic-auto-3"
+      "treeId": "harrowfield-elder-maeve-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-farmhand-pip-topic-auto-1",
@@ -3785,13 +3787,15 @@
       "id": "harrowfield-farmhand-pip-topic-auto-2",
       "npcId": "farmhand-pip",
       "label": "💬 \"Three seed-grain sacks have gone missing.\"",
-      "treeId": "harrowfield-farmhand-pip-topic-auto-2"
+      "treeId": "harrowfield-farmhand-pip-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-farmhand-pip-topic-auto-3",
       "npcId": "farmhand-pip",
       "label": "💬 \"The scarecrow moved again last night.\"",
-      "treeId": "harrowfield-farmhand-pip-topic-auto-3"
+      "treeId": "harrowfield-farmhand-pip-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-miller-rook-topic-auto-1",
@@ -3803,13 +3807,15 @@
       "id": "harrowfield-miller-rook-topic-auto-2",
       "npcId": "miller-rook",
       "label": "💬 \"The road south to the capital used to be safe.\"",
-      "treeId": "harrowfield-miller-rook-topic-auto-2"
+      "treeId": "harrowfield-miller-rook-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-miller-rook-topic-auto-3",
       "npcId": "miller-rook",
       "label": "💬 \"Bring me grain and the stones will sing.\"",
-      "treeId": "harrowfield-miller-rook-topic-auto-3"
+      "treeId": "harrowfield-miller-rook-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-shepherd-nan-topic-auto-1",
@@ -3821,13 +3827,15 @@
       "id": "harrowfield-shepherd-nan-topic-auto-2",
       "npcId": "shepherd-nan",
       "label": "💬 \"Floss keeps the flock, but she can't mend a…\"",
-      "treeId": "harrowfield-shepherd-nan-topic-auto-2"
+      "treeId": "harrowfield-shepherd-nan-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-shepherd-nan-topic-auto-3",
       "npcId": "shepherd-nan",
       "label": "💬 \"Wool to the market, mutton never if I can help…\"",
-      "treeId": "harrowfield-shepherd-nan-topic-auto-3"
+      "treeId": "harrowfield-shepherd-nan-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-baker-tovi-topic-auto-1",
@@ -3839,13 +3847,15 @@
       "id": "harrowfield-baker-tovi-topic-auto-2",
       "npcId": "baker-tovi",
       "label": "💬 \"Rook's flour, Maeve's blessing, my oven.\"",
-      "treeId": "harrowfield-baker-tovi-topic-auto-2"
+      "treeId": "harrowfield-baker-tovi-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-baker-tovi-topic-auto-3",
       "npcId": "baker-tovi",
       "label": "💬 \"Bring me what I need and I'll see the supper…\"",
-      "treeId": "harrowfield-baker-tovi-topic-auto-3"
+      "treeId": "harrowfield-baker-tovi-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-miller-wife-lark-topic-auto-1",
@@ -3857,13 +3867,15 @@
       "id": "harrowfield-miller-wife-lark-topic-auto-2",
       "npcId": "miller-wife-lark",
       "label": "💬 \"Wash day and the linens have gone clean over…\"",
-      "treeId": "harrowfield-miller-wife-lark-topic-auto-2"
+      "treeId": "harrowfield-miller-wife-lark-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-miller-wife-lark-topic-auto-3",
       "npcId": "miller-wife-lark",
       "label": "💬 \"Mind the lane — the cart ruts'll have your…\"",
-      "treeId": "harrowfield-miller-wife-lark-topic-auto-3"
+      "treeId": "harrowfield-miller-wife-lark-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-pedlar-quill-topic-auto-1",
@@ -3875,13 +3887,15 @@
       "id": "harrowfield-pedlar-quill-topic-auto-2",
       "npcId": "pedlar-quill",
       "label": "💬 \"Ravenwatch pays well for good country produce.\"",
-      "treeId": "harrowfield-pedlar-quill-topic-auto-2"
+      "treeId": "harrowfield-pedlar-quill-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-pedlar-quill-topic-auto-3",
       "npcId": "pedlar-quill",
       "label": "💬 \"Buy in the field, sell at the gate.\"",
-      "treeId": "harrowfield-pedlar-quill-topic-auto-3"
+      "treeId": "harrowfield-pedlar-quill-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-warden-bell-topic-auto-1",
@@ -3893,13 +3907,15 @@
       "id": "harrowfield-warden-bell-topic-auto-2",
       "npcId": "warden-bell",
       "label": "💬 \"We bless the first sheaf and the last loaf.\"",
-      "treeId": "harrowfield-warden-bell-topic-auto-2"
+      "treeId": "harrowfield-warden-bell-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-warden-bell-topic-auto-3",
       "npcId": "warden-bell",
       "label": "💬 \"Quiet hands and full barns.\"",
-      "treeId": "harrowfield-warden-bell-topic-auto-3"
+      "treeId": "harrowfield-warden-bell-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "harrowfield-child-bram-topic-auto-1",
@@ -3911,13 +3927,15 @@
       "id": "harrowfield-child-bram-topic-auto-2",
       "npcId": "child-bram",
       "label": "💬 \"I lost my things running from the moving…\"",
-      "treeId": "harrowfield-child-bram-topic-auto-2"
+      "treeId": "harrowfield-child-bram-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "harrowfield-child-bram-topic-auto-3",
       "npcId": "child-bram",
       "label": "💬 \"When I grow up I'm going to drive the cart all…\"",
-      "treeId": "harrowfield-child-bram-topic-auto-3"
+      "treeId": "harrowfield-child-bram-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/hollowmere/questDefs.json
+++ b/web/src/data/hub/hollowmere/questDefs.json
@@ -3280,7 +3280,8 @@
       "id": "hollowmere-pilgrim-darkwood-topic-auto-2",
       "npcId": "pilgrim-darkwood",
       "label": "💬 \"You've walked through a seam or two yourself, I…\"",
-      "treeId": "hollowmere-pilgrim-darkwood-topic-auto-2"
+      "treeId": "hollowmere-pilgrim-darkwood-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-ogrim-the-bouncer-topic-auto-1",
@@ -3292,13 +3293,15 @@
       "id": "hollowmere-ogrim-the-bouncer-topic-auto-2",
       "npcId": "ogrim-the-bouncer",
       "label": "💬 \"You smell like a hero.\"",
-      "treeId": "hollowmere-ogrim-the-bouncer-topic-auto-2"
+      "treeId": "hollowmere-ogrim-the-bouncer-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-ogrim-the-bouncer-topic-auto-3",
       "npcId": "ogrim-the-bouncer",
       "label": "💬 \"We're monsters, not animals.\"",
-      "treeId": "hollowmere-ogrim-the-bouncer-topic-auto-3"
+      "treeId": "hollowmere-ogrim-the-bouncer-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-fang-the-fence-topic-auto-1",
@@ -3310,13 +3313,15 @@
       "id": "hollowmere-fang-the-fence-topic-auto-2",
       "npcId": "fang-the-fence",
       "label": "💬 \"The undead up at Gravemoor are lovely neighbours.\"",
-      "treeId": "hollowmere-fang-the-fence-topic-auto-2"
+      "treeId": "hollowmere-fang-the-fence-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-fang-the-fence-topic-auto-3",
       "npcId": "fang-the-fence",
       "label": "💬 \"Everything here fell off a cart.\"",
-      "treeId": "hollowmere-fang-the-fence-topic-auto-3"
+      "treeId": "hollowmere-fang-the-fence-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-hedge-witch-morwen-topic-auto-1",
@@ -3328,13 +3333,15 @@
       "id": "hollowmere-hedge-witch-morwen-topic-auto-2",
       "npcId": "hedge-witch-morwen",
       "label": "💬 \"Hollowmere takes in what other towns turn away.\"",
-      "treeId": "hollowmere-hedge-witch-morwen-topic-auto-2"
+      "treeId": "hollowmere-hedge-witch-morwen-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-hedge-witch-morwen-topic-auto-3",
       "npcId": "hedge-witch-morwen",
       "label": "💬 \"Don't touch the bottles.\"",
-      "treeId": "hollowmere-hedge-witch-morwen-topic-auto-3"
+      "treeId": "hollowmere-hedge-witch-morwen-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-apothecary-herbalist-topic-auto-1",
@@ -3346,13 +3353,15 @@
       "id": "hollowmere-apothecary-herbalist-topic-auto-2",
       "npcId": "apothecary-herbalist",
       "label": "💬 \"A swamp is just an apothecary that hasn't been…\"",
-      "treeId": "hollowmere-apothecary-herbalist-topic-auto-2"
+      "treeId": "hollowmere-apothecary-herbalist-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-apothecary-herbalist-topic-auto-3",
       "npcId": "apothecary-herbalist",
       "label": "💬 \"Morwen brews the showy stuff.\"",
-      "treeId": "hollowmere-apothecary-herbalist-topic-auto-3"
+      "treeId": "hollowmere-apothecary-herbalist-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-goblin-curio-keep-topic-auto-1",
@@ -3364,13 +3373,15 @@
       "id": "hollowmere-goblin-curio-keep-topic-auto-2",
       "npcId": "goblin-curio-keep",
       "label": "💬 \"One monster's rubbish is another monster's…\"",
-      "treeId": "hollowmere-goblin-curio-keep-topic-auto-2"
+      "treeId": "hollowmere-goblin-curio-keep-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-goblin-curio-keep-topic-auto-3",
       "npcId": "goblin-curio-keep",
       "label": "💬 \"You break the merchandise, you marry the…\"",
-      "treeId": "hollowmere-goblin-curio-keep-topic-auto-3"
+      "treeId": "hollowmere-goblin-curio-keep-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-bog-troll-attendant-topic-auto-1",
@@ -3382,13 +3393,15 @@
       "id": "hollowmere-bog-troll-attendant-topic-auto-2",
       "npcId": "bog-troll-attendant",
       "label": "💬 \"A troll without a good wallow is just a grumpy…\"",
-      "treeId": "hollowmere-bog-troll-attendant-topic-auto-2"
+      "treeId": "hollowmere-bog-troll-attendant-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-bog-troll-attendant-topic-auto-3",
       "npcId": "bog-troll-attendant",
       "label": "💬 \"First soak's on the house.\"",
-      "treeId": "hollowmere-bog-troll-attendant-topic-auto-3"
+      "treeId": "hollowmere-bog-troll-attendant-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-tame-ogre-keeper-topic-auto-1",
@@ -3400,13 +3413,15 @@
       "id": "hollowmere-tame-ogre-keeper-topic-auto-2",
       "npcId": "tame-ogre-keeper",
       "label": "💬 \"Folk think monsters can't be kind.\"",
-      "treeId": "hollowmere-tame-ogre-keeper-topic-auto-2"
+      "treeId": "hollowmere-tame-ogre-keeper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-tame-ogre-keeper-topic-auto-3",
       "npcId": "tame-ogre-keeper",
       "label": "💬 \"You want to learn beast-taming?\"",
-      "treeId": "hollowmere-tame-ogre-keeper-topic-auto-3"
+      "treeId": "hollowmere-tame-ogre-keeper-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "hollowmere-swamp-hag-topic-auto-1",
@@ -3418,13 +3433,15 @@
       "id": "hollowmere-swamp-hag-topic-auto-2",
       "npcId": "swamp-hag",
       "label": "💬 \"Lost your way?\"",
-      "treeId": "hollowmere-swamp-hag-topic-auto-2"
+      "treeId": "hollowmere-swamp-hag-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "hollowmere-swamp-hag-topic-auto-3",
       "npcId": "swamp-hag",
       "label": "💬 \"I've sat in this bog longer than your town's…\"",
-      "treeId": "hollowmere-swamp-hag-topic-auto-3"
+      "treeId": "hollowmere-swamp-hag-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -6448,13 +6448,15 @@
       "id": "ironholdkeep-castle-cartographer-topic-auto-2",
       "npcId": "castle-cartographer",
       "label": "💬 \"I've surveyed this border three times.\"",
-      "treeId": "ironholdkeep-castle-cartographer-topic-auto-2"
+      "treeId": "ironholdkeep-castle-cartographer-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-cartographer-topic-auto-3",
       "npcId": "castle-cartographer",
       "label": "💬 \"A cartographer draws what is there.\"",
-      "treeId": "ironholdkeep-castle-cartographer-topic-auto-3"
+      "treeId": "ironholdkeep-castle-cartographer-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-commander-topic-auto-1",
@@ -6466,13 +6468,15 @@
       "id": "ironholdkeep-castle-commander-topic-auto-2",
       "npcId": "castle-commander",
       "label": "💬 \"The patrol routes have been compromised.\"",
-      "treeId": "ironholdkeep-castle-commander-topic-auto-2"
+      "treeId": "ironholdkeep-castle-commander-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-commander-topic-auto-3",
       "npcId": "castle-commander",
       "label": "💬 \"You fight well, traveller.\"",
-      "treeId": "ironholdkeep-castle-commander-topic-auto-3"
+      "treeId": "ironholdkeep-castle-commander-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-guard-master-topic-auto-1",
@@ -6484,13 +6488,15 @@
       "id": "ironholdkeep-castle-guard-master-topic-auto-2",
       "npcId": "castle-guard-master",
       "label": "💬 \"Every soldier here answers to me before they…\"",
-      "treeId": "ironholdkeep-castle-guard-master-topic-auto-2"
+      "treeId": "ironholdkeep-castle-guard-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-guard-master-topic-auto-3",
       "npcId": "castle-guard-master",
       "label": "💬 \"Stand a watch with us sometime, traveller.\"",
-      "treeId": "ironholdkeep-castle-guard-master-topic-auto-3"
+      "treeId": "ironholdkeep-castle-guard-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-blacksmith-topic-auto-1",
@@ -6502,13 +6508,15 @@
       "id": "ironholdkeep-castle-blacksmith-topic-auto-2",
       "npcId": "castle-blacksmith",
       "label": "💬 \"The weapon crates haven't been accounted for…\"",
-      "treeId": "ironholdkeep-castle-blacksmith-topic-auto-2"
+      "treeId": "ironholdkeep-castle-blacksmith-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-blacksmith-topic-auto-3",
       "npcId": "castle-blacksmith",
       "label": "💬 \"Iron doesn't lie — only men do.\"",
-      "treeId": "ironholdkeep-castle-blacksmith-topic-auto-3"
+      "treeId": "ironholdkeep-castle-blacksmith-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-quartermaster-topic-auto-1",
@@ -6520,13 +6528,15 @@
       "id": "ironholdkeep-castle-quartermaster-topic-auto-2",
       "npcId": "castle-quartermaster",
       "label": "💬 \"Grain, iron, arrows, salt — a castle eats as…\"",
-      "treeId": "ironholdkeep-castle-quartermaster-topic-auto-2"
+      "treeId": "ironholdkeep-castle-quartermaster-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-quartermaster-topic-auto-3",
       "npcId": "castle-quartermaster",
       "label": "💬 \"If you're after supplies, mind you sign for them.\"",
-      "treeId": "ironholdkeep-castle-quartermaster-topic-auto-3"
+      "treeId": "ironholdkeep-castle-quartermaster-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-cook-topic-auto-1",
@@ -6538,13 +6548,15 @@
       "id": "ironholdkeep-castle-cook-topic-auto-2",
       "npcId": "castle-cook",
       "label": "💬 \"Get out of my kitchen unless you're bringing me…\"",
-      "treeId": "ironholdkeep-castle-cook-topic-auto-2"
+      "treeId": "ironholdkeep-castle-cook-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-cook-topic-auto-3",
       "npcId": "castle-cook",
       "label": "💬 \"There's stew on the hearth if the guards have…\"",
-      "treeId": "ironholdkeep-castle-cook-topic-auto-3"
+      "treeId": "ironholdkeep-castle-cook-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-chaplain-topic-auto-1",
@@ -6556,13 +6568,15 @@
       "id": "ironholdkeep-castle-chaplain-topic-auto-2",
       "npcId": "castle-chaplain",
       "label": "💬 \"The crypt below holds the lords of Ironhold,…\"",
-      "treeId": "ironholdkeep-castle-chaplain-topic-auto-2"
+      "treeId": "ironholdkeep-castle-chaplain-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-chaplain-topic-auto-3",
       "npcId": "castle-chaplain",
       "label": "💬 \"Light a candle for the fallen.\"",
-      "treeId": "ironholdkeep-castle-chaplain-topic-auto-3"
+      "treeId": "ironholdkeep-castle-chaplain-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-archivist-topic-auto-1",
@@ -6574,13 +6588,15 @@
       "id": "ironholdkeep-castle-archivist-topic-auto-2",
       "npcId": "castle-archivist",
       "label": "💬 \"A siege chronicle was separated from the…\"",
-      "treeId": "ironholdkeep-castle-archivist-topic-auto-2"
+      "treeId": "ironholdkeep-castle-archivist-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-archivist-topic-auto-3",
       "npcId": "castle-archivist",
       "label": "💬 \"History is the only weapon that never dulls.\"",
-      "treeId": "ironholdkeep-castle-archivist-topic-auto-3"
+      "treeId": "ironholdkeep-castle-archivist-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-stablehand-topic-auto-1",
@@ -6592,13 +6608,15 @@
       "id": "ironholdkeep-castle-stablehand-topic-auto-2",
       "npcId": "castle-stablehand",
       "label": "💬 \"Mind where you step — a war horse spooks at…\"",
-      "treeId": "ironholdkeep-castle-stablehand-topic-auto-2"
+      "treeId": "ironholdkeep-castle-stablehand-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-stablehand-topic-auto-3",
       "npcId": "castle-stablehand",
       "label": "💬 \"If you ride out, I'll have a mount saddled…\"",
-      "treeId": "ironholdkeep-castle-stablehand-topic-auto-3"
+      "treeId": "ironholdkeep-castle-stablehand-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-knight-topic-auto-1",
@@ -6610,13 +6628,15 @@
       "id": "ironholdkeep-castle-knight-topic-auto-2",
       "npcId": "castle-knight",
       "label": "💬 \"A knight without a cause is just a man in…\"",
-      "treeId": "ironholdkeep-castle-knight-topic-auto-2"
+      "treeId": "ironholdkeep-castle-knight-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-knight-topic-auto-3",
       "npcId": "castle-knight",
       "label": "💬 \"The Guard-Master sets the rotation.\"",
-      "treeId": "ironholdkeep-castle-knight-topic-auto-3"
+      "treeId": "ironholdkeep-castle-knight-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-squire-topic-auto-1",
@@ -6628,13 +6648,15 @@
       "id": "ironholdkeep-castle-squire-topic-auto-2",
       "npcId": "castle-squire",
       "label": "💬 \"Sir Garrick says I've a good arm.\"",
-      "treeId": "ironholdkeep-castle-squire-topic-auto-2"
+      "treeId": "ironholdkeep-castle-squire-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-squire-topic-auto-3",
       "npcId": "castle-squire",
       "label": "💬 \"I dropped a training sword somewhere out here.\"",
-      "treeId": "ironholdkeep-castle-squire-topic-auto-3"
+      "treeId": "ironholdkeep-castle-squire-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-gatekeeper-topic-auto-1",
@@ -6646,13 +6668,15 @@
       "id": "ironholdkeep-castle-gatekeeper-topic-auto-2",
       "npcId": "castle-gatekeeper",
       "label": "💬 \"State your business at the gate or state it…\"",
-      "treeId": "ironholdkeep-castle-gatekeeper-topic-auto-2"
+      "treeId": "ironholdkeep-castle-gatekeeper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-gatekeeper-topic-auto-3",
       "npcId": "castle-gatekeeper",
       "label": "💬 \"Safe roads, traveller.\"",
-      "treeId": "ironholdkeep-castle-gatekeeper-topic-auto-3"
+      "treeId": "ironholdkeep-castle-gatekeeper-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-prisoner-topic-auto-1",
@@ -6664,13 +6688,15 @@
       "id": "ironholdkeep-castle-prisoner-topic-auto-2",
       "npcId": "castle-prisoner",
       "label": "💬 \"I know things about this keep that would turn…\"",
-      "treeId": "ironholdkeep-castle-prisoner-topic-auto-2"
+      "treeId": "ironholdkeep-castle-prisoner-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-prisoner-topic-auto-3",
       "npcId": "castle-prisoner",
       "label": "💬 \"Help me prove my innocence and the secret of…\"",
-      "treeId": "ironholdkeep-castle-prisoner-topic-auto-3"
+      "treeId": "ironholdkeep-castle-prisoner-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-guard-1-topic-auto-1",
@@ -6682,13 +6708,15 @@
       "id": "ironholdkeep-castle-guard-1-topic-auto-2",
       "npcId": "castle-guard-1",
       "label": "💬 \"Three of us dropped our patrol papers during…\"",
-      "treeId": "ironholdkeep-castle-guard-1-topic-auto-2"
+      "treeId": "ironholdkeep-castle-guard-1-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-guard-1-topic-auto-3",
       "npcId": "castle-guard-1",
       "label": "💬 \"The south gate is yours to use, traveller.\"",
-      "treeId": "ironholdkeep-castle-guard-1-topic-auto-3"
+      "treeId": "ironholdkeep-castle-guard-1-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ironholdkeep-castle-guard-2-topic-auto-1",
@@ -6700,13 +6728,15 @@
       "id": "ironholdkeep-castle-guard-2-topic-auto-2",
       "npcId": "castle-guard-2",
       "label": "💬 \"I lost my patrol report somewhere out in the…\"",
-      "treeId": "ironholdkeep-castle-guard-2-topic-auto-2"
+      "treeId": "ironholdkeep-castle-guard-2-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ironholdkeep-castle-guard-2-topic-auto-3",
       "npcId": "castle-guard-2",
       "label": "💬 \"Ironhold has never fallen.\"",
-      "treeId": "ironholdkeep-castle-guard-2-topic-auto-3"
+      "treeId": "ironholdkeep-castle-guard-2-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/loader.test.ts
+++ b/web/src/data/hub/loader.test.ts
@@ -206,6 +206,17 @@ describe('conversation topics parsing', () => {
     expect(topic.label).toBe('🕯️ Ask about the missing pendant')
     expect(topic.treeId).toBe('elder-topic-pendant')
   })
+
+  it('preserves an optional requireFriendshipLevel, and omits it when absent', () => {
+    const bundle = createHubQuestData(minimalQuestConfig({
+      conversationTopics: [
+        { id: 'topic-a', npcId: 'elder', label: 'A', treeId: 'topic-a' },
+        { id: 'topic-b', npcId: 'elder', label: 'B', treeId: 'topic-b', requireFriendshipLevel: 2 },
+      ],
+    }))
+    expect(bundle.HUB_CONVERSATION_TOPICS['topic-a'].requireFriendshipLevel).toBeUndefined()
+    expect(bundle.HUB_CONVERSATION_TOPICS['topic-b'].requireFriendshipLevel).toBe(2)
+  })
 })
 
 describe('ravenwatch config', () => {

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -5520,13 +5520,15 @@
       "id": "millhaven-mill-owner-topic-auto-2",
       "npcId": "mill-owner",
       "label": "💬 \"Three grain sacks went missing from the store.\"",
-      "treeId": "millhaven-mill-owner-topic-auto-2"
+      "treeId": "millhaven-mill-owner-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-mill-owner-topic-auto-3",
       "npcId": "mill-owner",
       "label": "💬 \"If you find those sacks, I'll remember the…\"",
-      "treeId": "millhaven-mill-owner-topic-auto-3"
+      "treeId": "millhaven-mill-owner-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-fishmonger-marta-topic-auto-1",
@@ -5538,13 +5540,15 @@
       "id": "millhaven-fishmonger-marta-topic-auto-2",
       "npcId": "fishmonger-marta",
       "label": "💬 \"I've got fish baskets missing somewhere around…\"",
-      "treeId": "millhaven-fishmonger-marta-topic-auto-2"
+      "treeId": "millhaven-fishmonger-marta-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-fishmonger-marta-topic-auto-3",
       "npcId": "fishmonger-marta",
       "label": "💬 \"Fresh catch, get your fresh catch!\"",
-      "treeId": "millhaven-fishmonger-marta-topic-auto-3"
+      "treeId": "millhaven-fishmonger-marta-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-innkeeper-millhaven-topic-auto-1",
@@ -5556,7 +5560,8 @@
       "id": "millhaven-innkeeper-millhaven-topic-auto-2",
       "npcId": "innkeeper-millhaven",
       "label": "💬 \"You look like someone who travels.\"",
-      "treeId": "millhaven-innkeeper-millhaven-topic-auto-2"
+      "treeId": "millhaven-innkeeper-millhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-town-elder-millhaven-topic-auto-1",
@@ -5568,13 +5573,15 @@
       "id": "millhaven-town-elder-millhaven-topic-auto-2",
       "npcId": "town-elder-millhaven",
       "label": "💬 \"The castle to the south needs resupply.\"",
-      "treeId": "millhaven-town-elder-millhaven-topic-auto-2"
+      "treeId": "millhaven-town-elder-millhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-town-elder-millhaven-topic-auto-3",
       "npcId": "town-elder-millhaven",
       "label": "💬 \"If you're heading to Ironhold Keep, perhaps you…\"",
-      "treeId": "millhaven-town-elder-millhaven-topic-auto-3"
+      "treeId": "millhaven-town-elder-millhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-sailor-finn-topic-auto-1",
@@ -5586,13 +5593,15 @@
       "id": "millhaven-sailor-finn-topic-auto-2",
       "npcId": "sailor-finn",
       "label": "💬 \"I've seen three ships go dark past the reef.\"",
-      "treeId": "millhaven-sailor-finn-topic-auto-2"
+      "treeId": "millhaven-sailor-finn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-sailor-finn-topic-auto-3",
       "npcId": "sailor-finn",
       "label": "💬 \"Marta thinks I'm superstitious.\"",
-      "treeId": "millhaven-sailor-finn-topic-auto-3"
+      "treeId": "millhaven-sailor-finn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-market-trader-topic-auto-1",
@@ -5604,13 +5613,15 @@
       "id": "millhaven-market-trader-topic-auto-2",
       "npcId": "market-trader",
       "label": "💬 \"Trade's been slow.\"",
-      "treeId": "millhaven-market-trader-topic-auto-2"
+      "treeId": "millhaven-market-trader-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-market-trader-topic-auto-3",
       "npcId": "market-trader",
       "label": "💬 \"Nice to see a fresh face in Millhaven.\"",
-      "treeId": "millhaven-market-trader-topic-auto-3"
+      "treeId": "millhaven-market-trader-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-baker-pernel-topic-auto-1",
@@ -5622,7 +5633,8 @@
       "id": "millhaven-baker-pernel-topic-auto-2",
       "npcId": "baker-pernel",
       "label": "💬 \"If you're passing the docks, folk down there…\"",
-      "treeId": "millhaven-baker-pernel-topic-auto-2"
+      "treeId": "millhaven-baker-pernel-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-smith-garrick-topic-auto-1",
@@ -5634,13 +5646,15 @@
       "id": "millhaven-smith-garrick-topic-auto-2",
       "npcId": "smith-garrick",
       "label": "💬 \"Net hooks, anchor chain, blades — if it's iron,…\"",
-      "treeId": "millhaven-smith-garrick-topic-auto-2"
+      "treeId": "millhaven-smith-garrick-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-smith-garrick-topic-auto-3",
       "npcId": "smith-garrick",
       "label": "💬 \"Scrap's been going missing from my yard.\"",
-      "treeId": "millhaven-smith-garrick-topic-auto-3"
+      "treeId": "millhaven-smith-garrick-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-dockhand-bram-topic-auto-1",
@@ -5652,13 +5666,15 @@
       "id": "millhaven-dockhand-bram-topic-auto-2",
       "npcId": "dockhand-bram",
       "label": "💬 \"Storm last week dragged half our nets out past…\"",
-      "treeId": "millhaven-dockhand-bram-topic-auto-2"
+      "treeId": "millhaven-dockhand-bram-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-dockhand-bram-topic-auto-3",
       "npcId": "dockhand-bram",
       "label": "💬 \"The boathouse keeps the town's boats — and most…\"",
-      "treeId": "millhaven-dockhand-bram-topic-auto-3"
+      "treeId": "millhaven-dockhand-bram-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-widow-tamsin-topic-auto-1",
@@ -5670,13 +5686,15 @@
       "id": "millhaven-widow-tamsin-topic-auto-2",
       "npcId": "widow-tamsin",
       "label": "💬 \"I lost my late husband's locket somewhere out…\"",
-      "treeId": "millhaven-widow-tamsin-topic-auto-2"
+      "treeId": "millhaven-widow-tamsin-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-widow-tamsin-topic-auto-3",
       "npcId": "widow-tamsin",
       "label": "💬 \"You have a kind face.\"",
-      "treeId": "millhaven-widow-tamsin-topic-auto-3"
+      "treeId": "millhaven-widow-tamsin-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-harbour-angler-topic-auto-1",
@@ -5688,13 +5706,15 @@
       "id": "millhaven-harbour-angler-topic-auto-2",
       "npcId": "harbour-angler",
       "label": "💬 \"Cast a line with me — the harbour's always…\"",
-      "treeId": "millhaven-harbour-angler-topic-auto-2"
+      "treeId": "millhaven-harbour-angler-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-harbour-angler-topic-auto-3",
       "npcId": "harbour-angler",
       "label": "💬 \"Patience and a steady hand, that's all it takes.\"",
-      "treeId": "millhaven-harbour-angler-topic-auto-3"
+      "treeId": "millhaven-harbour-angler-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-quartermaster-millhaven-topic-auto-1",
@@ -5706,13 +5726,15 @@
       "id": "millhaven-quartermaster-millhaven-topic-auto-2",
       "npcId": "quartermaster-millhaven",
       "label": "💬 \"A traveller far from home still needs to…\"",
-      "treeId": "millhaven-quartermaster-millhaven-topic-auto-2"
+      "treeId": "millhaven-quartermaster-millhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-quartermaster-millhaven-topic-auto-3",
       "npcId": "quartermaster-millhaven",
       "label": "💬 \"Coin for goods, that's the honest trade of…\"",
-      "treeId": "millhaven-quartermaster-millhaven-topic-auto-3"
+      "treeId": "millhaven-quartermaster-millhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-card-trader-millhaven-topic-auto-1",
@@ -5724,13 +5746,15 @@
       "id": "millhaven-card-trader-millhaven-topic-auto-2",
       "npcId": "card-trader-millhaven",
       "label": "💬 \"No need to trek back to Ravenwatch — I deal…\"",
-      "treeId": "millhaven-card-trader-millhaven-topic-auto-2"
+      "treeId": "millhaven-card-trader-millhaven-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-card-trader-millhaven-topic-auto-3",
       "npcId": "card-trader-millhaven",
       "label": "💬 \"Browse the wares, friend.\"",
-      "treeId": "millhaven-card-trader-millhaven-topic-auto-3"
+      "treeId": "millhaven-card-trader-millhaven-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "millhaven-regatta-master-topic-auto-1",
@@ -5742,13 +5766,15 @@
       "id": "millhaven-regatta-master-topic-auto-2",
       "npcId": "regatta-master",
       "label": "💬 \"Rigging's done and the buoys are set — care to…\"",
-      "treeId": "millhaven-regatta-master-topic-auto-2"
+      "treeId": "millhaven-regatta-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "millhaven-regatta-master-topic-auto-3",
       "npcId": "regatta-master",
       "label": "💬 \"Mark my words: the Millhaven Regatta will be…\"",
-      "treeId": "millhaven-regatta-master-topic-auto-3"
+      "treeId": "millhaven-regatta-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -276,6 +276,10 @@ export interface ConversationTopicDef {
   npcId?: string     // documentation only — which NPC this belongs to
   label: string      // topic-picker button text, e.g. "🕯️ Ask about the missing pendant"
   treeId: string     // id into this town's `dialogues` array (DialogueTree.id)
+  /** Only offered once getFriendshipLevel(npcId) >= this. Lets deeper topics
+   *  unlock as the player gets to know the NPC better; omit for a topic
+   *  available from the very first conversation. */
+  requireFriendshipLevel?: number
 }
 
 export interface RawQuestConfig {

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -22649,13 +22649,15 @@
       "id": "elder-topic-before-fracture",
       "npcId": "elder",
       "label": "📜 Ask what the courtyard was like before",
-      "treeId": "elder-topic-before-fracture"
+      "treeId": "elder-topic-before-fracture",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "elder-topic-roads",
       "npcId": "elder",
       "label": "🗺️ Ask about the roads beyond the walls",
-      "treeId": "elder-topic-roads"
+      "treeId": "elder-topic-roads",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "merchant-topic-routes",
@@ -22667,13 +22669,15 @@
       "id": "merchant-topic-caravans",
       "npcId": "merchant",
       "label": "🌅 Ask about the old caravan days",
-      "treeId": "merchant-topic-caravans"
+      "treeId": "merchant-topic-caravans",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "merchant-topic-trust",
       "npcId": "merchant",
       "label": "🔒 Ask who in town he doesn't trust",
-      "treeId": "merchant-topic-trust"
+      "treeId": "merchant-topic-trust",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "fisherman-topic-water",
@@ -22685,13 +22689,15 @@
       "id": "fisherman-topic-glowfish",
       "npcId": "fisherman",
       "label": "✨ Ask about the glowing fish he threw back",
-      "treeId": "fisherman-topic-glowfish"
+      "treeId": "fisherman-topic-glowfish",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "fisherman-topic-patience",
       "npcId": "fisherman",
       "label": "🎣 Ask him to teach you patience",
-      "treeId": "fisherman-topic-patience"
+      "treeId": "fisherman-topic-patience",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "dealer-topic-advice",
@@ -22703,13 +22709,15 @@
       "id": "dealer-topic-bigwin",
       "npcId": "dealer",
       "label": "💰 Ask about his biggest win or loss",
-      "treeId": "dealer-topic-bigwin"
+      "treeId": "dealer-topic-bigwin",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "dealer-topic-skeptic",
       "npcId": "dealer",
       "label": "🃏 Challenge his claim that 'the wheel never lies'",
-      "treeId": "dealer-topic-skeptic"
+      "treeId": "dealer-topic-skeptic",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "innkeeper-rosie-topic-business",
@@ -22721,13 +22729,15 @@
       "id": "innkeeper-rosie-topic-selfcare",
       "npcId": "innkeeper-rosie",
       "label": "☕ Ask if she ever rests herself",
-      "treeId": "innkeeper-rosie-topic-selfcare"
+      "treeId": "innkeeper-rosie-topic-selfcare",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "innkeeper-rosie-topic-history",
       "npcId": "innkeeper-rosie",
       "label": "📖 Ask how she ended up running the inn",
-      "treeId": "innkeeper-rosie-topic-history"
+      "treeId": "innkeeper-rosie-topic-history",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-scholar-topic-auto-1",
@@ -22739,13 +22749,15 @@
       "id": "ravenwatch-scholar-topic-auto-2",
       "npcId": "scholar",
       "label": "💬 \"The archives hold centuries of knowledge.\"",
-      "treeId": "ravenwatch-scholar-topic-auto-2"
+      "treeId": "ravenwatch-scholar-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-scholar-topic-auto-3",
       "npcId": "scholar",
       "label": "💬 \"Do not underestimate the power of knowing your…\"",
-      "treeId": "ravenwatch-scholar-topic-auto-3"
+      "treeId": "ravenwatch-scholar-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-campaign-gate-topic-auto-1",
@@ -22757,13 +22769,15 @@
       "id": "ravenwatch-campaign-gate-topic-auto-2",
       "npcId": "campaign-gate",
       "label": "💬 \"Every great victory began with a single step…\"",
-      "treeId": "ravenwatch-campaign-gate-topic-auto-2"
+      "treeId": "ravenwatch-campaign-gate-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-campaign-gate-topic-auto-3",
       "npcId": "campaign-gate",
       "label": "💬 \"I have delivered the call to arms.\"",
-      "treeId": "ravenwatch-campaign-gate-topic-auto-3"
+      "treeId": "ravenwatch-campaign-gate-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-endless-herald-topic-auto-1",
@@ -22775,13 +22789,15 @@
       "id": "ravenwatch-endless-herald-topic-auto-2",
       "npcId": "endless-herald",
       "label": "💬 \"Wave after wave.\"",
-      "treeId": "ravenwatch-endless-herald-topic-auto-2"
+      "treeId": "ravenwatch-endless-herald-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-endless-herald-topic-auto-3",
       "npcId": "endless-herald",
       "label": "💬 \"Glory awaits those who survive the endless…\"",
-      "treeId": "ravenwatch-endless-herald-topic-auto-3"
+      "treeId": "ravenwatch-endless-herald-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-challenge-herald-topic-auto-1",
@@ -22793,13 +22809,15 @@
       "id": "ravenwatch-challenge-herald-topic-auto-2",
       "npcId": "challenge-herald",
       "label": "💬 \"The daily trial resets at dawn.\"",
-      "treeId": "ravenwatch-challenge-herald-topic-auto-2"
+      "treeId": "ravenwatch-challenge-herald-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-challenge-herald-topic-auto-3",
       "npcId": "challenge-herald",
       "label": "💬 \"One challenge, one day.\"",
-      "treeId": "ravenwatch-challenge-herald-topic-auto-3"
+      "treeId": "ravenwatch-challenge-herald-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-weekly-herald-topic-auto-1",
@@ -22811,13 +22829,15 @@
       "id": "ravenwatch-weekly-herald-topic-auto-2",
       "npcId": "weekly-herald",
       "label": "💬 \"Three fragments forge a relic shard.\"",
-      "treeId": "ravenwatch-weekly-herald-topic-auto-2"
+      "treeId": "ravenwatch-weekly-herald-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-weekly-herald-topic-auto-3",
       "npcId": "weekly-herald",
       "label": "💬 \"A new trial begins each Monday at dawn.\"",
-      "treeId": "ravenwatch-weekly-herald-topic-auto-3"
+      "treeId": "ravenwatch-weekly-herald-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-quickbattle-gate-topic-auto-1",
@@ -22829,13 +22849,15 @@
       "id": "ravenwatch-quickbattle-gate-topic-auto-2",
       "npcId": "quickbattle-gate",
       "label": "💬 \"The quick battle pits are open.\"",
-      "treeId": "ravenwatch-quickbattle-gate-topic-auto-2"
+      "treeId": "ravenwatch-quickbattle-gate-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-quickbattle-gate-topic-auto-3",
       "npcId": "quickbattle-gate",
       "label": "💬 \"I've seen a thousand commanders step into the…\"",
-      "treeId": "ravenwatch-quickbattle-gate-topic-auto-3"
+      "treeId": "ravenwatch-quickbattle-gate-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-deck-gate-topic-auto-1",
@@ -22847,7 +22869,8 @@
       "id": "ravenwatch-deck-gate-topic-auto-2",
       "npcId": "deck-gate",
       "label": "💬 \"A strong army wins wars!\"",
-      "treeId": "ravenwatch-deck-gate-topic-auto-2"
+      "treeId": "ravenwatch-deck-gate-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-collection-gate-topic-auto-1",
@@ -22865,13 +22888,15 @@
       "id": "ravenwatch-draft-master-ravenwatch-topic-auto-2",
       "npcId": "draft-master-ravenwatch",
       "label": "💬 \"Pick your cards, Commander — eight choices…\"",
-      "treeId": "ravenwatch-draft-master-ravenwatch-topic-auto-2"
+      "treeId": "ravenwatch-draft-master-ravenwatch-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-draft-master-ravenwatch-topic-auto-3",
       "npcId": "draft-master-ravenwatch",
       "label": "💬 \"Every draft is a new deck.\"",
-      "treeId": "ravenwatch-draft-master-ravenwatch-topic-auto-3"
+      "treeId": "ravenwatch-draft-master-ravenwatch-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-minigames-npc-topic-auto-1",
@@ -22895,13 +22920,15 @@
       "id": "ravenwatch-gildwyn-topic-auto-2",
       "npcId": "gildwyn",
       "label": "💬 \"I just got a new shipment in.\"",
-      "treeId": "ravenwatch-gildwyn-topic-auto-2"
+      "treeId": "ravenwatch-gildwyn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-gildwyn-topic-auto-3",
       "npcId": "gildwyn",
       "label": "💬 \"Every card tells a story, wanderer.\"",
-      "treeId": "ravenwatch-gildwyn-topic-auto-3"
+      "treeId": "ravenwatch-gildwyn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-vorn-topic-auto-1",
@@ -22913,13 +22940,15 @@
       "id": "ravenwatch-vorn-topic-auto-2",
       "npcId": "vorn",
       "label": "💬 \"The shadows are patient with rare cards — they…\"",
-      "treeId": "ravenwatch-vorn-topic-auto-2"
+      "treeId": "ravenwatch-vorn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-vorn-topic-auto-3",
       "npcId": "vorn",
       "label": "💬 \"Gildwyn keeps the day trade.\"",
-      "treeId": "ravenwatch-vorn-topic-auto-3"
+      "treeId": "ravenwatch-vorn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-mira-topic-auto-1",
@@ -22931,13 +22960,15 @@
       "id": "ravenwatch-mira-topic-auto-2",
       "npcId": "mira",
       "label": "💬 \"The art of augmentation is older than the…\"",
-      "treeId": "ravenwatch-mira-topic-auto-2"
+      "treeId": "ravenwatch-mira-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-mira-topic-auto-3",
       "npcId": "mira",
       "label": "💬 \"I sense great potential in you, wanderer.\"",
-      "treeId": "ravenwatch-mira-topic-auto-3"
+      "treeId": "ravenwatch-mira-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-nox-topic-auto-1",
@@ -22949,13 +22980,15 @@
       "id": "ravenwatch-nox-topic-auto-2",
       "npcId": "nox",
       "label": "💬 \"A night owl's selection — curated, not cluttered.\"",
-      "treeId": "ravenwatch-nox-topic-auto-2"
+      "treeId": "ravenwatch-nox-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-nox-topic-auto-3",
       "npcId": "nox",
       "label": "💬 \"Mira keeps the daylight trade.\"",
-      "treeId": "ravenwatch-nox-topic-auto-3"
+      "treeId": "ravenwatch-nox-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-bramble-topic-auto-1",
@@ -22967,13 +23000,15 @@
       "id": "ravenwatch-bramble-topic-auto-2",
       "npcId": "bramble",
       "label": "💬 \"Stock up before you head out — the roads aren't…\"",
-      "treeId": "ravenwatch-bramble-topic-auto-2"
+      "treeId": "ravenwatch-bramble-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-bramble-topic-auto-3",
       "npcId": "bramble",
       "label": "💬 \"I've been supplying adventurers for thirty years.\"",
-      "treeId": "ravenwatch-bramble-topic-auto-3"
+      "treeId": "ravenwatch-bramble-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-grix-topic-auto-1",
@@ -22985,13 +23020,15 @@
       "id": "ravenwatch-grix-topic-auto-2",
       "npcId": "grix",
       "label": "💬 \"Goblin prices — same as everyone else, honest!\"",
-      "treeId": "ravenwatch-grix-topic-auto-2"
+      "treeId": "ravenwatch-grix-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-grix-topic-auto-3",
       "npcId": "grix",
       "label": "💬 \"Bramble sleeps, Grix sells.\"",
-      "treeId": "ravenwatch-grix-topic-auto-3"
+      "treeId": "ravenwatch-grix-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-trader-topic-auto-1",
@@ -23003,13 +23040,15 @@
       "id": "ravenwatch-trader-topic-auto-2",
       "npcId": "trader",
       "label": "💬 \"I found this stuff all over the Fracture zones.\"",
-      "treeId": "ravenwatch-trader-topic-auto-2"
+      "treeId": "ravenwatch-trader-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-trader-topic-auto-3",
       "npcId": "trader",
       "label": "💬 \"Make me an offer — I'm always looking to deal.\"",
-      "treeId": "ravenwatch-trader-topic-auto-3"
+      "treeId": "ravenwatch-trader-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-chronicler-topic-auto-1",
@@ -23021,13 +23060,15 @@
       "id": "ravenwatch-chronicler-topic-auto-2",
       "npcId": "chronicler",
       "label": "💬 \"The story of what shattered our world unfolds…\"",
-      "treeId": "ravenwatch-chronicler-topic-auto-2"
+      "treeId": "ravenwatch-chronicler-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-chronicler-topic-auto-3",
       "npcId": "chronicler",
       "label": "💬 \"A new chapter surfaces when the time is right.\"",
-      "treeId": "ravenwatch-chronicler-topic-auto-3"
+      "treeId": "ravenwatch-chronicler-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-naia-interior-topic-auto-1",
@@ -23039,13 +23080,15 @@
       "id": "ravenwatch-naia-interior-topic-auto-2",
       "npcId": "naia-interior",
       "label": "💬 \"Knowledge is power, Commander.\"",
-      "treeId": "ravenwatch-naia-interior-topic-auto-2"
+      "treeId": "ravenwatch-naia-interior-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-naia-interior-topic-auto-3",
       "npcId": "naia-interior",
       "label": "💬 \"The Fracture left many mysteries.\"",
-      "treeId": "ravenwatch-naia-interior-topic-auto-3"
+      "treeId": "ravenwatch-naia-interior-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-achievements-keeper-topic-auto-1",
@@ -23069,13 +23112,15 @@
       "id": "ravenwatch-home-shelf-topic-auto-2",
       "npcId": "home-shelf",
       "label": "💬 \"The shelf holds everything you've gathered on…\"",
-      "treeId": "ravenwatch-home-shelf-topic-auto-2"
+      "treeId": "ravenwatch-home-shelf-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-home-shelf-topic-auto-3",
       "npcId": "home-shelf",
       "label": "💬 \"Rest is just as important as battle.\"",
-      "treeId": "ravenwatch-home-shelf-topic-auto-3"
+      "treeId": "ravenwatch-home-shelf-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-fishing-hole-topic-auto-1",
@@ -23087,7 +23132,8 @@
       "id": "ravenwatch-fishing-hole-topic-auto-2",
       "npcId": "fishing-hole",
       "label": "💬 \"The fish are shy around here.\"",
-      "treeId": "ravenwatch-fishing-hole-topic-auto-2"
+      "treeId": "ravenwatch-fishing-hole-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-fishing-hole-2-topic-auto-1",
@@ -23105,7 +23151,8 @@
       "id": "ravenwatch-marble-master-topic-auto-2",
       "npcId": "marble-master",
       "label": "💬 \"Every marble tells a story.\"",
-      "treeId": "ravenwatch-marble-master-topic-auto-2"
+      "treeId": "ravenwatch-marble-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-the-flipper-topic-auto-1",
@@ -23117,7 +23164,8 @@
       "id": "ravenwatch-the-flipper-topic-auto-2",
       "npcId": "the-flipper",
       "label": "💬 \"Memory is a weapon.\"",
-      "treeId": "ravenwatch-the-flipper-topic-auto-2"
+      "treeId": "ravenwatch-the-flipper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-crystal-keeper-topic-auto-1",
@@ -23129,7 +23177,8 @@
       "id": "ravenwatch-crystal-keeper-topic-auto-2",
       "npcId": "crystal-keeper",
       "label": "💬 \"Speed and focus.\"",
-      "treeId": "ravenwatch-crystal-keeper-topic-auto-2"
+      "treeId": "ravenwatch-crystal-keeper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-spinner-sal-topic-auto-1",
@@ -23141,7 +23190,8 @@
       "id": "ravenwatch-spinner-sal-topic-auto-2",
       "npcId": "spinner-sal",
       "label": "💬 \"The wheel knows no favourites.\"",
-      "treeId": "ravenwatch-spinner-sal-topic-auto-2"
+      "treeId": "ravenwatch-spinner-sal-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-race-marshal-topic-auto-1",
@@ -23153,7 +23203,8 @@
       "id": "ravenwatch-race-marshal-topic-auto-2",
       "npcId": "race-marshal",
       "label": "💬 \"Place your bets and pick your marble.\"",
-      "treeId": "ravenwatch-race-marshal-topic-auto-2"
+      "treeId": "ravenwatch-race-marshal-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-card-sharp-topic-auto-1",
@@ -23165,7 +23216,8 @@
       "id": "ravenwatch-card-sharp-topic-auto-2",
       "npcId": "card-sharp",
       "label": "💬 \"Read the deck — or trust your gut.\"",
-      "treeId": "ravenwatch-card-sharp-topic-auto-2"
+      "treeId": "ravenwatch-card-sharp-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-reels-remy-topic-auto-1",
@@ -23177,7 +23229,8 @@
       "id": "ravenwatch-reels-remy-topic-auto-2",
       "npcId": "reels-remy",
       "label": "💬 \"Three in a row and the jackpot is yours.\"",
-      "treeId": "ravenwatch-reels-remy-topic-auto-2"
+      "treeId": "ravenwatch-reels-remy-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-poker-pete-topic-auto-1",
@@ -23189,7 +23242,8 @@
       "id": "ravenwatch-poker-pete-topic-auto-2",
       "npcId": "poker-pete",
       "label": "💬 \"Poker face optional.\"",
-      "treeId": "ravenwatch-poker-pete-topic-auto-2"
+      "treeId": "ravenwatch-poker-pete-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-prize-keeper-topic-auto-1",
@@ -23201,7 +23255,8 @@
       "id": "ravenwatch-prize-keeper-topic-auto-2",
       "npcId": "prize-keeper",
       "label": "💬 \"Trade in your winning tickets for something…\"",
-      "treeId": "ravenwatch-prize-keeper-topic-auto-2"
+      "treeId": "ravenwatch-prize-keeper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-siege-master-topic-auto-1",
@@ -23213,7 +23268,8 @@
       "id": "ravenwatch-siege-master-topic-auto-2",
       "npcId": "siege-master",
       "label": "💬 \"Every tower placed is a life saved.\"",
-      "treeId": "ravenwatch-siege-master-topic-auto-2"
+      "treeId": "ravenwatch-siege-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-town-planner-topic-auto-1",
@@ -23225,7 +23281,8 @@
       "id": "ravenwatch-town-planner-topic-auto-2",
       "npcId": "town-planner",
       "label": "💬 \"Lay the streets, raise the buildings — this…\"",
-      "treeId": "ravenwatch-town-planner-topic-auto-2"
+      "treeId": "ravenwatch-town-planner-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-home-steward-topic-auto-1",
@@ -23237,13 +23294,15 @@
       "id": "ravenwatch-home-steward-topic-auto-2",
       "npcId": "home-steward",
       "label": "💬 \"I have kept everything in order during your…\"",
-      "treeId": "ravenwatch-home-steward-topic-auto-2"
+      "treeId": "ravenwatch-home-steward-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-home-steward-topic-auto-3",
       "npcId": "home-steward",
       "label": "💬 \"Rest here.\"",
-      "treeId": "ravenwatch-home-steward-topic-auto-3"
+      "treeId": "ravenwatch-home-steward-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-apprentice-lyss-topic-auto-1",
@@ -23255,13 +23314,15 @@
       "id": "ravenwatch-apprentice-lyss-topic-auto-2",
       "npcId": "apprentice-lyss",
       "label": "💬 \"The northern library holds records predating…\"",
-      "treeId": "ravenwatch-apprentice-lyss-topic-auto-2"
+      "treeId": "ravenwatch-apprentice-lyss-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-apprentice-lyss-topic-auto-3",
       "npcId": "apprentice-lyss",
       "label": "💬 \"Please keep your voice down — scholars are…\"",
-      "treeId": "ravenwatch-apprentice-lyss-topic-auto-3"
+      "treeId": "ravenwatch-apprentice-lyss-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-cartographer-bram-topic-auto-1",
@@ -23273,13 +23334,15 @@
       "id": "ravenwatch-cartographer-bram-topic-auto-2",
       "npcId": "cartographer-bram",
       "label": "💬 \"I am charting safe passage routes through the…\"",
-      "treeId": "ravenwatch-cartographer-bram-topic-auto-2"
+      "treeId": "ravenwatch-cartographer-bram-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-cartographer-bram-topic-auto-3",
       "npcId": "cartographer-bram",
       "label": "💬 \"A good map can save your life, Commander.\"",
-      "treeId": "ravenwatch-cartographer-bram-topic-auto-3"
+      "treeId": "ravenwatch-cartographer-bram-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-professor-aldric-topic-auto-1",
@@ -23291,13 +23354,15 @@
       "id": "ravenwatch-professor-aldric-topic-auto-2",
       "npcId": "professor-aldric",
       "label": "💬 \"The study of Fracture shards is a discipline…\"",
-      "treeId": "ravenwatch-professor-aldric-topic-auto-2"
+      "treeId": "ravenwatch-professor-aldric-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-professor-aldric-topic-auto-3",
       "npcId": "professor-aldric",
       "label": "💬 \"Ask your questions, Commander.\"",
-      "treeId": "ravenwatch-professor-aldric-topic-auto-3"
+      "treeId": "ravenwatch-professor-aldric-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-guild-master-ferryn-topic-auto-1",
@@ -23309,13 +23374,15 @@
       "id": "ravenwatch-guild-master-ferryn-topic-auto-2",
       "npcId": "guild-master-ferryn",
       "label": "💬 \"Trade is the lifeblood of any civilisation.\"",
-      "treeId": "ravenwatch-guild-master-ferryn-topic-auto-2"
+      "treeId": "ravenwatch-guild-master-ferryn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-guild-master-ferryn-topic-auto-3",
       "npcId": "guild-master-ferryn",
       "label": "💬 \"You want something?\"",
-      "treeId": "ravenwatch-guild-master-ferryn-topic-auto-3"
+      "treeId": "ravenwatch-guild-master-ferryn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-market-warden-syla-topic-auto-1",
@@ -23327,13 +23394,15 @@
       "id": "ravenwatch-market-warden-syla-topic-auto-2",
       "npcId": "market-warden-syla",
       "label": "💬 \"The market never closes, Commander.\"",
-      "treeId": "ravenwatch-market-warden-syla-topic-auto-2"
+      "treeId": "ravenwatch-market-warden-syla-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-market-warden-syla-topic-auto-3",
       "npcId": "market-warden-syla",
       "label": "💬 \"I keep this hall running through chaos and war…\"",
-      "treeId": "ravenwatch-market-warden-syla-topic-auto-3"
+      "treeId": "ravenwatch-market-warden-syla-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-trophy-keeper-orin-topic-auto-1",
@@ -23345,13 +23414,15 @@
       "id": "ravenwatch-trophy-keeper-orin-topic-auto-2",
       "npcId": "trophy-keeper-orin",
       "label": "💬 \"Champions come and go, but their deeds are…\"",
-      "treeId": "ravenwatch-trophy-keeper-orin-topic-auto-2"
+      "treeId": "ravenwatch-trophy-keeper-orin-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-trophy-keeper-orin-topic-auto-3",
       "npcId": "trophy-keeper-orin",
       "label": "💬 \"Think you're good enough to earn a trophy?\"",
-      "treeId": "ravenwatch-trophy-keeper-orin-topic-auto-3"
+      "treeId": "ravenwatch-trophy-keeper-orin-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-games-host-zev-topic-auto-1",
@@ -23363,13 +23434,15 @@
       "id": "ravenwatch-games-host-zev-topic-auto-2",
       "npcId": "games-host-zev",
       "label": "💬 \"Skill, luck, or cunning — what'll it be,…\"",
-      "treeId": "ravenwatch-games-host-zev-topic-auto-2"
+      "treeId": "ravenwatch-games-host-zev-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-games-host-zev-topic-auto-3",
       "npcId": "games-host-zev",
       "label": "💬 \"Every game is a battle.\"",
-      "treeId": "ravenwatch-games-host-zev-topic-auto-3"
+      "treeId": "ravenwatch-games-host-zev-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-guard-captain-thorin-topic-auto-1",
@@ -23381,13 +23454,15 @@
       "id": "ravenwatch-guard-captain-thorin-topic-auto-2",
       "npcId": "guard-captain-thorin",
       "label": "💬 \"My guards are the finest in the hub.\"",
-      "treeId": "ravenwatch-guard-captain-thorin-topic-auto-2"
+      "treeId": "ravenwatch-guard-captain-thorin-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-guard-captain-thorin-topic-auto-3",
       "npcId": "guard-captain-thorin",
       "label": "💬 \"Need security?\"",
-      "treeId": "ravenwatch-guard-captain-thorin-topic-auto-3"
+      "treeId": "ravenwatch-guard-captain-thorin-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-drill-sergeant-varn-topic-auto-1",
@@ -23399,13 +23474,15 @@
       "id": "ravenwatch-drill-sergeant-varn-topic-auto-2",
       "npcId": "drill-sergeant-varn",
       "label": "💬 \"This hall forges soldiers from raw recruits.\"",
-      "treeId": "ravenwatch-drill-sergeant-varn-topic-auto-2"
+      "treeId": "ravenwatch-drill-sergeant-varn-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-drill-sergeant-varn-topic-auto-3",
       "npcId": "drill-sergeant-varn",
       "label": "💬 \"Training is the difference between victory and…\"",
-      "treeId": "ravenwatch-drill-sergeant-varn-topic-auto-3"
+      "treeId": "ravenwatch-drill-sergeant-varn-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "ravenwatch-marble-master-int-topic-auto-1",
@@ -23417,7 +23494,8 @@
       "id": "ravenwatch-marble-master-int-topic-auto-2",
       "npcId": "marble-master-int",
       "label": "💬 \"Every marble tells a story.\"",
-      "treeId": "ravenwatch-marble-master-int-topic-auto-2"
+      "treeId": "ravenwatch-marble-master-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-the-flipper-int-topic-auto-1",
@@ -23429,7 +23507,8 @@
       "id": "ravenwatch-the-flipper-int-topic-auto-2",
       "npcId": "the-flipper-int",
       "label": "💬 \"Memory is a weapon.\"",
-      "treeId": "ravenwatch-the-flipper-int-topic-auto-2"
+      "treeId": "ravenwatch-the-flipper-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-crystal-keeper-int-topic-auto-1",
@@ -23441,7 +23520,8 @@
       "id": "ravenwatch-crystal-keeper-int-topic-auto-2",
       "npcId": "crystal-keeper-int",
       "label": "💬 \"Speed and focus.\"",
-      "treeId": "ravenwatch-crystal-keeper-int-topic-auto-2"
+      "treeId": "ravenwatch-crystal-keeper-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-prize-keeper-int-topic-auto-1",
@@ -23453,7 +23533,8 @@
       "id": "ravenwatch-prize-keeper-int-topic-auto-2",
       "npcId": "prize-keeper-int",
       "label": "💬 \"Trade in your winning tickets for something…\"",
-      "treeId": "ravenwatch-prize-keeper-int-topic-auto-2"
+      "treeId": "ravenwatch-prize-keeper-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-spinner-sal-int-topic-auto-1",
@@ -23465,7 +23546,8 @@
       "id": "ravenwatch-spinner-sal-int-topic-auto-2",
       "npcId": "spinner-sal-int",
       "label": "💬 \"The wheel knows no favourites.\"",
-      "treeId": "ravenwatch-spinner-sal-int-topic-auto-2"
+      "treeId": "ravenwatch-spinner-sal-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-race-marshal-int-topic-auto-1",
@@ -23477,7 +23559,8 @@
       "id": "ravenwatch-race-marshal-int-topic-auto-2",
       "npcId": "race-marshal-int",
       "label": "💬 \"Place your bets and pick your marble.\"",
-      "treeId": "ravenwatch-race-marshal-int-topic-auto-2"
+      "treeId": "ravenwatch-race-marshal-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-card-sharp-int-topic-auto-1",
@@ -23489,7 +23572,8 @@
       "id": "ravenwatch-card-sharp-int-topic-auto-2",
       "npcId": "card-sharp-int",
       "label": "💬 \"Read the deck — or trust your gut.\"",
-      "treeId": "ravenwatch-card-sharp-int-topic-auto-2"
+      "treeId": "ravenwatch-card-sharp-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-reels-remy-int-topic-auto-1",
@@ -23501,7 +23585,8 @@
       "id": "ravenwatch-reels-remy-int-topic-auto-2",
       "npcId": "reels-remy-int",
       "label": "💬 \"Three in a row and the jackpot is yours.\"",
-      "treeId": "ravenwatch-reels-remy-int-topic-auto-2"
+      "treeId": "ravenwatch-reels-remy-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-poker-pete-int-topic-auto-1",
@@ -23513,7 +23598,8 @@
       "id": "ravenwatch-poker-pete-int-topic-auto-2",
       "npcId": "poker-pete-int",
       "label": "💬 \"Poker face optional.\"",
-      "treeId": "ravenwatch-poker-pete-int-topic-auto-2"
+      "treeId": "ravenwatch-poker-pete-int-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "ravenwatch-npc_1781629843466-topic-auto-1",

--- a/web/src/data/hub/royalpalace/questDefs.json
+++ b/web/src/data/hub/royalpalace/questDefs.json
@@ -5620,13 +5620,15 @@
       "id": "royalpalace-royal-steward-topic-auto-2",
       "npcId": "royal-steward",
       "label": "💬 \"Their Majesties are in session.\"",
-      "treeId": "royalpalace-royal-steward-topic-auto-2"
+      "treeId": "royalpalace-royal-steward-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-royal-steward-topic-auto-3",
       "npcId": "royal-steward",
       "label": "💬 \"If you've a strong back and a willing heart,…\"",
-      "treeId": "royalpalace-royal-steward-topic-auto-3"
+      "treeId": "royalpalace-royal-steward-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-royal-herald-topic-auto-1",
@@ -5638,13 +5640,15 @@
       "id": "royalpalace-royal-herald-topic-auto-2",
       "npcId": "royal-herald",
       "label": "💬 \"Hear ye, hear ye — the proclamations have gone…\"",
-      "treeId": "royalpalace-royal-herald-topic-auto-2"
+      "treeId": "royalpalace-royal-herald-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-royal-herald-topic-auto-3",
       "npcId": "royal-herald",
       "label": "💬 \"Protocol is the art of standing in the right…\"",
-      "treeId": "royalpalace-royal-herald-topic-auto-3"
+      "treeId": "royalpalace-royal-herald-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-palace-guard-topic-auto-1",
@@ -5656,13 +5660,15 @@
       "id": "royalpalace-palace-guard-topic-auto-2",
       "npcId": "palace-guard",
       "label": "💬 \"Nobody enters the throne room without an…\"",
-      "treeId": "royalpalace-palace-guard-topic-auto-2"
+      "treeId": "royalpalace-palace-guard-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-palace-guard-topic-auto-3",
       "npcId": "palace-guard",
       "label": "💬 \"Quietest post in the kingdom, this.\"",
-      "treeId": "royalpalace-palace-guard-topic-auto-3"
+      "treeId": "royalpalace-palace-guard-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-king-topic-auto-1",
@@ -5674,13 +5680,15 @@
       "id": "royalpalace-king-topic-auto-2",
       "npcId": "king",
       "label": "💬 \"A crown is heavier than it looks, and most of…\"",
-      "treeId": "royalpalace-king-topic-auto-2"
+      "treeId": "royalpalace-king-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-king-topic-auto-3",
       "npcId": "king",
       "label": "💬 \"Serve the realm well and the realm remembers.\"",
-      "treeId": "royalpalace-king-topic-auto-3"
+      "treeId": "royalpalace-king-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-queen-topic-auto-1",
@@ -5692,13 +5700,15 @@
       "id": "royalpalace-queen-topic-auto-2",
       "npcId": "queen",
       "label": "💬 \"The King rules the realm; I rule the garden.\"",
-      "treeId": "royalpalace-queen-topic-auto-2"
+      "treeId": "royalpalace-queen-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-queen-topic-auto-3",
       "npcId": "queen",
       "label": "💬 \"A kingdom is judged by its kindnesses, not its…\"",
-      "treeId": "royalpalace-queen-topic-auto-3"
+      "treeId": "royalpalace-queen-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-princess-topic-auto-1",
@@ -5710,13 +5720,15 @@
       "id": "royalpalace-princess-topic-auto-2",
       "npcId": "princess",
       "label": "💬 \"Everyone says a princess should be content.\"",
-      "treeId": "royalpalace-princess-topic-auto-2"
+      "treeId": "royalpalace-princess-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-princess-topic-auto-3",
       "npcId": "princess",
       "label": "💬 \"The goblin and the ogre by the fountain only…\"",
-      "treeId": "royalpalace-princess-topic-auto-3"
+      "treeId": "royalpalace-princess-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-lady-penrose-topic-auto-1",
@@ -5728,13 +5740,15 @@
       "id": "royalpalace-lady-penrose-topic-auto-2",
       "npcId": "lady-penrose",
       "label": "💬 \"Court is a garden of its own, dear.\"",
-      "treeId": "royalpalace-lady-penrose-topic-auto-2"
+      "treeId": "royalpalace-lady-penrose-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-lady-penrose-topic-auto-3",
       "npcId": "lady-penrose",
       "label": "💬 \"I have a small matter that wants a discreet hand.\"",
-      "treeId": "royalpalace-lady-penrose-topic-auto-3"
+      "treeId": "royalpalace-lady-penrose-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-treasurer-topic-auto-1",
@@ -5746,13 +5760,15 @@
       "id": "royalpalace-treasurer-topic-auto-2",
       "npcId": "treasurer",
       "label": "💬 \"The audit is overdue and the inner vault stays…\"",
-      "treeId": "royalpalace-treasurer-topic-auto-2"
+      "treeId": "royalpalace-treasurer-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-treasurer-topic-auto-3",
       "npcId": "treasurer",
       "label": "💬 \"Bring me the scattered tallies and I'll open…\"",
-      "treeId": "royalpalace-treasurer-topic-auto-3"
+      "treeId": "royalpalace-treasurer-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-chaplain-topic-auto-1",
@@ -5764,13 +5780,15 @@
       "id": "royalpalace-chaplain-topic-auto-2",
       "npcId": "chaplain",
       "label": "💬 \"The crypt below holds kings long past.\"",
-      "treeId": "royalpalace-chaplain-topic-auto-2"
+      "treeId": "royalpalace-chaplain-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-chaplain-topic-auto-3",
       "npcId": "chaplain",
       "label": "💬 \"Our candles have a way of wandering off.\"",
-      "treeId": "royalpalace-chaplain-topic-auto-3"
+      "treeId": "royalpalace-chaplain-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-royal-cook-topic-auto-1",
@@ -5782,13 +5800,15 @@
       "id": "royalpalace-royal-cook-topic-auto-2",
       "npcId": "royal-cook",
       "label": "💬 \"A royal feast does not cook itself, more's the…\"",
-      "treeId": "royalpalace-royal-cook-topic-auto-2"
+      "treeId": "royalpalace-royal-cook-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-royal-cook-topic-auto-3",
       "npcId": "royal-cook",
       "label": "💬 \"Fetch me what I need and the court eats like…\"",
-      "treeId": "royalpalace-royal-cook-topic-auto-3"
+      "treeId": "royalpalace-royal-cook-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-royal-gardener-topic-auto-1",
@@ -5800,13 +5820,15 @@
       "id": "royalpalace-royal-gardener-topic-auto-2",
       "npcId": "royal-gardener",
       "label": "💬 \"The Queen wants roses, the King wants order,…\"",
-      "treeId": "royalpalace-royal-gardener-topic-auto-2"
+      "treeId": "royalpalace-royal-gardener-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-royal-gardener-topic-auto-3",
       "npcId": "royal-gardener",
       "label": "💬 \"If you've a good eye, there's a rare bloom or…\"",
-      "treeId": "royalpalace-royal-gardener-topic-auto-3"
+      "treeId": "royalpalace-royal-gardener-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-stable-master-topic-auto-1",
@@ -5818,13 +5840,15 @@
       "id": "royalpalace-stable-master-topic-auto-2",
       "npcId": "stable-master",
       "label": "💬 \"One of the ponies slipped its tack and bolted…\"",
-      "treeId": "royalpalace-stable-master-topic-auto-2"
+      "treeId": "royalpalace-stable-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-stable-master-topic-auto-3",
       "npcId": "stable-master",
       "label": "💬 \"Help me round up the lost harness and there's…\"",
-      "treeId": "royalpalace-stable-master-topic-auto-3"
+      "treeId": "royalpalace-stable-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "royalpalace-npc_1781196539810-topic-auto-1",
@@ -5860,13 +5884,15 @@
       "id": "royalpalace-master-of-coin-aldric-topic-auto-2",
       "npcId": "master-of-coin-aldric",
       "label": "💬 \"Every coin in this room has a ledger entry.\"",
-      "treeId": "royalpalace-master-of-coin-aldric-topic-auto-2"
+      "treeId": "royalpalace-master-of-coin-aldric-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "royalpalace-master-of-coin-aldric-topic-auto-3",
       "npcId": "master-of-coin-aldric",
       "label": "💬 \"The vault proper is for the king's treasures.\"",
-      "treeId": "royalpalace-master-of-coin-aldric-topic-auto-3"
+      "treeId": "royalpalace-master-of-coin-aldric-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -4934,13 +4934,15 @@
       "id": "saltmereport-harbourmaster-vane-topic-auto-2",
       "npcId": "harbourmaster-vane",
       "label": "💬 \"Cargo's been going missing off the quay.\"",
-      "treeId": "saltmereport-harbourmaster-vane-topic-auto-2"
+      "treeId": "saltmereport-harbourmaster-vane-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-harbourmaster-vane-topic-auto-3",
       "npcId": "harbourmaster-vane",
       "label": "💬 \"Pirates to the north, smugglers to the south,…\"",
-      "treeId": "saltmereport-harbourmaster-vane-topic-auto-3"
+      "treeId": "saltmereport-harbourmaster-vane-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-fishwife-pearl-topic-auto-1",
@@ -4952,13 +4954,15 @@
       "id": "saltmereport-fishwife-pearl-topic-auto-2",
       "npcId": "fishwife-pearl",
       "label": "💬 \"The reef's been restless.\"",
-      "treeId": "saltmereport-fishwife-pearl-topic-auto-2"
+      "treeId": "saltmereport-fishwife-pearl-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-fishwife-pearl-topic-auto-3",
       "npcId": "fishwife-pearl",
       "label": "💬 \"You buy, or you're blocking the stall.\"",
-      "treeId": "saltmereport-fishwife-pearl-topic-auto-3"
+      "treeId": "saltmereport-fishwife-pearl-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-dockhand-tam-topic-auto-1",
@@ -4970,13 +4974,15 @@
       "id": "saltmereport-dockhand-tam-topic-auto-2",
       "npcId": "dockhand-tam",
       "label": "💬 \"Found a barrel of navy rum washed up under the…\"",
-      "treeId": "saltmereport-dockhand-tam-topic-auto-2"
+      "treeId": "saltmereport-dockhand-tam-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-dockhand-tam-topic-auto-3",
       "npcId": "dockhand-tam",
       "label": "💬 \"Vane counts the cargo twice.\"",
-      "treeId": "saltmereport-dockhand-tam-topic-auto-3"
+      "treeId": "saltmereport-dockhand-tam-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-old-salt-topic-auto-1",
@@ -4988,13 +4994,15 @@
       "id": "saltmereport-old-salt-topic-auto-2",
       "npcId": "old-salt",
       "label": "💬 \"There's a cove east of here no chart will show…\"",
-      "treeId": "saltmereport-old-salt-topic-auto-2"
+      "treeId": "saltmereport-old-salt-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-old-salt-topic-auto-3",
       "npcId": "old-salt",
       "label": "💬 \"The tide takes and the tide gives back.\"",
-      "treeId": "saltmereport-old-salt-topic-auto-3"
+      "treeId": "saltmereport-old-salt-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-shipwright-topic-auto-1",
@@ -5006,13 +5014,15 @@
       "id": "saltmereport-shipwright-topic-auto-2",
       "npcId": "shipwright",
       "label": "💬 \"Good timber, good pitch, good rope — that's the…\"",
-      "treeId": "saltmereport-shipwright-topic-auto-2"
+      "treeId": "saltmereport-shipwright-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-shipwright-topic-auto-3",
       "npcId": "shipwright",
       "label": "💬 \"She'll float.\"",
-      "treeId": "saltmereport-shipwright-topic-auto-3"
+      "treeId": "saltmereport-shipwright-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-customs-officer-topic-auto-1",
@@ -5024,13 +5034,15 @@
       "id": "saltmereport-customs-officer-topic-auto-2",
       "npcId": "customs-officer",
       "label": "💬 \"The numbers on Vane's manifest and the numbers…\"",
-      "treeId": "saltmereport-customs-officer-topic-auto-2"
+      "treeId": "saltmereport-customs-officer-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-customs-officer-topic-auto-3",
       "npcId": "customs-officer",
       "label": "💬 \"I've seen smugglers, thieves, and men who…\"",
-      "treeId": "saltmereport-customs-officer-topic-auto-3"
+      "treeId": "saltmereport-customs-officer-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-lighthouse-keeper-topic-auto-1",
@@ -5042,13 +5054,15 @@
       "id": "saltmereport-lighthouse-keeper-topic-auto-2",
       "npcId": "lighthouse-keeper",
       "label": "💬 \"Oil runs low faster than it should.\"",
-      "treeId": "saltmereport-lighthouse-keeper-topic-auto-2"
+      "treeId": "saltmereport-lighthouse-keeper-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-lighthouse-keeper-topic-auto-3",
       "npcId": "lighthouse-keeper",
       "label": "💬 \"I watch so the rest of you can sleep.\"",
-      "treeId": "saltmereport-lighthouse-keeper-topic-auto-3"
+      "treeId": "saltmereport-lighthouse-keeper-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-net-maker-topic-auto-1",
@@ -5060,13 +5074,15 @@
       "id": "saltmereport-net-maker-topic-auto-2",
       "npcId": "net-maker",
       "label": "💬 \"Every knot's got a name, if you know where to…\"",
-      "treeId": "saltmereport-net-maker-topic-auto-2"
+      "treeId": "saltmereport-net-maker-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-net-maker-topic-auto-3",
       "npcId": "net-maker",
       "label": "💬 \"Good nets outlast the boats they're tied to.\"",
-      "treeId": "saltmereport-net-maker-topic-auto-3"
+      "treeId": "saltmereport-net-maker-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-chandler-topic-auto-1",
@@ -5078,13 +5094,15 @@
       "id": "saltmereport-chandler-topic-auto-2",
       "npcId": "chandler",
       "label": "💬 \"Stores are running thin and the next supply run…\"",
-      "treeId": "saltmereport-chandler-topic-auto-2"
+      "treeId": "saltmereport-chandler-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-chandler-topic-auto-3",
       "npcId": "chandler",
       "label": "💬 \"Buy local.\"",
-      "treeId": "saltmereport-chandler-topic-auto-3"
+      "treeId": "saltmereport-chandler-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-smokehouse-master-topic-auto-1",
@@ -5096,13 +5114,15 @@
       "id": "saltmereport-smokehouse-master-topic-auto-2",
       "npcId": "smokehouse-master",
       "label": "💬 \"That dock cat's been eyeing my racks again.\"",
-      "treeId": "saltmereport-smokehouse-master-topic-auto-2"
+      "treeId": "saltmereport-smokehouse-master-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-smokehouse-master-topic-auto-3",
       "npcId": "smokehouse-master",
       "label": "💬 \"Nothing wrong with a few scraps for a hungry…\"",
-      "treeId": "saltmereport-smokehouse-master-topic-auto-3"
+      "treeId": "saltmereport-smokehouse-master-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-tavern-sailor-topic-auto-1",
@@ -5114,13 +5134,15 @@
       "id": "saltmereport-tavern-sailor-topic-auto-2",
       "npcId": "tavern-sailor",
       "label": "💬 \"The Brined Anchor pours the only rum on this…\"",
-      "treeId": "saltmereport-tavern-sailor-topic-auto-2"
+      "treeId": "saltmereport-tavern-sailor-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-tavern-sailor-topic-auto-3",
       "npcId": "tavern-sailor",
       "label": "💬 \"Sleep below deck, drink above it.\"",
-      "treeId": "saltmereport-tavern-sailor-topic-auto-3"
+      "treeId": "saltmereport-tavern-sailor-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "saltmereport-smuggler-topic-auto-1",
@@ -5132,13 +5154,15 @@
       "id": "saltmereport-smuggler-topic-auto-2",
       "npcId": "smuggler",
       "label": "💬 \"Rum's a victimless trade until the watch starts…\"",
-      "treeId": "saltmereport-smuggler-topic-auto-2"
+      "treeId": "saltmereport-smuggler-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "saltmereport-smuggler-topic-auto-3",
       "npcId": "smuggler",
       "label": "💬 \"Whatever Vane thinks he knows, he can't prove.\"",
-      "treeId": "saltmereport-smuggler-topic-auto-3"
+      "treeId": "saltmereport-smuggler-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/data/hub/thornwoodcamp/questDefs.json
+++ b/web/src/data/hub/thornwoodcamp/questDefs.json
@@ -1972,13 +1972,15 @@
       "id": "thornwoodcamp-warden-rell-topic-auto-2",
       "npcId": "warden-rell",
       "label": "💬 \"I keep the fire and the fire keeps the wolves…\"",
-      "treeId": "thornwoodcamp-warden-rell-topic-auto-2"
+      "treeId": "thornwoodcamp-warden-rell-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "thornwoodcamp-warden-rell-topic-auto-3",
       "npcId": "warden-rell",
       "label": "💬 \"Firewood's running low again.\"",
-      "treeId": "thornwoodcamp-warden-rell-topic-auto-3"
+      "treeId": "thornwoodcamp-warden-rell-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "thornwoodcamp-forager-mott-topic-auto-1",
@@ -1990,13 +1992,15 @@
       "id": "thornwoodcamp-forager-mott-topic-auto-2",
       "npcId": "forager-mott",
       "label": "💬 \"There's queer little stones in the scree where…\"",
-      "treeId": "thornwoodcamp-forager-mott-topic-auto-2"
+      "treeId": "thornwoodcamp-forager-mott-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "thornwoodcamp-forager-mott-topic-auto-3",
       "npcId": "forager-mott",
       "label": "💬 \"Warden Rell's up by the fire, if you can get…\"",
-      "treeId": "thornwoodcamp-forager-mott-topic-auto-3"
+      "treeId": "thornwoodcamp-forager-mott-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "thornwoodcamp-ranger-sable-topic-auto-1",
@@ -2008,13 +2012,15 @@
       "id": "thornwoodcamp-ranger-sable-topic-auto-2",
       "npcId": "ranger-sable",
       "label": "💬 \"The pack's been bold since the bad winter.\"",
-      "treeId": "thornwoodcamp-ranger-sable-topic-auto-2"
+      "treeId": "thornwoodcamp-ranger-sable-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "thornwoodcamp-ranger-sable-topic-auto-3",
       "npcId": "ranger-sable",
       "label": "💬 \"Forage what you can.\"",
-      "treeId": "thornwoodcamp-ranger-sable-topic-auto-3"
+      "treeId": "thornwoodcamp-ranger-sable-topic-auto-3",
+      "requireFriendshipLevel": 2
     },
     {
       "id": "thornwoodcamp-trader-pell-topic-auto-1",
@@ -2026,13 +2032,15 @@
       "id": "thornwoodcamp-trader-pell-topic-auto-2",
       "npcId": "trader-pell",
       "label": "💬 \"A camp like this is worth more than a city to a…\"",
-      "treeId": "thornwoodcamp-trader-pell-topic-auto-2"
+      "treeId": "thornwoodcamp-trader-pell-topic-auto-2",
+      "requireFriendshipLevel": 1
     },
     {
       "id": "thornwoodcamp-trader-pell-topic-auto-3",
       "npcId": "trader-pell",
       "label": "💬 \"If you're headed Ravenwatch way, I've a parcel…\"",
-      "treeId": "thornwoodcamp-trader-pell-topic-auto-3"
+      "treeId": "thornwoodcamp-trader-pell-topic-auto-3",
+      "requireFriendshipLevel": 2
     }
   ]
 }

--- a/web/src/game/hub/shuffle.test.ts
+++ b/web/src/game/hub/shuffle.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { shuffled } from './shuffle'
+
+describe('shuffled', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns a copy — does not mutate the input array', () => {
+    const input = [1, 2, 3, 4, 5]
+    const copy = [...input]
+    shuffled(input)
+    expect(input).toEqual(copy)
+  })
+
+  it('preserves every element (same multiset, no additions/drops)', () => {
+    const input = ['warm', 'practical', 'blunt']
+    const result = shuffled(input)
+    expect(result).toHaveLength(input.length)
+    expect([...result].sort()).toEqual([...input].sort())
+  })
+
+  it('handles empty and single-element arrays without error', () => {
+    expect(shuffled([])).toEqual([])
+    expect(shuffled(['only'])).toEqual(['only'])
+  })
+
+  it('does not always leave the first element in the first position', () => {
+    // Force Math.random to always return 0, which always picks index 0 as
+    // the swap partner — for this array size that chain of swaps ends with
+    // 'a' displaced from position 0 — a regression to "return arr unchanged"
+    // (or any variant that never touches index 0) would fail this.
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const result = shuffled(['a', 'b', 'c', 'd'])
+    expect(result[0]).not.toBe('a')
+  })
+})

--- a/web/src/game/hub/shuffle.ts
+++ b/web/src/game/hub/shuffle.ts
@@ -1,0 +1,11 @@
+// Fisher-Yates shuffle (returns a copy, does not mutate the input) — used to
+// randomize dialogue-tree choice order so a "good"/"neutral"/"bad" outcome
+// isn't always in the same list position.
+export function shuffled<T>(arr: T[]): T[] {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}


### PR DESCRIPTION
## Summary

Three follow-up improvements to the branching "Make Conversation" system (#2026, #2027):

1. **New dialogue options unlock as friendship increases.** `ConversationTopicDef` gets an optional `requireFriendshipLevel` — a topic is hidden from the picker until the player's friendship with that NPC reaches that level. All 593 existing topics (the 5 hand-authored pilot NPCs and the 211 auto-generated ones) are retrofitted with a graduated convention: an NPC's first topic is always available, the second unlocks at friendship level 1, the third at level 2. So every NPC now opens up gradually instead of showing every topic from the very first conversation.
2. **Randomized choice order.** Dialogue-tree choices (a topic's tone/follow-up choices, and any other authored `dialogueTree` node) are shuffled before display, so the good/neutral/bad outcome isn't reliably in the same list position — a player has to read the options instead of learning "top button is always safe." Extracted into a small unit-tested `shuffled()` helper (`web/src/game/hub/shuffle.ts`).
3. **Map editor support.** The visual map editor (`NpcEditor.tsx`/`DialogueEditor.tsx`) can now author this content: a reorderable "Conversation Topics" field on the NPC form (order drives both display and the friendship-gate convention above), and a "Conversation Topics" section for the topic definitions themselves (id, npcId, label, treeId, requireFriendshipLevel).

## Test plan

- [x] `npm run test` — full suite passes (1886 tests), including new unit tests for the `shuffled()` helper and loader-parsing coverage for `requireFriendshipLevel`; the existing `conversation topic coverage`/`conversation topic trees terminate` guards still pass across all 593 topics with the new field present.
- [x] `npm run build` — TypeScript compiles cleanly and the production build succeeds.
- [ ] Manual walkthrough (recommend before merge): talk to an NPC repeatedly across several real days and confirm a second/third topic appears in the menu as friendship rises; confirm the same topic's choice order visibly changes across repeated visits to the same node; open the map editor, verify an NPC's Conversation Topics field lets you add/reorder/remove topic ids, and the Dialogue Editor's new Conversation Topics section lets you edit a topic's label/treeId/requireFriendshipLevel and Save writes it to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xndHTwGUzwZiEzqWJTjym

---
_Generated by [Claude Code](https://claude.ai/code/session_012xndHTwGUzwZiEzqWJTjym)_