### PR TITLE
Add GitHub Codespaces devcontainer for editing Storybook from anywhere

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Jarv's Amazing Web Game",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "cd web && npm install",
+  "containerEnv": {
+    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1"
+  },
+  "forwardPorts": [6006],
+  "portsAttributes": {
+    "6006": {
+      "label": "Storybook",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "ms-vscode.vscode-typescript-next"
+      ]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,36 @@ npm run build    # TypeScript check + Vite build
 npm run preview  # Preview production build locally
 ```
 
+## Editing via GitHub Codespaces
+
+Storybook (`npm run storybook`, `web/.storybook/`) renders the game's real components,
+and several stories (map editor, bundle editor, battlefield editor) save changes by
+writing JSON files directly under `web/src/data/...` through custom dev-server
+middleware in `web/.storybook/main.ts`. That only works against a live Node process —
+not a static Storybook build — so a GitHub Codespace (a hosted dev container) is how to
+get this editing experience from any device without a local dev machine.
+
+1. Open a Codespace on this repo/branch: GitHub UI → **Code → Codespaces → Create
+   codespace**. `.devcontainer/devcontainer.json` runs `npm install` automatically.
+2. Inside the Codespace, run:
+   ```bash
+   cd web && npm run storybook -- --host 0.0.0.0
+   ```
+   The `--host 0.0.0.0` flag is required for Codespaces' port forwarding to reach the
+   dev server — pass it ad hoc like this rather than adding it to the `storybook`
+   script, so local dev on your own machine keeps binding to `localhost` only.
+3. Open the forwarded port 6006 (Codespaces will prompt "Open in Browser").
+4. Use the map/bundle/battlefield editor stories as normal — saves write real files
+   inside the Codespace's filesystem, exactly like local dev.
+5. Commit and push from the Codespace (VS Code Web's git UI or the terminal) to persist
+   edits to the repo — the Codespace itself is ephemeral, so uncommitted changes are
+   lost if it's deleted or reclaimed after its idle timeout.
+
+**Security:** keep the forwarded port's visibility set to **Private** (Codespaces'
+default). The editor save endpoints have no authentication of their own — they rely
+entirely on Codespaces' private-port GitHub auth to keep them from being reachable by
+anyone else. Never switch the port to "Public" while editing.
+
 ## Game Design
 - **Mana system:** Player starts with 3 mana/turn; Farms increase max mana permanently
 - **Card types:** Unit (deploy fighters), Structure (build Walls/Farms/Barracks), Upgrade (buff/heal all units), Area Of Effect (causes damage to an area of the battlefield damaging all units)


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` so opening a GitHub Codespace on this repo installs dependencies automatically and forwards Storybook's port (6006).
- Documents an "Editing via GitHub Codespaces" workflow in `AGENTS.md`, so the map/bundle/battlefield in-app editors (which save by writing JSON files via local dev-server middleware in `web/.storybook/main.ts`) can be used from any browser, without a local dev machine.
- No changes to the editor save logic, `web/package.json`, or the existing GitHub Pages deploy (`.github/workflows/deploy.yml`) — this only adds the container config + docs.

## Why this approach

A static Storybook build (GitHub Pages/Chromatic/Vercel) can't support the in-app editors, since their "save" writes real files on a live Node process — something a static export has no server for. Codespaces runs the existing dev server unmodified inside a hosted container, so file writes keep working exactly as they do locally. GitHub's free tier (120 core-hours/month) comfortably covers casual editing sessions.

To avoid widening local dev's network exposure, the devcontainer does **not** change the default `storybook` script — the docs instead show running `npm run storybook -- --host 0.0.0.0` ad hoc, only inside the Codespace, needed for Codespaces' port forwarding to reach the server. Local dev keeps binding to `localhost` only.

## Security

- The editor save endpoints have no authentication of their own — security relies entirely on Codespaces' forwarded ports defaulting to **Private** (requires GitHub auth to reach). Docs call this out explicitly and warn never to set the port to Public while editing.
- No new secrets, tokens, or credentials are introduced.

## Test plan

- [ ] Open a Codespace on this branch from the GitHub UI
- [ ] Confirm `postCreateCommand` (`cd web && npm install`) completes successfully
- [ ] Run `cd web && npm run storybook -- --host 0.0.0.0`
- [ ] Confirm the port-6006 forward prompt appears and Storybook loads in the browser
- [ ] Open a map/bundle/battlefield editor story, make a change, save, and confirm the expected JSON file under `web/src/data/...` is modified (`git status`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rk6uCnYBzpPqUrvWecTmdE)_