### PR TITLE
Add a Storybook-hosted battlefield editor (roads + terrain obstacles)

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -88,6 +88,15 @@ const config: StorybookConfig = {
             return
           }
 
+          if (req.url === '/api/battlefield-editor/save') {
+            try {
+              const { actId, data } = JSON.parse(await readBody(req))
+              writeFileSync(resolve(SRC, `data/acts/${actId}.json`), JSON.stringify(data, null, 2))
+              jsonOk(res, { ok: true })
+            } catch (e) { jsonErr(res, 500, `battlefield act save failed: ${String(e)}`) }
+            return
+          }
+
           next()
         })
       },

--- a/web/src/components/battlefieldEditor/BattlefieldEditor.stories.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditor.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { BattlefieldEditor } from './BattlefieldEditor'
+
+const meta = {
+  title:      'Battlefield Editor/BattlefieldEditor',
+  component:  BattlefieldEditor,
+  parameters: {
+    layout: 'fullscreen',
+    docs:   { description: { component: 'Visual editor for battlefield roads and terrain obstacles, authored into act JSON. Dev-only — requires Storybook dev server for file saves.' } },
+  },
+} satisfies Meta<typeof BattlefieldEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Act1: Story = { args: { initialActId: 'act1' } }
+export const Act2: Story = { args: { initialActId: 'act2' } }
+export const Act3: Story = { args: { initialActId: 'act3' } }
+export const Act4: Story = { args: { initialActId: 'act4' } }
+export const Act5: Story = { args: { initialActId: 'act5' } }
+export const Act6: Story = { args: { initialActId: 'act6' } }
+export const Act7: Story = { args: { initialActId: 'act7' } }
+export const Act8: Story = { args: { initialActId: 'act8' } }
+export const Act9: Story = { args: { initialActId: 'act9' } }
+export const Act10: Story = { args: { initialActId: 'act10' } }
+export const Act11: Story = { args: { initialActId: 'act11' } }
+export const Act12: Story = { args: { initialActId: 'act12' } }
+export const Act13: Story = { args: { initialActId: 'act13' } }
+export const ActFinale: Story = { name: 'Act Finale', args: { initialActId: 'actfinale' } }
+export const C2Act1: Story = { name: 'Ch2 Act 1', args: { initialActId: 'c2act1' } }
+export const C2Act2: Story = { name: 'Ch2 Act 2', args: { initialActId: 'c2act2' } }
+export const C2Act3: Story = { name: 'Ch2 Act 3', args: { initialActId: 'c2act3' } }
+export const C2Act4: Story = { name: 'Ch2 Act 4', args: { initialActId: 'c2act4' } }
+export const C2Act5: Story = { name: 'Ch2 Act 5', args: { initialActId: 'c2act5' } }
+export const World: Story = { name: 'World Battles', args: { initialActId: 'world' } }

--- a/web/src/components/battlefieldEditor/BattlefieldEditor.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditor.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react'
+import { useBattlefieldEditorState } from './useBattlefieldEditorState'
+import { BattlefieldEditorCanvas } from './BattlefieldEditorCanvas'
+import { BattlefieldEditorInspector } from './BattlefieldEditorInspector'
+import { BattlefieldEditorToolbar } from './BattlefieldEditorToolbar'
+import { WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
+import { ENV_TILES } from '../../data/tiles/tileIndex'
+
+export interface Props {
+  initialActId?: string
+}
+
+/**
+ * Storybook-hosted battlefield editor — authors act/node `roads` and `terrain`
+ * on the exact same WYSIWYG rendering the live Battlefield uses. Mirrors the
+ * hub Map Editor's architecture (web/src/components/mapEditor/), scoped down
+ * for this much smaller domain. Dev-only — requires the Storybook dev server
+ * for file saves (see .storybook/main.ts's /api/battlefield-editor/save route).
+ */
+export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
+  const editor = useBattlefieldEditorState(initialActId)
+  const { state } = editor
+  const [showGuides, setShowGuides] = useState(true)
+
+  const node = state.nodeId === 'act-default' ? undefined : state.actData.nodes[state.nodeId]
+  const environment = node?.environment ?? state.actData.environment ?? 'forest'
+  const envDef = WORLD_ENV_TILES[environment] ?? ENV_TILES[environment]
+  const roads = editor.resolveRoadsForTarget(state.actData, state.nodeId)
+  const terrain = editor.resolveTerrainForTarget(state.actData, state.nodeId)
+  const hasNodeRoadsOverride = state.nodeId !== 'act-default' && node?.roads !== undefined
+  const hasNodeTerrainOverride = state.nodeId !== 'act-default' && node?.terrain !== undefined
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#111', color: '#eee' }}>
+      <BattlefieldEditorToolbar
+        actId={state.actId}
+        actData={state.actData}
+        nodeId={state.nodeId}
+        tool={state.tool}
+        activeObstacleType={state.activeObstacleType}
+        inProgressRoadIndex={state.inProgressRoadIndex}
+        showGuides={showGuides}
+        environment={environment}
+        canUndo={state.undoStack.length > 0}
+        canRedo={state.redoStack.length > 0}
+        isDirty={state.isDirty}
+        onSetActId={editor.setActId}
+        onSetNodeId={editor.setNodeId}
+        onSetTool={editor.setTool}
+        onSetActiveObstacleType={editor.setActiveObstacleType}
+        onFinishRoad={editor.finishRoad}
+        onToggleGuides={() => setShowGuides(g => !g)}
+        onUndo={editor.undo}
+        onRedo={editor.redo}
+        onSaved={editor.markSaved}
+      />
+      <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        <div style={{ flex: 1, position: 'relative' }}>
+          <BattlefieldEditorCanvas
+            environment={environment}
+            envDef={envDef}
+            id={`${state.actId}-${state.nodeId}`}
+            roads={roads}
+            terrain={terrain}
+            tool={state.tool}
+            activeObstacleType={state.activeObstacleType}
+            inProgressRoadIndex={state.inProgressRoadIndex}
+            selectedEntities={state.selectedEntities}
+            showGuides={showGuides}
+            onSelectEntities={editor.selectEntities}
+            onRoadClick={editor.clickRoadTool}
+            onObstacleClick={(x, y) => editor.addObstacle(x, y, state.activeObstacleType)}
+            onMoveRoadPoint={editor.moveRoadPoint}
+            onMoveObstacle={editor.moveObstacle}
+            onDeleteRoad={editor.deleteRoad}
+            onDeleteRoadPoint={editor.deleteRoadPoint}
+            onDeleteObstacle={editor.deleteObstacle}
+          />
+        </div>
+        <BattlefieldEditorInspector
+          selectedEntities={state.selectedEntities}
+          roads={roads}
+          terrain={terrain}
+          nodeId={state.nodeId}
+          hasNodeRoadsOverride={hasNodeRoadsOverride}
+          hasNodeTerrainOverride={hasNodeTerrainOverride}
+          onUpdateRoad={editor.updateRoad}
+          onMoveRoadPoint={editor.moveRoadPoint}
+          onDeleteRoad={editor.deleteRoad}
+          onDeleteRoadPoint={editor.deleteRoadPoint}
+          onUpdateObstacle={editor.updateObstacle}
+          onMoveObstacle={editor.moveObstacle}
+          onDeleteObstacle={editor.deleteObstacle}
+          onRevertRoads={() => editor.revertToActDefault('roads')}
+          onRevertTerrain={() => editor.revertToActDefault('terrain')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -1,0 +1,245 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import {
+  buildTerrainGfx, buildBgTileGfx, buildBorderGfx, buildDecorGfx,
+  buildRoadGfx, buildTerrainDecorGfx, gameToPixel, pixelToGame,
+} from '../../utils/terrainLayer'
+import { TILE_SIZE, EnvTileDef } from '../../data/tiles/tileIndex'
+import { TERRAIN_CLEAR_Y } from '../../game/engine/terrain'
+import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity } from './battlefieldEditorTypes'
+
+export interface Props {
+  environment: string
+  envDef: EnvTileDef
+  /** Stable key for WYSIWYG decor scatter — pass actId+nodeId. */
+  id: string
+  roads: RoadDef[]
+  terrain: TerrainObstacle[]
+  tool: ToolMode
+  activeObstacleType: TerrainType
+  inProgressRoadIndex: number | null
+  selectedEntities: SelectedEntity[]
+  showGuides: boolean
+  onSelectEntities: (entities: SelectedEntity[]) => void
+  onRoadClick: (x: number, y: number) => void
+  onObstacleClick: (x: number, y: number) => void
+  onMoveRoadPoint: (roadIndex: number, pointIndex: number, x: number, y: number) => void
+  onMoveObstacle: (index: number, x: number, y: number) => void
+  onDeleteRoad: (roadIndex: number) => void
+  onDeleteRoadPoint: (roadIndex: number, pointIndex: number) => void
+  onDeleteObstacle: (index: number) => void
+}
+
+const HANDLE_RADIUS = 6
+const SELECTED_COLOR = 0xffcc33
+const HANDLE_COLOR = 0x33ccff
+const OBSTACLE_COLOR = 0xff5566
+
+type Drag =
+  | { kind: 'roadPoint'; roadIndex: number; pointIndex: number }
+  | { kind: 'obstacle'; index: number }
+
+// Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
+function EditorPixi(props: Props & { w: number; h: number }) {
+  const { w, h } = props
+  const containerRef = useRef<HTMLDivElement>(null)
+  const propsRef = useRef(props)
+  propsRef.current = props
+  const dragRef = useRef<Drag | null>(null)
+
+  const appRef = usePixiApp(containerRef, w, h, useCallback((app: PIXI.Application) => {
+    const stage = app.stage
+    stage.eventMode = 'static'
+    stage.hitArea = new PIXI.Rectangle(0, 0, w, h)
+
+    stage.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      const { tool, onRoadClick, onObstacleClick, onSelectEntities } = propsRef.current
+      const pos = e.getLocalPosition(stage)
+      const { x, y } = pixelToGame(pos.x, pos.y, w, h)
+      if (tool === 'road') { onRoadClick(x, y); return }
+      if (tool === 'obstacle') { onObstacleClick(x, y); return }
+      if (tool === 'select') { onSelectEntities([]) }
+    })
+
+    stage.on('pointermove', (e: PIXI.FederatedPointerEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+      const pos = e.getLocalPosition(stage)
+      const { x, y } = pixelToGame(pos.x, pos.y, w, h)
+      if (drag.kind === 'roadPoint') propsRef.current.onMoveRoadPoint(drag.roadIndex, drag.pointIndex, x, y)
+      else propsRef.current.onMoveObstacle(drag.index, x, y)
+    })
+
+    const endDrag = () => { dragRef.current = null }
+    stage.on('pointerup', endDrag)
+    stage.on('pointerupoutside', endDrag)
+  }, [w, h]))
+
+  // Rebuilds the scene whenever anything render-affecting changes. Mirrors
+  // MapEditorCanvas.tsx: tear down stage children and redraw, rather than
+  // remounting the whole PixiJS Application (which usePixiApp only does when
+  // w/h change).
+  useEffect(() => {
+    const app = appRef.current
+    if (!app) return
+    const stage = app.stage
+
+    // Destroy (not just detach) old children so their in-flight async texture
+    // loads (container.destroyed checks in the build*Gfx helpers) abort cleanly
+    // instead of resolving into a detached, unreachable container.
+    for (const child of [...stage.children]) {
+      stage.removeChild(child)
+      child.destroy({ children: true })
+    }
+
+    const base           = new PIXI.Container()
+    const bg             = new PIXI.Container()
+    const road           = new PIXI.Container()
+    const border         = new PIXI.Container()
+    const decor          = new PIXI.Container()
+    const decorObstacles = new PIXI.Container()
+    const world          = new PIXI.Container()
+    const guides         = new PIXI.Graphics()
+    const editOverlay    = new PIXI.Container()
+    stage.addChild(base, bg, road, border, decor, decorObstacles, world, guides, editOverlay)
+
+    const { environment, envDef, id, roads, terrain } = props
+    buildTerrainGfx(base, new PIXI.Container(), world, { environment, envDef, id, rivers: [], terrainItems: [] }, w, h)
+    buildBgTileGfx(bg, { environment, envDef }, w, h)
+    buildRoadGfx(road, roads, { environment, envDef }, w, h)
+    buildBorderGfx(border, { environment, envDef }, w, h)
+    buildDecorGfx(decor, { environment, envDef, id }, w, h)
+    buildTerrainDecorGfx(decorObstacles, terrain, { environment, envDef }, w, h)
+
+    if (props.showGuides) drawGuides(guides, w, h)
+    drawEditOverlay(editOverlay, props, w, h, dragRef)
+  })
+
+  return <div ref={containerRef} style={{ width: w, height: h }} />
+}
+
+function drawGuides(g: PIXI.Graphics, w: number, h: number) {
+  const cols = Math.ceil(w / TILE_SIZE)
+  const rows = Math.ceil(h / TILE_SIZE)
+  for (let c = 0; c <= cols; c++) g.moveTo(c * TILE_SIZE, 0).lineTo(c * TILE_SIZE, h)
+  for (let r = 0; r <= rows; r++) g.moveTo(0, r * TILE_SIZE).lineTo(w, r * TILE_SIZE)
+  g.stroke({ color: 0xffffff, width: 1, alpha: 0.06 })
+
+  for (const cy of TERRAIN_CLEAR_Y) {
+    const { py } = gameToPixel(250, cy, w, h)
+    g.moveTo(0, py).lineTo(w, py).stroke({ color: 0x33ff99, width: 2, alpha: 0.35 })
+  }
+}
+
+function isRoadSelected(sel: SelectedEntity[], roadIndex: number): boolean {
+  return sel.some(s => (s.type === 'road' && s.index === roadIndex) || (s.type === 'roadPoint' && s.roadIndex === roadIndex))
+}
+function isPointSelected(sel: SelectedEntity[], roadIndex: number, pointIndex: number): boolean {
+  return sel.some(s => s.type === 'roadPoint' && s.roadIndex === roadIndex && s.pointIndex === pointIndex)
+}
+function isObstacleSelected(sel: SelectedEntity[], index: number): boolean {
+  return sel.some(s => s.type === 'obstacle' && s.index === index)
+}
+
+function drawEditOverlay(
+  container: PIXI.Container,
+  props: Props,
+  w: number,
+  h: number,
+  dragRef: React.MutableRefObject<Drag | null>,
+) {
+  const { roads, terrain, selectedEntities, tool, onSelectEntities, onDeleteRoad, onDeleteRoadPoint, onDeleteObstacle } = props
+
+  // Road strokes + waypoint handles
+  roads.forEach((road, roadIndex) => {
+    const pts = road.points.map(p => gameToPixel(p.x, p.y, w, h))
+    if (pts.length >= 2) {
+      const line = new PIXI.Graphics()
+      line.moveTo(pts[0].px, pts[0].py)
+      for (let i = 1; i < pts.length; i++) line.lineTo(pts[i].px, pts[i].py)
+      line.stroke({ color: isRoadSelected(selectedEntities, roadIndex) ? SELECTED_COLOR : HANDLE_COLOR, width: 3, alpha: 0.85 })
+      line.eventMode = 'static'
+      line.cursor = 'pointer'
+      line.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        if (tool === 'delete') { onDeleteRoad(roadIndex); return }
+        onSelectEntities([{ type: 'road', index: roadIndex }])
+      })
+      container.addChild(line)
+    }
+
+    road.points.forEach((_, pointIndex) => {
+      const { px, py } = pts[pointIndex]
+      const handle = new PIXI.Graphics()
+      const selected = isPointSelected(selectedEntities, roadIndex, pointIndex)
+      handle.circle(0, 0, HANDLE_RADIUS).fill({ color: selected ? SELECTED_COLOR : HANDLE_COLOR, alpha: 0.95 })
+      handle.position.set(px, py)
+      handle.eventMode = 'static'
+      handle.cursor = 'pointer'
+      handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        if (tool === 'delete') { onDeleteRoadPoint(roadIndex, pointIndex); return }
+        onSelectEntities([{ type: 'roadPoint', roadIndex, pointIndex }])
+        dragRef.current = { kind: 'roadPoint', roadIndex, pointIndex }
+      })
+      container.addChild(handle)
+    })
+  })
+
+  // Obstacle drag handles
+  terrain.forEach((obs, index) => {
+    const { px, py } = gameToPixel(obs.x, obs.y, w, h)
+    const selected = isObstacleSelected(selectedEntities, index)
+    const handle = new PIXI.Graphics()
+    handle.circle(0, 0, HANDLE_RADIUS).stroke({ color: selected ? SELECTED_COLOR : OBSTACLE_COLOR, width: 3, alpha: 0.95 })
+    handle.position.set(px, py)
+    handle.eventMode = 'static'
+    handle.cursor = 'pointer'
+    handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      e.stopPropagation()
+      if (tool === 'delete') { onDeleteObstacle(index); return }
+      onSelectEntities([{ type: 'obstacle', index }])
+      dragRef.current = { kind: 'obstacle', index }
+    })
+    container.addChild(handle)
+  })
+}
+
+/**
+ * WYSIWYG, editable battlefield lane canvas — mirrors BattlefieldTerrainCanvas's
+ * sizing (ResizeObserver-measured, no fixed grid) and renders through the exact
+ * same terrainLayer build*Gfx functions the live game uses, plus an editable
+ * overlay for roads/obstacles.
+ */
+export function BattlefieldEditorCanvas(props: Props) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    let raf = 0
+    const measure = () => {
+      const { width, height } = el.getBoundingClientRect()
+      if (width > 0 && height > 0) {
+        const w = Math.ceil(width)
+        const h = Math.ceil(height)
+        setDims(prev => (prev && prev.w === w && prev.h === h) ? prev : { w, h })
+      }
+    }
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(measure)
+    })
+    ro.observe(el)
+    measure()
+    return () => { cancelAnimationFrame(raf); ro.disconnect() }
+  }, [])
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}>
+      {dims && <EditorPixi key={`${dims.w}x${dims.h}`} {...props} w={dims.w} h={dims.h} />}
+    </div>
+  )
+}

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -31,7 +31,7 @@ export interface Props {
   onDeleteObstacle: (index: number) => void
 }
 
-const HANDLE_RADIUS = 6
+const HANDLE_RADIUS = 8
 const SELECTED_COLOR = 0xffcc33
 const HANDLE_COLOR = 0x33ccff
 const OBSTACLE_COLOR = 0xff5566
@@ -126,9 +126,12 @@ function drawGuides(g: PIXI.Graphics, w: number, h: number) {
   for (let r = 0; r <= rows; r++) g.moveTo(0, r * TILE_SIZE).lineTo(w, r * TILE_SIZE)
   g.stroke({ color: 0xffffff, width: 1, alpha: 0.06 })
 
+  // TERRAIN_CLEAR_Y corridors are lateral (y-axis) positions procedural terrain
+  // avoids — lateral y maps to screen-x (gameToPixel's px depends only on y),
+  // so each corridor is a vertical line spanning the full forward (x) extent.
   for (const cy of TERRAIN_CLEAR_Y) {
-    const { py } = gameToPixel(250, cy, w, h)
-    g.moveTo(0, py).lineTo(w, py).stroke({ color: 0x33ff99, width: 2, alpha: 0.35 })
+    const { px } = gameToPixel(0, cy, w, h)
+    g.moveTo(px, 0).lineTo(px, h).stroke({ color: 0x33ff99, width: 2, alpha: 0.35 })
   }
 }
 
@@ -177,6 +180,7 @@ function drawEditOverlay(
       handle.position.set(px, py)
       handle.eventMode = 'static'
       handle.cursor = 'pointer'
+      handle.hitArea = new PIXI.Circle(0, 0, HANDLE_RADIUS * 2)
       handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
         e.stopPropagation()
         if (tool === 'delete') { onDeleteRoadPoint(roadIndex, pointIndex); return }
@@ -196,6 +200,7 @@ function drawEditOverlay(
     handle.position.set(px, py)
     handle.eventMode = 'static'
     handle.cursor = 'pointer'
+    handle.hitArea = new PIXI.Circle(0, 0, HANDLE_RADIUS * 2)
     handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
       e.stopPropagation()
       if (tool === 'delete') { onDeleteObstacle(index); return }

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -11,7 +11,7 @@ import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity } 
 
 export interface Props {
   environment: string
-  envDef: EnvTileDef
+  envDef?: EnvTileDef
   /** Stable key for WYSIWYG decor scatter — pass actId+nodeId. */
   id: string
   roads: RoadDef[]

--- a/web/src/components/battlefieldEditor/BattlefieldEditorInspector.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorInspector.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import type { SelectedEntity, RoadDef, TerrainObstacle, TerrainType, EditTarget } from './battlefieldEditorTypes'
+import { WORLD_PATH_TILE } from '../../data/tiles/worldTileIndex'
+
+const TERRAIN_TYPES: TerrainType[] = ['rock', 'tree', 'water', 'ruin']
+const ROAD_TILE_OPTIONS = Object.entries(WORLD_PATH_TILE)
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <label style={{ display: 'block', fontSize: 11, opacity: 0.7, marginBottom: 2 }}>{label}</label>
+      {children}
+    </div>
+  )
+}
+
+function numInput(value: number, onChange: (v: number) => void) {
+  return (
+    <input
+      type="number"
+      value={value}
+      onChange={e => { const v = parseFloat(e.target.value); if (!Number.isNaN(v)) onChange(v) }}
+      style={{ width: 70 }}
+    />
+  )
+}
+
+interface RoadInspectorProps {
+  roadIndex: number
+  road: RoadDef
+  onUpdateRoad: (roadIndex: number, patch: Partial<Pick<RoadDef, 'width' | 'tileFile'>>) => void
+  onMoveRoadPoint: (roadIndex: number, pointIndex: number, x: number, y: number) => void
+  onDeleteRoad: (roadIndex: number) => void
+  onDeleteRoadPoint: (roadIndex: number, pointIndex: number) => void
+}
+
+function RoadInspector({ roadIndex, road, onUpdateRoad, onMoveRoadPoint, onDeleteRoad, onDeleteRoadPoint }: RoadInspectorProps) {
+  return (
+    <div>
+      <h4 style={{ margin: '0 0 8px' }}>Road #{roadIndex + 1}</h4>
+      <Field label="Width (tiles)">
+        {numInput(road.width ?? 2, v => onUpdateRoad(roadIndex, { width: Math.max(1, Math.round(v)) }))}
+      </Field>
+      <Field label="Tileset">
+        <select
+          value={road.tileFile ?? ''}
+          onChange={e => onUpdateRoad(roadIndex, { tileFile: e.target.value || undefined })}
+          style={{ width: '100%' }}
+        >
+          <option value="">(environment default)</option>
+          {ROAD_TILE_OPTIONS.map(([key, file]) => <option key={key} value={file}>{key}</option>)}
+        </select>
+      </Field>
+      <Field label={`Waypoints (${road.points.length})`}>
+        <div style={{ maxHeight: 180, overflowY: 'auto' }}>
+          {road.points.map((p, i) => (
+            <div key={i} style={{ display: 'flex', gap: 4, marginBottom: 4, alignItems: 'center' }}>
+              <span style={{ fontSize: 10, opacity: 0.6, width: 14 }}>{i + 1}</span>
+              {numInput(Math.round(p.x), v => onMoveRoadPoint(roadIndex, i, v, p.y))}
+              {numInput(Math.round(p.y), v => onMoveRoadPoint(roadIndex, i, p.x, v))}
+              <button onClick={() => onDeleteRoadPoint(roadIndex, i)} disabled={road.points.length <= 2} title="Delete waypoint">×</button>
+            </div>
+          ))}
+        </div>
+      </Field>
+      <button onClick={() => onDeleteRoad(roadIndex)}>Delete Road</button>
+    </div>
+  )
+}
+
+interface ObstacleInspectorProps {
+  index: number
+  obstacle: TerrainObstacle
+  onUpdateObstacle: (index: number, patch: Partial<Pick<TerrainObstacle, 'type' | 'radius'>>) => void
+  onMoveObstacle: (index: number, x: number, y: number) => void
+  onDeleteObstacle: (index: number) => void
+}
+
+function ObstacleInspector({ index, obstacle, onUpdateObstacle, onMoveObstacle, onDeleteObstacle }: ObstacleInspectorProps) {
+  return (
+    <div>
+      <h4 style={{ margin: '0 0 8px' }}>Obstacle #{index + 1}</h4>
+      <Field label="Type">
+        <select
+          value={obstacle.type}
+          onChange={e => onUpdateObstacle(index, { type: e.target.value as TerrainType })}
+          style={{ width: '100%' }}
+        >
+          {TERRAIN_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </Field>
+      <Field label="Radius">
+        {numInput(obstacle.radius, v => onUpdateObstacle(index, { radius: Math.max(1, v) }))}
+      </Field>
+      <Field label="Position (x, y)">
+        <div style={{ display: 'flex', gap: 4 }}>
+          {numInput(Math.round(obstacle.x), v => onMoveObstacle(index, v, obstacle.y))}
+          {numInput(Math.round(obstacle.y), v => onMoveObstacle(index, obstacle.x, v))}
+        </div>
+      </Field>
+      <button onClick={() => onDeleteObstacle(index)}>Delete Obstacle</button>
+    </div>
+  )
+}
+
+export interface InspectorProps {
+  selectedEntities: SelectedEntity[]
+  roads: RoadDef[]
+  terrain: TerrainObstacle[]
+  nodeId: EditTarget
+  hasNodeRoadsOverride: boolean
+  hasNodeTerrainOverride: boolean
+  onUpdateRoad: RoadInspectorProps['onUpdateRoad']
+  onMoveRoadPoint: RoadInspectorProps['onMoveRoadPoint']
+  onDeleteRoad: RoadInspectorProps['onDeleteRoad']
+  onDeleteRoadPoint: RoadInspectorProps['onDeleteRoadPoint']
+  onUpdateObstacle: ObstacleInspectorProps['onUpdateObstacle']
+  onMoveObstacle: ObstacleInspectorProps['onMoveObstacle']
+  onDeleteObstacle: ObstacleInspectorProps['onDeleteObstacle']
+  onRevertRoads: () => void
+  onRevertTerrain: () => void
+}
+
+export function BattlefieldEditorInspector(props: InspectorProps) {
+  const { selectedEntities, roads, terrain, nodeId, hasNodeRoadsOverride, hasNodeTerrainOverride, onRevertRoads, onRevertTerrain } = props
+  const sel = selectedEntities[0]
+
+  let body: React.ReactNode = <p style={{ opacity: 0.6, fontSize: 12 }}>Select a road or obstacle to edit it.</p>
+  if (sel?.type === 'road' && roads[sel.index]) {
+    body = <RoadInspector roadIndex={sel.index} road={roads[sel.index]} onUpdateRoad={props.onUpdateRoad} onMoveRoadPoint={props.onMoveRoadPoint} onDeleteRoad={props.onDeleteRoad} onDeleteRoadPoint={props.onDeleteRoadPoint} />
+  } else if (sel?.type === 'roadPoint' && roads[sel.roadIndex]) {
+    body = <RoadInspector roadIndex={sel.roadIndex} road={roads[sel.roadIndex]} onUpdateRoad={props.onUpdateRoad} onMoveRoadPoint={props.onMoveRoadPoint} onDeleteRoad={props.onDeleteRoad} onDeleteRoadPoint={props.onDeleteRoadPoint} />
+  } else if (sel?.type === 'obstacle' && terrain[sel.index]) {
+    body = <ObstacleInspector index={sel.index} obstacle={terrain[sel.index]} onUpdateObstacle={props.onUpdateObstacle} onMoveObstacle={props.onMoveObstacle} onDeleteObstacle={props.onDeleteObstacle} />
+  }
+
+  return (
+    <div style={{ width: 220, padding: 12, overflowY: 'auto', borderLeft: '1px solid #333', fontSize: 12 }}>
+      {nodeId !== 'act-default' && (
+        <div style={{ marginBottom: 12, paddingBottom: 12, borderBottom: '1px solid #333' }}>
+          <div style={{ marginBottom: 4 }}>
+            Roads: {hasNodeRoadsOverride ? 'node override' : 'inherited from act'}
+            {hasNodeRoadsOverride && <button style={{ marginLeft: 6 }} onClick={onRevertRoads}>Clear</button>}
+          </div>
+          <div>
+            Terrain: {hasNodeTerrainOverride ? 'node override' : 'inherited / procedural'}
+            {hasNodeTerrainOverride && <button style={{ marginLeft: 6 }} onClick={onRevertTerrain}>Clear</button>}
+          </div>
+        </div>
+      )}
+      {body}
+    </div>
+  )
+}

--- a/web/src/components/battlefieldEditor/BattlefieldEditorToolbar.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorToolbar.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react'
+import type { Act, ToolMode, TerrainType, EditTarget } from './battlefieldEditorTypes'
+import { BATTLEFIELD_ACT_IDS } from './useBattlefieldEditorState'
+import { saveBattlefieldAct } from './battlefieldEditorApi'
+import { markSelfSave } from '../../utils/hotReloadGuard'
+
+const TOOLS: { tool: ToolMode; label: string }[] = [
+  { tool: 'select', label: 'Select' },
+  { tool: 'road', label: 'Road' },
+  { tool: 'obstacle', label: 'Obstacle' },
+  { tool: 'delete', label: 'Delete' },
+]
+
+const OBSTACLE_TYPES: TerrainType[] = ['rock', 'tree', 'water', 'ruin']
+
+export interface Props {
+  actId: string
+  actData: Act
+  nodeId: EditTarget
+  tool: ToolMode
+  activeObstacleType: TerrainType
+  inProgressRoadIndex: number | null
+  showGuides: boolean
+  environment: string
+  canUndo: boolean
+  canRedo: boolean
+  isDirty: boolean
+  onSetActId: (actId: string) => void
+  onSetNodeId: (nodeId: EditTarget) => void
+  onSetTool: (tool: ToolMode) => void
+  onSetActiveObstacleType: (type: TerrainType) => void
+  onFinishRoad: () => void
+  onToggleGuides: () => void
+  onUndo: () => void
+  onRedo: () => void
+  onSaved: () => void
+}
+
+export function BattlefieldEditorToolbar(props: Props) {
+  const {
+    actId, actData, nodeId, tool, activeObstacleType, inProgressRoadIndex, showGuides,
+    environment, canUndo, canRedo, isDirty,
+    onSetActId, onSetNodeId, onSetTool, onSetActiveObstacleType, onFinishRoad,
+    onToggleGuides, onUndo, onRedo, onSaved,
+  } = props
+
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'ok' | 'error'>('idle')
+  const [saveError, setSaveError] = useState('')
+
+  const handleSave = async () => {
+    setSaveState('saving')
+    setSaveError('')
+    markSelfSave()
+    try {
+      await saveBattlefieldAct(actId, actData)
+      setSaveState('ok')
+      onSaved()
+      setTimeout(() => setSaveState('idle'), 2000)
+    } catch (e) {
+      setSaveState('error')
+      setSaveError(e instanceof Error ? e.message : String(e))
+      setTimeout(() => setSaveState('idle'), 4000)
+    }
+  }
+
+  const nodeIds = Object.keys(actData.nodes)
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 8, borderBottom: '1px solid #333', flexWrap: 'wrap' }}>
+      <label>
+        Act:{' '}
+        <select value={actId} onChange={e => onSetActId(e.target.value)}>
+          {BATTLEFIELD_ACT_IDS.map(id => <option key={id} value={id}>{id}</option>)}
+        </select>
+      </label>
+
+      <label>
+        Node:{' '}
+        <select value={nodeId} onChange={e => onSetNodeId(e.target.value)}>
+          <option value="act-default">(act default)</option>
+          {nodeIds.map(id => <option key={id} value={id}>{actData.nodes[id].label || id}</option>)}
+        </select>
+      </label>
+
+      <span style={{ fontSize: 11, opacity: 0.7 }}>env: {environment}</span>
+
+      <div style={{ display: 'flex', gap: 4 }}>
+        {TOOLS.map(t => (
+          <button
+            key={t.tool}
+            onClick={() => onSetTool(t.tool)}
+            style={{ fontWeight: tool === t.tool ? 'bold' : 'normal', textDecoration: tool === t.tool ? 'underline' : 'none' }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tool === 'obstacle' && (
+        <label>
+          Type:{' '}
+          <select value={activeObstacleType} onChange={e => onSetActiveObstacleType(e.target.value as TerrainType)}>
+            {OBSTACLE_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </label>
+      )}
+
+      {tool === 'road' && inProgressRoadIndex !== null && (
+        <button onClick={onFinishRoad}>Finish road</button>
+      )}
+
+      <label style={{ fontSize: 11 }}>
+        <input type="checkbox" checked={showGuides} onChange={onToggleGuides} /> Guides
+      </label>
+
+      <button onClick={onUndo} disabled={!canUndo}>Undo</button>
+      <button onClick={onRedo} disabled={!canRedo}>Redo</button>
+
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+        {saveState === 'error' && <span style={{ color: '#f88', fontSize: 10 }}>{saveError}</span>}
+        <button
+          onClick={handleSave}
+          disabled={saveState === 'saving'}
+          style={{
+            color: saveState === 'ok' ? '#8f8' : saveState === 'error' ? '#f88' : undefined,
+            fontWeight: isDirty ? 'bold' : 'normal',
+          }}
+        >
+          {saveState === 'saving' ? 'Saving…' : saveState === 'ok' ? '✓ Saved' : saveState === 'error' ? 'Save failed' : isDirty ? 'Save*' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/battlefieldEditor/battlefieldEditorApi.ts
+++ b/web/src/components/battlefieldEditor/battlefieldEditorApi.ts
@@ -1,0 +1,11 @@
+export async function saveBattlefieldAct(actId: string, data: unknown): Promise<void> {
+  const res = await fetch('/api/battlefield-editor/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ actId, data }),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText)
+    throw new Error(`Save failed: ${text}`)
+  }
+}

--- a/web/src/components/battlefieldEditor/battlefieldEditorTypes.ts
+++ b/web/src/components/battlefieldEditor/battlefieldEditorTypes.ts
@@ -1,0 +1,28 @@
+import type { Act } from '../../game/questline'
+import type { RoadDef, TerrainObstacle, TerrainType } from '../../game/engine/terrain'
+
+export type ToolMode = 'select' | 'road' | 'obstacle' | 'delete'
+
+export type SelectedEntity =
+  | { type: 'road'; index: number }
+  | { type: 'roadPoint'; roadIndex: number; pointIndex: number }
+  | { type: 'obstacle'; index: number }
+
+/** 'act-default' edits the act-level roads/terrain; otherwise a specific node id. */
+export type EditTarget = 'act-default' | string
+
+export interface BattlefieldEditorState {
+  actId: string
+  nodeId: EditTarget
+  actData: Act
+  tool: ToolMode
+  activeObstacleType: TerrainType
+  /** Index into the current target's roads array while a road is being drawn point-by-point. */
+  inProgressRoadIndex: number | null
+  selectedEntities: SelectedEntity[]
+  undoStack: Act[]
+  redoStack: Act[]
+  isDirty: boolean
+}
+
+export type { Act, RoadDef, TerrainObstacle, TerrainType }

--- a/web/src/components/battlefieldEditor/useBattlefieldEditorState.ts
+++ b/web/src/components/battlefieldEditor/useBattlefieldEditorState.ts
@@ -1,0 +1,426 @@
+import { useState, useCallback } from 'react'
+import type { Act, RoadDef, TerrainObstacle, TerrainType, ToolMode, EditTarget, SelectedEntity, BattlefieldEditorState } from './battlefieldEditorTypes'
+import { generateTerrain } from '../../game/engine/terrain'
+import { isSelfSave } from '../../utils/hotReloadGuard'
+
+import act1 from '../../data/acts/act1.json'
+import act2 from '../../data/acts/act2.json'
+import act3 from '../../data/acts/act3.json'
+import act4 from '../../data/acts/act4.json'
+import act5 from '../../data/acts/act5.json'
+import act6 from '../../data/acts/act6.json'
+import act7 from '../../data/acts/act7.json'
+import act8 from '../../data/acts/act8.json'
+import act9 from '../../data/acts/act9.json'
+import act10 from '../../data/acts/act10.json'
+import act11 from '../../data/acts/act11.json'
+import act12 from '../../data/acts/act12.json'
+import act13 from '../../data/acts/act13.json'
+import actfinale from '../../data/acts/actfinale.json'
+import c2act1 from '../../data/acts/c2act1.json'
+import c2act2 from '../../data/acts/c2act2.json'
+import c2act3 from '../../data/acts/c2act3.json'
+import c2act4 from '../../data/acts/c2act4.json'
+import c2act5 from '../../data/acts/c2act5.json'
+import worldbattles from '../../data/acts/worldbattles.json'
+
+// Exported so the toolbar's act picker and the Storybook stories can enumerate
+// every editable act without re-importing the JSON.
+export const RAW_ACTS: Record<string, Act> = {
+  act1: act1 as unknown as Act,
+  act2: act2 as unknown as Act,
+  act3: act3 as unknown as Act,
+  act4: act4 as unknown as Act,
+  act5: act5 as unknown as Act,
+  act6: act6 as unknown as Act,
+  act7: act7 as unknown as Act,
+  act8: act8 as unknown as Act,
+  act9: act9 as unknown as Act,
+  act10: act10 as unknown as Act,
+  act11: act11 as unknown as Act,
+  act12: act12 as unknown as Act,
+  act13: act13 as unknown as Act,
+  actfinale: actfinale as unknown as Act,
+  c2act1: c2act1 as unknown as Act,
+  c2act2: c2act2 as unknown as Act,
+  c2act3: c2act3 as unknown as Act,
+  c2act4: c2act4 as unknown as Act,
+  c2act5: c2act5 as unknown as Act,
+  world: worldbattles as unknown as Act,
+}
+
+export const BATTLEFIELD_ACT_IDS: string[] = Object.keys(RAW_ACTS)
+
+// Saving writes straight onto these same act JSON files, which Vite would
+// otherwise respond to with a full page reload (see hotReloadGuard.ts). A
+// self-triggered save's data already matches what's in memory, so we no-op;
+// an external change (another tab, or a hand-edit) also no-ops but warns,
+// since silently reloading could discard unsaved work in this tab.
+if (import.meta.hot) {
+  import.meta.hot.accept([
+    '../../data/acts/act1.json',
+    '../../data/acts/act2.json',
+    '../../data/acts/act3.json',
+    '../../data/acts/act4.json',
+    '../../data/acts/act5.json',
+    '../../data/acts/act6.json',
+    '../../data/acts/act7.json',
+    '../../data/acts/act8.json',
+    '../../data/acts/act9.json',
+    '../../data/acts/act10.json',
+    '../../data/acts/act11.json',
+    '../../data/acts/act12.json',
+    '../../data/acts/act13.json',
+    '../../data/acts/actfinale.json',
+    '../../data/acts/c2act1.json',
+    '../../data/acts/c2act2.json',
+    '../../data/acts/c2act3.json',
+    '../../data/acts/c2act4.json',
+    '../../data/acts/c2act5.json',
+    '../../data/acts/worldbattles.json',
+  ], () => {
+    if (!isSelfSave()) {
+      console.warn('[battlefield editor] An act JSON file changed on disk outside this tab. Refresh to pick it up — unsaved changes here were left alone.')
+    }
+  })
+}
+
+const MAX_UNDO = 50
+
+// ─── Target resolution ────────────────────────────────────────────────────
+// A node without its own `roads`/`terrain` inherits the act-level default.
+// Reading always resolves the effective (rendered) value; writing always
+// targets exactly the level currently being edited (act-default or a
+// specific node), never the level it happened to inherit from.
+
+function resolveRoadsForTarget(act: Act, nodeId: EditTarget): RoadDef[] {
+  if (nodeId === 'act-default') return act.roads ?? []
+  return act.nodes[nodeId]?.roads ?? act.roads ?? []
+}
+
+/** Unlike roads, terrain always resolves to *something* — the procedural
+ *  generator's output — so a node-level edit starts from what's already
+ *  rendering rather than a blank field. */
+function resolveTerrainForTarget(act: Act, nodeId: EditTarget): TerrainObstacle[] {
+  if (nodeId === 'act-default') return act.terrain ?? []
+  const node = act.nodes[nodeId]
+  if (node?.terrain) return node.terrain
+  if (act.terrain) return act.terrain
+  const environment = node?.environment ?? act.environment ?? 'forest'
+  return generateTerrain(nodeId, environment)
+}
+
+function withRoads(act: Act, nodeId: EditTarget, roads: RoadDef[]): Act {
+  if (nodeId === 'act-default') return { ...act, roads }
+  const node = act.nodes[nodeId]
+  if (!node) return act
+  return { ...act, nodes: { ...act.nodes, [nodeId]: { ...node, roads } } }
+}
+
+function withTerrain(act: Act, nodeId: EditTarget, terrain: TerrainObstacle[]): Act {
+  if (nodeId === 'act-default') return { ...act, terrain }
+  const node = act.nodes[nodeId]
+  if (!node) return act
+  return { ...act, nodes: { ...act.nodes, [nodeId]: { ...node, terrain } } }
+}
+
+function nextObstacleId(existing: TerrainObstacle[]): string {
+  const ids = new Set(existing.map(o => o.id))
+  let n = existing.length + 1
+  while (ids.has(`t${n}`)) n++
+  return `t${n}`
+}
+
+export function useBattlefieldEditorState(initialActId: string = 'act1') {
+  const [state, setState] = useState<BattlefieldEditorState>(() => ({
+    actId:               initialActId,
+    actData:             structuredClone(RAW_ACTS[initialActId]),
+    nodeId:              'act-default',
+    tool:                'select',
+    activeObstacleType:  'rock',
+    inProgressRoadIndex: null,
+    selectedEntities:    [],
+    undoStack:           [],
+    redoStack:           [],
+    isDirty:             false,
+  }))
+
+  const setActId = useCallback((actId: string) => {
+    setState(s => ({
+      ...s,
+      actId,
+      actData:             structuredClone(RAW_ACTS[actId]),
+      nodeId:              'act-default',
+      tool:                'select',
+      inProgressRoadIndex: null,
+      selectedEntities:    [],
+      undoStack:           [],
+      redoStack:           [],
+      isDirty:             false,
+    }))
+  }, [])
+
+  const setNodeId = useCallback((nodeId: EditTarget) => {
+    setState(s => ({ ...s, nodeId, inProgressRoadIndex: null, selectedEntities: [] }))
+  }, [])
+
+  const setTool = useCallback((tool: ToolMode) => {
+    setState(s => ({ ...s, tool, inProgressRoadIndex: tool === 'road' ? s.inProgressRoadIndex : null }))
+  }, [])
+
+  const setActiveObstacleType = useCallback((activeObstacleType: TerrainType) => {
+    setState(s => ({ ...s, activeObstacleType }))
+  }, [])
+
+  const selectEntities = useCallback((entities: SelectedEntity[]) => {
+    setState(s => ({ ...s, selectedEntities: entities }))
+  }, [])
+
+  // ── Roads ─────────────────────────────────────────────────────────────
+
+  /** 'road' tool click: extends the in-progress road, or starts a new one. */
+  const clickRoadTool = useCallback((x: number, y: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveRoadsForTarget(prevAct, s.nodeId)
+      const inProgress = s.inProgressRoadIndex !== null && current[s.inProgressRoadIndex]
+      const roadIndex = inProgress ? s.inProgressRoadIndex! : current.length
+      const newRoads = inProgress
+        ? current.map((r, i) => i === roadIndex ? { ...r, points: [...r.points, { x, y }] } : r)
+        : [...current, { points: [{ x, y }] }]
+      const newAct = withRoads(prevAct, s.nodeId, newRoads)
+      return {
+        ...s,
+        actData:             newAct,
+        inProgressRoadIndex: roadIndex,
+        selectedEntities:    [{ type: 'road' as const, index: roadIndex }],
+        undoStack:           [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:           [],
+        isDirty:             true,
+      }
+    })
+  }, [])
+
+  const finishRoad = useCallback(() => {
+    setState(s => s.inProgressRoadIndex === null ? s : { ...s, inProgressRoadIndex: null })
+  }, [])
+
+  const moveRoadPoint = useCallback((roadIndex: number, pointIndex: number, x: number, y: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveRoadsForTarget(prevAct, s.nodeId)
+      if (!current[roadIndex]?.points[pointIndex]) return s
+      const newRoads = current.map((r, i) => i !== roadIndex ? r : {
+        ...r, points: r.points.map((p, j) => j === pointIndex ? { x, y } : p),
+      })
+      return {
+        ...s,
+        actData:   withRoads(prevAct, s.nodeId, newRoads),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const updateRoad = useCallback((roadIndex: number, patch: Partial<Pick<RoadDef, 'width' | 'tileFile'>>) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveRoadsForTarget(prevAct, s.nodeId)
+      if (!current[roadIndex]) return s
+      const newRoads = current.map((r, i) => i === roadIndex ? { ...r, ...patch } : r)
+      return {
+        ...s,
+        actData:   withRoads(prevAct, s.nodeId, newRoads),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const deleteRoadPoint = useCallback((roadIndex: number, pointIndex: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveRoadsForTarget(prevAct, s.nodeId)
+      const road = current[roadIndex]
+      if (!road?.points[pointIndex]) return s
+      const points = road.points.filter((_, j) => j !== pointIndex)
+      const newRoads = points.length >= 2
+        ? current.map((r, i) => i === roadIndex ? { ...r, points } : r)
+        : current.filter((_, i) => i !== roadIndex)
+      return {
+        ...s,
+        actData:             withRoads(prevAct, s.nodeId, newRoads),
+        selectedEntities:    [],
+        inProgressRoadIndex: s.inProgressRoadIndex === roadIndex ? null : s.inProgressRoadIndex,
+        undoStack:           [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:           [],
+        isDirty:             true,
+      }
+    })
+  }, [])
+
+  const deleteRoad = useCallback((roadIndex: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveRoadsForTarget(prevAct, s.nodeId)
+      if (!current[roadIndex]) return s
+      const newRoads = current.filter((_, i) => i !== roadIndex)
+      return {
+        ...s,
+        actData:             withRoads(prevAct, s.nodeId, newRoads),
+        selectedEntities:    [],
+        inProgressRoadIndex: s.inProgressRoadIndex === roadIndex ? null : s.inProgressRoadIndex,
+        undoStack:           [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:           [],
+        isDirty:             true,
+      }
+    })
+  }, [])
+
+  // ── Obstacles ─────────────────────────────────────────────────────────
+
+  const addObstacle = useCallback((x: number, y: number, type: TerrainType) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainForTarget(prevAct, s.nodeId)
+      const obstacle: TerrainObstacle = { id: nextObstacleId(current), type, x, y, radius: 20 }
+      const newTerrain = [...current, obstacle]
+      return {
+        ...s,
+        actData:          withTerrain(prevAct, s.nodeId, newTerrain),
+        selectedEntities: [{ type: 'obstacle' as const, index: newTerrain.length - 1 }],
+        undoStack:        [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:        [],
+        isDirty:          true,
+      }
+    })
+  }, [])
+
+  const moveObstacle = useCallback((index: number, x: number, y: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainForTarget(prevAct, s.nodeId)
+      if (!current[index]) return s
+      const newTerrain = current.map((o, i) => i === index ? { ...o, x, y } : o)
+      return {
+        ...s,
+        actData:   withTerrain(prevAct, s.nodeId, newTerrain),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const updateObstacle = useCallback((index: number, patch: Partial<Pick<TerrainObstacle, 'type' | 'radius'>>) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainForTarget(prevAct, s.nodeId)
+      if (!current[index]) return s
+      const newTerrain = current.map((o, i) => i === index ? { ...o, ...patch } : o)
+      return {
+        ...s,
+        actData:   withTerrain(prevAct, s.nodeId, newTerrain),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const deleteObstacle = useCallback((index: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainForTarget(prevAct, s.nodeId)
+      if (!current[index]) return s
+      const newTerrain = current.filter((_, i) => i !== index)
+      return {
+        ...s,
+        actData:          withTerrain(prevAct, s.nodeId, newTerrain),
+        selectedEntities: [],
+        undoStack:        [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:        [],
+        isDirty:          true,
+      }
+    })
+  }, [])
+
+  // ── Inheritance ───────────────────────────────────────────────────────
+
+  const revertToActDefault = useCallback((field: 'roads' | 'terrain') => {
+    setState(s => {
+      if (s.nodeId === 'act-default') return s
+      const prevAct = s.actData
+      const node = prevAct.nodes[s.nodeId]
+      if (!node || node[field] === undefined) return s
+      const { [field]: _drop, ...rest } = node
+      const newAct = { ...prevAct, nodes: { ...prevAct.nodes, [s.nodeId]: rest } }
+      return {
+        ...s,
+        actData:          newAct,
+        selectedEntities: [],
+        undoStack:        [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:        [],
+        isDirty:          true,
+      }
+    })
+  }, [])
+
+  // ── Undo / redo / save ───────────────────────────────────────────────
+
+  const undo = useCallback(() => {
+    setState(s => {
+      if (s.undoStack.length === 0) return s
+      const undoStack = [...s.undoStack]
+      const prevAct = undoStack.pop()!
+      return {
+        ...s,
+        actData:          prevAct,
+        undoStack,
+        redoStack:        [s.actData, ...s.redoStack],
+        selectedEntities: [],
+        isDirty:          undoStack.length > 0,
+      }
+    })
+  }, [])
+
+  const redo = useCallback(() => {
+    setState(s => {
+      if (s.redoStack.length === 0) return s
+      const redoStack = [...s.redoStack]
+      const nextAct = redoStack.shift()!
+      return { ...s, actData: nextAct, undoStack: [...s.undoStack, s.actData], redoStack, isDirty: true }
+    })
+  }, [])
+
+  const markSaved = useCallback(() => {
+    setState(s => ({ ...s, isDirty: false }))
+  }, [])
+
+  return {
+    state,
+    resolveRoadsForTarget,
+    resolveTerrainForTarget,
+    setActId,
+    setNodeId,
+    setTool,
+    setActiveObstacleType,
+    selectEntities,
+    clickRoadTool,
+    finishRoad,
+    moveRoadPoint,
+    updateRoad,
+    deleteRoadPoint,
+    deleteRoad,
+    addObstacle,
+    moveObstacle,
+    updateObstacle,
+    deleteObstacle,
+    revertToActDefault,
+    undo,
+    redo,
+    markSaved,
+  }
+}

--- a/web/src/game/campaignHelpers.ts
+++ b/web/src/game/campaignHelpers.ts
@@ -155,6 +155,7 @@ export function resolvedNodeOpts(
     terrainSeed: node.id,
     environment: node.environment ?? act?.environment,
     roads: node.roads ?? act?.roads,
+    terrain: node.terrain ?? act?.terrain,
     opponentIntervalMs: adjustedInterval,
     opponentBaseHp: adjustedHp,
     opponentStartCards: handBonus,

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -15,7 +15,7 @@ import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
 import { triggerBattleEvent, BATTLE_EVENT_BASE_MS } from './engine/battleEvents'
 import { generateTerrain } from './engine/terrain'
-import type { RoadDef } from './engine/terrain'
+import type { RoadDef, TerrainObstacle } from './engine/terrain'
 import { processEndlessModeAdditions, triggerNextEndlessWave, spawnEndlessCommander } from './engine/endlessMode'
 import { handleSuddentDeath } from './engine/suddenDeath'
 
@@ -122,6 +122,8 @@ export interface NewGameOptions {
   environment?: string
   /** Act/node-authored road paths for the battlefield. Rendered only — does not affect unit movement. */
   roads?: RoadDef[]
+  /** Act/node-authored terrain obstacles for the battlefield. When present, replaces the procedurally-generated default. */
+  terrain?: TerrainObstacle[]
   /** Override opponent play interval (ms). Defined per-node in act JSON. */
   opponentIntervalMs?: number
   /** Override opponent base HP. Defined per-node in act JSON. */
@@ -174,6 +176,7 @@ export function newGame(
     terrainSeed,
     environment,
     roads,
+    terrain: authoredTerrain,
     opponentIntervalMs: intervalOverride,
     opponentBaseHp: hpOverride,
     bossSpawnKillPct,
@@ -324,7 +327,7 @@ export function newGame(
       traitFired: false,
       baseInvulnerableUntilMs: 0,
     } : undefined,
-    terrain: generateTerrain(terrainSeed, environment),
+    terrain: authoredTerrain ?? generateTerrain(terrainSeed, environment),
     roads,
     environment,
     battleStats: { cardsPlayed: {}, playerKills: 0, playerUnitsLost: 0 },

--- a/web/src/game/engine/terrain.ts
+++ b/web/src/game/engine/terrain.ts
@@ -43,7 +43,7 @@ export interface RoadDef {
 // Two Y edge corridors are guaranteed clear so units always have
 // walkable paths from base to base.
 
-const TERRAIN_CLEAR_Y    = [-70, 70] as const  // edge corridors units route around
+export const TERRAIN_CLEAR_Y = [-70, 70] as const  // edge corridors units route around
 const TERRAIN_CLEAR_HALF = 12                  // half-width of each corridor (px)
 
 /** Tiny seeded PRNG (mulberry32) — deterministic given the same seed. */

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1,5 +1,5 @@
 import { CardRarity, Archetype } from './types'
-import type { RoadDef } from './engine/terrain'
+import type { RoadDef, TerrainObstacle } from './engine/terrain'
 import { loadPlayerStats } from './playerStats'
 import { logError } from '../logger'
 import { getCardCatalog } from './cards'
@@ -165,6 +165,8 @@ export interface QuestNode {
   environment?: string
   /** Battlefield road paths for this node, overriding the act's `roads`. Rendered only — does not affect unit movement. */
   roads?: RoadDef[]
+  /** Battlefield terrain obstacles for this node, overriding the act's `terrain` and replacing the procedurally-generated default. Affects unit avoidance, same as procedural terrain. */
+  terrain?: TerrainObstacle[]
   /** Override opponent play interval (ms). Replaces handicap-derived default. */
   opponentIntervalMs?: number
   /** Override opponent base HP. Replaces engine default (95 for bosses, 82 for others). */
@@ -306,6 +308,15 @@ export interface WorldMap {
    * screen); a QuestNode's own `roads` overrides this per-node. Visual only.
    */
   roads?: RoadDef[]
+
+  /**
+   * Default battlefield terrain obstacles for battles in this act, in the same
+   * game-unit coord space as `roads`. When present, replaces the procedurally
+   * generated default (see `generateTerrain` in `game/engine/terrain.ts`) for
+   * battles in this act; a QuestNode's own `terrain` overrides this per-node.
+   * Affects unit avoidance, same as procedural terrain.
+   */
+  terrain?: TerrainObstacle[]
 
 }
 

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -12,6 +12,21 @@ import type { TerrainObstacle, RoadDef } from '../game/engine/terrain'
 // so clusters show real size variety instead of always rounding to a single uniform "plus" shape.
 export const TILE_RADIUS_SCALE = 220
 
+/**
+ * Battlefield lane coordinate mapping: game units (x: 0–500 forward base→base,
+ * y: -80..80 lateral) → canvas pixels, and back. buildRoadGfx/buildTerrainDecorGfx
+ * derive their tile coordinates from gameToPixel below; the battlefield editor uses
+ * pixelToGame to turn a pointer click into a game-unit waypoint/obstacle position —
+ * sharing this single definition keeps the two forever in lockstep.
+ */
+export function gameToPixel(x: number, y: number, w: number, h: number): { px: number; py: number } {
+  return { px: (0.5 + (y / 80) * 0.36) * w, py: (1 - x / 500) * h }
+}
+
+export function pixelToGame(px: number, py: number, w: number, h: number): { x: number; y: number } {
+  return { x: 500 * (1 - py / h), y: 80 * ((px / w - 0.5) / 0.36) }
+}
+
 export interface TerrainLayerOptions {
   environment?: string
   envDef?: EnvTileDef
@@ -237,8 +252,7 @@ export async function buildDecorGfx(
  * renderPathTiles() autotiler as hub streets and battlefield water patches.
  * Visual only — does not affect unit movement/avoidance.
  *
- * Game coords → tile coords use the same projection as buildTerrainDecorGfx's
- * toTile(): tcx = (0.5 + (y/80)*0.36) * w/TILE_SIZE, tcy = (1 - x/500) * h/TILE_SIZE.
+ * Game coords → tile coords via gameToPixel() (see above), divided by TILE_SIZE.
  */
 export async function buildRoadGfx(
   container: PIXI.Container,
@@ -250,10 +264,10 @@ export async function buildRoadGfx(
   if (roads.length === 0) return
   const def = opts.envDef ?? ENV_TILES[opts.environment ?? '']
 
-  const toTile = (x: number, y: number) => ({
-    tcx: Math.round(((0.5 + (y / 80) * 0.36) * w) / TILE_SIZE),
-    tcy: Math.round(((1 - x / 500) * h) / TILE_SIZE),
-  })
+  const toTile = (x: number, y: number) => {
+    const { px, py } = gameToPixel(x, y, w, h)
+    return { tcx: Math.round(px / TILE_SIZE), tcy: Math.round(py / TILE_SIZE) }
+  }
 
   for (const road of roads) {
     if (container.destroyed) return
@@ -345,9 +359,7 @@ async function renderSceneryPatch(
  * are organic rather than single scaled tiles. Ruins fall back to a single
  * WORLD_DECOR tile (gravestone, house, etc.).
  *
- * Game coords → canvas px:
- *   cx = (0.5 + (obs.y / 80) * 0.36) * w
- *   cy = (1 - obs.x / 500) * h
+ * Game coords → canvas px via gameToPixel() (see above).
  */
 export async function buildTerrainDecorGfx(
   container: PIXI.Container,
@@ -362,10 +374,10 @@ export async function buildTerrainDecorGfx(
   const envPatchMap = TERRAIN_PATCH_MAP[env] ?? {}
   const envDecorMap = TERRAIN_DECOR_MAP[env] ?? {}
 
-  const toTile = (obs: TerrainObstacle) => ({
-    tcx: Math.round(((0.5 + (obs.y / 80) * 0.36) * w) / TILE_SIZE),
-    tcy: Math.round(((1 - obs.x / 500) * h) / TILE_SIZE),
-  })
+  const toTile = (obs: TerrainObstacle) => {
+    const { px, py } = gameToPixel(obs.x, obs.y, w, h)
+    return { tcx: Math.round(px / TILE_SIZE), tcy: Math.round(py / TILE_SIZE) }
+  }
 
   // terrain.ts only guarantees a minimum *game-unit* separation between obstacle
   // centers, but the canvas projection below doesn't scale 1:1 with tile distance —


### PR DESCRIPTION
## Summary

Adds a visual, Storybook-hosted **Battlefield Editor** for authoring act/node combat-lane roads and terrain obstacles — the same delivery model as the existing hub-world Map Editor (`web/src/components/mapEditor/`).

- **Data model**: adds an optional `terrain?: TerrainObstacle[]` field to `QuestNode`/`WorldMap` (mirrors the existing `roads?: RoadDef[]`: act-level default + per-node override). When present, it replaces the procedurally-generated battlefield obstacles (`generateTerrain()`) for that battle — this is not purely visual like roads; obstacles already drive real unit-avoidance behavior in `game/engine/units.ts`, so authoring them here is WYSIWYG in both look and function.
- **Shared coordinate math**: extracts `gameToPixel`/`pixelToGame` in `terrainLayer.ts` (previously duplicated inline in `buildRoadGfx`/`buildTerrainDecorGfx`) so the renderer and the new editor can never drift out of sync.
- **New editor** — `web/src/components/battlefieldEditor/`:
  - `BattlefieldEditorCanvas.tsx` renders through the *exact same* `terrainLayer.ts` build functions the live `Battlefield` uses, so the editor is pixel-identical to an actual battle, plus an editable overlay (draggable road waypoints, obstacle handles, tile grid + `TERRAIN_CLEAR_Y` corridor guides).
  - `useBattlefieldEditorState.ts` — snapshot-based undo/redo, act-default vs. per-node targeting, and "seed a node override from the inherited act default (or procedural generator, for terrain) on first edit" so a first edit starts from what's already rendering.
  - `BattlefieldEditorInspector.tsx` / `BattlefieldEditorToolbar.tsx` — per-road/obstacle property panels, act/node pickers, tools, undo/redo, save.
  - One Storybook story per act (`BattlefieldEditor.stories.tsx`).
- **Persistence**: a new `/api/battlefield-editor/save` route in `.storybook/main.ts` (mirrors `/api/map-editor/save`) writes the whole edited act object back to `data/acts/<actId>.json` — verified the round-trip touches only the intended `roads`/`terrain` fields, nothing else in the file.

## Test plan

- [x] `npm run build` (typecheck) passes
- [x] `npx vitest run` — 1886 tests pass, no regressions
- [x] Interactive Storybook smoke test (Playwright against the running dev server): placed/selected/dragged an obstacle, drew and saved a road, confirmed zero console errors and that the saved `act1.json` diff contained only the intended `roads`/`terrain` fields (then reverted the test data)
- [ ] Manual: `npm run storybook` → "Battlefield Editor" → author real content for an act


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjufoNfRt3kJxoNKKQvdG)_