### PR TITLE
Add act/node-authored road rendering to the battlefield

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -851,7 +851,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         onContextMenu={pendingAoeCard ? (e) => { e.preventDefault(); setPendingAoeCard(null); setAoeHoverPos(null) } : undefined}
       >
         <div className="lane-ground" />
-        <BattlefieldTerrainCanvas environment={state.environment} id={state.environment} terrain={state.terrain} />
+        <BattlefieldTerrainCanvas environment={state.environment} id={state.environment} terrain={state.terrain} roads={state.roads} />
         {isDebugMode() && (state.terrain ?? []).map(obs => {
           // Avoidance ellipse matching TERRAIN_AVOID_SHAPE used by the engine.
           // x-axis (forward/vertical on screen): 500 units → 100% field height → 0.2% per unit

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,20 +1,22 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx, buildTerrainDecorGfx } from '../../../utils/terrainLayer'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx, buildTerrainDecorGfx, buildRoadGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
-import type { TerrainObstacle } from '../../../game/engine/terrain'
+import type { TerrainObstacle, RoadDef } from '../../../game/engine/terrain'
 
 export interface Props {
   environment?: string
   /** Stable ID used as terrain scatter seed — use node/act ID for deterministic decoration */
   id?: string
   terrain?: TerrainObstacle[]
+  /** Act/node-authored road paths. Rendered only — does not affect unit movement. */
+  roads?: RoadDef[]
 }
 
 // Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
-function TerrainPixi({ environment, id, terrain, w, h }: Props & { w: number; h: number }) {
+function TerrainPixi({ environment, id, terrain, roads, w, h }: Props & { w: number; h: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const envDef = WORLD_ENV_TILES[environment ?? ''] ?? ENV_TILES[environment ?? '']
 
@@ -23,14 +25,16 @@ function TerrainPixi({ environment, id, terrain, w, h }: Props & { w: number; h:
     const river          = new PIXI.Container() // not added to stage — rivers suppressed on battlefield
     const world          = new PIXI.Container()
     const bg             = new PIXI.Container()
+    const road           = new PIXI.Container()
     const decor          = new PIXI.Container()
     const border         = new PIXI.Container()
     const decorObstacles = new PIXI.Container()
-    app.stage.addChild(base, bg, border, decor, decorObstacles, world)
+    app.stage.addChild(base, bg, road, border, decor, decorObstacles, world)
     buildTerrainGfx(base, river, world,
       { environment, envDef, id, rivers: [], terrainItems: [] },
       w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
+    buildRoadGfx(road, roads ?? [], { environment, envDef }, w, h)
     buildBorderGfx(border, { environment, envDef }, w, h)
     buildDecorGfx(decor, { environment, envDef, id }, w, h)
     buildTerrainDecorGfx(decorObstacles, terrain ?? [], { environment, envDef }, w, h)
@@ -44,7 +48,7 @@ function TerrainPixi({ environment, id, terrain, w, h }: Props & { w: number; h:
  * Measures its container after mount, then renders a PixiJS tile scene.
  * Replaces the SVG layer approach of BattlefieldBackground.
  */
-export function BattlefieldTerrainCanvas({ environment, id, terrain }: Props) {
+export function BattlefieldTerrainCanvas({ environment, id, terrain, roads }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
 
@@ -81,7 +85,7 @@ export function BattlefieldTerrainCanvas({ environment, id, terrain }: Props) {
       {/* Re-key on size/environment/id so the Pixi scene remounts and rebuilds — usePixiApp's
           onReady closure only runs once per mount, so changing terrain/environment/id alone
           (with the same dimensions) would otherwise silently keep rendering the stale scene. */}
-      {dims && <TerrainPixi key={`${dims.w}x${dims.h}-${environment}-${id}`} environment={environment} id={id} terrain={terrain} w={dims.w} h={dims.h} />}
+      {dims && <TerrainPixi key={`${dims.w}x${dims.h}-${environment}-${id}`} environment={environment} id={id} terrain={terrain} roads={roads} w={dims.w} h={dims.h} />}
     </div>
   )
 }

--- a/web/src/game/campaignHelpers.ts
+++ b/web/src/game/campaignHelpers.ts
@@ -154,6 +154,7 @@ export function resolvedNodeOpts(
     enemyDeckNames: node.enemyDeck,
     terrainSeed: node.id,
     environment: node.environment ?? act?.environment,
+    roads: node.roads ?? act?.roads,
     opponentIntervalMs: adjustedInterval,
     opponentBaseHp: adjustedHp,
     opponentStartCards: handBonus,

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -15,6 +15,7 @@ import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
 import { triggerBattleEvent, BATTLE_EVENT_BASE_MS } from './engine/battleEvents'
 import { generateTerrain } from './engine/terrain'
+import type { RoadDef } from './engine/terrain'
 import { processEndlessModeAdditions, triggerNextEndlessWave, spawnEndlessCommander } from './engine/endlessMode'
 import { handleSuddentDeath } from './engine/suddenDeath'
 
@@ -119,6 +120,8 @@ export interface NewGameOptions {
   terrainSeed?: string
   /** Act environment ('forest' | 'citadel' | 'ashen') — themes terrain and log. */
   environment?: string
+  /** Act/node-authored road paths for the battlefield. Rendered only — does not affect unit movement. */
+  roads?: RoadDef[]
   /** Override opponent play interval (ms). Defined per-node in act JSON. */
   opponentIntervalMs?: number
   /** Override opponent base HP. Defined per-node in act JSON. */
@@ -170,6 +173,7 @@ export function newGame(
     prebuiltPlayerDeck,
     terrainSeed,
     environment,
+    roads,
     opponentIntervalMs: intervalOverride,
     opponentBaseHp: hpOverride,
     bossSpawnKillPct,
@@ -321,6 +325,7 @@ export function newGame(
       baseInvulnerableUntilMs: 0,
     } : undefined,
     terrain: generateTerrain(terrainSeed, environment),
+    roads,
     environment,
     battleStats: { cardsPlayed: {}, playerKills: 0, playerUnitsLost: 0 },
     animEvents: [],

--- a/web/src/game/engine/terrain.ts
+++ b/web/src/game/engine/terrain.ts
@@ -24,6 +24,19 @@ export interface TerrainObstacle {
   radius: number // base avoidance radius in game units, 12–22
 }
 
+/**
+ * Act/node-authored road path for the battlefield, rendered visually only —
+ * does not affect unit movement/avoidance (see game/engine/units.ts).
+ */
+export interface RoadDef {
+  /** Waypoints in game-unit coords — same space as TerrainObstacle: x 0–500 (forward, base→base), y -80..80 (lateral). */
+  points: Array<{ x: number; y: number }>
+  /** Tile-count width of the road band. Default 2. */
+  width?: number
+  /** Optional tileset override (defaults to envDef.pathFile). */
+  tileFile?: string
+}
+
 // ─── Terrain Generation ───────────────────────────────────
 //
 // Scatter rocks, trees, water, and ruins across the mid-field.

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1,4 +1,5 @@
 import { CardRarity, Archetype } from './types'
+import type { RoadDef } from './engine/terrain'
 import { loadPlayerStats } from './playerStats'
 import { logError } from '../logger'
 import { getCardCatalog } from './cards'
@@ -162,6 +163,8 @@ export interface QuestNode {
   enemyDeck?: string[]
   /** Visual background theme for this node's battlefield ('forest' | 'ruins' | 'camp' | 'citadel' | 'ashen'). */
   environment?: string
+  /** Battlefield road paths for this node, overriding the act's `roads`. Rendered only — does not affect unit movement. */
+  roads?: RoadDef[]
   /** Override opponent play interval (ms). Replaces handicap-derived default. */
   opponentIntervalMs?: number
   /** Override opponent base HP. Replaces engine default (95 for bosses, 82 for others). */
@@ -295,6 +298,14 @@ export interface WorldMap {
    * All values are pixel coordinates relative to the map canvas size.
    */
   rivers?: Array<{ x1: number; y1: number; x2: number; y2: number; cx1: number; cy1: number; cx2: number; cy2: number }>
+
+  /**
+   * Default battlefield road paths for battles in this act, in game-unit coords
+   * (x 0–500 forward base→base, y -80..80 lateral) — the same space as
+   * TerrainObstacle. Rendered on the combat lane only (not the node-map
+   * screen); a QuestNode's own `roads` overrides this per-node. Visual only.
+   */
+  roads?: RoadDef[]
 
 }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -370,10 +370,11 @@ export interface BattleEventState {
 // Types and constants owned by engine/terrain.ts; re-exported here for
 // consumers that import from the top-level types module.
 
-import type { TerrainObstacle as _TerrainObstacle } from './engine/terrain'
-export type { TerrainType, TerrainObstacle } from './engine/terrain'
+import type { TerrainObstacle as _TerrainObstacle, RoadDef as _RoadDef } from './engine/terrain'
+export type { TerrainType, TerrainObstacle, RoadDef } from './engine/terrain'
 export { TERRAIN_AVOID_SHAPE } from './engine/terrain'
 type TerrainObstacle = _TerrainObstacle
+type RoadDef = _RoadDef
 
 // ─── Game ────────────────────────────────────────────────
 
@@ -434,6 +435,7 @@ export interface GameState {
   /** Live state for the active boss's trait system. Undefined when not in a boss fight. */
   bossTraitState?: BossTraitState
   terrain: TerrainObstacle[]
+  roads?: RoadDef[]          // act/node-authored road paths for the battlefield (visual only)
   environment?: string       // battlefield background theme ('forest' | 'ruins' | 'camp' | 'citadel' | 'ashen')
   unitReviveHp?: 'half' | 'full' | number      // pending one-time unit revive at this HP value (set by Soulstone/Salvage Hook relics)
   relicManaBonus?: number             // passive +N to maxMana cap (set by Prism Lens relic)

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -5,7 +5,7 @@ import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
 import { renderPathTiles } from './tileLookup'
-import type { TerrainObstacle } from '../game/engine/terrain'
+import type { TerrainObstacle, RoadDef } from '../game/engine/terrain'
 
 // Divisor controlling how obstacle radius (game units) maps to tile-ring radius (tiles).
 // Tuned against the realistic range of obstacle radius (20-32) and lane CSS height (~318-842px)
@@ -229,6 +229,74 @@ export async function buildDecorGfx(
       s.position.set(c * TILE_SIZE, r * TILE_SIZE)
       container.addChild(s)
     }
+  }
+}
+
+/**
+ * Renders act/node-authored road paths on the battlefield lane, using the same
+ * renderPathTiles() autotiler as hub streets and battlefield water patches.
+ * Visual only — does not affect unit movement/avoidance.
+ *
+ * Game coords → tile coords use the same projection as buildTerrainDecorGfx's
+ * toTile(): tcx = (0.5 + (y/80)*0.36) * w/TILE_SIZE, tcy = (1 - x/500) * h/TILE_SIZE.
+ */
+export async function buildRoadGfx(
+  container: PIXI.Container,
+  roads: RoadDef[],
+  opts: { environment?: string; envDef?: EnvTileDef },
+  w: number,
+  h: number,
+): Promise<void> {
+  if (roads.length === 0) return
+  const def = opts.envDef ?? ENV_TILES[opts.environment ?? '']
+
+  const toTile = (x: number, y: number) => ({
+    tcx: Math.round(((0.5 + (y / 80) * 0.36) * w) / TILE_SIZE),
+    tcy: Math.round(((1 - x / 500) * h) / TILE_SIZE),
+  })
+
+  for (const road of roads) {
+    if (container.destroyed) return
+    if (road.points.length < 2) continue
+
+    // Rasterize the centerline tile-by-tile between consecutive waypoints.
+    const centerline = new Set<string>()
+    let prev = toTile(road.points[0].x, road.points[0].y)
+    centerline.add(`${prev.tcx},${prev.tcy}`)
+    for (let i = 1; i < road.points.length; i++) {
+      const cur = toTile(road.points[i].x, road.points[i].y)
+      const dx = cur.tcx - prev.tcx
+      const dy = cur.tcy - prev.tcy
+      const steps = Math.max(Math.abs(dx), Math.abs(dy))
+      for (let s = 1; s <= steps; s++) {
+        const tx = Math.round(prev.tcx + (dx * s) / steps)
+        const ty = Math.round(prev.tcy + (dy * s) / steps)
+        centerline.add(`${tx},${ty}`)
+      }
+      prev = cur
+    }
+
+    // Widen the centerline into a band via circular dilation — the same
+    // technique buildTerrainDecorGfx uses for its obstacle ringSet. Note the
+    // resulting band diameter is 2*floor(width/2)+1, so this is an
+    // approximate (not exact-integer) tile width.
+    const width = road.width ?? 2
+    const tileRadius = Math.max(0, Math.floor(width / 2))
+    const roadSet = new Set<string>()
+    for (const key of centerline) {
+      const [c, r] = key.split(',').map(Number)
+      for (let dr = -tileRadius; dr <= tileRadius; dr++) {
+        for (let dc = -tileRadius; dc <= tileRadius; dc++) {
+          if (dr * dr + dc * dc > tileRadius * tileRadius) continue
+          roadSet.add(`${c + dc},${r + dr}`)
+        }
+      }
+    }
+
+    const roadContainer = new PIXI.Container()
+    container.addChild(roadContainer)
+    await renderPathTiles(roadContainer, roadSet, opts.environment, road.tileFile, width > 1, def)
+    if (container.destroyed) return
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds an optional `roads` field to act JSON (`WorldMap`/`Act`, with per-node override on `QuestNode`), authored as polyline waypoints in the same game-unit coordinate space already used by `TerrainObstacle` (x: 0–500 forward base→base, y: -80..80 lateral).
- Renders roads on the battlefield lane using the existing `renderPathTiles()` autotiler — the same function hub-world streets and the battlefield's water-obstacle patches already use — and the road tileset (`WORLD_PATH_TILE`) already assigned per environment, which lives in the same tileset family (`/nodemap/32x32/`) as the mountain/scenery art.
- New `buildRoadGfx()` in `terrainLayer.ts` converts road waypoints to tile coordinates using the exact same projection as the existing obstacle-placement code (`buildTerrainDecorGfx`'s `toTile()`), so roads stay pixel-aligned with obstacles, units, and bases at the battlefield's current scale.
- Threaded `roads` through the existing `environment`/`terrainSeed` pipeline: `QuestNode`/`Act` → `campaignHelpers.resolvedNodeOpts` → `NewGameOptions`/`GameState` → `Battlefield.tsx` → `BattlefieldTerrainCanvas`.

## Scope

- **Visual only** — roads do not affect unit movement or avoidance (`game/engine/units.ts` is untouched). Gameplay routing along roads is left for a future follow-up.
- **Infrastructure only** — no existing act JSON files were edited to add road content, so this is a no-op for every current battle (`buildRoadGfx` early-returns when `roads` is empty/undefined).

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] Full test suite (`npx vitest run`) passes: 1886 tests, 52 files, no regressions
- [ ] Author a `roads` array on a quest node and confirm in-browser that a road band renders, autotiles correctly, and sits under mountain/tree obstacle art (left for follow-up content work)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjufoNfRt3kJxoNKKQvdG)_