### PR TITLE
Lock the battlefield to a fixed, letterboxed aspect ratio (production + editor)

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { BattlefieldTerrainCanvas } from './battlefield/BattlefieldTerrainCanvas'
-import { GameState, Unit, LANE_WIDTH, Card, TerrainObstacle, BuffTag, TERRAIN_AVOID_SHAPE } from '../../game/types'
+import { GameState, Unit, LANE_WIDTH, BATTLEFIELD_ASPECT_RATIO, Card, TerrainObstacle, BuffTag, TERRAIN_AVOID_SHAPE } from '../../game/types'
 import { CardTile } from '../cards/CardTile'
 import { useCardDetail } from '../cards/useCardDetail'
 import { SpriteImg, AnimatedSpriteImg } from '../ui/SpriteImg'
@@ -20,6 +20,7 @@ import { loadBattlePopups } from '../screens/SettingsScreen'
 import { TutorialOverlay } from '../modals/TutorialOverlay'
 import { hasSeen, markSeen } from '../../game/tutorial'
 import { usePixiApp } from '../../hooks/usePixiApp'
+import { useLetterboxSize } from '../../hooks/useLetterboxSize'
 
 const modalAutoDismissTime = 2000
 const BATTLE_TUTORIAL_ID = 'gameplay'
@@ -618,6 +619,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const [pendingAoeCard, setPendingAoeCard] = useState<Card | null>(null)
   const [aoeHoverPos, setAoeHoverPos] = useState<{ top: number; left: number } | null>(null)
   const laneRef = useRef<HTMLDivElement>(null)
+  const stageRef = useRef<HTMLDivElement>(null)
+  const frameSize = useLetterboxSize(stageRef, BATTLEFIELD_ASPECT_RATIO)
   const playerName   = loadPlayerName()
   const playerAvatar = loadPlayerAvatar()
 
@@ -726,11 +729,23 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
   // })
 
+  // The battlefield always renders at a fixed aspect ratio (BATTLEFIELD_ASPECT_RATIO),
+  // letterboxed within the stage rather than stretched — see useLetterboxSize. Falls
+  // back to filling the stage until the first ResizeObserver measurement lands.
+  const frameStyle: React.CSSProperties = frameSize
+    ? { width: frameSize.width, height: frameSize.height }
+    : { width: '100%', height: '100%' }
+  const isCompactFrame = !!frameSize && frameSize.width <= 480
+  const isTinyFrame = !!frameSize && frameSize.width <= 380
+  const frameClassName = `battlefield-frame${isCompactFrame ? ' battlefield-frame--compact' : ''}${isTinyFrame ? ' battlefield-frame--tiny' : ''}`
+
   return (
     <div
+      ref={stageRef}
       className={`battlefield u-grow${actTheme ? ` battlefield--${actTheme}` : ''}${paused ? ' battlefield--paused' : ''}`}
       onClick={paused && !inspectedUnit ? () => doPause(false) : undefined}
     >
+    <div className={frameClassName} style={frameStyle}>
 
       {/* Dramatic battle event overlay (center-screen flash) */}
       <BattleEventOverlay event={event} />
@@ -1330,6 +1345,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           onDone={() => { markSeen(BATTLE_TUTORIAL_ID); setShowBattleTutorial(false) }}
         />
       )}
+    </div>
     </div>
   )
 }

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -1,12 +1,14 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react'
+import React, { useRef, useEffect, useCallback } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
+import { useLetterboxSize } from '../../hooks/useLetterboxSize'
 import {
   buildTerrainGfx, buildBgTileGfx, buildBorderGfx, buildDecorGfx,
   buildRoadGfx, buildTerrainDecorGfx, gameToPixel, pixelToGame,
 } from '../../utils/terrainLayer'
 import { TILE_SIZE, EnvTileDef } from '../../data/tiles/tileIndex'
 import { TERRAIN_CLEAR_Y } from '../../game/engine/terrain'
+import { BATTLEFIELD_ASPECT_RATIO } from '../../game/types'
 import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity } from './battlefieldEditorTypes'
 
 export interface Props {
@@ -218,32 +220,15 @@ function drawEditOverlay(
  * overlay for roads/obstacles.
  */
 export function BattlefieldEditorCanvas(props: Props) {
-  const wrapRef = useRef<HTMLDivElement>(null)
-  const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
-
-  useEffect(() => {
-    const el = wrapRef.current
-    if (!el) return
-    let raf = 0
-    const measure = () => {
-      const { width, height } = el.getBoundingClientRect()
-      if (width > 0 && height > 0) {
-        const w = Math.ceil(width)
-        const h = Math.ceil(height)
-        setDims(prev => (prev && prev.w === w && prev.h === h) ? prev : { w, h })
-      }
-    }
-    const ro = new ResizeObserver(() => {
-      cancelAnimationFrame(raf)
-      raf = requestAnimationFrame(measure)
-    })
-    ro.observe(el)
-    measure()
-    return () => { cancelAnimationFrame(raf); ro.disconnect() }
-  }, [])
+  const stageRef = useRef<HTMLDivElement>(null)
+  const rawSize = useLetterboxSize(stageRef, BATTLEFIELD_ASPECT_RATIO)
+  const dims = rawSize ? { w: Math.floor(rawSize.width), h: Math.floor(rawSize.height) } : null
 
   return (
-    <div ref={wrapRef} style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}>
+    <div
+      ref={stageRef}
+      style={{ position: 'relative', width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden' }}
+    >
       {dims && <EditorPixi key={`${dims.w}x${dims.h}`} {...props} w={dims.w} h={dims.h} />}
     </div>
   )

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -392,6 +392,12 @@ export type GamePhase =
 
 export const LANE_WIDTH = 500
 
+/** Fixed width/height ratio the battlefield always renders at (production and the
+ *  battlefield editor) — matches a modern phone's portrait shape (e.g. 390x844).
+ *  The battlefield letterboxes (centers with dead space) rather than stretching
+ *  to fill wider/shorter containers. See web/src/hooks/useLetterboxSize.ts. */
+export const BATTLEFIELD_ASPECT_RATIO = 9 / 19.5
+
 /** In endless mode, player structures may not be placed beyond this forward x-coordinate (3 rows from base). */
 export const ENDLESS_STRUCTURE_MAX_X = 60
 

--- a/web/src/hooks/useLetterboxSize.ts
+++ b/web/src/hooks/useLetterboxSize.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+export interface LetterboxSize {
+  width: number
+  height: number
+}
+
+/**
+ * Measures `containerRef` via ResizeObserver and returns the largest box that
+ * preserves `aspectRatio` (width / height) while fitting inside the container —
+ * the same scale-to-fit letterbox math HubMinimap.tsx uses for its own canvas
+ * (`Math.min(availW/targetW, availH/targetH)`), generalized to any ratio.
+ * Returns null until the first measurement, so callers can avoid rendering at 0x0.
+ */
+export function useLetterboxSize(
+  containerRef: RefObject<HTMLElement | null>,
+  aspectRatio: number,
+): LetterboxSize | null {
+  const [size, setSize] = useState<LetterboxSize | null>(null)
+  const rafRef = useRef(0)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    const measure = () => {
+      const { width: availW, height: availH } = el.getBoundingClientRect()
+      if (availW <= 0 || availH <= 0) return
+      const fitted = availW / availH > aspectRatio
+        ? { width: availH * aspectRatio, height: availH }
+        : { width: availW, height: availW / aspectRatio }
+      setSize(prev => (prev && prev.width === fitted.width && prev.height === fitted.height) ? prev : fitted)
+    }
+
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = requestAnimationFrame(measure)
+    })
+    ro.observe(el)
+    measure()
+    return () => { cancelAnimationFrame(rafRef.current); ro.disconnect() }
+  }, [containerRef, aspectRatio])
+
+  return size
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -208,15 +208,38 @@ body {
 
 /* ─── Battlefield ────────────────────────────────────── */
 
+/* The outer "stage" — fills whatever space the game container gives it, and
+   centers the fixed-aspect-ratio frame inside it (letterboxing any extra room). */
 .battlefield {
   position: relative;
   min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--game-bg);
+}
+
+/* The inner "frame" — locked to BATTLEFIELD_ASPECT_RATIO via inline width/height
+   from useLetterboxSize, so the battlefield renders identically shaped on every
+   device. Positioning ancestor for every absolutely-positioned battle element. */
+.battlefield-frame {
+  position: relative;
+  overflow: hidden;
   /* Fixed bands reserved for the floating bar clusters. The lane fills the space
-     between them, so the play area's size depends only on the viewport — never on
+     between them, so the play area's size depends only on the frame — never on
      bar content (long scores, wave status, event tags, card-bar height changes). */
   --bf-top-buffer: 80px;
   --bf-bottom-buffer: 230px;
 }
+
+/* Narrower-frame tuning — keyed off the letterboxed frame's own computed width
+   (set as classes from Battlefield.tsx), not the device viewport: a wide desktop
+   window letterboxed down to a phone-width frame needs the same phone tuning a
+   real phone gets, which a viewport @media query alone could never detect. */
+.battlefield-frame--compact { --bf-top-buffer: 74px; --bf-bottom-buffer: 200px; }
+.battlefield-frame--compact .lane { min-height: 120px; }
+.battlefield-frame--tiny { --bf-top-buffer: 68px; --bf-bottom-buffer: 182px; }
+.battlefield-frame--tiny .lane { min-height: 90px; }
 
 /* Floating bar clusters: absolutely positioned in the reserved bands above/below
    the lane. Their content can grow/wrap without ever resizing or reflowing the lane. */
@@ -1383,15 +1406,12 @@ body {
   .game-container { padding: 4px 6px; }
   .game-title { font-size: var(--font-base); letter-spacing: 1px; }
 
-  .battlefield { --bf-top-buffer: 74px; --bf-bottom-buffer: 200px; }
-
   .hand-cards { gap: 4px; padding-bottom: 4px; }
   .card-tile { width: 78px; padding: 6px 8px; }
   .card-title { font-size: var(--font-xxs); }
   .card-stats { font-size: 0.571rem; }
   .card-tag   { font-size: 0.5rem; }
 
-  .lane { min-height: 120px; }
   .lane-unit-name { font-size: 0.571rem; }
   .mana-pip { width: 8px; height: 8px; }
 
@@ -1408,9 +1428,6 @@ body {
   .hand-cards { gap: 3px; }
   .hand-cards .card-tile { padding: 4px 5px; }
   .card-title { font-size: 0.571rem; }
-
-  .lane { min-height: 90px; }
-  .battlefield { --bf-top-buffer: 68px; --bf-bottom-buffer: 182px; }
 }
 
 /* ─── Intro Screen ───────────────────────────────────── */


### PR DESCRIPTION
## Summary

The battlefield previously rendered with no fixed shape — `.game-container` caps width at 740px but height is always `100vh`/`100dvh` (independent constraints, not an aspect lock), so the battle screen looked tall/narrow on a real phone and noticeably wider/shorter on desktop, even though the game was clearly designed around a tall-phone shape. This locks the battlefield to **one fixed aspect ratio on every device** (9:19.5, ≈0.46, matching modern phone shapes), with letterbox dead-space filling extra room on wider/shorter screens — and applies the exact same shape to the battlefield editor, so "what does this look like on a phone" is no longer a separate preview mode, just the one true shape.

- **`web/src/hooks/useLetterboxSize.ts`**: new shared hook — measures a container via `ResizeObserver` and returns the largest box preserving a given aspect ratio, adapted from the scale-to-fit formula `HubMinimap.tsx` already uses for its own canvas.
- **`BATTLEFIELD_ASPECT_RATIO`** (`web/src/game/types.ts`, next to `LANE_WIDTH`): single source of truth consumed by both production and the editor.
- **Production (`Battlefield.tsx` + `styles.css`)**: the battle screen is restructured into two nested layers — the outer `.battlefield` is now a flex-centering "stage," and the inner `.battlefield-frame` (renamed from the old `.battlefield`) is sized via the hook to always match the target ratio. Every existing absolutely-positioned battle element already depended on one positioning ancestor, so this is a pure rename of that ancestor (plus its buffer CSS vars) — no other rule needed to change. The two old `max-width` media queries (which retuned buffer bands/lane min-height for narrow devices) are replaced with `.battlefield-frame--compact`/`--tiny` classes driven by the *frame's own computed width* — a viewport-keyed media query would otherwise miss a landscape window that's been letterboxed down to phone width.
- **Editor (`BattlefieldEditorCanvas.tsx`)**: swapped its fill-everything sizing for the same hook + constant, so the editor canvas is always pixel-identical in shape to a real battle.

## Test plan

- [x] `npm run build` (typecheck) passes
- [x] `npx vitest run` — 1886 tests pass, no regressions
- [x] Verified production layout via the existing `Battlefield.stories.tsx` Storybook story (bypasses this sandbox's Firebase-auth limitation) at four window shapes — tall phone, wide desktop, short/wide, and square — measuring the rendered `.battlefield-frame`'s aspect ratio locks to exactly `9/19.5 ≈ 0.4615` in every case, with correct letterboxing and HUD scaling, zero console errors
- [x] Verified the editor via Storybook at three window shapes — same ratio lock confirmed, zero console errors
- [ ] Manual: spot-check on a real phone and a real wide desktop browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMjufoNfRt3kJxoNKKQvdG)_