### PR TITLE
Campaign 2, Act 13 + Finale: The City of Vigils / The Throne of the Unremembered + campaign-wide node-map variety

### DIFF
--- a/web/public/cutscenes/c2act13-intro-1.svg
+++ b/web/public/cutscenes/c2act13-intro-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2a13i1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0e1420"/>
+    <stop offset="100%" stop-color="#1a2436"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2a13i1-sky)"/>
+  <rect y="150" width="180" height="90" fill="#2a2a30"/>
+  <rect x="180" y="150" width="220" height="90" fill="#2a2436"/>
+  <rect x="230" y="90" width="28" height="60" fill="#332c44"/>
+  <rect x="280" y="70" width="32" height="80" fill="#3a3350"/>
+  <g fill="#FFC94A" opacity="0.8">
+    <rect x="240" y="110" width="3" height="3"/>
+    <rect x="290" y="90" width="3" height="3"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="16" fill="#FFC94A" opacity="0.15"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE CROWN REACHES END. THE CITY OF VIGILS BEGINS.</text>
+</svg>

--- a/web/public/cutscenes/c2act13-intro-2.svg
+++ b/web/public/cutscenes/c2act13-intro-2.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2a13i2-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#12101c"/>
+    <stop offset="100%" stop-color="#231d30"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2a13i2-sky)"/>
+  <rect y="150" width="400" height="90" fill="#2a2436"/>
+  <rect x="50" y="90" width="30" height="60" fill="#332c44"/>
+  <rect x="100" y="60" width="34" height="90" fill="#3a3350"/>
+  <rect x="150" y="80" width="28" height="70" fill="#332c44"/>
+  <rect x="220" y="55" width="36" height="95" fill="#3a3350"/>
+  <rect x="270" y="85" width="30" height="65" fill="#332c44"/>
+  <rect x="315" y="70" width="32" height="80" fill="#3a3350"/>
+  <g fill="#FFE9A8" opacity="0.9">
+    <rect x="58" y="105" width="4" height="4"/>
+    <rect x="112" y="80" width="4" height="4"/>
+    <rect x="122" y="100" width="4" height="4"/>
+    <rect x="160" y="95" width="4" height="4"/>
+    <rect x="232" y="75" width="4" height="4"/>
+    <rect x="242" y="95" width="4" height="4"/>
+    <rect x="280" y="100" width="4" height="4"/>
+    <rect x="326" y="88" width="4" height="4"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="17" fill="#FFC94A" opacity="0.15"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">EVERY WINDOW HOLDS A CANDLE, THREE CENTURIES RUNNING.</text>
+</svg>

--- a/web/public/cutscenes/c2act13-intro-3.svg
+++ b/web/public/cutscenes/c2act13-intro-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2a13i3-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#12101c"/>
+    <stop offset="100%" stop-color="#231d30"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2a13i3-sky)"/>
+  <rect y="150" width="400" height="90" fill="#2a2436"/>
+  <g fill="#E8E4D8">
+    <path d="M225,105 Q240,88 255,105 L253,112 Q240,103 227,112 Z" fill="#4A5FC9"/>
+    <circle cx="240" cy="114" r="10"/>
+    <path d="M224,128 Q240,118 256,128 L256,145 L224,145 Z" fill="#4A5FC9"/>
+    <path d="M215,120 Q205,110 218,105" stroke="#FFC94A" stroke-width="2" fill="none"/>
+    <path d="M265,120 Q275,110 262,105" stroke="#FFC94A" stroke-width="2" fill="none"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="17" fill="#FFC94A" opacity="0.15"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE VIGIL QUEEN HAS KEPT THIS CITY LIT LONGER THAN ANY REASON TO.</text>
+</svg>

--- a/web/public/cutscenes/c2act13-outro-1.svg
+++ b/web/public/cutscenes/c2act13-outro-1.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2a13o1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#12101c"/>
+    <stop offset="100%" stop-color="#231d30"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2a13o1-sky)"/>
+  <rect y="150" width="400" height="90" fill="#2a2436"/>
+  <g fill="#E8E4D8">
+    <circle cx="200" cy="128" r="10"/>
+    <path d="M184,138 Q200,128 216,138 L216,155 L184,155 Z" fill="#4A5FC9"/>
+    <rect x="198" y="140" width="4" height="18" fill="#FFC94A" opacity="0.4"/>
+  </g>
+  <ellipse cx="200" cy="205" rx="140" ry="17" fill="#4A5FC9" opacity="0.2"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">"NOT ONE WARD UNDER MY KEEPING EVER TOLD ME IF LIT WAS THE SAME AS SAFE."</text>
+</svg>

--- a/web/public/cutscenes/c2act13-outro-2.svg
+++ b/web/public/cutscenes/c2act13-outro-2.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2a13o2-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e14"/>
+    <stop offset="100%" stop-color="#241d14"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2a13o2-sky)"/>
+  <rect y="150" width="400" height="90" fill="#1c1712"/>
+  <rect x="192" y="110" width="16" height="55" rx="4" fill="#FFF3C4"/>
+  <ellipse cx="200" cy="105" rx="5" ry="8" fill="#FFC94A"/>
+  <ellipse cx="200" cy="103" rx="2.5" ry="4.5" fill="#FFF8E0"/>
+  <ellipse cx="200" cy="205" rx="90" ry="14" fill="#FFC94A" opacity="0.2"/>
+
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">QUEEN'S CANDLE — IT HAS NEVER ONCE BEEN ALLOWED TO GUTTER OUT.</text>
+</svg>

--- a/web/public/cutscenes/c2act13-outro-3.svg
+++ b/web/public/cutscenes/c2act13-outro-3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2a13o3-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0810"/>
+    <stop offset="100%" stop-color="#1a1428"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2a13o3-sky)"/>
+  <rect y="150" width="400" height="90" fill="#241d30"/>
+  <path d="M170,150 L170,90 L230,90 L230,150 Z" fill="#332c44"/>
+  <path d="M180,90 Q200,60 220,90 Z" fill="#3a3350"/>
+  <rect x="196" y="30" width="8" height="60" fill="#1c1712"/>
+  <g fill="#FFC94A" opacity="0.7">
+    <rect x="186" y="100" width="3" height="3"/>
+    <rect x="211" y="100" width="3" height="3"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="17" fill="#4A5FC9" opacity="0.2"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE VIGIL CHAMBER AWAITS — WHERE THE VIGIL KING HOLDS THE LAST RITE.</text>
+</svg>

--- a/web/public/cutscenes/c2finale-intro-1.svg
+++ b/web/public/cutscenes/c2finale-intro-1.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2fi1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0810"/>
+    <stop offset="100%" stop-color="#1a1428"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2fi1-sky)"/>
+  <rect y="150" width="400" height="90" fill="#241d30"/>
+  <path d="M170,240 L185,150 L215,150 L230,240 Z" fill="#332c44"/>
+  <rect x="196" y="90" width="8" height="60" fill="#1c1712"/>
+  <g fill="#FFC94A" opacity="0.6">
+    <rect x="80" y="200" width="4" height="4"/>
+    <rect x="120" y="210" width="4" height="4"/>
+    <rect x="300" y="205" width="4" height="4"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="16" fill="#F5D061" opacity="0.15"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE CITY OF VIGILS ENDS. THE LAST STAIR BEGINS.</text>
+</svg>

--- a/web/public/cutscenes/c2finale-intro-2.svg
+++ b/web/public/cutscenes/c2finale-intro-2.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2fi2-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0810"/>
+    <stop offset="100%" stop-color="#1a1428"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2fi2-sky)"/>
+  <rect y="150" width="400" height="90" fill="#241d30"/>
+  <path d="M100,150 Q200,80 300,150 Z" fill="#332c44"/>
+  <g fill="#FFE9A8" opacity="0.9">
+    <rect x="120" y="130" width="3" height="3"/>
+    <rect x="150" y="115" width="3" height="3"/>
+    <rect x="180" y="105" width="3" height="3"/>
+    <rect x="210" y="105" width="3" height="3"/>
+    <rect x="240" y="115" width="3" height="3"/>
+    <rect x="270" y="130" width="3" height="3"/>
+    <rect x="200" y="95" width="3" height="3"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="17" fill="#F5D061" opacity="0.18"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">A ROOM BUILT TO HOLD A RITE STEADY, WHATEVER THE COST.</text>
+</svg>

--- a/web/public/cutscenes/c2finale-intro-3.svg
+++ b/web/public/cutscenes/c2finale-intro-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2fi3-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0810"/>
+    <stop offset="100%" stop-color="#1a1428"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2fi3-sky)"/>
+  <rect y="150" width="400" height="90" fill="#241d30"/>
+  <path d="M175,150 L175,95 L225,95 L225,150 Z" fill="#332c44"/>
+  <path d="M185,95 Q200,70 215,95 Z" fill="#3a3350"/>
+  <rect x="196" y="40" width="8" height="55" fill="#1c1712"/>
+  <g fill="#E8E4D8">
+    <circle cx="200" cy="118" r="9"/>
+    <path d="M191,111 Q200,98 209,111 Z" fill="#F5D061"/>
+    <rect x="186" y="126" width="28" height="24" fill="#5B3A8E"/>
+  </g>
+  <ellipse cx="200" cy="200" rx="150" ry="17" fill="#F5D061" opacity="0.18"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">THE VIGIL KING HAS HELD THIS RITE LONGER THAN ANY OF HIS COURT.</text>
+</svg>

--- a/web/public/cutscenes/c2finale-outro-1.svg
+++ b/web/public/cutscenes/c2finale-outro-1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2fo1-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#0a0810"/>
+    <stop offset="100%" stop-color="#1a1428"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2fo1-sky)"/>
+  <rect y="150" width="400" height="90" fill="#241d30"/>
+  <g fill="#E8E4D8" opacity="0.85">
+    <circle cx="200" cy="122" r="9"/>
+    <rect x="186" y="130" width="28" height="24" fill="#5B3A8E"/>
+  </g>
+  <g fill="#5B3A8E" opacity="0.5">
+    <rect x="120" y="130" width="3" height="3"/>
+    <rect x="150" y="115" width="3" height="3"/>
+    <rect x="250" y="115" width="3" height="3"/>
+    <rect x="280" y="130" width="3" height="3"/>
+  </g>
+  <ellipse cx="200" cy="205" rx="140" ry="17" fill="#5B3A8E" opacity="0.2"/>
+  <g fill="#11141f">
+    <circle cx="200" cy="140" r="10"/>
+    <rect x="189" y="150" width="22" height="34" rx="4"/>
+  </g>
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">"I HELD THIS KINGDOM IN MY OWN MIND BECAUSE NO ONE ELSE'S WOULD HOLD IT."</text>
+</svg>

--- a/web/public/cutscenes/c2finale-outro-2.svg
+++ b/web/public/cutscenes/c2finale-outro-2.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2fo2-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#100e14"/>
+    <stop offset="100%" stop-color="#241d14"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2fo2-sky)"/>
+  <rect y="150" width="400" height="90" fill="#1c1712"/>
+  <path d="M175,140 L182,110 L192,128 L200,105 L208,128 L218,110 L225,140 Z" fill="#F5D061"/>
+  <rect x="175" y="140" width="50" height="10" rx="3" fill="#5B3A8E"/>
+  <ellipse cx="200" cy="205" rx="90" ry="14" fill="#F5D061" opacity="0.2"/>
+
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">CROWN OF THE REMEMBERED — THE PLAIN, WORN CIRCLET OF A KING.</text>
+</svg>

--- a/web/public/cutscenes/c2finale-outro-3.svg
+++ b/web/public/cutscenes/c2finale-outro-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240">
+  <rect width="400" height="240" fill="#0a1218"/>
+  <linearGradient id="c2fo3-sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="#101a24"/>
+    <stop offset="100%" stop-color="#1a2c3a"/>
+  </linearGradient>
+  <rect width="400" height="150" fill="url(#c2fo3-sky)"/>
+  <rect y="150" width="400" height="90" fill="#1c2b33"/>
+  <rect x="40" y="170" width="320" height="2" stroke="#C9CBDA" fill="#C9CBDA" opacity="0.4"/>
+  <rect x="60" y="185" width="280" height="2" fill="#C9CBDA" opacity="0.3"/>
+  <circle cx="200" cy="160" r="18" fill="none" stroke="#F5D061" stroke-width="2" opacity="0.8"/>
+  <text x="200" y="165" text-anchor="middle" font-family="monospace" font-size="9" fill="#F5D061">AMARATH</text>
+  <ellipse cx="200" cy="205" rx="150" ry="17" fill="#4C7A5E" opacity="0.15"/>
+
+  <rect y="206" width="400" height="34" fill="#080a12"/>
+  <text x="200" y="228" text-anchor="middle" font-family="monospace" font-size="12" fill="#C9CBDA">AMARATH IS REMEMBERED — WRITTEN BACK ONTO EVERY MAP IN THE DOMINION.</text>
+</svg>

--- a/web/public/sprites/boss-vigilking-1.svg
+++ b/web/public/sprites/boss-vigilking-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="0.9" fill="#12141f"/>
+  <path d="M9,14 Q16,16.5 23,14" stroke="#5B3A8E" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilking-2.svg
+++ b/web/public/sprites/boss-vigilking-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="1.05" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="1.05" fill="#12141f"/>
+  <path d="M9,14 Q16,18 23,14" stroke="#5B3A8E" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilking-3.svg
+++ b/web/public/sprites/boss-vigilking-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="1.05" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="1.05" fill="#12141f"/>
+  <path d="M9,14 Q16,16.5 23,14" stroke="#5B3A8E" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilking.svg
+++ b/web/public/sprites/boss-vigilking.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="0.9" fill="#12141f"/>
+  <path d="M9,14 Q16,18 23,14" stroke="#5B3A8E" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilqueen-1.svg
+++ b/web/public/sprites/boss-vigilqueen-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="0.9" fill="#12141f"/>
+  <path d="M9,14 Q16,16.5 23,14" stroke="#4A5FC9" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilqueen-2.svg
+++ b/web/public/sprites/boss-vigilqueen-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="1.05" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="1.05" fill="#12141f"/>
+  <path d="M9,14 Q16,18 23,14" stroke="#4A5FC9" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilqueen-3.svg
+++ b/web/public/sprites/boss-vigilqueen-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="1.05" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="1.05" fill="#12141f"/>
+  <path d="M9,14 Q16,16.5 23,14" stroke="#4A5FC9" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/boss-vigilqueen.svg
+++ b/web/public/sprites/boss-vigilqueen.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="9" r="6" fill="#E8E4D8"/>
+  <circle cx="14" cy="9.5" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="9.5" r="0.9" fill="#12141f"/>
+  <path d="M9,14 Q16,18 23,14" stroke="#4A5FC9" stroke-width="2" fill="none"/>
+</svg>

--- a/web/public/sprites/candle-archer-1.svg
+++ b/web/public/sprites/candle-archer-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,15 10,12 Z" fill="#5E6A8C"/>
+  <path d="M23,13 Q28,17 23,21" stroke="#FFC94A" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="13" x2="23" y2="21" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-archer-2.svg
+++ b/web/public/sprites/candle-archer-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.6" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,16 10,13 Z" fill="#5E6A8C"/>
+  <path d="M23,14 Q28,18 23,22" stroke="#FFC94A" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="14" x2="23" y2="22" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-archer-3.svg
+++ b/web/public/sprites/candle-archer-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,15 10,12 Z" fill="#5E6A8C"/>
+  <path d="M23,13 Q28,17 23,21" stroke="#FFC94A" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="13" x2="23" y2="21" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-archer.svg
+++ b/web/public/sprites/candle-archer.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.6" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,16 10,13 Z" fill="#5E6A8C"/>
+  <path d="M23,14 Q28,18 23,22" stroke="#FFC94A" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="14" x2="23" y2="22" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-foundry.svg
+++ b/web/public/sprites/candle-foundry.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="6" y="16" width="20" height="13" fill="#5E6A8C"/>
+  <path d="M6,16 L16,7 L26,16 Z" fill="#2B2F3E"/>
+  <rect x="13" y="20" width="6" height="9" fill="#3F5170"/>
+  <ellipse cx="16" cy="24" rx="3" ry="4" fill="#FFC94A" opacity="0.8"/>
+  <rect x="20" y="9" width="3" height="8" fill="#2B2F3E"/>
+  <ellipse cx="21.5" cy="8" rx="2" ry="1.4" fill="#FFC94A" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/candle-runner-1.svg
+++ b/web/public/sprites/candle-runner-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-runner-2.svg
+++ b/web/public/sprites/candle-runner-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-runner-3.svg
+++ b/web/public/sprites/candle-runner-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-runner.svg
+++ b/web/public/sprites/candle-runner.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candle-sconce.svg
+++ b/web/public/sprites/candle-sconce.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="14" y="16" width="4" height="14" fill="#2B2F3E"/>
+  <path d="M10,10 Q16,4 22,10 L20,16 L12,16 Z" fill="#5E6A8C"/>
+  <ellipse cx="16" cy="9" rx="4.5" ry="6" fill="#FFC94A" opacity="0.85"/>
+  <ellipse cx="16" cy="9" rx="2" ry="3.5" fill="#FFF3C4" opacity="0.9"/>
+  <ellipse cx="16" cy="29" rx="8" ry="1.4" fill="#FFC94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/candle-sentry.svg
+++ b/web/public/sprites/candle-sentry.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="10" y="10" width="12" height="19" fill="#8A97A0"/>
+  <rect x="8" y="5" width="16" height="6" fill="#5E6A8C"/>
+  <rect x="8" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <rect x="12.5" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <rect x="17" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <rect x="21" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <circle cx="16" cy="18" r="2.4" fill="#FFC94A"/>
+  <ellipse cx="16" cy="29" rx="8" ry="1.3" fill="#FFC94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/candle-watchtower.svg
+++ b/web/public/sprites/candle-watchtower.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="12" y="4" width="8" height="10" fill="#5E6A8C"/>
+  <rect x="9" y="12" width="14" height="17" fill="#8A97A0"/>
+  <rect x="9" y="12" width="14" height="3" fill="#FFC94A"/>
+  <rect x="13" y="18" width="6" height="5" fill="#2B2F3E"/>
+  <rect x="8" y="3" width="2" height="4" fill="#2B2F3E"/>
+  <rect x="22" y="3" width="2" height="4" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="29" rx="9" ry="1.4" fill="#FFC94A" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/candlebound-knight-1.svg
+++ b/web/public/sprites/candlebound-knight-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1 Q16,-5 19,1 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11 L6.5,24 L25.5,24 L24,11 Q16,17 8,11 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14 L13,21 L19,21 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="10.5" y="24" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candlebound-knight-2.svg
+++ b/web/public/sprites/candlebound-knight-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1.5 Q16,-4.5 19,1.5 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2.5" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11.5 L6.5,24.5 L25.5,24.5 L24,11.5 Q16,17.5 8,11.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14.5" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14.5 L13,21.5 L19,21.5 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="9" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candlebound-knight-3.svg
+++ b/web/public/sprites/candlebound-knight-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1 Q16,-5 19,1 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11 L6.5,24 L25.5,24 L24,11 Q16,17 8,11 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14 L13,21 L19,21 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="10.5" y="24" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/candlebound-knight.svg
+++ b/web/public/sprites/candlebound-knight.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1.5 Q16,-4.5 19,1.5 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2.5" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11.5 L6.5,24.5 L25.5,24.5 L24,11.5 Q16,17.5 8,11.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14.5" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14.5 L13,21.5 L19,21.5 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="9" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-candles-1.svg
+++ b/web/public/sprites/choir-of-the-candles-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-candles-2.svg
+++ b/web/public/sprites/choir-of-the-candles-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-candles-3.svg
+++ b/web/public/sprites/choir-of-the-candles-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-candles.svg
+++ b/web/public/sprites/choir-of-the-candles.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-remembered-1.svg
+++ b/web/public/sprites/choir-of-the-remembered-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-remembered-2.svg
+++ b/web/public/sprites/choir-of-the-remembered-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-remembered-3.svg
+++ b/web/public/sprites/choir-of-the-remembered-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/choir-of-the-remembered.svg
+++ b/web/public/sprites/choir-of-the-remembered.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-bearer-1.svg
+++ b/web/public/sprites/diadem-bearer-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-bearer-2.svg
+++ b/web/public/sprites/diadem-bearer-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-bearer-3.svg
+++ b/web/public/sprites/diadem-bearer-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-bearer.svg
+++ b/web/public/sprites/diadem-bearer.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-chanter-1.svg
+++ b/web/public/sprites/diadem-chanter-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-chanter-2.svg
+++ b/web/public/sprites/diadem-chanter-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-chanter-3.svg
+++ b/web/public/sprites/diadem-chanter-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-chanter.svg
+++ b/web/public/sprites/diadem-chanter.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#F5D061"/>
+  <circle cx="17" cy="8.5" r="1" fill="#F5D061"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#F5D061" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadem-foundry.svg
+++ b/web/public/sprites/diadem-foundry.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="6" y="16" width="20" height="13" fill="#5E6A8C"/>
+  <path d="M6,16 L16,7 L26,16 Z" fill="#2B2F3E"/>
+  <rect x="13" y="20" width="6" height="9" fill="#3F5170"/>
+  <ellipse cx="16" cy="24" rx="3" ry="4" fill="#F5D061" opacity="0.8"/>
+  <rect x="20" y="9" width="3" height="8" fill="#2B2F3E"/>
+  <ellipse cx="21.5" cy="8" rx="2" ry="1.4" fill="#F5D061" opacity="0.7"/>
+</svg>

--- a/web/public/sprites/diadembound-knight-1.svg
+++ b/web/public/sprites/diadembound-knight-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1 Q16,-5 19,1 Z" fill="#F5D061"/>
+  <rect x="10.5" y="2" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7" r="0.9" fill="#F5D061"/>
+  <circle cx="18" cy="7" r="0.9" fill="#F5D061"/>
+  <path d="M8,11 L6.5,24 L25.5,24 L24,11 Q16,17 8,11 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,14 L13,21 L19,21 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="10.5" y="24" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadembound-knight-2.svg
+++ b/web/public/sprites/diadembound-knight-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1.5 Q16,-4.5 19,1.5 Z" fill="#F5D061"/>
+  <rect x="10.5" y="2.5" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.5" r="0.9" fill="#F5D061"/>
+  <circle cx="18" cy="7.5" r="0.9" fill="#F5D061"/>
+  <path d="M8,11.5 L6.5,24.5 L25.5,24.5 L24,11.5 Q16,17.5 8,11.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14.5" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,14.5 L13,21.5 L19,21.5 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="9" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadembound-knight-3.svg
+++ b/web/public/sprites/diadembound-knight-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1 Q16,-5 19,1 Z" fill="#F5D061"/>
+  <rect x="10.5" y="2" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7" r="0.9" fill="#F5D061"/>
+  <circle cx="18" cy="7" r="0.9" fill="#F5D061"/>
+  <path d="M8,11 L6.5,24 L25.5,24 L24,11 Q16,17 8,11 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,14 L13,21 L19,21 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="10.5" y="24" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/diadembound-knight.svg
+++ b/web/public/sprites/diadembound-knight.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1.5 Q16,-4.5 19,1.5 Z" fill="#F5D061"/>
+  <rect x="10.5" y="2.5" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.5" r="0.9" fill="#F5D061"/>
+  <circle cx="18" cy="7.5" r="0.9" fill="#F5D061"/>
+  <path d="M8,11.5 L6.5,24.5 L25.5,24.5 L24,11.5 Q16,17.5 8,11.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14.5" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,14.5 L13,21.5 L19,21.5 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="9" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/regalia-courier-1.svg
+++ b/web/public/sprites/regalia-courier-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/regalia-courier-2.svg
+++ b/web/public/sprites/regalia-courier-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/regalia-courier-3.svg
+++ b/web/public/sprites/regalia-courier-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/regalia-courier.svg
+++ b/web/public/sprites/regalia-courier.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-automaton.svg
+++ b/web/public/sprites/rite-automaton.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="6" width="14" height="14" rx="2" fill="#8A97A0"/>
+  <circle cx="13" cy="12" r="1.6" fill="#F5D061"/>
+  <circle cx="19" cy="12" r="1.6" fill="#F5D061"/>
+  <rect x="12" y="16" width="8" height="2" fill="#2B2F3E"/>
+  <rect x="7" y="20" width="18" height="9" fill="#5E6A8C"/>
+  <rect x="10" y="23" width="4" height="4" fill="#F5D061" opacity="0.6"/>
+  <rect x="18" y="23" width="4" height="4" fill="#F5D061" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/rite-guard-1.svg
+++ b/web/public/sprites/rite-guard-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-guard-2.svg
+++ b/web/public/sprites/rite-guard-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-guard-3.svg
+++ b/web/public/sprites/rite-guard-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-guard.svg
+++ b/web/public/sprites/rite-guard.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-sentry-1.svg
+++ b/web/public/sprites/rite-sentry-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-sentry-2.svg
+++ b/web/public/sprites/rite-sentry-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-sentry-3.svg
+++ b/web/public/sprites/rite-sentry-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-sentry.svg
+++ b/web/public/sprites/rite-sentry.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-vanguard-1.svg
+++ b/web/public/sprites/rite-vanguard-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-vanguard-2.svg
+++ b/web/public/sprites/rite-vanguard-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-vanguard-3.svg
+++ b/web/public/sprites/rite-vanguard-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/rite-vanguard.svg
+++ b/web/public/sprites/rite-vanguard.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#F5D061"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/sealed-chantry.svg
+++ b/web/public/sprites/sealed-chantry.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M5,28 L5,13 Q16,4 27,13 L27,28 Z" fill="#5E6A8C"/>
+  <path d="M9,28 L9,16 Q16,9 23,16 L23,28 Z" fill="#1c1f2c"/>
+  <rect x="4" y="26" width="24" height="3" fill="#2B2F3E"/>
+  <circle cx="16" cy="10" r="1.6" fill="#FFC94A"/>
+  <rect x="9" y="16" width="3" height="12" fill="#FFC94A" opacity="0.5"/>
+  <rect x="20" y="16" width="3" height="12" fill="#FFC94A" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/sealed-reliquary.svg
+++ b/web/public/sprites/sealed-reliquary.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M5,28 L5,13 Q16,4 27,13 L27,28 Z" fill="#5E6A8C"/>
+  <path d="M9,28 L9,16 Q16,9 23,16 L23,28 Z" fill="#1c1f2c"/>
+  <rect x="4" y="26" width="24" height="3" fill="#2B2F3E"/>
+  <circle cx="16" cy="10" r="1.6" fill="#F5D061"/>
+  <rect x="9" y="16" width="3" height="12" fill="#F5D061" opacity="0.5"/>
+  <rect x="20" y="16" width="3" height="12" fill="#F5D061" opacity="0.5"/>
+</svg>

--- a/web/public/sprites/the-last-rite-1.svg
+++ b/web/public/sprites/the-last-rite-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#F5D061"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#5B3A8E" opacity="0.75"/>
+  <rect x="9" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="18.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-rite-2.svg
+++ b/web/public/sprites/the-last-rite-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#F5D061"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#5B3A8E" opacity="0.75"/>
+  <rect x="7.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="17" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-rite-3.svg
+++ b/web/public/sprites/the-last-rite-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#F5D061"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#5B3A8E" opacity="0.75"/>
+  <rect x="9" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="18.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-rite.svg
+++ b/web/public/sprites/the-last-rite.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#F5D061"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#5B3A8E" opacity="0.75"/>
+  <rect x="7.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="17" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-vigil-1.svg
+++ b/web/public/sprites/the-last-vigil-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#FFC94A"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#4A5FC9" opacity="0.75"/>
+  <rect x="9" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="18.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-vigil-2.svg
+++ b/web/public/sprites/the-last-vigil-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#FFC94A"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#4A5FC9" opacity="0.75"/>
+  <rect x="7.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="17" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-vigil-3.svg
+++ b/web/public/sprites/the-last-vigil-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#FFC94A"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#4A5FC9" opacity="0.75"/>
+  <rect x="9" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="18.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-last-vigil.svg
+++ b/web/public/sprites/the-last-vigil.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="12" cy="9" r="3.6" fill="#8A97A0"/>
+  <circle cx="20" cy="8" r="3.6" fill="#8A97A0"/>
+  <circle cx="11" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="13" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="19" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="21" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M6,12 L5,24 L27,24 L26,12 Q16,17 6,12 Z" fill="#5E6A8C"/>
+  <rect x="11" y="16" width="10" height="1.6" fill="#FFC94A"/>
+  <path d="M16,16 L13,22 L19,22 Z" fill="#4A5FC9" opacity="0.75"/>
+  <rect x="7.5" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+  <rect x="17" y="24" width="4.5" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-king-1.svg
+++ b/web/public/sprites/the-vigil-king-1.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="8" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <path d="M8,13 L6.5,25 L25.5,25 L24,13 Q16,18 8,13 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,16 L13,23 L19,23 Z" fill="#5B3A8E" opacity="0.7"/>
+  <rect x="9.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-king-2.svg
+++ b/web/public/sprites/the-vigil-king-2.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3.5 Q16,-1.5 23,3.5 L21,7.5 Q16,4.5 11,7.5 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="2.0" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0.5" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="2.0" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="8.5" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <path d="M8,13.5 L6.5,25.5 L25.5,25.5 L24,13.5 Q16,18.5 8,13.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16.5" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,16.5 L13,23.5 L19,23.5 Z" fill="#5B3A8E" opacity="0.7"/>
+  <rect x="8" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-king-3.svg
+++ b/web/public/sprites/the-vigil-king-3.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="1.5" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="8" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <path d="M8,13 L6.5,25 L25.5,25 L24,13 Q16,18 8,13 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,16 L13,23 L19,23 Z" fill="#5B3A8E" opacity="0.7"/>
+  <rect x="9.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-king.svg
+++ b/web/public/sprites/the-vigil-king.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3.5 Q16,-1.5 23,3.5 L21,7.5 Q16,4.5 11,7.5 Z" fill="#5B3A8E"/>
+  <circle cx="13" cy="2.0" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="0.5" r="1" fill="#F5D061"/>
+  <circle cx="19" cy="2.0" r="1" fill="#F5D061"/>
+  <circle cx="16" cy="8.5" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <path d="M8,13.5 L6.5,25.5 L25.5,25.5 L24,13.5 Q16,18.5 8,13.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16.5" width="8" height="1.8" fill="#F5D061"/>
+  <path d="M16,16.5 L13,23.5 L19,23.5 Z" fill="#5B3A8E" opacity="0.7"/>
+  <rect x="8" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-queen-1.svg
+++ b/web/public/sprites/the-vigil-queen-1.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="8" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <path d="M8,13 L6.5,25 L25.5,25 L24,13 Q16,18 8,13 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,16 L13,23 L19,23 Z" fill="#4A5FC9" opacity="0.7"/>
+  <rect x="9.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-queen-2.svg
+++ b/web/public/sprites/the-vigil-queen-2.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3.5 Q16,-1.5 23,3.5 L21,7.5 Q16,4.5 11,7.5 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="2.0" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0.5" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="2.0" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="8.5" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <path d="M8,13.5 L6.5,25.5 L25.5,25.5 L24,13.5 Q16,18.5 8,13.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16.5" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,16.5 L13,23.5 L19,23.5 Z" fill="#4A5FC9" opacity="0.7"/>
+  <rect x="8" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-queen-3.svg
+++ b/web/public/sprites/the-vigil-queen-3.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3 Q16,-2 23,3 L21,7 Q16,4 11,7 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="1.5" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="8" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.3" r="0.7" fill="#12141f"/>
+  <path d="M8,13 L6.5,25 L25.5,25 L24,13 Q16,18 8,13 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,16 L13,23 L19,23 Z" fill="#4A5FC9" opacity="0.7"/>
+  <rect x="9.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16.5" y="25" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/the-vigil-queen.svg
+++ b/web/public/sprites/the-vigil-queen.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M9,3.5 Q16,-1.5 23,3.5 L21,7.5 Q16,4.5 11,7.5 Z" fill="#4A5FC9"/>
+  <circle cx="13" cy="2.0" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="0.5" r="1" fill="#FFC94A"/>
+  <circle cx="19" cy="2.0" r="1" fill="#FFC94A"/>
+  <circle cx="16" cy="8.5" r="5" fill="#E8E4D8"/>
+  <circle cx="14.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <circle cx="17.5" cy="8.8" r="0.7" fill="#12141f"/>
+  <path d="M8,13.5 L6.5,25.5 L25.5,25.5 L24,13.5 Q16,18.5 8,13.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="16.5" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,16.5 L13,23.5 L19,23.5 Z" fill="#4A5FC9" opacity="0.7"/>
+  <rect x="8" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="25.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-archer-1.svg
+++ b/web/public/sprites/throne-archer-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,15 10,12 Z" fill="#5E6A8C"/>
+  <path d="M23,13 Q28,17 23,21" stroke="#F5D061" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="13" x2="23" y2="21" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-archer-2.svg
+++ b/web/public/sprites/throne-archer-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.6" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,16 10,13 Z" fill="#5E6A8C"/>
+  <path d="M23,14 Q28,18 23,22" stroke="#F5D061" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="14" x2="23" y2="22" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-archer-3.svg
+++ b/web/public/sprites/throne-archer-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="8" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.6" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,15 10,12 Z" fill="#5E6A8C"/>
+  <path d="M23,13 Q28,17 23,21" stroke="#F5D061" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="13" x2="23" y2="21" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-archer.svg
+++ b/web/public/sprites/throne-archer.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4" fill="#E8B4C8"/>
+  <circle cx="15" cy="9" r="0.6" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.6" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,16 10,13 Z" fill="#5E6A8C"/>
+  <path d="M23,14 Q28,18 23,22" stroke="#F5D061" stroke-width="1.3" fill="none"/>
+  <line x1="23" y1="14" x2="23" y2="22" stroke="#8A97A0" stroke-width="0.6"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-barricade.svg
+++ b/web/public/sprites/throne-barricade.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="4" y="14" width="24" height="14" fill="#5E6A8C"/>
+  <rect x="4" y="14" width="24" height="3" fill="#F5D061"/>
+  <rect x="7" y="18" width="4" height="4" fill="#3F5170"/>
+  <rect x="14" y="18" width="4" height="4" fill="#3F5170"/>
+  <rect x="21" y="18" width="4" height="4" fill="#3F5170"/>
+  <rect x="4" y="24" width="24" height="4" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="29" rx="14" ry="1.6" fill="#F5D061" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/throne-runner-1.svg
+++ b/web/public/sprites/throne-runner-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-runner-2.svg
+++ b/web/public/sprites/throne-runner-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-runner-3.svg
+++ b/web/public/sprites/throne-runner-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-runner.svg
+++ b/web/public/sprites/throne-runner.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#F5D061"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/throne-sconce.svg
+++ b/web/public/sprites/throne-sconce.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="14" y="16" width="4" height="14" fill="#2B2F3E"/>
+  <path d="M10,10 Q16,4 22,10 L20,16 L12,16 Z" fill="#5E6A8C"/>
+  <ellipse cx="16" cy="9" rx="4.5" ry="6" fill="#F5D061" opacity="0.85"/>
+  <ellipse cx="16" cy="9" rx="2" ry="3.5" fill="#FFF3C4" opacity="0.9"/>
+  <ellipse cx="16" cy="29" rx="8" ry="1.4" fill="#F5D061" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/throne-sentry.svg
+++ b/web/public/sprites/throne-sentry.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="10" y="10" width="12" height="19" fill="#8A97A0"/>
+  <rect x="8" y="5" width="16" height="6" fill="#5E6A8C"/>
+  <rect x="8" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <rect x="12.5" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <rect x="17" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <rect x="21" y="5" width="3" height="6" fill="#2B2F3E"/>
+  <circle cx="16" cy="18" r="2.4" fill="#F5D061"/>
+  <ellipse cx="16" cy="29" rx="8" ry="1.3" fill="#F5D061" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/throne-watchtower.svg
+++ b/web/public/sprites/throne-watchtower.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="12" y="4" width="8" height="10" fill="#5E6A8C"/>
+  <rect x="9" y="12" width="14" height="17" fill="#8A97A0"/>
+  <rect x="9" y="12" width="14" height="3" fill="#F5D061"/>
+  <rect x="13" y="18" width="6" height="5" fill="#2B2F3E"/>
+  <rect x="8" y="3" width="2" height="4" fill="#2B2F3E"/>
+  <rect x="22" y="3" width="2" height="4" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="29" rx="9" ry="1.4" fill="#F5D061" opacity="0.25"/>
+</svg>

--- a/web/public/sprites/vigil-knight-1.svg
+++ b/web/public/sprites/vigil-knight-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1 Q16,-5 19,1 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11 L6.5,24 L25.5,24 L24,11 Q16,17 8,11 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14 L13,21 L19,21 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="10.5" y="24" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/vigil-knight-2.svg
+++ b/web/public/sprites/vigil-knight-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1.5 Q16,-4.5 19,1.5 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2.5" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11.5 L6.5,24.5 L25.5,24.5 L24,11.5 Q16,17.5 8,11.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14.5" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14.5 L13,21.5 L19,21.5 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="9" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/vigil-knight-3.svg
+++ b/web/public/sprites/vigil-knight-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1 Q16,-5 19,1 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11 L6.5,24 L25.5,24 L24,11 Q16,17 8,11 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14 L13,21 L19,21 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="10.5" y="24" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/vigil-knight.svg
+++ b/web/public/sprites/vigil-knight.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5.2" fill="#8A97A0"/>
+  <path d="M13,1.5 Q16,-4.5 19,1.5 Z" fill="#FFC94A"/>
+  <rect x="10.5" y="2.5" width="11" height="7" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <circle cx="18" cy="7.5" r="0.9" fill="#FFC94A"/>
+  <path d="M8,11.5 L6.5,24.5 L25.5,24.5 L24,11.5 Q16,17.5 8,11.5 Z" fill="#5E6A8C"/>
+  <rect x="12" y="14.5" width="8" height="1.8" fill="#FFC94A"/>
+  <path d="M16,14.5 L13,21.5 L19,21.5 Z" fill="#E8B4C8" opacity="0.7"/>
+  <rect x="9" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="24.5" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-automaton.svg
+++ b/web/public/sprites/ward-automaton.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="9" y="6" width="14" height="14" rx="2" fill="#8A97A0"/>
+  <circle cx="13" cy="12" r="1.6" fill="#FFC94A"/>
+  <circle cx="19" cy="12" r="1.6" fill="#FFC94A"/>
+  <rect x="12" y="16" width="8" height="2" fill="#2B2F3E"/>
+  <rect x="7" y="20" width="18" height="9" fill="#5E6A8C"/>
+  <rect x="10" y="23" width="4" height="4" fill="#FFC94A" opacity="0.6"/>
+  <rect x="18" y="23" width="4" height="4" fill="#FFC94A" opacity="0.6"/>
+</svg>

--- a/web/public/sprites/ward-barricade.svg
+++ b/web/public/sprites/ward-barricade.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="4" y="14" width="24" height="14" fill="#5E6A8C"/>
+  <rect x="4" y="14" width="24" height="3" fill="#FFC94A"/>
+  <rect x="7" y="18" width="4" height="4" fill="#3F5170"/>
+  <rect x="14" y="18" width="4" height="4" fill="#3F5170"/>
+  <rect x="21" y="18" width="4" height="4" fill="#3F5170"/>
+  <rect x="4" y="24" width="24" height="4" fill="#2B2F3E"/>
+  <ellipse cx="16" cy="29" rx="14" ry="1.6" fill="#FFC94A" opacity="0.3"/>
+</svg>

--- a/web/public/sprites/ward-courier-1.svg
+++ b/web/public/sprites/ward-courier-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-courier-2.svg
+++ b/web/public/sprites/ward-courier-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-courier-3.svg
+++ b/web/public/sprites/ward-courier-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-courier.svg
+++ b/web/public/sprites/ward-courier.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-guard-1.svg
+++ b/web/public/sprites/ward-guard-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-guard-2.svg
+++ b/web/public/sprites/ward-guard-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-guard-3.svg
+++ b/web/public/sprites/ward-guard-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-guard.svg
+++ b/web/public/sprites/ward-guard.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-herald-1.svg
+++ b/web/public/sprites/ward-herald-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-herald-2.svg
+++ b/web/public/sprites/ward-herald-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-herald-3.svg
+++ b/web/public/sprites/ward-herald-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-herald.svg
+++ b/web/public/sprites/ward-herald.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-vanguard-1.svg
+++ b/web/public/sprites/ward-vanguard-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-vanguard-2.svg
+++ b/web/public/sprites/ward-vanguard-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-vanguard-3.svg
+++ b/web/public/sprites/ward-vanguard-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="6.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="3.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="7.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="7.0" r="0.9" fill="#12141f"/>
+  <path d="M8,11.0 L7,24.0 L25,24.0 L24,11.0 Q16,17.0 8,11.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="14.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="17.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="16.5" r="2" fill="#6B4F3A"/>
+  <rect x="10.5" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="16" y="24.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/ward-vanguard.svg
+++ b/web/public/sprites/ward-vanguard.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="7.5" r="5" fill="#8A97A0"/>
+  <rect x="10.5" y="4.0" width="11" height="6" rx="2" fill="#2B2F3E"/>
+  <circle cx="14" cy="8.0" r="0.9" fill="#12141f"/>
+  <circle cx="18" cy="8.0" r="0.9" fill="#12141f"/>
+  <path d="M8,12.0 L7,25.0 L25,25.0 L24,12.0 Q16,18.0 8,12.0 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15.0" width="6" height="1.6" fill="#FFC94A"/>
+  <circle cx="9" cy="18.0" r="1.8" fill="#6B4F3A"/>
+  <circle cx="23" cy="17.5" r="2" fill="#6B4F3A"/>
+  <rect x="9" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+  <rect x="17.5" y="25.0" width="6" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-chanter-1.svg
+++ b/web/public/sprites/window-chanter-1.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-chanter-2.svg
+++ b/web/public/sprites/window-chanter-2.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-chanter-3.svg
+++ b/web/public/sprites/window-chanter-3.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17.3" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="12" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-chanter.svg
+++ b/web/public/sprites/window-chanter.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4" fill="#2B2F3E"/>
+  <path d="M11.5,8 Q16,1 20.5,8 L20.5,9.5 Q16,6.5 11.5,9.5 Z" fill="#5E6A8C"/>
+  <circle cx="15" cy="8.5" r="1" fill="#FFC94A"/>
+  <circle cx="17" cy="8.5" r="1" fill="#FFC94A"/>
+  <path d="M10,12 L9,23 L23,23 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <path d="M16,12 L14,19 L18,19 Z" fill="#FFC94A" opacity="0.8"/>
+  <rect x="11.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-sentry-1.svg
+++ b/web/public/sprites/window-sentry-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-sentry-2.svg
+++ b/web/public/sprites/window-sentry-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-sentry-3.svg
+++ b/web/public/sprites/window-sentry-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="8" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="8" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="8" r="0.7" fill="#12141f"/>
+  <path d="M10,12 L9,22 L23,22 L22,12 Q16,16 10,12 Z" fill="#5E6A8C"/>
+  <rect x="13" y="15" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="15" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="14.5" r="1.6" fill="#8A97A0"/>
+  <rect x="11.5" y="22" width="4" height="6" fill="#2B2F3E"/>
+  <rect x="16.5" y="22" width="4" height="7" fill="#2B2F3E"/>
+</svg>

--- a/web/public/sprites/window-sentry.svg
+++ b/web/public/sprites/window-sentry.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="9" r="4.2" fill="#8A97A0"/>
+  <circle cx="15" cy="9" r="0.7" fill="#12141f"/>
+  <circle cx="17" cy="9" r="0.7" fill="#12141f"/>
+  <path d="M10,13 L9,23 L23,23 L22,13 Q16,17 10,13 Z" fill="#5E6A8C"/>
+  <rect x="13" y="16" width="6" height="1.4" fill="#FFC94A"/>
+  <circle cx="12" cy="16" r="1.4" fill="#8A97A0"/>
+  <circle cx="20" cy="15.5" r="1.6" fill="#8A97A0"/>
+  <rect x="10" y="23" width="4" height="7" fill="#2B2F3E"/>
+  <rect x="18" y="23" width="4" height="6" fill="#2B2F3E"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3604,7 +3604,10 @@ export default function App() {
       )}
 
       {screen === 'campaignvictory' && (
-        <CampaignVictoryScreen onBeginAnew={() => setScreen('statupgrade')} />
+        <CampaignVictoryScreen
+          onBeginAnew={() => setScreen('statupgrade')}
+          campaignId={run ? getCampaignForAct(run.actId).id : 'c1'}
+        />
       )}
 
       {screen === 'tobecontinued' && (

--- a/web/src/components/battle/CampaignVictoryScreen.tsx
+++ b/web/src/components/battle/CampaignVictoryScreen.tsx
@@ -3,10 +3,35 @@ import { loadPlayerName } from '../../game/questline'
 
 interface Props {
   onBeginAnew: () => void
+  campaignId?: string
 }
 
-export function CampaignVictoryScreen({ onBeginAnew }: Props) {
+interface VictoryCopy {
+  title: string
+  lines: string[]
+}
+
+const VICTORY_COPY: Record<string, VictoryCopy> = {
+  c1: {
+    title: '⚡ Worldmender ⚡',
+    lines: [
+      'The Fracture is sealed. The shards breathe again.',
+      "{playerName}'s legend echoes across the Dominion.",
+    ],
+  },
+  c2: {
+    title: '🕯️ The Kingdom Remembered 🕯️',
+    lines: [
+      "Amarath is written back onto every map in the Dominion — remembered, at peace, part of the mended Dominion.",
+      "{playerName}'s name joins a vigil three centuries kept for exactly this.",
+      'Somewhere, the Dominion’s other maps still hold blank quarters. The Fracture erased more than one kingdom.',
+    ],
+  },
+}
+
+export function CampaignVictoryScreen({ onBeginAnew, campaignId = 'c1' }: Props) {
   const playerName = loadPlayerName()
+  const copy = VICTORY_COPY[campaignId] ?? VICTORY_COPY.c1
   return (
     <div className="campaign-victory u-col u-items-c u-just-c u-relative u-text-c">
       <div className="cv-glow" />
@@ -14,9 +39,10 @@ export function CampaignVictoryScreen({ onBeginAnew }: Props) {
   ║  QUESTLINE  COMPLETE ║
   ╚══════════════════════╝`}</pre>
       <div className="cv-body">
-        <p className="cv-title">⚡ Worldmender ⚡</p>
-        <p>The Fracture is sealed. The shards breathe again.</p>
-        <p>{playerName}'s legend echoes across the Dominion.</p>
+        <p className="cv-title">{copy.title}</p>
+        {copy.lines.map((line, i) => (
+          <p key={i}>{line.replace('{playerName}', playerName)}</p>
+        ))}
         <p className="cv-reward">+500 ◆ awarded for completing the questline.</p>
       </div>
       <button className="action-btn action-btn--large action-btn--gold" onClick={onBeginAnew}>

--- a/web/src/data/acts/c2act1.json
+++ b/web/src/data/acts/c2act1.json
@@ -159,6 +159,7 @@
       "rowCols": 3,
       "childIds": [
         "mist-picket",
+        "border-clash",
         "toll-bridge"
       ],
       "handicap": 14,
@@ -179,10 +180,9 @@
       "description": "Sentries hold the western fenceline of the Marches.",
       "row": 1,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
-        "waymeet-shrine",
-        "wardens-camp"
+        "waymeet-shrine"
       ],
       "handicap": 16,
       "opponentIntervalMs": 3300,
@@ -196,14 +196,37 @@
         "March Ration"
       ]
     },
+    "border-clash": {
+      "id": "border-clash",
+      "type": "battle",
+      "label": "The Border Clash",
+      "description": "A running fight along a fenceline no Dominion map ever drew.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "wardens-camp"
+      ],
+      "handicap": 16,
+      "opponentIntervalMs": 3300,
+      "opponentBaseHp": 222,
+      "environment": "frost",
+      "enemyDeck": [
+        "Mist Skirmisher",
+        "Marchland Pikeman",
+        "Wardstone",
+        "Candle Bearer",
+        "March Ration"
+      ]
+    },
     "toll-bridge": {
       "id": "toll-bridge",
       "type": "battle",
       "label": "Old Toll Bridge",
       "description": "A bridge that was never on the survey — with a garrison that was never on the rolls.",
       "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "blank-map",
         "drovers-market"
@@ -229,8 +252,7 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "vanguard-line",
-        "mem-c2act1-1"
+        "vanguard-line"
       ],
       "eventConfig": {
         "title": "The Waymeet Shrine",
@@ -296,7 +318,8 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "vanguard-line"
+        "vanguard-line",
+        "mem-c2act1-1"
       ],
       "restHeal": 8
     },
@@ -403,7 +426,8 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "palisade-push"
+        "palisade-push",
+        "fog-riders"
       ],
       "fragmentId": "c2act1-frag-1",
       "environment": "frost"
@@ -417,7 +441,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "fog-riders"
+        "fog-riders",
+        "watch-line"
       ],
       "handicap": 20,
       "opponentIntervalMs": 3100,
@@ -440,7 +465,7 @@
       "description": "The vanguard's field works block the road west.",
       "row": 4,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "last-lamp"
       ],
@@ -457,16 +482,40 @@
         "Mist Archer"
       ]
     },
+    "watch-line": {
+      "id": "watch-line",
+      "type": "battle",
+      "label": "The Watch Line",
+      "description": "A last defensive line, dug in before the Herald's own ground.",
+      "row": 4,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "last-lamp",
+        "mem-c2act1-2"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "frost",
+      "enemyDeck": [
+        "Pale Rider",
+        "Marchland Pikeman",
+        "Watch Beacon",
+        "Unremembered Soldier",
+        "Fog Veil",
+        "Wardstone"
+      ]
+    },
     "fog-riders": {
       "id": "fog-riders",
       "type": "battle",
       "label": "Riders in the Fog",
       "description": "Cavalry with no hoofbeats, closing fast.",
       "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
-        "last-lamp",
         "mem-c2act1-2"
       ],
       "handicap": 22,

--- a/web/src/data/acts/c2act10.json
+++ b/web/src/data/acts/c2act10.json
@@ -4,7 +4,7 @@
   "title": "ACT X",
   "subtitle": "The Bone Orchards",
   "rewardRelic": "Orchard Blossom",
-  "rewardRelicDesc": "All friendly units gain +5 max HP — a blossom grown from a grief the orchard never finished tending.",
+  "rewardRelicDesc": "All friendly units gain +5 max HP \u2014 a blossom grown from a grief the orchard never finished tending.",
   "environment": "orchard",
   "rewardTags": [
     "forgotten",
@@ -58,7 +58,7 @@
       "Three centuries of tending taught her one thing the Pale Court never had to teach: a grief kept long enough stops being sorrow and starts being love. She has not yet decided what the Worldmender is here to prune."
     ],
     "priorRunOpenings": [
-      "The orchard threshold was already tended when you reached it, same as always — the grove remembers being crossed even when it doesn't remember by whom.",
+      "The orchard threshold was already tended when you reached it, same as always \u2014 the grove remembers being crossed even when it doesn't remember by whom.",
       "You knew the root-sconces' light this time. The bonewood company knew you knowing it.",
       "The grove ledger at the threshold already had your crossing recorded. You are becoming a familiar entry in someone's tending.",
       "The Keeper's retinue was already standing among the rows when you arrived. She does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE BONE ORCHARDS",
-          "text": "The orchard threshold is freshly tended — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The orchard threshold is freshly tended \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -122,7 +122,7 @@
     },
     {
       "title": "THE BONE ORCHARDS",
-      "text": "This is not an orchard that grew by accident. It is an orchard Amarath planted on purpose, three centuries ago, so that every grave the void claimed would have something to grow into. The garrisons here are not guarding a grove — they are guarding a grief the whole kingdom agreed to keep tending.",
+      "text": "This is not an orchard that grew by accident. It is an orchard Amarath planted on purpose, three centuries ago, so that every grave the void claimed would have something to grow into. The garrisons here are not guarding a grove \u2014 they are guarding a grief the whole kingdom agreed to keep tending.",
       "image": "cutscenes/c2act10-intro-2.svg"
     },
     {
@@ -139,7 +139,7 @@
     },
     {
       "title": "ORCHARD BLOSSOM",
-      "text": "It is a small thing to have cost a kingdom a grove's worth of grief — a single blossom that gives every friendly line a little more to hold. Holding it, you understand the Keeper better than her own tending ever explained her: a grief kept long enough doesn't stop being sorrow. It starts being love.",
+      "text": "It is a small thing to have cost a kingdom a grove's worth of grief \u2014 a single blossom that gives every friendly line a little more to hold. Holding it, you understand the Keeper better than her own tending ever explained her: a grief kept long enough doesn't stop being sorrow. It starts being love.",
       "image": "cutscenes/c2act10-outro-2.svg"
     },
     {
@@ -200,7 +200,7 @@
       "id": "the-bonewood-ramparts",
       "type": "battle",
       "label": "The Bonewood Ramparts",
-      "description": "A rampart line garrisoned like the grove still needs guarding — because to the Court, it does.",
+      "description": "A rampart line garrisoned like the grove still needs guarding \u2014 because to the Court, it does.",
       "row": 1,
       "col": 3,
       "rowCols": 4,
@@ -451,7 +451,7 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-final-groveline"
+        "the-inner-grove-gate"
       ],
       "handicap": 40,
       "opponentIntervalMs": 2600,
@@ -475,8 +475,7 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-final-groveline",
-        "mem-c2act10-2"
+        "the-inner-grove-gate"
       ],
       "handicap": 40,
       "opponentIntervalMs": 2600,
@@ -496,9 +495,9 @@
       "type": "rest",
       "label": "The Final Groveline",
       "description": "The last tended row before the Keeper's own ward. Someone has already trimmed it.",
-      "row": 5,
+      "row": 10,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 1,
       "childIds": [
         "orchardkeeper-node"
       ],
@@ -508,12 +507,12 @@
       "id": "mem-c2act10-2",
       "type": "memory",
       "label": "Memory Fragment",
-      "description": "A grove-tender's log from the night the orchard finally rooted.",
-      "row": 5,
+      "description": "A grove-tender's log from the night the heartwood first sealed its own gate.",
+      "row": 9,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
-        "orchardkeeper-node"
+        "the-final-groveline"
       ],
       "fragmentId": "c2act10-frag-2",
       "environment": "orchard"
@@ -523,7 +522,7 @@
       "type": "boss",
       "label": "The Orchard Keeper",
       "description": "Three centuries of tending end here, before a gardener who decides which grief still deserves company.",
-      "row": 6,
+      "row": 11,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -547,6 +546,352 @@
         "The Court does not ask me to grow this orchard. It only asks that I keep every name in it from being forgotten twice. Let's begin."
       ],
       "bossCard": "The Orchard Keeper"
+    },
+    "the-inner-grove-gate": {
+      "id": "the-inner-grove-gate",
+      "type": "battle",
+      "label": "The Inner Grove Gate",
+      "description": "A second grove-gate, deeper in the orchard than any grief was ever meant to reach.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [
+        "the-heartwood-corridor",
+        "the-gilded-canopy",
+        "the-hollow-roots"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 320,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Bonewood Guard",
+        "Sapling Runner",
+        "Root Sconce",
+        "Grove Tender"
+      ]
+    },
+    "the-heartwood-corridor": {
+      "id": "the-heartwood-corridor",
+      "type": "battle",
+      "label": "The Heartwood Corridor",
+      "description": "A corridor grown through the orchard's own heartwood, older than the rows around it.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-deep-ledger"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 320,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Bonewood Guard",
+        "Root Barricade",
+        "Grove Archer",
+        "Orchard Draught"
+      ]
+    },
+    "the-gilded-canopy": {
+      "id": "the-gilded-canopy",
+      "type": "battle",
+      "label": "The Gilded Canopy",
+      "description": "A canopy gilded over for a Keeper who has not received a real guest in three centuries.",
+      "row": 6,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-canopy-hearth",
+        "the-sealed-heartwood-gate"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 320,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Bonewood Scout",
+        "Bonewood Watchtower",
+        "Grove Archer",
+        "Blossom Toll"
+      ]
+    },
+    "the-hollow-roots": {
+      "id": "the-hollow-roots",
+      "type": "battle",
+      "label": "The Hollow Roots",
+      "description": "A root-hollow kept shrouded since the tending that named it stopped being spoken of.",
+      "row": 6,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "the-root-cellar-cart"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 320,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Sapling Runner",
+        "Orchard Courier",
+        "Blossom Foundry",
+        "Root Lens"
+      ]
+    },
+    "the-deep-ledger": {
+      "id": "the-deep-ledger",
+      "type": "event",
+      "label": "The Deep Ledger",
+      "description": "A ledger kept apart from the outer grove, recording graves the first ledger was never shown.",
+      "row": 7,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-heartwood-company"
+      ],
+      "eventConfig": {
+        "title": "The Deep Ledger",
+        "description": "This ledger sits behind a gate the outer clerks do not have keys to, recording graves the Court decided the first ledger should never see. Every entry is a name that was planted twice, once in error.",
+        "pools": [
+          [
+            {
+              "label": "Read the deep ledger (lose 6 HP, gain a rare card)",
+              "consequence": "A record within a record costs more to read. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the clerk's deep cache (gain 70 crystals)",
+              "consequence": "A cache the first ledger never accounted for. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest behind the deep gate (heal 9 HP)",
+              "consequence": "Quieter than a grove that keeps two ledgers has any right to be. You heal 9 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 9
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the deep ledger unread",
+              "consequence": "Some graves are better left double-uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-canopy-hearth": {
+      "id": "the-canopy-hearth",
+      "type": "rest",
+      "label": "The Canopy Hearth",
+      "description": "A second hearth, kept for tenders who serve a grove nobody outside ever hears of.",
+      "row": 7,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-heartwood-company"
+      ],
+      "restHeal": 10
+    },
+    "the-sealed-heartwood-gate": {
+      "id": "the-sealed-heartwood-gate",
+      "type": "event",
+      "label": "The Sealed Heartwood Gate",
+      "description": "A second sealed gate, posting orders for a tending the outer grove was never told existed.",
+      "row": 7,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "the-root-bound-line"
+      ],
+      "eventConfig": {
+        "title": "The Sealed Heartwood Gate",
+        "description": "The writ on this gate is signed by the Keeper twice \u2014 once in the hand the outer grove knows, once in a hand nobody has seen in three hundred years. Both signatures agree on every row.",
+        "pools": [
+          [
+            {
+              "label": "Read the heartwood writ (lose 6 HP, gain a rare card)",
+              "consequence": "Two signatures cost more to read past than one. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the heartwood gate's cache (gain 70 crystals)",
+              "consequence": "A cache nobody past the outer gate was ever going to collect. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest behind the heartwood seals (heal 8 HP)",
+              "consequence": "Quieter than a twice-sealed gate has any right to be. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the heartwood writ unread",
+              "consequence": "Some orders are better left twice-uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-root-cellar-cart": {
+      "id": "the-root-cellar-cart",
+      "type": "merchant",
+      "label": "The Root Cellar Cart",
+      "description": "A second trading cart, further in than the Keeper admits any cart has reason to be.",
+      "row": 7,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-root-bound-line"
+      ]
+    },
+    "the-heartwood-company": {
+      "id": "the-heartwood-company",
+      "type": "elite",
+      "label": "The Heartwood Company",
+      "description": "A second file of Court soldiers, rooted in ground finer than anything the outer grove grows.",
+      "row": 8,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "the-last-heartwood"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 328,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Orchard Vanguard",
+        "Bonewood Guard",
+        "Blossom Foundry",
+        "Choir of Roots",
+        "Blossom Toll",
+        "Sealed Grovehouse"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-root-bound-line": {
+      "id": "the-root-bound-line",
+      "type": "elite",
+      "label": "The Root-Bound Line",
+      "description": "A line of tenders bound to the roots rather than the rows, for a rank the outer orchard never named.",
+      "row": 8,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "the-last-heartwood",
+        "mem-c2act10-2",
+        "the-final-canopy"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 328,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Root Chanter",
+        "Grove Automaton",
+        "Blossom Sentry",
+        "Grove Writ",
+        "Choir of Roots",
+        "Grove Archer"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-last-heartwood": {
+      "id": "the-last-heartwood",
+      "type": "battle",
+      "label": "The Last Heartwood",
+      "description": "The final heartwood stand before the Keeper receives anyone at all.",
+      "row": 9,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-groveline"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 328,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Bonewood Guard",
+        "Root Barricade",
+        "Bonewood Watchtower",
+        "Orchard Courier",
+        "Blossom Toll"
+      ]
+    },
+    "the-final-canopy": {
+      "id": "the-final-canopy",
+      "type": "battle",
+      "label": "The Final Canopy",
+      "description": "The last canopy stand before the Keeper receives anyone at all.",
+      "row": 9,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-groveline"
+      ],
+      "handicap": 41,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 328,
+      "environment": "orchard",
+      "enemyDeck": [
+        "Orchard Courier",
+        "Choir of Roots",
+        "Blossom Sentry",
+        "Grove Writ",
+        "Grove Archer"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act11.json
+++ b/web/src/data/acts/c2act11.json
@@ -4,7 +4,7 @@
   "title": "ACT XI",
   "subtitle": "The Vigil Roads",
   "rewardRelic": "Procession Bell",
-  "rewardRelicDesc": "Your maximum mana is increased by 1, and you begin every battle with 2 mana already banked — the bell rings before the march even begins.",
+  "rewardRelicDesc": "Your maximum mana is increased by 1, and you begin every battle with 2 mana already banked \u2014 the bell rings before the march even begins.",
   "environment": "road",
   "rewardTags": [
     "forgotten",
@@ -58,7 +58,7 @@
       "Three centuries of marching taught him one thing the Pale Court never had to teach: a rite kept long enough stops needing a reason. He has not yet decided what the Worldmender is here to interrupt."
     ],
     "priorRunOpenings": [
-      "The vigil threshold was already marching when you reached it, same as always — the road remembers being crossed even when it doesn't remember by whom.",
+      "The vigil threshold was already marching when you reached it, same as always \u2014 the road remembers being crossed even when it doesn't remember by whom.",
       "You knew the sconce-bearers' step this time. The vigil company knew you knowing it.",
       "The mile ledger at the threshold already had your crossing recorded. You are becoming a familiar entry in someone's procession.",
       "The Master's retinue was already marching the road when you arrived. He does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE VIGIL ROADS",
-          "text": "The vigil threshold is freshly marching — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The vigil threshold is freshly marching \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -122,7 +122,7 @@
     },
     {
       "title": "THE VIGIL ROADS",
-      "text": "This is not a road that grew from travel. It is a road Amarath built on purpose, three centuries ago, so the vigil-rite would always have somewhere to march. The garrisons here are not guarding a highway — they are guarding a procession that has never once needed their protection as much as it needs their company.",
+      "text": "This is not a road that grew from travel. It is a road Amarath built on purpose, three centuries ago, so the vigil-rite would always have somewhere to march. The garrisons here are not guarding a highway \u2014 they are guarding a procession that has never once needed their protection as much as it needs their company.",
       "image": "cutscenes/c2act11-intro-2.svg"
     },
     {
@@ -139,12 +139,12 @@
     },
     {
       "title": "PROCESSION BELL",
-      "text": "It is a small thing to have marched a road for three centuries — a single bell that rings before the march even begins, giving you a little more to spend before the first mile. Holding it, you understand the Master better than his own procession ever explained him: a vigil kept long enough doesn't need a reason anymore. It only needs someone still willing to walk it.",
+      "text": "It is a small thing to have marched a road for three centuries \u2014 a single bell that rings before the march even begins, giving you a little more to spend before the first mile. Holding it, you understand the Master better than his own procession ever explained him: a vigil kept long enough doesn't need a reason anymore. It only needs someone still willing to walk it.",
       "image": "cutscenes/c2act11-outro-2.svg"
     },
     {
       "title": "THE CROWN REACHES AHEAD",
-      "text": "Past the road's last mile-marker, the ground rises toward the fortified approach to the capital — the Pale Court's last field army, dug in and waiting. Somewhere beyond the reaches, the Court is already deciding whether the Worldmender is worth meeting with everything it has left.",
+      "text": "Past the road's last mile-marker, the ground rises toward the fortified approach to the capital \u2014 the Pale Court's last field army, dug in and waiting. Somewhere beyond the reaches, the Court is already deciding whether the Worldmender is worth meeting with everything it has left.",
       "image": "cutscenes/c2act11-outro-3.svg"
     }
   ],
@@ -200,7 +200,7 @@
       "id": "the-vigil-ramparts",
       "type": "battle",
       "label": "The Vigil Ramparts",
-      "description": "A rampart line garrisoned like the road still needs guarding — because to the Court, it does.",
+      "description": "A rampart line garrisoned like the road still needs guarding \u2014 because to the Court, it does.",
       "row": 1,
       "col": 3,
       "rowCols": 4,
@@ -296,7 +296,8 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "the-vigil-company"
+        "the-vigil-company",
+        "the-processional-line"
       ],
       "restHeal": 9
     },
@@ -375,7 +376,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-processional-line"
+        "the-processional-line",
+        "the-vigil-company"
       ]
     },
     "the-vigil-company": {
@@ -426,7 +428,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-last-procession"
+        "the-last-procession",
+        "the-outer-mile"
       ],
       "handicap": 40,
       "opponentIntervalMs": 2700,
@@ -449,7 +452,7 @@
       "description": "A stretch of road deep enough that even the mist stops following.",
       "row": 4,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-final-mile"
       ],
@@ -472,8 +475,8 @@
       "label": "The Last Procession",
       "description": "The final marching stretch before the Master's own waystation.",
       "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "col": 1,
+      "rowCols": 3,
       "childIds": [
         "the-final-mile",
         "mem-c2act11-2"
@@ -498,7 +501,7 @@
       "description": "The last marching mile before the Master's own ward. Someone has already lit its sconces.",
       "row": 5,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "processionmaster-node"
       ],
@@ -511,7 +514,7 @@
       "description": "A road-walker's log from the night the procession lost count of its own miles.",
       "row": 5,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
         "processionmaster-node"
       ],
@@ -547,6 +550,43 @@
         "The Court does not ask me to keep this procession marching. It only asks that the vigil never once goes silent. Let's begin."
       ],
       "bossCard": "The Procession Master"
+    },
+    "the-outer-mile": {
+      "id": "the-outer-mile",
+      "type": "battle",
+      "label": "The Outer Mile",
+      "description": "A stretch of road further out than any waystation admits patrolling.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "mem-c2act11-2",
+        "the-way-marker"
+      ],
+      "handicap": 42,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 322,
+      "environment": "road",
+      "enemyDeck": [
+        "Vigil Guard",
+        "Road Barricade",
+        "Procession Courier",
+        "Vigil Archer",
+        "Road Watchtower"
+      ]
+    },
+    "the-way-marker": {
+      "id": "the-way-marker",
+      "type": "rest",
+      "label": "The Way-Marker Rest",
+      "description": "A lesser mile-marker rest stop, kept for road-walkers who take the outer mile.",
+      "row": 5,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "processionmaster-node"
+      ],
+      "restHeal": 11
     }
   }
 }

--- a/web/src/data/acts/c2act12.json
+++ b/web/src/data/acts/c2act12.json
@@ -1,5 +1,6 @@
 {
   "id": "c2act12",
+  "nextActId": "c2act13",
   "title": "ACT XII",
   "subtitle": "The Crown Reaches",
   "rewardRelic": "Marshal's Baton",

--- a/web/src/data/acts/c2act12.json
+++ b/web/src/data/acts/c2act12.json
@@ -4,7 +4,7 @@
   "title": "ACT XII",
   "subtitle": "The Crown Reaches",
   "rewardRelic": "Marshal's Baton",
-  "rewardRelicDesc": "All friendly units gain +3 attack — a baton that has commanded the Court's last army for three centuries, and still knows how to make a line hit harder.",
+  "rewardRelicDesc": "All friendly units gain +3 attack \u2014 a baton that has commanded the Court's last army for three centuries, and still knows how to make a line hit harder.",
   "environment": "camp",
   "rewardTags": [
     "forgotten",
@@ -58,7 +58,7 @@
       "Three centuries of holding taught him one thing the Pale Court never had to teach: a last army does not get to lose twice. He has not yet decided if the Worldmender is the reason it finally does."
     ],
     "priorRunOpenings": [
-      "The reach threshold was already fortified when you reached it, same as always — the line remembers being crossed even when it doesn't remember by whom.",
+      "The reach threshold was already fortified when you reached it, same as always \u2014 the line remembers being crossed even when it doesn't remember by whom.",
       "You knew the sconce-bearers' step this time. The crown company knew you knowing it.",
       "The reach ledger at the threshold already had your crossing recorded. You are becoming a familiar entry in someone's last stand.",
       "The Marshal's retinue was already holding the line when you arrived. He does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE CROWN REACHES",
-          "text": "The reach threshold is freshly fortified — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The reach threshold is freshly fortified \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -122,7 +122,7 @@
     },
     {
       "title": "THE CROWN REACHES",
-      "text": "This is not a line built to advance. It is a line Amarath built to hold, three centuries ago, so that whatever came marching up the vigil roads would find the capital defended to the last soldier. The garrisons here are not guarding a border anymore — they are guarding the only thing the Court has left to lose.",
+      "text": "This is not a line built to advance. It is a line Amarath built to hold, three centuries ago, so that whatever came marching up the vigil roads would find the capital defended to the last soldier. The garrisons here are not guarding a border anymore \u2014 they are guarding the only thing the Court has left to lose.",
       "image": "cutscenes/c2act12-intro-2.svg"
     },
     {
@@ -139,12 +139,12 @@
     },
     {
       "title": "MARSHAL'S BATON",
-      "text": "It is a small thing to have commanded a kingdom's last army — a single baton that makes every line hit a little harder. Holding it, you understand the Marshal better than his own command ever explained him: holding a line to the last soldier is not the same as losing. Not even, it turns out, when the line finally gives way.",
+      "text": "It is a small thing to have commanded a kingdom's last army \u2014 a single baton that makes every line hit a little harder. Holding it, you understand the Marshal better than his own command ever explained him: holding a line to the last soldier is not the same as losing. Not even, it turns out, when the line finally gives way.",
       "image": "cutscenes/c2act12-outro-2.svg"
     },
     {
       "title": "THE CITY OF VIGILS AHEAD",
-      "text": "Past the reach's last fortified line, the road opens onto Amarath's capital itself — the City of Vigils, where every window still holds a candle after three centuries. Somewhere within its walls, the Vigil Queen is already deciding what the Worldmender's arrival means for a kingdom that has nothing left to hold but its own capital.",
+      "text": "Past the reach's last fortified line, the road opens onto Amarath's capital itself \u2014 the City of Vigils, where every window still holds a candle after three centuries. Somewhere within its walls, the Vigil Queen is already deciding what the Worldmender's arrival means for a kingdom that has nothing left to hold but its own capital.",
       "image": "cutscenes/c2act12-outro-3.svg"
     }
   ],
@@ -159,6 +159,7 @@
       "rowCols": 3,
       "childIds": [
         "the-crown-causeway",
+        "the-fortress-flank",
         "the-banner-ramparts"
       ],
       "handicap": 36,
@@ -179,10 +180,9 @@
       "description": "A causeway fortified so thoroughly the stones remember every siege it's survived.",
       "row": 1,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
-        "the-reach-ledger",
-        "the-field-hearth"
+        "the-reach-ledger"
       ],
       "handicap": 38,
       "opponentIntervalMs": 2900,
@@ -200,10 +200,10 @@
       "id": "the-banner-ramparts",
       "type": "battle",
       "label": "The Banner Ramparts",
-      "description": "A rampart line garrisoned like the reach still needs guarding — because to the Court, it does.",
+      "description": "A rampart line garrisoned like the reach still needs guarding \u2014 because to the Court, it does.",
       "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-sealed-bulwark-gate",
         "the-marshal-cart"
@@ -547,6 +547,29 @@
         "The Court does not ask me to win this reach. It only asks that I hold it long enough for the capital to decide what you're worth. Let's begin."
       ],
       "bossCard": "The Pale Marshal"
+    },
+    "the-fortress-flank": {
+      "id": "the-fortress-flank",
+      "type": "battle",
+      "label": "The Fortress Flank",
+      "description": "A flanking stretch of the reach, fortified the same as the main causeway.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-field-hearth"
+      ],
+      "handicap": 38,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 304,
+      "environment": "camp",
+      "enemyDeck": [
+        "Reach Runner",
+        "Crown Sentry",
+        "Banner Herald",
+        "Reach Sconce",
+        "Reach Step"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act13.json
+++ b/web/src/data/acts/c2act13.json
@@ -1,0 +1,551 @@
+{
+  "id": "c2act13",
+  "title": "ACT XIII",
+  "subtitle": "The City of Vigils",
+  "rewardRelic": "Queen's Candle",
+  "rewardRelicDesc": "All friendly units gain +4 max HP and heal 2 HP every 6 seconds in battle — a candle that has never once been allowed to gutter out.",
+  "environment": "citadel",
+  "rewardTags": [
+    "forgotten",
+    "vigilcity"
+  ],
+  "replayModifiers": [
+    {
+      "type": "enemyHpPercent",
+      "value": 15,
+      "label": "+15% enemy HP"
+    },
+    {
+      "type": "enemyIntervalReduction",
+      "value": 500,
+      "label": "Enemies act faster"
+    },
+    {
+      "type": "enemyHandBonus",
+      "value": 1,
+      "label": "Enemies start +1 card"
+    },
+    {
+      "type": "crystalBonus",
+      "value": 10,
+      "label": "+10 crystals per battle"
+    },
+    {
+      "type": "enemyHpPercent",
+      "value": 25,
+      "label": "+25% enemy HP"
+    }
+  ],
+  "startNodeIds": [
+    "the-city-gate"
+  ],
+  "variantPools": {
+    "jarvMoods": [
+      "Now, past the Crown Reaches' last fortified line, carrying a baton that still hits harder than it has any right to.",
+      "Now, the Worldmender, walking into a capital that never stopped lighting its own windows, three centuries running.",
+      "Now, wondering what a kingdom's last capital looks like from the inside, when every reach between here and the border has already fallen.",
+      "Now, past the Marshal's fall, learning that holding a reach was never the same thing as holding a throne."
+    ],
+    "cityDesc": [
+      "The City of Vigils rises past the Crown Reaches' last fortified line, every window in it lit the same way it has been since before the Fracture.",
+      "This is not a city that forgot to go dark. It is a city that decided, three centuries ago, that going dark was the one thing it would never do again.",
+      "The wards here are not guarding a border or a reach anymore. They are guarding the only capital the Court has left to lose."
+    ],
+    "vigilqueenDesc": [
+      "The Vigil Queen has kept this city lit longer than any sovereign still counting windows, and she has never once let a single one go dark.",
+      "She does not hold the city the way the Marshal held a reach. She keeps it — candle by candle, ward by ward, making sure the Court still has a capital worth deciding anything about.",
+      "Three centuries of keeping taught her one thing the Pale Court never had to teach: a last capital does not get to go dark twice. She has not yet decided if the Worldmender is the reason it finally does."
+    ],
+    "priorRunOpenings": [
+      "The city gate was already lit when you reached it, same as always — the wards remember being crossed even when they don't remember by whom.",
+      "You knew the ward-guards' rounds this time. The palace guard knew you knowing them.",
+      "The ward registry at the gate already had your crossing recorded. You are becoming a familiar entry in someone's last capital.",
+      "The Queen's retinue was already keeping the wards when you arrived. She does not believe in being surprised twice, either."
+    ]
+  },
+  "midRunTemplates": [
+    "The {ordinalLower} crossing of the City of Vigils. The candles rise a little sooner every time.",
+    "Campaign {n}. The city wards have a whole ward reserved for you now, all of it already lit.",
+    "{n} crossings counted, by the registry at the gate. You have stopped correcting the number.",
+    "Run {n}. The city keeps the same watch every time, and every time it seems to expect you.",
+    "The {ordinalLower} vigil. You know the ward-captains by name now. The city had names for them first."
+  ],
+  "introRules": [
+    {
+      "condition": {
+        "op": "gte",
+        "value": 10
+      },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:priorRunOpenings:1}"
+        },
+        {
+          "title": "THE CITY OF VIGILS",
+          "text": "{pool:cityDesc:1}\n\n{pool:vigilqueenDesc:1}"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 9
+      },
+      "panels": [
+        {
+          "title": "THE CITY OF VIGILS",
+          "text": "The city gate is freshly lit — again.\n\n{pool:priorRunOpenings:0}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:cityDesc:2}"
+        },
+        {
+          "title": "THE VIGIL QUEEN",
+          "text": "{pool:vigilqueenDesc:0}"
+        }
+      ]
+    }
+  ],
+  "intro": [
+    {
+      "title": "MARSHAL'S BATON",
+      "text": "The Marshal's line stood down at your back, and the baton he pressed into your hand still makes every stand hit a little harder. Past the reach's last fortified line, the road opens onto Amarath's capital itself — the City of Vigils, where every window still holds a candle after three centuries.",
+      "image": "cutscenes/c2act13-intro-1.svg"
+    },
+    {
+      "title": "THE CITY OF VIGILS",
+      "text": "This is not a city that forgot to go dark. It is a city that decided, three centuries ago, that going dark was the one thing it would never do again. The wards here are not guarding a border or a reach anymore — they are guarding the only capital the Court has left to lose.",
+      "image": "cutscenes/c2act13-intro-2.svg"
+    },
+    {
+      "title": "THE VIGIL QUEEN",
+      "text": "The Court's own sovereign of the vigil-rite has kept this city lit longer than any monarch still counting windows, and she has never once let a single one go dark. She does not hold the city the way the Marshal held a reach. She keeps it, candle by candle, making sure the Court still has a capital worth deciding anything about.",
+      "image": "cutscenes/c2act13-intro-3.svg"
+    }
+  ],
+  "outro": [
+    {
+      "title": "THE QUEEN'S ACCOUNTING",
+      "text": "She does not fall like a soldier or a marshal. She simply lets her candle go out, and for the first time in three centuries every window in the city dims with it. \"I kept this capital lit,\" she says, \"and not one ward under my keeping ever told me if lit was the same as safe. Tell the Court that, if it still remembers how to listen to anything that isn't its own reflection.\" She presses her candle into your hand. It is still warm.",
+      "image": "cutscenes/c2act13-outro-1.svg"
+    },
+    {
+      "title": "QUEEN'S CANDLE",
+      "text": "It is a small thing to have kept a kingdom's last capital lit — a single candle that never quite goes out, and never quite lets what stands near it go out either. Holding it, you understand the Queen better than her own city ever explained her: keeping a light lit to the last window is not the same as being safe. Not even, it turns out, when the light finally goes to someone else's hand.",
+      "image": "cutscenes/c2act13-outro-2.svg"
+    },
+    {
+      "title": "THE THRONE AHEAD",
+      "text": "Past the city's dimming wards, a single stair climbs toward the vigil chamber at the heart of the capital — the last room in Amarath that has never once been opened to anyone outside the Court. Somewhere within it, the Vigil King is still holding the rite that has held this kingdom together since the Fracture, and he has not yet decided what the Worldmender's arrival means for a vigil he has never once been asked to end.",
+      "image": "cutscenes/c2act13-outro-3.svg"
+    }
+  ],
+  "nodes": {
+    "the-city-gate": {
+      "id": "the-city-gate",
+      "type": "battle",
+      "label": "The City Gate",
+      "description": "Where the reach's last fortified line gives way to the capital's own lit wards.",
+      "row": 0,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-candlelit-colonnade",
+        "the-ward-approach"
+      ],
+      "handicap": 40,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 310,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Candle Runner",
+        "Ward Herald",
+        "Window Sentry",
+        "Candle Sconce"
+      ]
+    },
+    "the-candlelit-colonnade": {
+      "id": "the-candlelit-colonnade",
+      "type": "battle",
+      "label": "The Candlelit Colonnade",
+      "description": "A colonnade lined with sconces that have never once been allowed to gutter.",
+      "row": 1,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-ward-registry",
+        "the-chantry-hearth"
+      ],
+      "handicap": 42,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 318,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Candle Runner",
+        "Window Sentry",
+        "Ward Barricade",
+        "Ward Guard",
+        "Candle Step"
+      ]
+    },
+    "the-ward-approach": {
+      "id": "the-ward-approach",
+      "type": "battle",
+      "label": "The Ward Approach",
+      "description": "An approach garrisoned like the city still needs guarding — because to the Court, it does.",
+      "row": 1,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-sealed-vigil-archive",
+        "the-candle-market"
+      ],
+      "handicap": 42,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 318,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Ward Herald",
+        "Candle Sconce",
+        "Candle Watchtower",
+        "Ward Guard",
+        "Ward Draught"
+      ]
+    },
+    "the-ward-registry": {
+      "id": "the-ward-registry",
+      "type": "event",
+      "label": "The Ward Registry",
+      "description": "A Court clerk tallying every ward lit against a capital still owed its watch.",
+      "row": 2,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-palace-guard",
+        "mem-c2act13-1"
+      ],
+      "eventConfig": {
+        "title": "The Ward Registry",
+        "description": "A clerk keeps the tally at a lectern set inside the gatehouse, marking every window lit against a watch three centuries deep. She does not ask why you're crossing. She only asks whether you intend to be registered.",
+        "pools": [
+          [
+            {
+              "label": "Pay the registry's toll (lose 6 HP, gain a rare card)",
+              "consequence": "Every ward tallied costs a little of your own light. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the clerk's wax stipend (gain 60 crystals)",
+              "consequence": "Wax set aside for a watch that never quite runs short. You gain 60 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 60
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest at the registry's brazier (heal 10 HP)",
+              "consequence": "The brazier holds the ward's chill back better than it has any right to. You heal 10 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the registry uncounted",
+              "consequence": "You leave the clerk to her tally.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-chantry-hearth": {
+      "id": "the-chantry-hearth",
+      "type": "rest",
+      "label": "The Chantry Hearth",
+      "description": "A chantry hearth, kept lit for ward-guards coming off a long watch.",
+      "row": 2,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-palace-guard"
+      ],
+      "restHeal": 9
+    },
+    "the-sealed-vigil-archive": {
+      "id": "the-sealed-vigil-archive",
+      "type": "event",
+      "label": "The Sealed Vigil Archive",
+      "description": "An archive posting standing orders that read like they were never meant for a city this ordinary.",
+      "row": 2,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "the-ward-line"
+      ],
+      "eventConfig": {
+        "title": "The Sealed Vigil Archive",
+        "description": "The writ archived here names every ward in the city and the hour each is due to light its candles. It is signed by the Queen, countersigned by nobody the city has ever met, and dated the same day the vanguard crossed the Marches.",
+        "pools": [
+          [
+            {
+              "label": "Read the sealed vigil writ (lose 6 HP, gain a rare card)",
+              "consequence": "Every ward named costs you something to read past. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the archive's wax cache (gain 70 crystals)",
+              "consequence": "A cache nobody in this city was ever going to collect. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest behind the archive's seals (heal 8 HP)",
+              "consequence": "Quieter than a lit city has any right to be. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the writ unread",
+              "consequence": "Some orders are better left uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-candle-market": {
+      "id": "the-candle-market",
+      "type": "merchant",
+      "label": "The Candle Market",
+      "description": "A trading market lit by a thousand candles the city has never once let gutter.",
+      "row": 2,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-ward-line"
+      ]
+    },
+    "the-palace-guard": {
+      "id": "the-palace-guard",
+      "type": "elite",
+      "label": "The Palace Guard",
+      "description": "A file of Court soldiers holding formation in the last ward the capital has left.",
+      "row": 3,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-deep-wards"
+      ],
+      "handicap": 46,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 336,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Ward Guard",
+        "Ward Vanguard",
+        "Sealed Chantry",
+        "Window Toll",
+        "Candle Foundry",
+        "Choir of the Candles"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "mem-c2act13-1": {
+      "id": "mem-c2act13-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A founding charter of the city's first ward wards.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-deep-wards"
+      ],
+      "fragmentId": "c2act13-frag-1",
+      "environment": "citadel"
+    },
+    "the-ward-line": {
+      "id": "the-ward-line",
+      "type": "elite",
+      "label": "The Ward Line",
+      "description": "A line of guards who never got new orders when the city became the Court's last one.",
+      "row": 3,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-last-lit-ward"
+      ],
+      "handicap": 46,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 336,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Window Chanter",
+        "Ward Automaton",
+        "Candle Sentry",
+        "Ward Writ",
+        "Choir of the Candles",
+        "Candle Archer"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-deep-wards": {
+      "id": "the-deep-wards",
+      "type": "battle",
+      "label": "The Deep Wards",
+      "description": "A stretch of ward lit deep enough that even the mist stops following.",
+      "row": 4,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-final-sconce"
+      ],
+      "handicap": 48,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 346,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Ward Guard",
+        "Ward Barricade",
+        "Candle Watchtower",
+        "Ward Courier",
+        "Window Toll",
+        "Candle Archer"
+      ]
+    },
+    "the-last-lit-ward": {
+      "id": "the-last-lit-ward",
+      "type": "battle",
+      "label": "The Last Lit Ward",
+      "description": "The final lit line before the Queen's own vigil chamber.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-final-sconce",
+        "mem-c2act13-2"
+      ],
+      "handicap": 48,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 346,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Ward Courier",
+        "Choir of the Candles",
+        "Candlebound Knight",
+        "Ward Writ",
+        "Candle Sentry",
+        "Window Chanter"
+      ]
+    },
+    "the-final-sconce": {
+      "id": "the-final-sconce",
+      "type": "rest",
+      "label": "The Final Sconce",
+      "description": "The last lit line before the Queen's own vigil chamber. Someone has already lit its candles.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "vigilqueen-node"
+      ],
+      "restHeal": 11
+    },
+    "mem-c2act13-2": {
+      "id": "mem-c2act13-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A ward-guard's log from the night the last capital learned it was the last.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "vigilqueen-node"
+      ],
+      "fragmentId": "c2act13-frag-2",
+      "environment": "citadel"
+    },
+    "vigilqueen-node": {
+      "id": "vigilqueen-node",
+      "type": "boss",
+      "label": "The Vigil Queen",
+      "description": "Three centuries of keeping end here, before a sovereign who decides whether the Court has a capital left at all.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [],
+      "handicap": 50,
+      "opponentIntervalMs": 5000,
+      "opponentBaseHp": 368,
+      "environment": "citadel",
+      "enemyDeck": [
+        "The Vigil Queen",
+        "Ward Vanguard",
+        "Candlebound Knight",
+        "The Last Vigil",
+        "Choir of the Candles",
+        "Candle Sentry",
+        "Ward Writ"
+      ],
+      "bossAI": "vigilqueen",
+      "bossDialogue": [
+        "You crossed the Crown Reaches, Worldmender. The Marshal gave you a baton that outlasted his own line. I give you a capital that has never once let a window go dark, and I intend to keep it that way.",
+        "Three centuries of keeping this city lit, and not one ward under my crown has ever asked why we're the last capital standing. The Marshal decided which reach still deserved holding. I decide whether the Court gets a capital left at all.",
+        "The Court does not ask me to win this city. It only asks that I keep it lit long enough for the vigil chamber to decide what you're worth. Let's begin."
+      ],
+      "bossCard": "The Vigil Queen"
+    }
+  }
+}

--- a/web/src/data/acts/c2act13.json
+++ b/web/src/data/acts/c2act13.json
@@ -1,5 +1,6 @@
 {
   "id": "c2act13",
+  "nextActId": "c2finale",
   "title": "ACT XIII",
   "subtitle": "The City of Vigils",
   "rewardRelic": "Queen's Candle",

--- a/web/src/data/acts/c2act13.json
+++ b/web/src/data/acts/c2act13.json
@@ -3,7 +3,7 @@
   "title": "ACT XIII",
   "subtitle": "The City of Vigils",
   "rewardRelic": "Queen's Candle",
-  "rewardRelicDesc": "All friendly units gain +4 max HP and heal 2 HP every 6 seconds in battle — a candle that has never once been allowed to gutter out.",
+  "rewardRelicDesc": "All friendly units gain +4 max HP and heal 2 HP every 6 seconds in battle \u2014 a candle that has never once been allowed to gutter out.",
   "environment": "citadel",
   "rewardTags": [
     "forgotten",
@@ -53,11 +53,11 @@
     ],
     "vigilqueenDesc": [
       "The Vigil Queen has kept this city lit longer than any sovereign still counting windows, and she has never once let a single one go dark.",
-      "She does not hold the city the way the Marshal held a reach. She keeps it — candle by candle, ward by ward, making sure the Court still has a capital worth deciding anything about.",
+      "She does not hold the city the way the Marshal held a reach. She keeps it \u2014 candle by candle, ward by ward, making sure the Court still has a capital worth deciding anything about.",
       "Three centuries of keeping taught her one thing the Pale Court never had to teach: a last capital does not get to go dark twice. She has not yet decided if the Worldmender is the reason it finally does."
     ],
     "priorRunOpenings": [
-      "The city gate was already lit when you reached it, same as always — the wards remember being crossed even when they don't remember by whom.",
+      "The city gate was already lit when you reached it, same as always \u2014 the wards remember being crossed even when they don't remember by whom.",
       "You knew the ward-guards' rounds this time. The palace guard knew you knowing them.",
       "The ward registry at the gate already had your crossing recorded. You are becoming a familiar entry in someone's last capital.",
       "The Queen's retinue was already keeping the wards when you arrived. She does not believe in being surprised twice, either."
@@ -100,7 +100,7 @@
       "panels": [
         {
           "title": "THE CITY OF VIGILS",
-          "text": "The city gate is freshly lit — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The city gate is freshly lit \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -116,12 +116,12 @@
   "intro": [
     {
       "title": "MARSHAL'S BATON",
-      "text": "The Marshal's line stood down at your back, and the baton he pressed into your hand still makes every stand hit a little harder. Past the reach's last fortified line, the road opens onto Amarath's capital itself — the City of Vigils, where every window still holds a candle after three centuries.",
+      "text": "The Marshal's line stood down at your back, and the baton he pressed into your hand still makes every stand hit a little harder. Past the reach's last fortified line, the road opens onto Amarath's capital itself \u2014 the City of Vigils, where every window still holds a candle after three centuries.",
       "image": "cutscenes/c2act13-intro-1.svg"
     },
     {
       "title": "THE CITY OF VIGILS",
-      "text": "This is not a city that forgot to go dark. It is a city that decided, three centuries ago, that going dark was the one thing it would never do again. The wards here are not guarding a border or a reach anymore — they are guarding the only capital the Court has left to lose.",
+      "text": "This is not a city that forgot to go dark. It is a city that decided, three centuries ago, that going dark was the one thing it would never do again. The wards here are not guarding a border or a reach anymore \u2014 they are guarding the only capital the Court has left to lose.",
       "image": "cutscenes/c2act13-intro-2.svg"
     },
     {
@@ -138,12 +138,12 @@
     },
     {
       "title": "QUEEN'S CANDLE",
-      "text": "It is a small thing to have kept a kingdom's last capital lit — a single candle that never quite goes out, and never quite lets what stands near it go out either. Holding it, you understand the Queen better than her own city ever explained her: keeping a light lit to the last window is not the same as being safe. Not even, it turns out, when the light finally goes to someone else's hand.",
+      "text": "It is a small thing to have kept a kingdom's last capital lit \u2014 a single candle that never quite goes out, and never quite lets what stands near it go out either. Holding it, you understand the Queen better than her own city ever explained her: keeping a light lit to the last window is not the same as being safe. Not even, it turns out, when the light finally goes to someone else's hand.",
       "image": "cutscenes/c2act13-outro-2.svg"
     },
     {
       "title": "THE THRONE AHEAD",
-      "text": "Past the city's dimming wards, a single stair climbs toward the vigil chamber at the heart of the capital — the last room in Amarath that has never once been opened to anyone outside the Court. Somewhere within it, the Vigil King is still holding the rite that has held this kingdom together since the Fracture, and he has not yet decided what the Worldmender's arrival means for a vigil he has never once been asked to end.",
+      "text": "Past the city's dimming wards, a single stair climbs toward the vigil chamber at the heart of the capital \u2014 the last room in Amarath that has never once been opened to anyone outside the Court. Somewhere within it, the Vigil King is still holding the rite that has held this kingdom together since the Fracture, and he has not yet decided what the Worldmender's arrival means for a vigil he has never once been asked to end.",
       "image": "cutscenes/c2act13-outro-3.svg"
     }
   ],
@@ -158,6 +158,7 @@
       "rowCols": 3,
       "childIds": [
         "the-candlelit-colonnade",
+        "the-lantern-flank",
         "the-ward-approach"
       ],
       "handicap": 40,
@@ -178,7 +179,7 @@
       "description": "A colonnade lined with sconces that have never once been allowed to gutter.",
       "row": 1,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-ward-registry",
         "the-chantry-hearth"
@@ -199,10 +200,10 @@
       "id": "the-ward-approach",
       "type": "battle",
       "label": "The Ward Approach",
-      "description": "An approach garrisoned like the city still needs guarding — because to the Court, it does.",
+      "description": "An approach garrisoned like the city still needs guarding \u2014 because to the Court, it does.",
       "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-sealed-vigil-archive",
         "the-candle-market"
@@ -308,7 +309,7 @@
       "col": 2,
       "rowCols": 4,
       "childIds": [
-        "the-ward-line"
+        "the-palace-guard"
       ],
       "eventConfig": {
         "title": "The Sealed Vigil Archive",
@@ -374,7 +375,7 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-ward-line"
+        "the-palace-guard"
       ]
     },
     "the-palace-guard": {
@@ -384,9 +385,9 @@
       "description": "A file of Court soldiers holding formation in the last ward the capital has left.",
       "row": 3,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 2,
       "childIds": [
-        "the-deep-wards"
+        "the-ward-line"
       ],
       "handicap": 46,
       "opponentIntervalMs": 2700,
@@ -409,9 +410,9 @@
       "description": "A founding charter of the city's first ward wards.",
       "row": 3,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 2,
       "childIds": [
-        "the-deep-wards"
+        "the-ward-line"
       ],
       "fragmentId": "c2act13-frag-1",
       "environment": "citadel"
@@ -421,11 +422,13 @@
       "type": "elite",
       "label": "The Ward Line",
       "description": "A line of guards who never got new orders when the city became the Court's last one.",
-      "row": 3,
-      "col": 3,
-      "rowCols": 4,
+      "row": 4,
+      "col": 0,
+      "rowCols": 1,
       "childIds": [
-        "the-last-lit-ward"
+        "the-deep-wards",
+        "the-last-lit-ward",
+        "the-far-ward"
       ],
       "handicap": 46,
       "opponentIntervalMs": 2700,
@@ -446,9 +449,9 @@
       "type": "battle",
       "label": "The Deep Wards",
       "description": "A stretch of ward lit deep enough that even the mist stops following.",
-      "row": 4,
+      "row": 5,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-final-sconce"
       ],
@@ -470,9 +473,9 @@
       "type": "battle",
       "label": "The Last Lit Ward",
       "description": "The final lit line before the Queen's own vigil chamber.",
-      "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "row": 5,
+      "col": 1,
+      "rowCols": 3,
       "childIds": [
         "the-final-sconce",
         "mem-c2act13-2"
@@ -495,7 +498,7 @@
       "type": "rest",
       "label": "The Final Sconce",
       "description": "The last lit line before the Queen's own vigil chamber. Someone has already lit its candles.",
-      "row": 5,
+      "row": 6,
       "col": 0,
       "rowCols": 2,
       "childIds": [
@@ -508,7 +511,7 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A ward-guard's log from the night the last capital learned it was the last.",
-      "row": 5,
+      "row": 6,
       "col": 1,
       "rowCols": 2,
       "childIds": [
@@ -522,7 +525,7 @@
       "type": "boss",
       "label": "The Vigil Queen",
       "description": "Three centuries of keeping end here, before a sovereign who decides whether the Court has a capital left at all.",
-      "row": 6,
+      "row": 7,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -546,6 +549,52 @@
         "The Court does not ask me to win this city. It only asks that I keep it lit long enough for the vigil chamber to decide what you're worth. Let's begin."
       ],
       "bossCard": "The Vigil Queen"
+    },
+    "the-lantern-flank": {
+      "id": "the-lantern-flank",
+      "type": "battle",
+      "label": "The Lantern Flank",
+      "description": "A flanking approach lit by lanterns instead of sconces, guarded the same as any ward.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-chantry-hearth"
+      ],
+      "handicap": 42,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 318,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Candle Runner",
+        "Ward Herald",
+        "Window Sentry",
+        "Candle Sconce",
+        "Candle Step"
+      ]
+    },
+    "the-far-ward": {
+      "id": "the-far-ward",
+      "type": "battle",
+      "label": "The Far Ward",
+      "description": "A ward further from the palace than the registry admits patrolling.",
+      "row": 5,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "mem-c2act13-2"
+      ],
+      "handicap": 48,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 346,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Ward Guard",
+        "Ward Barricade",
+        "Ward Courier",
+        "Candle Archer",
+        "Candle Watchtower"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act2.json
+++ b/web/src/data/acts/c2act2.json
@@ -4,7 +4,7 @@
   "title": "ACT II",
   "subtitle": "The Grey Causeway",
   "rewardRelic": "Toll Warden's Scale",
-  "rewardRelicDesc": "Your base gains +10 max HP, and every card you play permanently adds +1 attack to all your units — the scale keeps its own ledger.",
+  "rewardRelicDesc": "Your base gains +10 max HP, and every card you play permanently adds +1 attack to all your units \u2014 the scale keeps its own ledger.",
   "environment": "ruins",
   "rewardTags": [
     "forgotten",
@@ -50,7 +50,7 @@
     "causewayDesc": [
       "The Grey Causeway runs a mile dead straight into Amarath, stone the colour of old rain. Every lamp along it stands unlit, waiting for a traveller worth the oil.",
       "This is the road every Dominion envoy should have walked to Amarath, and none ever did. Three hundred years of lamps lit for guests who never came.",
-      "The causeway does not feel abandoned. It feels attended — swept, mended, watched. Something has been keeping this road ready the entire time nobody used it."
+      "The causeway does not feel abandoned. It feels attended \u2014 swept, mended, watched. Something has been keeping this road ready the entire time nobody used it."
     ],
     "wardenDesc": [
       "The Toll Warden keeps a ledger with no entries from outside Amarath. He intends to fix that personally, one traveller at a time.",
@@ -58,14 +58,14 @@
       "Eleven generations of his family have kept this gate. He is the first to keep it for a road nobody walked. He has not once considered closing it."
     ],
     "priorRunOpenings": [
-      "The first lamp on the causeway was cold when you reached it, same as always — it only lights once you're closer than the Warden thinks proper.",
+      "The first lamp on the causeway was cold when you reached it, same as always \u2014 it only lights once you're closer than the Warden thinks proper.",
       "You remembered the milestones this time. The causeway remembered you remembering them.",
       "The tollhouse ledger was still open to the same page. You are becoming a repeat entry.",
       "The Warden's scale was already out when you arrived. He does not believe in being surprised twice."
     ]
   },
   "midRunTemplates": [
-    "The {ordinalLower} walk down the Grey Causeway. The lamps light a little sooner every time — for you, at least.",
+    "The {ordinalLower} walk down the Grey Causeway. The lamps light a little sooner every time \u2014 for you, at least.",
     "Campaign {n}. The Warden's ledger has a whole page for you now, all of it unpaid by his accounting.",
     "{n} tolls collected, by his count. You have stopped arguing about the number.",
     "Run {n}. The causeway is a mile long every time, and every time it feels like it's getting shorter.",
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE GREY CAUSEWAY",
-          "text": "The lamps are still unlit at the gate — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The lamps are still unlit at the gate \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -139,7 +139,7 @@
     },
     {
       "title": "THE TOLL WARDEN'S SCALE",
-      "text": "He leaves you the scale from around his neck — the one that weighed every traveller who never came. It still tips, faintly, on its own. It has not found balance in three hundred years, and it does not stop looking.",
+      "text": "He leaves you the scale from around his neck \u2014 the one that weighed every traveller who never came. It still tips, faintly, on its own. It has not found balance in three hundred years, and it does not stop looking.",
       "image": "cutscenes/c2act2-outro-2.svg"
     },
     {
@@ -153,13 +153,12 @@
       "id": "causeway-gate",
       "type": "battle",
       "label": "The Sundered Tollgate",
-      "description": "The first gate on the causeway — its arm broken, its ledger still open.",
+      "description": "The first gate on the causeway \u2014 its arm broken, its ledger still open.",
       "row": 0,
       "col": 1,
       "rowCols": 3,
       "childIds": [
-        "unlit-mile",
-        "farthing-crossing"
+        "the-broken-tollarm"
       ],
       "handicap": 16,
       "opponentIntervalMs": 3300,
@@ -172,14 +171,38 @@
         "Toll Chit"
       ]
     },
+    "the-broken-tollarm": {
+      "id": "the-broken-tollarm",
+      "type": "battle",
+      "label": "The Broken Tollarm",
+      "description": "A snapped tollgate arm, still garrisoned like it could swing shut again any day.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "unlit-mile",
+        "farthing-crossing"
+      ],
+      "handicap": 17,
+      "opponentIntervalMs": 3250,
+      "opponentBaseHp": 226,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Causeway Sentry",
+        "Tollgate Pikeman",
+        "Causeway Lamp",
+        "Grey Mile Runner",
+        "Toll Chit"
+      ]
+    },
     "unlit-mile": {
       "id": "unlit-mile",
       "type": "battle",
       "label": "The Unlit Mile",
       "description": "A stretch of causeway where every lamp has stood cold for three hundred years.",
-      "row": 1,
+      "row": 2,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 2,
       "childIds": [
         "lamplighters-vigil",
         "waystation-hearth"
@@ -200,10 +223,10 @@
       "id": "farthing-crossing",
       "type": "battle",
       "label": "The Farthing Crossing",
-      "description": "A minor crossroads garrisoned like it still matters — because to Amarath, it does.",
-      "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "description": "A minor crossroads garrisoned like it still matters \u2014 because to Amarath, it does.",
+      "row": 2,
+      "col": 1,
+      "rowCols": 2,
       "childIds": [
         "the-ledger-of-fares",
         "tollmans-cart"
@@ -225,7 +248,7 @@
       "type": "event",
       "label": "The Lamplighter's Vigil",
       "description": "A solitary lamplighter still tends lamps that haven't held a flame in three centuries.",
-      "row": 2,
+      "row": 3,
       "col": 0,
       "rowCols": 4,
       "childIds": [
@@ -292,7 +315,7 @@
       "type": "rest",
       "label": "The Waystation Hearth",
       "description": "A traveller's waystation, kept ready for guests who never arrived.",
-      "row": 2,
+      "row": 3,
       "col": 1,
       "rowCols": 4,
       "childIds": [
@@ -305,7 +328,7 @@
       "type": "event",
       "label": "The Ledger of Fares",
       "description": "An abandoned tollhouse, its strongbox open and its ledger still recording names.",
-      "row": 2,
+      "row": 3,
       "col": 2,
       "rowCols": 4,
       "childIds": [
@@ -313,7 +336,7 @@
       ],
       "eventConfig": {
         "title": "The Ledger of Fares",
-        "description": "The tollhouse is empty but not abandoned — the ledger on the counter is open to today's page, ink still wet, though no hand is in sight. Every name on every page above it is Amarath's own. The strongbox beside it has never once been emptied by a Dominion traveller.",
+        "description": "The tollhouse is empty but not abandoned \u2014 the ledger on the counter is open to today's page, ink still wet, though no hand is in sight. Every name on every page above it is Amarath's own. The strongbox beside it has never once been emptied by a Dominion traveller.",
         "pools": [
           [
             {
@@ -371,7 +394,7 @@
       "type": "merchant",
       "label": "The Tollman's Cart",
       "description": "A merchant's cart parked at a crossing that hasn't seen trade in centuries.",
-      "row": 2,
+      "row": 3,
       "col": 3,
       "rowCols": 4,
       "childIds": [
@@ -383,9 +406,9 @@
       "type": "elite",
       "label": "The Toll Collectors",
       "description": "A file of collectors holding the causeway in strict, patient order.",
-      "row": 3,
+      "row": 4,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "milestone-forty"
       ],
@@ -408,9 +431,9 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A tollgate charter, founding the causeway on a toll of one memory freely given.",
-      "row": 3,
+      "row": 4,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "milestone-forty"
       ],
@@ -422,11 +445,12 @@
       "type": "elite",
       "label": "The Unpaid Line",
       "description": "A queue of collectors, still holding places for travellers who never came.",
-      "row": 3,
-      "col": 3,
-      "rowCols": 4,
+      "row": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
-        "the-long-dark-mile"
+        "the-long-dark-mile",
+        "grey-mist-crossing"
       ],
       "handicap": 22,
       "opponentIntervalMs": 3000,
@@ -447,9 +471,9 @@
       "type": "battle",
       "label": "Milestone Forty",
       "description": "A stacked cairn marking the causeway's fortieth mile, and its garrison.",
-      "row": 4,
+      "row": 5,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-final-lamp"
       ],
@@ -471,9 +495,9 @@
       "type": "battle",
       "label": "The Long Dark Mile",
       "description": "The causeway's final stretch, where even the mist gives up trying to lighten it.",
-      "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "row": 5,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-final-lamp",
         "mem-c2act2-2"
@@ -496,7 +520,7 @@
       "type": "rest",
       "label": "The Final Lamp",
       "description": "The last lamp before the tollgate proper. Someone has already lit it.",
-      "row": 5,
+      "row": 6,
       "col": 0,
       "rowCols": 2,
       "childIds": [
@@ -508,8 +532,8 @@
       "id": "mem-c2act2-2",
       "type": "memory",
       "label": "Memory Fragment",
-      "description": "A court chronicle entry on the Toll Warden's appointment — and his vow.",
-      "row": 5,
+      "description": "A court chronicle entry on the Toll Warden's appointment \u2014 and his vow.",
+      "row": 6,
       "col": 1,
       "rowCols": 2,
       "childIds": [
@@ -523,7 +547,7 @@
       "type": "boss",
       "label": "The Toll Warden",
       "description": "Eleven generations of gatekeepers end here, with a scale that has never once balanced.",
-      "row": 6,
+      "row": 7,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -547,6 +571,31 @@
         "The Court sent the Herald to announce us. It sent me to collect. Stand at the gate, or be entered in the ledger as unpaid."
       ],
       "bossCard": "The Toll Warden"
+    },
+    "grey-mist-crossing": {
+      "id": "grey-mist-crossing",
+      "type": "battle",
+      "label": "The Grey Mist Crossing",
+      "description": "A ford where the causeway mist pools thick enough to swallow footsteps.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-lamp",
+        "mem-c2act2-2"
+      ],
+      "handicap": 24,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 254,
+      "environment": "ruins",
+      "enemyDeck": [
+        "Grey Rider",
+        "Causeway Rail",
+        "Toll Barracks",
+        "Debtor's Pace",
+        "Grey Mist Veil",
+        "Watchlamp Tower"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act3.json
+++ b/web/src/data/acts/c2act3.json
@@ -4,7 +4,7 @@
   "title": "ACT III",
   "subtitle": "The Unremembered Fields",
   "rewardRelic": "Sheaf of Names",
-  "rewardRelicDesc": "Your maximum mana is increased by 1, and you begin every battle with 2 mana already banked — names given back, spent again.",
+  "rewardRelicDesc": "Your maximum mana is increased by 1, and you begin every battle with 2 mana already banked \u2014 names given back, spent again.",
   "environment": "farmland",
   "rewardTags": [
     "forgotten",
@@ -48,17 +48,17 @@
       "Now, past two gates of Amarath, discovering the third is a field, and the field is watching him walk it."
     ],
     "fieldsDesc": [
-      "The Unremembered Fields run further than the mist should allow — rows of pale grain under a sky that never quite lightens, tended by hands that never stopped working.",
+      "The Unremembered Fields run further than the mist should allow \u2014 rows of pale grain under a sky that never quite lightens, tended by hands that never stopped working.",
       "This is the grain that fed Amarath through three centuries of the dark. It does not grow like wheat should. It grows like it remembers being planted.",
       "The harvesters here do not look up as you pass. They are not ignoring you. They are simply mid-verse in a harvest that started before the Fracture and has not once paused since."
     ],
     "queenDesc": [
       "The Gleaner Queen walks the furrows herself, gathering what the world dropped one stalk at a time. She has never once left a row half-gleaned.",
-      "She does not glean out of cruelty. She gleans because leaving a memory ungathered, out here, is the same as losing it twice — and Amarath has already lost enough twice.",
+      "She does not glean out of cruelty. She gleans because leaving a memory ungathered, out here, is the same as losing it twice \u2014 and Amarath has already lost enough twice.",
       "Eleven granaries answer to her. Every one of them is full. Every one of them, she says, still has room for one more name."
     ],
     "priorRunOpenings": [
-      "The first furrow was still turned when you reached it, same as always — the fields remember being crossed even when they don't remember by whom.",
+      "The first furrow was still turned when you reached it, same as always \u2014 the fields remember being crossed even when they don't remember by whom.",
       "You knew the row markers this time. The grain knew you knowing them.",
       "The granary door was open to the same shelf. You are becoming a familiar harvest.",
       "The Queen's scale was already balanced when you arrived. She does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE UNREMEMBERED FIELDS",
-          "text": "The furrow at the boundary is freshly turned — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The furrow at the boundary is freshly turned \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -127,24 +127,24 @@
     },
     {
       "title": "THE HARVEST WATCHES",
-      "text": "The harvesters do not look up as you pass. They are not the enemy — the Court is. But somewhere in these fields, a Queen gleans what the world drops, and she has not yet decided whether what you carry counts as lost. You go on regardless.",
+      "text": "The harvesters do not look up as you pass. They are not the enemy \u2014 the Court is. But somewhere in these fields, a Queen gleans what the world drops, and she has not yet decided whether what you carry counts as lost. You go on regardless.",
       "image": "cutscenes/c2act3-intro-3.svg"
     }
   ],
   "outro": [
     {
       "title": "THE QUEEN'S GLEANING",
-      "text": "The Gleaner Queen falls the way a season ends — not suddenly, but all at once, three scattered effigies going still in the same held breath. 'I gleaned so carefully,' she says. 'I never once dropped a name on purpose. Tell me you can say the same, Worldmender.'\n\nYou cannot. You take her sheaf anyway.",
+      "text": "The Gleaner Queen falls the way a season ends \u2014 not suddenly, but all at once, three scattered effigies going still in the same held breath. 'I gleaned so carefully,' she says. 'I never once dropped a name on purpose. Tell me you can say the same, Worldmender.'\n\nYou cannot. You take her sheaf anyway.",
       "image": "cutscenes/c2act3-outro-1.svg"
     },
     {
       "title": "SHEAF OF NAMES",
-      "text": "She leaves you a sheaf bound from the first stalks she ever gleaned — grain that still holds the shape of every memory it returned. It is warm in your hand, the way a held name is warm. It has not once, in three hundred years, forgotten what it's for.",
+      "text": "She leaves you a sheaf bound from the first stalks she ever gleaned \u2014 grain that still holds the shape of every memory it returned. It is warm in your hand, the way a held name is warm. It has not once, in three hundred years, forgotten what it's for.",
       "image": "cutscenes/c2act3-outro-2.svg"
     },
     {
       "title": "THE ARCHIVE AHEAD",
-      "text": "Past the last granary, the fields give way to shelving that runs further than any hall should — the Archive of Names, where Amarath keeps every erased name it ever recovered, guarded, and fed. Somewhere in it, something has been waiting a very long time to be found.",
+      "text": "Past the last granary, the fields give way to shelving that runs further than any hall should \u2014 the Archive of Names, where Amarath keeps every erased name it ever recovered, guarded, and fed. Somewhere in it, something has been waiting a very long time to be found.",
       "image": "cutscenes/c2act3-outro-3.svg"
     }
   ],
@@ -156,9 +156,11 @@
       "description": "Where the causeway's last stone gives way to the first turned earth of the fields.",
       "row": 0,
       "col": 1,
-      "rowCols": 3,
+      "rowCols": 4,
       "childIds": [
         "the-long-swath",
+        "mid-furrow-watch",
+        "high-furrow-line",
         "the-gleaners-row"
       ],
       "handicap": 18,
@@ -181,8 +183,7 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-scarecrow-vigil",
-        "the-granary-hearth"
+        "the-scarecrow-vigil"
       ],
       "handicap": 20,
       "opponentIntervalMs": 3100,
@@ -200,12 +201,11 @@
       "id": "the-gleaners-row",
       "type": "battle",
       "label": "The Gleaners' Row",
-      "description": "A row garrisoned like it still needs guarding — because to Amarath, it does.",
+      "description": "A row garrisoned like it still needs guarding \u2014 because to Amarath, it does.",
       "row": 1,
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-harvest-ledger",
         "the-gleaners-cart"
       ],
       "handicap": 20,
@@ -385,7 +385,7 @@
       "description": "A file of straw-bound effigies holding the furrow in strict, patient order.",
       "row": 3,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-forty-acre-stand"
       ],
@@ -410,9 +410,10 @@
       "description": "A field record of Amarath's very first memory-wheat sowing.",
       "row": 3,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
-        "the-forty-acre-stand"
+        "the-forty-acre-stand",
+        "the-last-threshing"
       ],
       "fragmentId": "c2act3-frag-1",
       "environment": "farmland"
@@ -423,10 +424,12 @@
       "label": "The Unharvested Row",
       "description": "A row of harvesters, still holding places for a gleaning that never comes.",
       "row": 3,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
-        "the-last-threshing"
+        "the-last-threshing",
+        "the-fallow-stretch",
+        "reap-line-flank"
       ],
       "handicap": 24,
       "opponentIntervalMs": 2900,
@@ -472,7 +475,7 @@
       "label": "The Last Threshing",
       "description": "The fields' final threshing floor, where even the mist gives up trying to lighten it.",
       "row": 4,
-      "col": 3,
+      "col": 1,
       "rowCols": 4,
       "childIds": [
         "the-last-scarecrow",
@@ -543,10 +546,102 @@
       "bossAI": "gleanerqueen",
       "bossDialogue": [
         "You crossed the causeway. The Warden's toll is paid, and still you walk further into what's ours.",
-        "We remember the old world seed for seed, Worldmender. Whatever the Dominion forgot, the fields kept growing anyway — even the memories that were never Amarath's to grow.",
+        "We remember the old world seed for seed, Worldmender. Whatever the Dominion forgot, the fields kept growing anyway \u2014 even the memories that were never Amarath's to grow.",
         "Every sheaf in this field remembers a name the world dropped. The Court sent me to glean what's yours next. I intend to be thorough."
       ],
       "bossCard": "The Gleaner Queen"
+    },
+    "mid-furrow-watch": {
+      "id": "mid-furrow-watch",
+      "type": "battle",
+      "label": "The Mid-Furrow Watch",
+      "description": "A watch line cut straight through the standing grain, garrisoned like a wall.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-granary-hearth"
+      ],
+      "handicap": 20,
+      "opponentIntervalMs": 3100,
+      "opponentBaseHp": 238,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Granary Archer",
+        "Wheatrow Runner",
+        "Grain Palisade",
+        "Field Gleaner",
+        "Harvest Haste"
+      ]
+    },
+    "high-furrow-line": {
+      "id": "high-furrow-line",
+      "type": "battle",
+      "label": "The High Furrow Line",
+      "description": "A raised furrow-bank overlooking the fields, held like high ground always is.",
+      "row": 1,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "the-harvest-ledger"
+      ],
+      "handicap": 20,
+      "opponentIntervalMs": 3100,
+      "opponentBaseHp": 238,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Sickle-Line Reaper",
+        "Granary Archer",
+        "Sheaf Cairn",
+        "Field Gleaner",
+        "Sheaf-Bread"
+      ]
+    },
+    "the-fallow-stretch": {
+      "id": "the-fallow-stretch",
+      "type": "battle",
+      "label": "The Fallow Stretch",
+      "description": "A stretch left deliberately unplanted, and just as deliberately defended.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "mem-c2act3-2"
+      ],
+      "handicap": 26,
+      "opponentIntervalMs": 2800,
+      "opponentBaseHp": 262,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Sickle-Line Reaper",
+        "Grain Palisade",
+        "Unremembered Harvester",
+        "Ledger of Gleanings",
+        "Watchtower Scarecrow"
+      ]
+    },
+    "reap-line-flank": {
+      "id": "reap-line-flank",
+      "type": "battle",
+      "label": "The Reap-Line Flank",
+      "description": "A flanking reap-line, cutting a path the main harvest never touches.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "mem-c2act3-2"
+      ],
+      "handicap": 26,
+      "opponentIntervalMs": 2800,
+      "opponentBaseHp": 262,
+      "environment": "farmland",
+      "enemyDeck": [
+        "Threshing Rider",
+        "Wheatrow Runner",
+        "Effigy Granary",
+        "Harvest Haste",
+        "Mistwheat Veil"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act4.json
+++ b/web/src/data/acts/c2act4.json
@@ -4,7 +4,7 @@
   "title": "ACT IV",
   "subtitle": "The Archive of Names",
   "rewardRelic": "Index of the Lost",
-  "rewardRelicDesc": "All friendly units gain +2 attack and +4 max HP — you carry the shape of what the Archive lost, and it carries you back.",
+  "rewardRelicDesc": "All friendly units gain +2 attack and +4 max HP \u2014 you carry the shape of what the Archive lost, and it carries you back.",
   "environment": "vault",
   "rewardTags": [
     "forgotten",
@@ -48,9 +48,9 @@
       "Now, past the Gleaner Queen's fall, learning that the fields were only the outer wall of something far larger."
     ],
     "archiveDesc": [
-      "The Archive of Names runs further than the mist should allow — aisle after aisle of sealed registers, lit by reading-lamps that have not gone dark in three centuries.",
+      "The Archive of Names runs further than the mist should allow \u2014 aisle after aisle of sealed registers, lit by reading-lamps that have not gone dark in three centuries.",
       "This is where Amarath shelved every name the Fracture erased. It does not read like a library. It reads like a held breath, three hundred years long.",
-      "The archivists here do not look up as you pass. They are not the enemy — the Court is. But something moves between the shelves that even they don't fully trust."
+      "The archivists here do not look up as you pass. They are not the enemy \u2014 the Court is. But something moves between the shelves that even they don't fully trust."
     ],
     "eaterDesc": [
       "The Name-Eater has kept the deep stacks since before the current archivists were born. Prisoner and librarian both, the Court says, and has never once clarified which came first.",
@@ -58,7 +58,7 @@
       "Eleven wings of shelving answer to it, and it has never once let a name go unread before it was gleaned. It has not decided yet whether yours counts as one it's owed."
     ],
     "priorRunOpenings": [
-      "The threshold shelf was still warm when you reached it, same as always — the Archive remembers being entered even when it doesn't remember by whom.",
+      "The threshold shelf was still warm when you reached it, same as always \u2014 the Archive remembers being entered even when it doesn't remember by whom.",
       "You knew the aisle markers this time. The dark between the shelves knew you knowing them.",
       "The reading-lamp at the door was already lit to your usual page. You are becoming a familiar entry.",
       "The Name-Eater's stacks were already disturbed when you arrived. It does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE ARCHIVE OF NAMES",
-          "text": "The threshold shelf is freshly dusted — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The threshold shelf is freshly dusted \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -117,7 +117,7 @@
   "intro": [
     {
       "title": "THE QUEEN'S SHEAF",
-      "text": "The Gleaner Queen fell in three scattered pieces and left you her sheaf anyway — grain that still remembers every name it ever returned. Past the last granary, the fields simply stop, and the ground becomes a threshold of dressed stone shelving.",
+      "text": "The Gleaner Queen fell in three scattered pieces and left you her sheaf anyway \u2014 grain that still remembers every name it ever returned. Past the last granary, the fields simply stop, and the ground becomes a threshold of dressed stone shelving.",
       "image": "cutscenes/c2act4-intro-1.svg"
     },
     {
@@ -127,7 +127,7 @@
     },
     {
       "title": "THE THING BETWEEN THE SHELVES",
-      "text": "The archivists are not the enemy — the Court is. But somewhere in the deep stacks, something the Court calls both prisoner and librarian keeps its own accounting of who's owed what. You go in anyway, sheaf in hand, to find what the Fracture erased of a kingdom that was never Amarath's to forget.",
+      "text": "The archivists are not the enemy \u2014 the Court is. But somewhere in the deep stacks, something the Court calls both prisoner and librarian keeps its own accounting of who's owed what. You go in anyway, sheaf in hand, to find what the Fracture erased of a kingdom that was never Amarath's to forget.",
       "image": "cutscenes/c2act4-intro-3.svg"
     }
   ],
@@ -139,12 +139,12 @@
     },
     {
       "title": "INDEX OF THE LOST",
-      "text": "It leaves you an index bound from every name it ever catalogued and never once misplaced — a record of what was lost, cross-referenced against what came back. Holding it, you know exactly what you're still carrying, and exactly what it cost.",
+      "text": "It leaves you an index bound from every name it ever catalogued and never once misplaced \u2014 a record of what was lost, cross-referenced against what came back. Holding it, you know exactly what you're still carrying, and exactly what it cost.",
       "image": "cutscenes/c2act4-outro-2.svg"
     },
     {
       "title": "THE CANDLE CITY AHEAD",
-      "text": "Past the last reading-room, the shelving gives way to a skyline of ten thousand vigil flames — the Candle City, Amarath's second seat, lit against a dark it has never once trusted to stay gone. Somewhere in it, a Lamplighter General is already counting the wicks that still need tending.",
+      "text": "Past the last reading-room, the shelving gives way to a skyline of ten thousand vigil flames \u2014 the Candle City, Amarath's second seat, lit against a dark it has never once trusted to stay gone. Somewhere in it, a Lamplighter General is already counting the wicks that still need tending.",
       "image": "cutscenes/c2act4-outro-3.svg"
     }
   ],
@@ -156,10 +156,12 @@
       "description": "Where the last turned furrow gives way to the first dressed shelf of the Archive.",
       "row": 0,
       "col": 1,
-      "rowCols": 3,
+      "rowCols": 4,
       "childIds": [
         "the-first-aisle",
-        "the-outer-shelves"
+        "the-annex-wing",
+        "the-outer-shelves",
+        "the-side-gallery"
       ],
       "handicap": 20,
       "opponentIntervalMs": 3100,
@@ -181,8 +183,7 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-lantern-vigil",
-        "the-reading-hearth"
+        "the-lantern-vigil"
       ],
       "handicap": 22,
       "opponentIntervalMs": 3000,
@@ -200,9 +201,9 @@
       "id": "the-outer-shelves",
       "type": "battle",
       "label": "The Outer Shelves",
-      "description": "A wing garrisoned like it still needs guarding — because to Amarath, it does.",
+      "description": "A wing garrisoned like it still needs guarding \u2014 because to Amarath, it does.",
       "row": 1,
-      "col": 3,
+      "col": 2,
       "rowCols": 4,
       "childIds": [
         "the-sealed-ledger",
@@ -309,7 +310,7 @@
       "col": 2,
       "rowCols": 4,
       "childIds": [
-        "the-unshelved-row"
+        "the-warden-line"
       ],
       "eventConfig": {
         "title": "The Sealed Ledger",
@@ -375,7 +376,7 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-unshelved-row"
+        "the-warden-line"
       ]
     },
     "the-warden-line": {
@@ -385,9 +386,9 @@
       "description": "A file of archive wardens holding the deep stacks in strict, patient order.",
       "row": 3,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 2,
       "childIds": [
-        "the-deep-stacks"
+        "the-unshelved-row"
       ],
       "handicap": 26,
       "opponentIntervalMs": 2800,
@@ -410,9 +411,9 @@
       "description": "A founding record of the Archive's very first shelving.",
       "row": 3,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 2,
       "childIds": [
-        "the-deep-stacks"
+        "the-unshelved-row"
       ],
       "fragmentId": "c2act4-frag-1",
       "environment": "vault"
@@ -422,11 +423,15 @@
       "type": "elite",
       "label": "The Unshelved Row",
       "description": "A row of archivists, still holding places for a cataloguing that never comes.",
-      "row": 3,
-      "col": 3,
-      "rowCols": 4,
+      "row": 4,
+      "col": 0,
+      "rowCols": 1,
       "childIds": [
-        "the-last-registry"
+        "the-deep-stacks",
+        "the-archivists-vault",
+        "the-last-registry",
+        "the-silent-wing",
+        "the-marginal-stacks"
       ],
       "handicap": 26,
       "opponentIntervalMs": 2800,
@@ -447,9 +452,9 @@
       "type": "battle",
       "label": "The Deep Stacks",
       "description": "Shelving garrisoned like a border, deep enough that the mist forgets to follow.",
-      "row": 4,
+      "row": 5,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 5,
       "childIds": [
         "the-final-lamp"
       ],
@@ -471,9 +476,9 @@
       "type": "battle",
       "label": "The Last Registry",
       "description": "The Archive's final registry room, where even the reading-lamps burn lower.",
-      "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "row": 5,
+      "col": 2,
+      "rowCols": 5,
       "childIds": [
         "the-final-lamp",
         "mem-c2act4-2"
@@ -496,7 +501,7 @@
       "type": "rest",
       "label": "The Final Lamp",
       "description": "The last reading-lamp before the deep stacks proper. Someone has already trimmed its wick.",
-      "row": 5,
+      "row": 6,
       "col": 0,
       "rowCols": 2,
       "childIds": [
@@ -509,7 +514,7 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A librarian's note on the day the Name-Eater first appeared.",
-      "row": 5,
+      "row": 6,
       "col": 1,
       "rowCols": 2,
       "childIds": [
@@ -523,7 +528,7 @@
       "type": "boss",
       "label": "The Name-Eater",
       "description": "Eleven wings of shelving end here, with a warden the Court calls both prisoner and librarian.",
-      "row": 6,
+      "row": 7,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -547,6 +552,121 @@
         "Every register in this hall remembers a name the world erased. The Court sent me to see that yours joins them. I have not been hungry in three hundred years for nothing."
       ],
       "bossCard": "The Name-Eater"
+    },
+    "the-annex-wing": {
+      "id": "the-annex-wing",
+      "type": "battle",
+      "label": "The Annex Wing",
+      "description": "A side wing appended to the Archive long after the original plan ran out of shelves.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-reading-hearth"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "vault",
+      "enemyDeck": [
+        "Stack Runner",
+        "Index Warden",
+        "Reading Lamp",
+        "Register Bearer",
+        "Quickening Ink"
+      ]
+    },
+    "the-side-gallery": {
+      "id": "the-side-gallery",
+      "type": "battle",
+      "label": "The Side Gallery",
+      "description": "A gallery of unshelved portraits, each frame facing the wall.",
+      "row": 1,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-catalogue-cart"
+      ],
+      "handicap": 22,
+      "opponentIntervalMs": 3000,
+      "opponentBaseHp": 246,
+      "environment": "vault",
+      "enemyDeck": [
+        "Lamp Acolyte",
+        "Lectern Archer",
+        "Sealed Stack",
+        "Parchment Poultice",
+        "Reading Lamp"
+      ]
+    },
+    "the-archivists-vault": {
+      "id": "the-archivists-vault",
+      "type": "battle",
+      "label": "The Archivist's Vault",
+      "description": "A sealed vault of registers no living archivist was ever cleared to open.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 5,
+      "childIds": [
+        "the-final-lamp"
+      ],
+      "handicap": 28,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 270,
+      "environment": "vault",
+      "enemyDeck": [
+        "Register Bearer",
+        "Shelf Barricade",
+        "Sealed Courier",
+        "Marginal Notes",
+        "Sealed Stack"
+      ]
+    },
+    "the-silent-wing": {
+      "id": "the-silent-wing",
+      "type": "battle",
+      "label": "The Silent Wing",
+      "description": "A wing of the Archive where even the Silence Bell has stopped needing to ring.",
+      "row": 5,
+      "col": 3,
+      "rowCols": 5,
+      "childIds": [
+        "mem-c2act4-2"
+      ],
+      "handicap": 28,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 270,
+      "environment": "vault",
+      "enemyDeck": [
+        "Stackbound Knight",
+        "Sealed Courier",
+        "Watch-Lectern",
+        "Silence Bell",
+        "Hollow Cataloguer"
+      ]
+    },
+    "the-marginal-stacks": {
+      "id": "the-marginal-stacks",
+      "type": "battle",
+      "label": "The Marginal Stacks",
+      "description": "Shelving reserved for records too minor for the main registry, and guarded anyway.",
+      "row": 5,
+      "col": 4,
+      "rowCols": 5,
+      "childIds": [
+        "mem-c2act4-2"
+      ],
+      "handicap": 28,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 270,
+      "environment": "vault",
+      "enemyDeck": [
+        "Lectern Archer",
+        "Marginal Notes",
+        "Cataloguer Automaton",
+        "Lamp-Oil Reserve",
+        "Index Warden"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act5.json
+++ b/web/src/data/acts/c2act5.json
@@ -4,7 +4,7 @@
   "title": "ACT V",
   "subtitle": "The Candle City",
   "rewardRelic": "Lamplighter's Wick",
-  "rewardRelicDesc": "Once per battle, the first friendly unit that falls is relit at half its original HP — the wick catches before the flame can go out for good.",
+  "rewardRelicDesc": "Once per battle, the first friendly unit that falls is relit at half its original HP \u2014 the wick catches before the flame can go out for good.",
   "environment": "citadel",
   "rewardTags": [
     "forgotten",
@@ -49,16 +49,16 @@
     ],
     "cityDesc": [
       "The Candle City runs uphill from the Archive's last threshold, every window holding a flame, every street its own lamplighter company keeping doctrine three centuries deep.",
-      "This is not a ruin and not a vault. It is alive — crowded, devout, ordinary — and every one of its ten thousand vigil flames is watched by someone who has never known a night without a watch to keep.",
+      "This is not a ruin and not a vault. It is alive \u2014 crowded, devout, ordinary \u2014 and every one of its ten thousand vigil flames is watched by someone who has never known a night without a watch to keep.",
       "The people here are not the enemy. They are lighting their windows the way they have every night since the void, on Court orders that call the Worldmender an invading army. Most of them do not know why."
     ],
     "generalDesc": [
-      "The Lamplighter General commands every flame-keeper company in the city as a standing military order — light on the hour, snuff on the hour, no exceptions the Court has ever written down.",
-      "She did not choose the doctrine. She has simply never once, in three centuries of drill, been given a reason to question it — until an order came down to let a district go dark on purpose.",
+      "The Lamplighter General commands every flame-keeper company in the city as a standing military order \u2014 light on the hour, snuff on the hour, no exceptions the Court has ever written down.",
+      "She did not choose the doctrine. She has simply never once, in three centuries of drill, been given a reason to question it \u2014 until an order came down to let a district go dark on purpose.",
       "Eleven companies answer to her wick-scepter, and she has never once let a street burn unwatched. She has not decided yet whether the Worldmender counts as a fire to put out or a name to relight."
     ],
     "priorRunOpenings": [
-      "The threshold wick was already lit when you reached it, same as always — the city remembers being entered even when it doesn't remember by whom.",
+      "The threshold wick was already lit when you reached it, same as always \u2014 the city remembers being entered even when it doesn't remember by whom.",
       "You knew the company markers this time. The vigil round knew you knowing them.",
       "The watch-lamp at the gate was already trimmed to your usual hour. You are becoming a familiar entry in someone's ledger.",
       "The General's companies were already drilling when you arrived. She does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE CANDLE CITY",
-          "text": "The threshold wick is freshly trimmed — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The threshold wick is freshly trimmed \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -117,17 +117,17 @@
   "intro": [
     {
       "title": "THE INDEX OF THE LOST",
-      "text": "The Name-Eater folded shelf by shelf and left you an index bound from every name it ever catalogued — a record of what was lost, cross-referenced against what came back. Past the Archive's last reading-room, the shelving gives way to a skyline of ten thousand vigil flames.",
+      "text": "The Name-Eater folded shelf by shelf and left you an index bound from every name it ever catalogued \u2014 a record of what was lost, cross-referenced against what came back. Past the Archive's last reading-room, the shelving gives way to a skyline of ten thousand vigil flames.",
       "image": "cutscenes/c2act5-intro-1.svg"
     },
     {
       "title": "THE CANDLE CITY",
-      "text": "This is Amarath's second seat, and it is not a vault or a battlefield — it is a city, lit window by window by lamplighter companies who have kept the same doctrine for three centuries: light on the hour, snuff on the hour. The people here are ordinary. The Court's orders about you are not.",
+      "text": "This is Amarath's second seat, and it is not a vault or a battlefield \u2014 it is a city, lit window by window by lamplighter companies who have kept the same doctrine for three centuries: light on the hour, snuff on the hour. The people here are ordinary. The Court's orders about you are not.",
       "image": "cutscenes/c2act5-intro-2.svg"
     },
     {
       "title": "THE LAMPLIGHTER GENERAL",
-      "text": "The Court has named the Worldmender an invading army and given the city's flame-keepers standing orders to treat you as one. The lamplighters are not the enemy — the Court is. But the General commands eleven companies who have never once questioned a lit window, and she will not start with you.",
+      "text": "The Court has named the Worldmender an invading army and given the city's flame-keepers standing orders to treat you as one. The lamplighters are not the enemy \u2014 the Court is. But the General commands eleven companies who have never once questioned a lit window, and she will not start with you.",
       "image": "cutscenes/c2act5-intro-3.svg"
     }
   ],
@@ -139,12 +139,12 @@
     },
     {
       "title": "LAMPLIGHTER'S WICK",
-      "text": "It is a small thing to have cost so many companies so many centuries — a single wick that relights whatever the wax-fall smothers. Holding it, you understand the doctrine better than the General ever explained it: nothing is allowed to go out for good. Not even, it turns out, you.",
+      "text": "It is a small thing to have cost so many companies so many centuries \u2014 a single wick that relights whatever the wax-fall smothers. Holding it, you understand the doctrine better than the General ever explained it: nothing is allowed to go out for good. Not even, it turns out, you.",
       "image": "cutscenes/c2act5-outro-2.svg"
     },
     {
       "title": "THE SUNKEN BORDER AHEAD",
-      "text": "Past the city's last lit gate, the road drops toward a coastline that came back wrong — towers standing in a tide that shouldn't reach them, drowned streets holding their shape underwater like a memory that refused to dissolve. Somewhere out past the new waterline, something is already watching the road come down to meet it.",
+      "text": "Past the city's last lit gate, the road drops toward a coastline that came back wrong \u2014 towers standing in a tide that shouldn't reach them, drowned streets holding their shape underwater like a memory that refused to dissolve. Somewhere out past the new waterline, something is already watching the road come down to meet it.",
       "image": "cutscenes/c2act5-outro-3.svg"
     }
   ],
@@ -156,10 +156,9 @@
       "description": "Where the Archive's last reading-lamp gives way to the city's first vigil flame.",
       "row": 0,
       "col": 1,
-      "rowCols": 3,
+      "rowCols": 1,
       "childIds": [
-        "the-first-district",
-        "the-outer-wards"
+        "the-first-district"
       ],
       "handicap": 22,
       "opponentIntervalMs": 3000,
@@ -179,10 +178,9 @@
       "description": "A tenement street still smelling of Archive dust from the threshold behind it.",
       "row": 1,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 1,
       "childIds": [
-        "the-vigil-round",
-        "the-warming-hearth"
+        "the-second-ward"
       ],
       "handicap": 24,
       "opponentIntervalMs": 2900,
@@ -200,11 +198,13 @@
       "id": "the-outer-wards",
       "type": "battle",
       "label": "The Outer Wards",
-      "description": "A ward garrisoned like it still needs guarding — because to the Court, it does.",
-      "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "description": "A ward garrisoned like it still needs guarding \u2014 because to the Court, it does.",
+      "row": 3,
+      "col": 0,
+      "rowCols": 1,
       "childIds": [
+        "the-vigil-round",
+        "the-warming-hearth",
         "the-sealed-curfew",
         "the-chandlers-cart"
       ],
@@ -225,7 +225,7 @@
       "type": "event",
       "label": "The Vigil Round",
       "description": "The nightly round where a company checks every window on a street, one by one.",
-      "row": 2,
+      "row": 4,
       "col": 0,
       "rowCols": 4,
       "childIds": [
@@ -292,7 +292,7 @@
       "type": "rest",
       "label": "The Warming Hearth",
       "description": "A company hearth, kept lit for lamplighters coming off a cold round.",
-      "row": 2,
+      "row": 4,
       "col": 1,
       "rowCols": 4,
       "childIds": [
@@ -305,7 +305,7 @@
       "type": "event",
       "label": "The Sealed Curfew",
       "description": "A watch-post posting curfew orders that read like they were never meant for a district this ordinary.",
-      "row": 2,
+      "row": 4,
       "col": 2,
       "rowCols": 4,
       "childIds": [
@@ -371,7 +371,7 @@
       "type": "merchant",
       "label": "The Chandler's Cart",
       "description": "A chandler's cart parked at a ward that hasn't seen open trade in centuries.",
-      "row": 2,
+      "row": 4,
       "col": 3,
       "rowCols": 4,
       "childIds": [
@@ -383,11 +383,12 @@
       "type": "elite",
       "label": "The Company Line",
       "description": "A file of lamplighter sergeants holding the ward in strict, patient formation.",
-      "row": 3,
+      "row": 5,
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-deep-wards"
+        "the-deep-wards",
+        "the-farthest-ward"
       ],
       "handicap": 28,
       "opponentIntervalMs": 2700,
@@ -408,11 +409,12 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A founding charter of the very first lamplighter companies.",
-      "row": 3,
+      "row": 5,
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "the-deep-wards"
+        "the-deep-wards",
+        "the-last-vigil"
       ],
       "fragmentId": "c2act5-frag-1",
       "environment": "citadel"
@@ -422,11 +424,13 @@
       "type": "elite",
       "label": "The Unlit Row",
       "description": "A row of lamplighters, still holding posts for windows that keep going dark anyway.",
-      "row": 3,
+      "row": 5,
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-last-vigil"
+        "the-last-vigil",
+        "the-curfew-line",
+        "the-watch-remnant"
       ],
       "handicap": 28,
       "opponentIntervalMs": 2700,
@@ -447,9 +451,9 @@
       "type": "battle",
       "label": "The Deep Wards",
       "description": "Streets garrisoned like a border, deep enough that the mist forgets to follow.",
-      "row": 4,
+      "row": 6,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 5,
       "childIds": [
         "the-final-taper"
       ],
@@ -471,9 +475,9 @@
       "type": "battle",
       "label": "The Last Vigil",
       "description": "The city's final vigil-ward, where even the watch-lamps burn lower.",
-      "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "row": 6,
+      "col": 1,
+      "rowCols": 5,
       "childIds": [
         "the-final-taper",
         "mem-c2act5-2"
@@ -496,7 +500,7 @@
       "type": "rest",
       "label": "The Final Taper",
       "description": "The last watch-lamp before the General's own ward. Someone has already trimmed its wick.",
-      "row": 5,
+      "row": 7,
       "col": 0,
       "rowCols": 2,
       "childIds": [
@@ -509,7 +513,7 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A lamplighter's log from the night a district's candles guttered.",
-      "row": 5,
+      "row": 7,
       "col": 1,
       "rowCols": 2,
       "childIds": [
@@ -523,7 +527,7 @@
       "type": "boss",
       "label": "The Lamplighter General",
       "description": "Eleven companies end here, before a commander who has never once let a street burn unwatched.",
-      "row": 6,
+      "row": 8,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -547,6 +551,98 @@
         "Ten thousand flames answer to my scepter, and not one of them has ever asked permission to go out. I do not know yet if you're a fire to put out or a name I'm still owed. Let's find out."
       ],
       "bossCard": "The Lamplighter General"
+    },
+    "the-second-ward": {
+      "id": "the-second-ward",
+      "type": "battle",
+      "label": "The Second Ward",
+      "description": "A ward abutting the first district, garrisoned the same as every ward here.",
+      "row": 2,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [
+        "the-outer-wards"
+      ],
+      "handicap": 24,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 254,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Wick Runner",
+        "Lamplighter Cadet",
+        "Watch Lamp",
+        "Wax Bearer",
+        "Swift Wick"
+      ]
+    },
+    "the-farthest-ward": {
+      "id": "the-farthest-ward",
+      "type": "battle",
+      "label": "The Farthest Ward",
+      "description": "The furthest ward the company still bothers to walk, and still guards anyway.",
+      "row": 6,
+      "col": 2,
+      "rowCols": 5,
+      "childIds": [
+        "the-final-taper"
+      ],
+      "handicap": 30,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 278,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Wax Bearer",
+        "Wax Barricade",
+        "Beacon Tower",
+        "Sconce Archer",
+        "Vigil Oil"
+      ]
+    },
+    "the-curfew-line": {
+      "id": "the-curfew-line",
+      "type": "battle",
+      "label": "The Curfew Line",
+      "description": "A line held to the curfew's own hour, and not one minute later.",
+      "row": 6,
+      "col": 3,
+      "rowCols": 5,
+      "childIds": [
+        "mem-c2act5-2"
+      ],
+      "handicap": 30,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 278,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Company Courier",
+        "Curfew Bell",
+        "Candle Automaton",
+        "Wax Bearer",
+        "Sconce Archer"
+      ]
+    },
+    "the-watch-remnant": {
+      "id": "the-watch-remnant",
+      "type": "battle",
+      "label": "The Watch Remnant",
+      "description": "What's left of a watch company that never got the order to stand down.",
+      "row": 6,
+      "col": 4,
+      "rowCols": 5,
+      "childIds": [
+        "mem-c2act5-2"
+      ],
+      "handicap": 30,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 278,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Hollow Snuffer",
+        "Wick Oil Cache",
+        "Company Courier",
+        "Wax Barricade",
+        "Beacon Tower"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act6.json
+++ b/web/src/data/acts/c2act6.json
@@ -4,7 +4,7 @@
   "title": "ACT VI",
   "subtitle": "The Sunken Border",
   "rewardRelic": "Envoy's Pearl",
-  "rewardRelicDesc": "Your units heal 3 HP every 8 seconds — the tide keeps giving back a little of what it takes.",
+  "rewardRelicDesc": "Your units heal 3 HP every 8 seconds \u2014 the tide keeps giving back a little of what it takes.",
   "environment": "coast",
   "rewardTags": [
     "forgotten",
@@ -48,17 +48,17 @@
       "Now, past the General's fall, learning that doctrine was only ever the city's problem. The border has its own."
     ],
     "coastDesc": [
-      "The Sunken Border runs downhill from the Candle City's last gate to a coastline that came back misaligned — drowned towers standing in a tide that shouldn't reach them, streets holding their shape underwater like a memory that refuses to dissolve.",
+      "The Sunken Border runs downhill from the Candle City's last gate to a coastline that came back misaligned \u2014 drowned towers standing in a tide that shouldn't reach them, streets holding their shape underwater like a memory that refuses to dissolve.",
       "This is not a ruin the sea claimed. It is a shoreline that the void gave back changed, twenty miles further in than any chart remembers, and the water has not yet decided whether to keep the difference.",
       "The causeway garrisons here are not defending a border. They are defending the idea that the border used to be somewhere else, and they will hold that idea until the tide corrects them or doesn't."
     ],
     "envoyDesc": [
-      "The Drowned Envoy was sent by the Pale Court to meet whatever crossed the Marches first — and the tide crossed with it, the way it always follows where the Envoy walks.",
+      "The Drowned Envoy was sent by the Pale Court to meet whatever crossed the Marches first \u2014 and the tide crossed with it, the way it always follows where the Envoy walks.",
       "It does not command companies the way the General did. It commands a coastline, and the coastline has never once disobeyed.",
       "Three centuries in the void taught it one thing the Court never had to teach: what the water takes, it gives back changed. It has not yet decided what the Worldmender counts as."
     ],
     "priorRunOpenings": [
-      "The waterline threshold was already redrawn when you reached it, same as always — the border remembers being crossed even when it doesn't remember by whom.",
+      "The waterline threshold was already redrawn when you reached it, same as always \u2014 the border remembers being crossed even when it doesn't remember by whom.",
       "You knew the tide-bells' ring this time. The causeway garrison knew you knowing it.",
       "The tally-ledger at the gate already had your crossing counted. You are becoming a familiar entry in someone's tide-chart.",
       "The Envoy's retinue was already standing at the waterline when you arrived. It does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE SUNKEN BORDER",
-          "text": "The waterline threshold is freshly redrawn — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The waterline threshold is freshly redrawn \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -117,17 +117,17 @@
   "intro": [
     {
       "title": "THE LAMPLIGHTER'S WICK",
-      "text": "The General's companies stood down at your back, and the wick she left burning has not once gone out since. Past the Candle City's last lit gate, the road drops toward a coastline that came back wrong — towers standing in a tide that shouldn't reach them.",
+      "text": "The General's companies stood down at your back, and the wick she left burning has not once gone out since. Past the Candle City's last lit gate, the road drops toward a coastline that came back wrong \u2014 towers standing in a tide that shouldn't reach them.",
       "image": "cutscenes/c2act6-intro-1.svg"
     },
     {
       "title": "THE SUNKEN BORDER",
-      "text": "This is not a ruin the sea claimed. It is a border the void gave back changed — twenty miles further in than any chart remembers, drowned streets holding their shape underwater like a memory refusing to dissolve. The garrisons here are not defending a coastline. They are defending where the coastline used to be.",
+      "text": "This is not a ruin the sea claimed. It is a border the void gave back changed \u2014 twenty miles further in than any chart remembers, drowned streets holding their shape underwater like a memory refusing to dissolve. The garrisons here are not defending a coastline. They are defending where the coastline used to be.",
       "image": "cutscenes/c2act6-intro-2.svg"
     },
     {
       "title": "THE DROWNED ENVOY",
-      "text": "The Court's herald crossed the Marches first, and the tide crossed with it, the way it always follows where the Envoy walks. It does not command companies. It commands a coastline, and the coastline has never once disobeyed — not even for the Worldmender.",
+      "text": "The Court's herald crossed the Marches first, and the tide crossed with it, the way it always follows where the Envoy walks. It does not command companies. It commands a coastline, and the coastline has never once disobeyed \u2014 not even for the Worldmender.",
       "image": "cutscenes/c2act6-intro-3.svg"
     }
   ],
@@ -139,12 +139,12 @@
     },
     {
       "title": "ENVOY'S PEARL",
-      "text": "It is a small thing to have carried a coastline's worth of grief — a single pearl that keeps giving back a little of what the tide takes. Holding it, you understand the Envoy better than its own retinue ever explained it: nothing crosses the border and comes back exactly as it left. Not even, it turns out, you.",
+      "text": "It is a small thing to have carried a coastline's worth of grief \u2014 a single pearl that keeps giving back a little of what the tide takes. Holding it, you understand the Envoy better than its own retinue ever explained it: nothing crosses the border and comes back exactly as it left. Not even, it turns out, you.",
       "image": "cutscenes/c2act6-outro-2.svg"
     },
     {
       "title": "THE MIRROR MARSH AHEAD",
-      "text": "Past the last drowned tower, the road gives way to still water — marsh water, flat as glass, holding a reflection that doesn't quite match the sky above it. Somewhere out past the reeds, something in the water is already looking back at you with a face the Fracture should have erased.",
+      "text": "Past the last drowned tower, the road gives way to still water \u2014 marsh water, flat as glass, holding a reflection that doesn't quite match the sky above it. Somewhere out past the reeds, something in the water is already looking back at you with a face the Fracture should have erased.",
       "image": "cutscenes/c2act6-outro-3.svg"
     }
   ],
@@ -181,8 +181,7 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-tide-ledger",
-        "the-salt-hearth"
+        "the-tide-ledger"
       ],
       "handicap": 26,
       "opponentIntervalMs": 2900,
@@ -205,8 +204,7 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-sealed-watergate",
-        "the-envoys-barge"
+        "the-tide-ledger"
       ],
       "handicap": 26,
       "opponentIntervalMs": 2900,
@@ -227,10 +225,11 @@
       "description": "A Court clerk tallying every crossing against a waterline that keeps moving.",
       "row": 2,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 1,
       "childIds": [
-        "the-sunken-company",
-        "mem-c2act6-1"
+        "the-salt-hearth",
+        "the-sealed-watergate",
+        "the-envoys-barge"
       ],
       "eventConfig": {
         "title": "The Tide Ledger",
@@ -292,11 +291,12 @@
       "type": "rest",
       "label": "The Salt Hearth",
       "description": "A garrison hearth, kept lit for causeway guards coming off a cold tide.",
-      "row": 2,
-      "col": 1,
-      "rowCols": 4,
+      "row": 3,
+      "col": 0,
+      "rowCols": 3,
       "childIds": [
-        "the-sunken-company"
+        "the-sunken-company",
+        "mem-c2act6-1"
       ],
       "restHeal": 9
     },
@@ -304,10 +304,10 @@
       "id": "the-sealed-watergate",
       "type": "event",
       "label": "The Sealed Watergate",
-      "description": "A watergate posting curfew orders for a flood that isn't rising anymore — just remembering how to.",
-      "row": 2,
-      "col": 2,
-      "rowCols": 4,
+      "description": "A watergate posting curfew orders for a flood that isn't rising anymore \u2014 just remembering how to.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 3,
       "childIds": [
         "the-waterlogged-line"
       ],
@@ -371,9 +371,9 @@
       "type": "merchant",
       "label": "The Envoy's Barge",
       "description": "A trading barge moored at a border that hasn't seen open trade in centuries.",
-      "row": 2,
-      "col": 3,
-      "rowCols": 4,
+      "row": 3,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-waterlogged-line"
       ]
@@ -383,9 +383,9 @@
       "type": "elite",
       "label": "The Sunken Company",
       "description": "A file of Court soldiers holding formation in water up to their knees, same as they have for three centuries.",
-      "row": 3,
+      "row": 4,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-deep-shoals"
       ],
@@ -408,11 +408,12 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A founding charter of the border's first causeway garrisons.",
-      "row": 3,
+      "row": 4,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
-        "the-deep-shoals"
+        "the-deep-shoals",
+        "the-last-landing"
       ],
       "fragmentId": "c2act6-frag-1",
       "environment": "coast"
@@ -422,9 +423,9 @@
       "type": "elite",
       "label": "The Waterlogged Line",
       "description": "A line of soldiers who never got new orders when the tide reclaimed their post.",
-      "row": 3,
-      "col": 3,
-      "rowCols": 4,
+      "row": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-last-landing"
       ],
@@ -447,9 +448,9 @@
       "type": "battle",
       "label": "The Deep Shoals",
       "description": "Shoals deep enough that even the mist stops following.",
-      "row": 4,
+      "row": 5,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 2,
       "childIds": [
         "the-final-tideline"
       ],
@@ -471,9 +472,9 @@
       "type": "battle",
       "label": "The Last Landing",
       "description": "The final stretch of shore before the Envoy's own ground.",
-      "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "row": 5,
+      "col": 1,
+      "rowCols": 2,
       "childIds": [
         "the-final-tideline",
         "mem-c2act6-2"
@@ -496,7 +497,7 @@
       "type": "rest",
       "label": "The Final Tideline",
       "description": "The last waterline before the Envoy's own ward. Someone has already redrawn it.",
-      "row": 5,
+      "row": 6,
       "col": 0,
       "rowCols": 2,
       "childIds": [
@@ -509,7 +510,7 @@
       "type": "memory",
       "label": "Memory Fragment",
       "description": "A causeway guard's log from the night the border moved.",
-      "row": 5,
+      "row": 6,
       "col": 1,
       "rowCols": 2,
       "childIds": [
@@ -523,7 +524,7 @@
       "type": "boss",
       "label": "The Drowned Envoy",
       "description": "Eleven miles of reclaimed coastline end here, before a herald who commands the tide itself.",
-      "row": 6,
+      "row": 7,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -544,7 +545,7 @@
       "bossDialogue": [
         "You crossed the Candle City, Worldmender. The General kept her doctrine lit. I keep a tide that doesn't ask permission to rise.",
         "Three centuries of vigil taught Amarath one lesson: what the void takes, it gives back changed. I was sent to meet you before you learned that the hard way.",
-        "The Court does not ask me to hold this coastline. It only asks that whatever crosses it — you included — arrives changed by the crossing. Let's begin."
+        "The Court does not ask me to hold this coastline. It only asks that whatever crosses it \u2014 you included \u2014 arrives changed by the crossing. Let's begin."
       ],
       "bossCard": "The Drowned Envoy"
     }

--- a/web/src/data/acts/c2act7.json
+++ b/web/src/data/acts/c2act7.json
@@ -4,7 +4,7 @@
   "title": "ACT VII",
   "subtitle": "The Mirror Marsh",
   "rewardRelic": "Backwards Glass",
-  "rewardRelicDesc": "Your units gain +2 attack whenever your base is below half HP — the glass shows you exactly how bad it could get, and you fight harder rather than let it happen.",
+  "rewardRelicDesc": "Your units gain +2 attack whenever your base is below half HP \u2014 the glass shows you exactly how bad it could get, and you fight harder rather than let it happen.",
   "environment": "marsh",
   "rewardTags": [
     "forgotten",
@@ -53,12 +53,12 @@
       "The garrisons here are not guarding a shoreline. They are guarding a memory, and the memory does not need their protection nearly as much as they need its company."
     ],
     "reflectionDesc": [
-      "The Reflection was sent by the Pale Court to meet whatever crossed the water first — and it did not need a body until it decided the Worldmender was worth answering.",
+      "The Reflection was sent by the Pale Court to meet whatever crossed the water first \u2014 and it did not need a body until it decided the Worldmender was worth answering.",
       "It does not command companies the way the Envoy commanded a tide. It commands a memory, and the memory has never once lied to it.",
       "Three centuries in the void taught it one thing the Court never had to teach: the world you remember and the world you're given are not always the same offer. It has not yet decided which one it's showing you."
     ],
     "priorRunOpenings": [
-      "The mirror threshold was already still when you reached it, same as always — the marsh remembers being crossed even when it doesn't remember by whom.",
+      "The mirror threshold was already still when you reached it, same as always \u2014 the marsh remembers being crossed even when it doesn't remember by whom.",
       "You knew the still-bells' ring this time. The reed garrison knew you knowing it.",
       "The still-ledger at the threshold already had your crossing counted. You are becoming a familiar entry in someone's reflected chart.",
       "The Reflection was already standing at the water's edge when you arrived. It does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE MIRROR MARSH",
-          "text": "The mirror threshold is freshly stilled — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The mirror threshold is freshly stilled \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -117,12 +117,12 @@
   "intro": [
     {
       "title": "ENVOY'S PEARL",
-      "text": "The Envoy's retinue stood down at your back, and the pearl it pressed into your hand has not once stopped mending since. Past the last drowned tower, the road gives way to still water — marsh water, flat as glass, holding a reflection that doesn't quite match the sky above it.",
+      "text": "The Envoy's retinue stood down at your back, and the pearl it pressed into your hand has not once stopped mending since. Past the last drowned tower, the road gives way to still water \u2014 marsh water, flat as glass, holding a reflection that doesn't quite match the sky above it.",
       "image": "cutscenes/c2act7-intro-1.svg"
     },
     {
       "title": "THE MIRROR MARSH",
-      "text": "This is not a marsh that grew wild. It is a marsh the void kept perfectly still for three centuries, so that when the world came back, the water remembered it exactly as it was — before the Fracture, before the Dominion ever broke. The garrisons here are not guarding a shoreline. They are guarding a memory.",
+      "text": "This is not a marsh that grew wild. It is a marsh the void kept perfectly still for three centuries, so that when the world came back, the water remembered it exactly as it was \u2014 before the Fracture, before the Dominion ever broke. The garrisons here are not guarding a shoreline. They are guarding a memory.",
       "image": "cutscenes/c2act7-intro-2.svg"
     },
     {
@@ -139,12 +139,12 @@
     },
     {
       "title": "BACKWARDS GLASS",
-      "text": "It is a small thing to have carried a marsh's worth of memory — a single pane that shows you exactly how bad things could get, so you fight harder rather than let them. Holding it, you understand the Reflection better than its own stillness ever explained it: showing the truth back is not the same as lying. Not even, it turns out, when it hurts.",
+      "text": "It is a small thing to have carried a marsh's worth of memory \u2014 a single pane that shows you exactly how bad things could get, so you fight harder rather than let them. Holding it, you understand the Reflection better than its own stillness ever explained it: showing the truth back is not the same as lying. Not even, it turns out, when it hurts.",
       "image": "cutscenes/c2act7-outro-2.svg"
     },
     {
       "title": "THE HOLLOW COURT AHEAD",
-      "text": "Past the last still reeds, the road climbs toward a court of masked nobility — Amarath's own, forgotten so thoroughly they forgot their own faces first. Somewhere beyond the marsh's edge, the Pale Court is already deciding what the Worldmender is worth to a kingdom that remembers everything and shows nothing.",
+      "text": "Past the last still reeds, the road climbs toward a court of masked nobility \u2014 Amarath's own, forgotten so thoroughly they forgot their own faces first. Somewhere beyond the marsh's edge, the Pale Court is already deciding what the Worldmender is worth to a kingdom that remembers everything and shows nothing.",
       "image": "cutscenes/c2act7-outro-3.svg"
     }
   ],
@@ -159,6 +159,7 @@
       "rowCols": 3,
       "childIds": [
         "the-reed-causeway",
+        "the-marsh-flank",
         "the-glasswater-ramparts"
       ],
       "handicap": 26,
@@ -179,7 +180,7 @@
       "description": "A causeway grown over with reeds tall enough to remember the world before the Fracture.",
       "row": 1,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-still-ledger",
         "the-reed-hearth"
@@ -202,8 +203,8 @@
       "label": "The Glasswater Ramparts",
       "description": "A rampart line built along water so still the garrison forgot which side of it was real.",
       "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-sealed-millsluice",
         "the-reflections-barge"
@@ -227,7 +228,7 @@
       "description": "A Court clerk tallying every crossing against a reflection that never blinks first.",
       "row": 2,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 5,
       "childIds": [
         "the-still-company",
         "mem-c2act7-1"
@@ -294,7 +295,7 @@
       "description": "A garrison hearth, kept lit for reed-guards coming off a cold stillness.",
       "row": 2,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 5,
       "childIds": [
         "the-still-company"
       ],
@@ -304,10 +305,10 @@
       "id": "the-sealed-millsluice",
       "type": "event",
       "label": "The Sealed Millsluice",
-      "description": "A millsluice posting curfew orders for a flood that isn't rising anymore — just remembering how to.",
+      "description": "A millsluice posting curfew orders for a flood that isn't rising anymore \u2014 just remembering how to.",
       "row": 2,
-      "col": 2,
-      "rowCols": 4,
+      "col": 3,
+      "rowCols": 5,
       "childIds": [
         "the-drowned-line"
       ],
@@ -372,8 +373,8 @@
       "label": "The Reflection's Barge",
       "description": "A trading barge moored at water that hasn't seen open trade in centuries.",
       "row": 2,
-      "col": 3,
-      "rowCols": 4,
+      "col": 4,
+      "rowCols": 5,
       "childIds": [
         "the-drowned-line"
       ]
@@ -385,7 +386,7 @@
       "description": "A file of Court soldiers holding formation in water so calm it never gives their positions away.",
       "row": 3,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-deep-shallows"
       ],
@@ -410,9 +411,10 @@
       "description": "A founding charter of the marsh's first reed garrisons.",
       "row": 3,
       "col": 1,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
-        "the-deep-shallows"
+        "the-deep-shallows",
+        "the-last-crossing"
       ],
       "fragmentId": "c2act7-frag-1",
       "environment": "marsh"
@@ -423,10 +425,12 @@
       "label": "The Drowned Line",
       "description": "A line of soldiers who never got new orders when the marsh reclaimed their post.",
       "row": 3,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
-        "the-last-crossing"
+        "the-last-crossing",
+        "the-sunken-flank",
+        "the-glass-shallows"
       ],
       "handicap": 32,
       "opponentIntervalMs": 2700,
@@ -472,7 +476,7 @@
       "label": "The Last Crossing",
       "description": "The final stretch of water before the Reflection's own ground.",
       "row": 4,
-      "col": 3,
+      "col": 1,
       "rowCols": 4,
       "childIds": [
         "the-final-stillwater",
@@ -544,9 +548,145 @@
       "bossDialogue": [
         "You crossed the Sunken Border, Worldmender. The Envoy gave you a tide that remembers changing. I give you a world that remembers not being broken at all.",
         "Three centuries in the void, and the marsh never once forgot what the Dominion looked like before you mended it. I only show it back. You are the one who has to decide whether that is a mercy or a wound.",
-        "The Court does not ask me to defend this water. It only asks that whatever looks into it — you included — has to answer for what it sees. Let's begin."
+        "The Court does not ask me to defend this water. It only asks that whatever looks into it \u2014 you included \u2014 has to answer for what it sees. Let's begin."
       ],
       "bossCard": "The Reflection"
+    },
+    "the-marsh-flank": {
+      "id": "the-marsh-flank",
+      "type": "battle",
+      "label": "The Marsh Flank",
+      "description": "A flanking stretch of marsh, garrisoned to keep the middle crossing honest.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-hidden-mire"
+      ],
+      "handicap": 28,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 266,
+      "environment": "marsh",
+      "enemyDeck": [
+        "Marsh Skulker",
+        "Reed Strider",
+        "Still Bell",
+        "Marsh Guard",
+        "Mirror Step"
+      ]
+    },
+    "the-hidden-mire": {
+      "id": "the-hidden-mire",
+      "type": "event",
+      "label": "The Hidden Mire",
+      "description": "A mire that swallows sound as thoroughly as it swallows footprints.",
+      "row": 2,
+      "col": 2,
+      "rowCols": 5,
+      "childIds": [
+        "the-still-company",
+        "the-drowned-line"
+      ],
+      "eventConfig": {
+        "title": "The Hidden Mire",
+        "description": "The mire has no bottom anyone has found, and no echo anyone has heard come back from it. Something down there has been keeping a very old count of what it swallows.",
+        "pools": [
+          [
+            {
+              "label": "Wade the mire for what it kept (lose 6 HP, gain a rare card)",
+              "consequence": "The mire does not give anything back for free. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the mire-silt caught in the reeds (gain 60 crystals)",
+              "consequence": "Silt rich enough to be worth something to somebody. You gain 60 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 60
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest on the one dry hummock (heal 10 HP)",
+              "consequence": "Solid ground, for once. You heal 10 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the mire to its count",
+              "consequence": "You leave the mire uncounted.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-sunken-flank": {
+      "id": "the-sunken-flank",
+      "type": "battle",
+      "label": "The Sunken Flank",
+      "description": "A flanking stretch of the last crossing, half under water already.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "mem-c2act7-2"
+      ],
+      "handicap": 34,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 292,
+      "environment": "marsh",
+      "enemyDeck": [
+        "Marsh Runner",
+        "Reed Barricade",
+        "Echo Toll",
+        "Reedline Archer",
+        "Marsh Guard"
+      ]
+    },
+    "the-glass-shallows": {
+      "id": "the-glass-shallows",
+      "type": "battle",
+      "label": "The Glass Shallows",
+      "description": "Shallows so still the garrison drills by watching their own doubled reflection.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "mem-c2act7-2"
+      ],
+      "handicap": 34,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 292,
+      "environment": "marsh",
+      "enemyDeck": [
+        "Glasswater Scout",
+        "Glass Foundry",
+        "Marsh Watchtower",
+        "Echo Caller",
+        "Reedline Archer"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act8.json
+++ b/web/src/data/acts/c2act8.json
@@ -4,7 +4,7 @@
   "title": "ACT VIII",
   "subtitle": "The Hollow Court",
   "rewardRelic": "Hollow Mask",
-  "rewardRelicDesc": "Whenever you play a card, your units gain +1 attack, stacking for the rest of the battle — every mask is a chance to become someone sharper.",
+  "rewardRelicDesc": "Whenever you play a card, your units gain +1 attack, stacking for the rest of the battle \u2014 every mask is a chance to become someone sharper.",
   "environment": "citadel",
   "rewardTags": [
     "forgotten",
@@ -58,7 +58,7 @@
       "Three centuries of ceremony taught him one thing the Pale Court never had to teach: a face you cannot remember is easier to lose twice. He has not yet decided if the Worldmender counts as a face worth keeping."
     ],
     "priorRunOpenings": [
-      "The court threshold was already ceremonied when you reached it, same as always — the hall remembers being entered even when it doesn't remember by whom.",
+      "The court threshold was already ceremonied when you reached it, same as always \u2014 the hall remembers being entered even when it doesn't remember by whom.",
       "You knew the sconce-bearers' step this time. The masked company knew you knowing it.",
       "The name-ledger at the threshold already had your crossing recorded. You are becoming a familiar entry in someone's ceremony.",
       "The Chamberlain's retinue was already standing in the antechamber when you arrived. He does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE HOLLOW COURT",
-          "text": "The court threshold is freshly ceremonied — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The court threshold is freshly ceremonied \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -122,7 +122,7 @@
     },
     {
       "title": "THE HOLLOW COURT",
-      "text": "This is not a court that forgot by accident. It is a court that forgot on purpose, three centuries ago, and built an entire ceremony out of not remembering who used to stand where. The masks are not a punishment — they are the kindest thing the Court could think to do for itself.",
+      "text": "This is not a court that forgot by accident. It is a court that forgot on purpose, three centuries ago, and built an entire ceremony out of not remembering who used to stand where. The masks are not a punishment \u2014 they are the kindest thing the Court could think to do for itself.",
       "image": "cutscenes/c2act8-intro-2.svg"
     },
     {
@@ -139,12 +139,12 @@
     },
     {
       "title": "HOLLOW MASK",
-      "text": "It is a small thing to have cost a Court its own face — a single mask that sharpens whoever wears it, one gesture at a time. Holding it, you understand the Chamberlain better than his own ceremony ever explained him: forgetting your face is not the same as losing yourself. Not even, it turns out, when the whole Court forgets together.",
+      "text": "It is a small thing to have cost a Court its own face \u2014 a single mask that sharpens whoever wears it, one gesture at a time. Holding it, you understand the Chamberlain better than his own ceremony ever explained him: forgetting your face is not the same as losing yourself. Not even, it turns out, when the whole Court forgets together.",
       "image": "cutscenes/c2act8-outro-2.svg"
     },
     {
       "title": "THE WINTER THAT WAITED AHEAD",
-      "text": "Past the Court's last antechamber, the corridors give way to a season the void kept in storage — a winter Amarath never got to have, waiting three centuries for someone to release it. Somewhere beyond the last silver mask, the cold is already deciding who it was owed to.",
+      "text": "Past the Court's last antechamber, the corridors give way to a season the void kept in storage \u2014 a winter Amarath never got to have, waiting three centuries for someone to release it. Somewhere beyond the last silver mask, the cold is already deciding who it was owed to.",
       "image": "cutscenes/c2act8-outro-3.svg"
     }
   ],
@@ -451,7 +451,7 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-final-antechamber"
+        "the-inner-gate"
       ],
       "handicap": 36,
       "opponentIntervalMs": 2600,
@@ -475,8 +475,7 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-final-antechamber",
-        "mem-c2act8-2"
+        "the-inner-gate"
       ],
       "handicap": 36,
       "opponentIntervalMs": 2600,
@@ -496,9 +495,9 @@
       "type": "rest",
       "label": "The Final Antechamber",
       "description": "The last antechamber before the Chamberlain's own hall. Someone has already lit its sconces.",
-      "row": 5,
+      "row": 10,
       "col": 0,
-      "rowCols": 2,
+      "rowCols": 1,
       "childIds": [
         "chamberlain-node"
       ],
@@ -508,12 +507,12 @@
       "id": "mem-c2act8-2",
       "type": "memory",
       "label": "Memory Fragment",
-      "description": "A courtier's log from the night the last unmasked face was recorded.",
-      "row": 5,
+      "description": "A courtier's log from the night the inner ceremony first sealed its own gate.",
+      "row": 9,
       "col": 1,
-      "rowCols": 2,
+      "rowCols": 3,
       "childIds": [
-        "chamberlain-node"
+        "the-final-antechamber"
       ],
       "fragmentId": "c2act8-frag-2",
       "environment": "citadel"
@@ -523,7 +522,7 @@
       "type": "boss",
       "label": "The Chamberlain",
       "description": "Every ceremony in the Hollow Court ends here, before a steward who decides what still deserves a name.",
-      "row": 6,
+      "row": 11,
       "col": 0,
       "rowCols": 1,
       "childIds": [],
@@ -547,6 +546,352 @@
         "The Court does not ask me to defend this ceremony. It only asks that I decide, gesture by gesture, what still deserves a name. Let's begin."
       ],
       "bossCard": "The Chamberlain"
+    },
+    "the-inner-gate": {
+      "id": "the-inner-gate",
+      "type": "battle",
+      "label": "The Inner Gate",
+      "description": "A second ceremonial gate, deeper in the Court than any outsider was ever meant to reach.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [
+        "the-veiled-corridor",
+        "the-gilded-antechamber",
+        "the-shrouded-flank"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 305,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Masked Guard",
+        "Silver Herald",
+        "Velvet Sconce",
+        "Court Attendant"
+      ]
+    },
+    "the-veiled-corridor": {
+      "id": "the-veiled-corridor",
+      "type": "battle",
+      "label": "The Veiled Corridor",
+      "description": "A corridor hung with veils instead of masks, for a ceremony the outer court never learned.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-second-ledger"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 305,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Masked Guard",
+        "Court Attendant",
+        "Velvet Barricade",
+        "Courtly Step"
+      ]
+    },
+    "the-gilded-antechamber": {
+      "id": "the-gilded-antechamber",
+      "type": "battle",
+      "label": "The Gilded Antechamber",
+      "description": "An antechamber gilded for a Chamberlain who has not received a real guest in three centuries.",
+      "row": 6,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-sealed-inner-gate",
+        "the-inner-cart"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 305,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Silver Herald",
+        "Silver Archer",
+        "Hollow Watchtower",
+        "Court Draught"
+      ]
+    },
+    "the-shrouded-flank": {
+      "id": "the-shrouded-flank",
+      "type": "battle",
+      "label": "The Shrouded Flank",
+      "description": "A flanking hall kept shrouded since the ceremony that named it stopped being spoken of.",
+      "row": 6,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "the-vigil-hearth"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 305,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Masked Page",
+        "Court Courier",
+        "Mask Foundry",
+        "Gesture Toll"
+      ]
+    },
+    "the-second-ledger": {
+      "id": "the-second-ledger",
+      "type": "event",
+      "label": "The Second Ledger",
+      "description": "A ledger kept apart from the outer court, recording names the first ledger was never shown.",
+      "row": 7,
+      "col": 0,
+      "rowCols": 4,
+      "childIds": [
+        "the-silver-company"
+      ],
+      "eventConfig": {
+        "title": "The Second Ledger",
+        "description": "This ledger sits behind a door the outer clerks do not have keys to, recording names the Court decided the first ledger should never see. Every entry is a name that was recorded twice, once in error.",
+        "pools": [
+          [
+            {
+              "label": "Read the second ledger (lose 6 HP, gain a rare card)",
+              "consequence": "A record within a record costs more to read. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the clerk's second cache (gain 70 crystals)",
+              "consequence": "A cache the first ledger never accounted for. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest behind the second door (heal 9 HP)",
+              "consequence": "Quieter than a hall that keeps two ledgers has any right to be. You heal 9 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 9
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the second ledger unread",
+              "consequence": "Some records are better left double-uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-vigil-hearth": {
+      "id": "the-vigil-hearth",
+      "type": "rest",
+      "label": "The Vigil Hearth",
+      "description": "A second hearth, kept for attendants who serve a ceremony nobody outside ever hears of.",
+      "row": 7,
+      "col": 1,
+      "rowCols": 4,
+      "childIds": [
+        "the-silver-company"
+      ],
+      "restHeal": 10
+    },
+    "the-sealed-inner-gate": {
+      "id": "the-sealed-inner-gate",
+      "type": "event",
+      "label": "The Sealed Inner Gate",
+      "description": "A second sealed gate, posting orders for a ceremony the outer court was never told existed.",
+      "row": 7,
+      "col": 2,
+      "rowCols": 4,
+      "childIds": [
+        "the-veiled-line"
+      ],
+      "eventConfig": {
+        "title": "The Sealed Inner Gate",
+        "description": "The writ on this gate is signed by the Chamberlain twice \u2014 once in the hand the outer court knows, once in a hand nobody has seen in three hundred years. Both signatures agree on every word.",
+        "pools": [
+          [
+            {
+              "label": "Read the inner writ (lose 6 HP, gain a rare card)",
+              "consequence": "Two signatures cost more to read past than one. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the inner gate's cache (gain 70 crystals)",
+              "consequence": "A cache nobody past the outer gate was ever going to collect. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest behind the inner seals (heal 8 HP)",
+              "consequence": "Quieter than a twice-sealed gate has any right to be. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the inner writ unread",
+              "consequence": "Some orders are better left twice-uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-inner-cart": {
+      "id": "the-inner-cart",
+      "type": "merchant",
+      "label": "The Inner Court's Cart",
+      "description": "A second trading cart, further in than the Chamberlain admits any cart has reason to be.",
+      "row": 7,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-veiled-line"
+      ]
+    },
+    "the-silver-company": {
+      "id": "the-silver-company",
+      "type": "elite",
+      "label": "The Silver Company",
+      "description": "A second file of Court soldiers, masked in silver finer than anything the outer court wears.",
+      "row": 8,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "the-gilt-corridors"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 312,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Court Vanguard",
+        "Masked Guard",
+        "Mask Foundry",
+        "Choir of Masks",
+        "Gesture Toll",
+        "Sealed Archive"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-veiled-line": {
+      "id": "the-veiled-line",
+      "type": "elite",
+      "label": "The Veiled Line",
+      "description": "A line of courtiers veiled rather than masked, for a rank the outer ceremony never named.",
+      "row": 8,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "the-gilt-corridors",
+        "mem-c2act8-2",
+        "the-last-veil"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 312,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Hollow Chanter",
+        "Court Automaton",
+        "Mask Sentry",
+        "Court Writ",
+        "Choir of Masks",
+        "Silver Archer"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-gilt-corridors": {
+      "id": "the-gilt-corridors",
+      "type": "battle",
+      "label": "The Gilt Corridors",
+      "description": "Corridors gilded over the same silver the outer court never sees polished.",
+      "row": 9,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-antechamber"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 312,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Masked Guard",
+        "Velvet Barricade",
+        "Hollow Watchtower",
+        "Court Courier",
+        "Gesture Toll"
+      ]
+    },
+    "the-last-veil": {
+      "id": "the-last-veil",
+      "type": "battle",
+      "label": "The Last Veil",
+      "description": "The final veiled hall before the Chamberlain receives anyone at all.",
+      "row": 9,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-antechamber"
+      ],
+      "handicap": 37,
+      "opponentIntervalMs": 2400,
+      "opponentBaseHp": 312,
+      "environment": "citadel",
+      "enemyDeck": [
+        "Court Courier",
+        "Choir of Masks",
+        "Mask Sentry",
+        "Court Writ",
+        "Silver Archer"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2act9.json
+++ b/web/src/data/acts/c2act9.json
@@ -4,7 +4,7 @@
   "title": "ACT IX",
   "subtitle": "The Winter That Waited",
   "rewardRelic": "Waited Snowflake",
-  "rewardRelicDesc": "Your base gains +12 max HP — a season that waited three centuries to matter finally gives your base something to hold.",
+  "rewardRelicDesc": "Your base gains +12 max HP \u2014 a season that waited three centuries to matter finally gives your base something to hold.",
   "environment": "frost",
   "rewardTags": [
     "forgotten",
@@ -58,7 +58,7 @@
       "Three centuries of storage taught her one thing the Pale Court never had to teach: a season kept waiting long enough stops being patient. She has not yet decided if the Worldmender is the reason it stops."
     ],
     "priorRunOpenings": [
-      "The frost threshold was already rimed when you reached it, same as always — the winter remembers being crossed even when it doesn't remember by whom.",
+      "The frost threshold was already rimed when you reached it, same as always \u2014 the winter remembers being crossed even when it doesn't remember by whom.",
       "You knew the sconce-bearers' step this time. The frostbound company knew you knowing it.",
       "The frost ledger at the threshold already had your crossing recorded. You are becoming a familiar entry in someone's stored season.",
       "The Regent's retinue was already standing in the frost when you arrived. She does not believe in being surprised twice, either."
@@ -101,7 +101,7 @@
       "panels": [
         {
           "title": "THE WINTER THAT WAITED",
-          "text": "The frost threshold is freshly rimed — again.\n\n{pool:priorRunOpenings:0}"
+          "text": "The frost threshold is freshly rimed \u2014 again.\n\n{pool:priorRunOpenings:0}"
         },
         {
           "title": "THE WORLDMENDER",
@@ -117,12 +117,12 @@
   "intro": [
     {
       "title": "HOLLOW MASK",
-      "text": "The Chamberlain's ceremony stood down at your back, and the mask he handed you has sharpened every stride since. Past the Hollow Court's last antechamber, the corridors give way to a season the void kept in storage — a winter Amarath never got to have.",
+      "text": "The Chamberlain's ceremony stood down at your back, and the mask he handed you has sharpened every stride since. Past the Hollow Court's last antechamber, the corridors give way to a season the void kept in storage \u2014 a winter Amarath never got to have.",
       "image": "cutscenes/c2act9-intro-1.svg"
     },
     {
       "title": "THE WINTER THAT WAITED",
-      "text": "This is not a winter that came naturally. It is a winter Amarath stored on purpose, three centuries ago, waiting for a reason worth releasing it. The garrisons here are not holding back a season — they are holding a promise the Court made to itself long before anyone thought it would need keeping.",
+      "text": "This is not a winter that came naturally. It is a winter Amarath stored on purpose, three centuries ago, waiting for a reason worth releasing it. The garrisons here are not holding back a season \u2014 they are holding a promise the Court made to itself long before anyone thought it would need keeping.",
       "image": "cutscenes/c2act9-intro-2.svg"
     },
     {
@@ -139,7 +139,7 @@
     },
     {
       "title": "WAITED SNOWFLAKE",
-      "text": "It is a small thing to have cost a kingdom a season — a single snowflake that gives your base something to hold, after three centuries of holding nothing at all. Holding it, you understand the Regent better than her own frost ever explained her: a thing kept waiting long enough doesn't stop mattering. It just stops being patient.",
+      "text": "It is a small thing to have cost a kingdom a season \u2014 a single snowflake that gives your base something to hold, after three centuries of holding nothing at all. Holding it, you understand the Regent better than her own frost ever explained her: a thing kept waiting long enough doesn't stop mattering. It just stops being patient.",
       "image": "cutscenes/c2act9-outro-2.svg"
     },
     {
@@ -159,6 +159,7 @@
       "rowCols": 3,
       "childIds": [
         "the-frost-causeway",
+        "the-frostbitten-flank",
         "the-rime-ramparts"
       ],
       "handicap": 30,
@@ -179,7 +180,7 @@
       "description": "A causeway rimed over so thoroughly the stones remember being warm.",
       "row": 1,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 3,
       "childIds": [
         "the-frost-ledger",
         "the-winter-hearth"
@@ -200,10 +201,10 @@
       "id": "the-rime-ramparts",
       "type": "battle",
       "label": "The Rime Ramparts",
-      "description": "A rampart line garrisoned like the winter still needs guarding — because to the Court, it does.",
+      "description": "A rampart line garrisoned like the winter still needs guarding \u2014 because to the Court, it does.",
       "row": 1,
-      "col": 3,
-      "rowCols": 4,
+      "col": 2,
+      "rowCols": 3,
       "childIds": [
         "the-sealed-icehouse-gate",
         "the-regents-cart"
@@ -296,7 +297,8 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "the-frostbound-company"
+        "the-frostbound-company",
+        "the-frozen-line"
       ],
       "restHeal": 9
     },
@@ -304,7 +306,7 @@
       "id": "the-sealed-icehouse-gate",
       "type": "event",
       "label": "The Sealed Icehouse Gate",
-      "description": "A gate posting orders for a winter that isn't rising anymore — just remembering how to.",
+      "description": "A gate posting orders for a winter that isn't rising anymore \u2014 just remembering how to.",
       "row": 2,
       "col": 2,
       "rowCols": 4,
@@ -375,7 +377,8 @@
       "col": 3,
       "rowCols": 4,
       "childIds": [
-        "the-frozen-line"
+        "the-frozen-line",
+        "the-glacier-flank"
       ]
     },
     "the-frostbound-company": {
@@ -387,7 +390,8 @@
       "col": 0,
       "rowCols": 4,
       "childIds": [
-        "the-deep-frost"
+        "the-deep-frost",
+        "the-last-glacier"
       ],
       "handicap": 36,
       "opponentIntervalMs": 2700,
@@ -412,7 +416,8 @@
       "col": 1,
       "rowCols": 4,
       "childIds": [
-        "the-deep-frost"
+        "the-deep-frost",
+        "the-last-thaw"
       ],
       "fragmentId": "c2act9-frag-1",
       "environment": "frost"
@@ -423,10 +428,12 @@
       "label": "The Frozen Line",
       "description": "A line of soldiers who never got new orders when the winter finally came out of storage.",
       "row": 3,
-      "col": 3,
+      "col": 2,
       "rowCols": 4,
       "childIds": [
-        "the-last-thaw"
+        "the-last-thaw",
+        "the-rime-remnant",
+        "the-cold-vanguard-line"
       ],
       "handicap": 36,
       "opponentIntervalMs": 2700,
@@ -449,7 +456,7 @@
       "description": "Frost deep enough that even the mist stops following.",
       "row": 4,
       "col": 0,
-      "rowCols": 4,
+      "rowCols": 6,
       "childIds": [
         "the-final-frostline"
       ],
@@ -472,8 +479,8 @@
       "label": "The Last Thaw",
       "description": "The final stretch of frost before the Regent's own ward.",
       "row": 4,
-      "col": 3,
-      "rowCols": 4,
+      "col": 1,
+      "rowCols": 6,
       "childIds": [
         "the-final-frostline",
         "mem-c2act9-2"
@@ -547,6 +554,147 @@
         "The Court does not ask me to keep this cold. It only asks that I choose, at last, who it was always meant for. Let's begin."
       ],
       "bossCard": "The Frost Regent"
+    },
+    "the-frostbitten-flank": {
+      "id": "the-frostbitten-flank",
+      "type": "battle",
+      "label": "The Frostbitten Flank",
+      "description": "A flanking causeway rimed over just as thoroughly as the main crossing.",
+      "row": 1,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-winter-hearth",
+        "the-sealed-icehouse-gate"
+      ],
+      "handicap": 32,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 280,
+      "environment": "frost",
+      "enemyDeck": [
+        "Frost Runner",
+        "Waiting Scout",
+        "Frost Guard",
+        "Waited Step",
+        "Frost Sconce"
+      ]
+    },
+    "the-glacier-flank": {
+      "id": "the-glacier-flank",
+      "type": "battle",
+      "label": "The Glacier Flank",
+      "description": "A flanking glacier the Court garrisons the same as any other stretch of frost.",
+      "row": 3,
+      "col": 3,
+      "rowCols": 4,
+      "childIds": [
+        "the-last-thaw",
+        "the-far-frostline"
+      ],
+      "handicap": 36,
+      "opponentIntervalMs": 2700,
+      "opponentBaseHp": 296,
+      "environment": "frost",
+      "enemyDeck": [
+        "Frost Guard",
+        "Sealed Icehouse",
+        "Blizzard Toll",
+        "Snowmelt Foundry",
+        "Choir of Frost"
+      ]
+    },
+    "the-far-frostline": {
+      "id": "the-far-frostline",
+      "type": "battle",
+      "label": "The Far Frostline",
+      "description": "A stretch of frost further out than any Court garrison admits patrolling.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 6,
+      "childIds": [
+        "mem-c2act9-2"
+      ],
+      "handicap": 38,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 306,
+      "environment": "frost",
+      "enemyDeck": [
+        "Frost Guard",
+        "Frost Barricade",
+        "Winter Courier",
+        "Icebound Archer",
+        "Rime Watchtower"
+      ]
+    },
+    "the-last-glacier": {
+      "id": "the-last-glacier",
+      "type": "battle",
+      "label": "The Last Glacier",
+      "description": "The final glacier before the frostline gives way to the Regent's own ward.",
+      "row": 4,
+      "col": 3,
+      "rowCols": 6,
+      "childIds": [
+        "mem-c2act9-2"
+      ],
+      "handicap": 38,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 306,
+      "environment": "frost",
+      "enemyDeck": [
+        "Winter Courier",
+        "Blizzard Toll",
+        "Choir of Frost",
+        "Snowbound Sentry",
+        "Icebound Archer"
+      ]
+    },
+    "the-rime-remnant": {
+      "id": "the-rime-remnant",
+      "type": "battle",
+      "label": "The Rime Remnant",
+      "description": "What's left of a garrison that never got the order to come in from the cold.",
+      "row": 4,
+      "col": 4,
+      "rowCols": 6,
+      "childIds": [
+        "the-final-frostline"
+      ],
+      "handicap": 38,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 306,
+      "environment": "frost",
+      "enemyDeck": [
+        "Rime Chanter",
+        "Frost Automaton",
+        "Snowbound Sentry",
+        "Winter Writ",
+        "Frost Barricade"
+      ]
+    },
+    "the-cold-vanguard-line": {
+      "id": "the-cold-vanguard-line",
+      "type": "battle",
+      "label": "The Cold Vanguard Line",
+      "description": "A vanguard line held to the letter, three centuries after the order that raised it.",
+      "row": 4,
+      "col": 5,
+      "rowCols": 6,
+      "childIds": [
+        "the-final-frostline",
+        "mem-c2act9-2"
+      ],
+      "handicap": 38,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 306,
+      "environment": "frost",
+      "enemyDeck": [
+        "Winter Vanguard",
+        "Rime Chanter",
+        "Choir of Frost",
+        "Winter Writ",
+        "Frost Automaton"
+      ]
     }
   }
 }

--- a/web/src/data/acts/c2finale.json
+++ b/web/src/data/acts/c2finale.json
@@ -1,0 +1,576 @@
+{
+  "id": "c2finale",
+  "title": "FINALE",
+  "subtitle": "The Throne of the Unremembered",
+  "rewardRelic": "Crown of the Remembered",
+  "rewardRelicDesc": "The mark of the one who remembered a kingdom back. Your base gains +30 max HP, all units gain +6 ATK and +8 max HP, and your maximum mana is increased by 2.",
+  "environment": "vault",
+  "rewardTags": [
+    "forgotten",
+    "throne"
+  ],
+  "replayModifiers": [
+    {
+      "type": "enemyHpPercent",
+      "value": 15,
+      "label": "+15% enemy HP"
+    },
+    {
+      "type": "enemyIntervalReduction",
+      "value": 500,
+      "label": "Enemies act faster"
+    },
+    {
+      "type": "enemyHandBonus",
+      "value": 1,
+      "label": "Enemies start +1 card"
+    },
+    {
+      "type": "crystalBonus",
+      "value": 10,
+      "label": "+10 crystals per battle"
+    },
+    {
+      "type": "enemyHpPercent",
+      "value": 25,
+      "label": "+25% enemy HP"
+    }
+  ],
+  "startNodeIds": [
+    "throne-approach"
+  ],
+  "variantPools": {
+    "jarvMoods": [
+      "Now, past the City of Vigils' last dimming ward, climbing a stair that has waited three centuries for someone to climb it.",
+      "Now, the Worldmender, one door away from the only room in Amarath the Court never let outsiders see.",
+      "Now, wondering whether ending a vigil-rite and erasing a kingdom are the same act, or whether there's a third thing nobody has tried yet.",
+      "Now, past the Queen's fall, understanding that the throne was never the Court's — it was always the King's alone to hold."
+    ],
+    "throneDesc": [
+      "The Throne of the Unremembered sits at the top of a single stair, in a chamber that has held one occupant for three centuries.",
+      "This is not a room built to impress a visitor. It is a room built to hold a rite steady, whatever the cost to the man reciting it.",
+      "Every candle in this chamber burns for the same reason every candle in the city below it burns: because the King decided, once, that going dark was unacceptable, and never revisited the decision."
+    ],
+    "vigilkingDesc": [
+      "The Vigil King has held this rite longer than any of his court, and he has never once asked to be relieved of it.",
+      "He does not command the Court the way the Queen commanded her city. He holds the entire kingdom in his own mind, memory by memory, so that none of it is ever fully lost.",
+      "Three centuries of holding taught him one thing his own court never had to teach: a kingdom remembered by one man is still a kingdom. He has not yet decided if the Worldmender's arrival means it can finally be remembered by more than one."
+    ],
+    "priorRunOpenings": [
+      "The last stair was already climbed when you reached it, same as always — the chamber remembers being climbed even when it doesn't remember by whom.",
+      "You knew the rite's cadence this time. The chamber knew you knowing it.",
+      "The vigil archive at the landing already had your crossing recorded. You are becoming a familiar name in a kingdom that forgets nothing.",
+      "The King's retinue was already holding the chamber when you arrived. He does not believe in being surprised twice, either."
+    ]
+  },
+  "midRunTemplates": [
+    "The {ordinalLower} climb to the Throne of the Unremembered. The candles light a little sooner every time.",
+    "Campaign {n}. The chamber has a whole page in its own ledger reserved for you now.",
+    "{n} climbs counted, by the vigil archive. You have stopped correcting the number.",
+    "Run {n}. The stair is the same length every time, and every time it feels like it already expects you.",
+    "The {ordinalLower} vigil. You know the chamber's every candle by now. The King had names for them first."
+  ],
+  "introRules": [
+    {
+      "condition": {
+        "op": "gte",
+        "value": 10
+      },
+      "panels": [
+        {
+          "title": "THE {ORDINAL} TIME",
+          "text": "{midRunTemplate}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:priorRunOpenings:1}"
+        },
+        {
+          "title": "THE THRONE OF THE UNREMEMBERED",
+          "text": "{pool:throneDesc:1}\n\n{pool:vigilkingDesc:1}"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "op": "range",
+        "min": 2,
+        "max": 9
+      },
+      "panels": [
+        {
+          "title": "THE THRONE OF THE UNREMEMBERED",
+          "text": "The last stair is freshly lit — again.\n\n{pool:priorRunOpenings:0}"
+        },
+        {
+          "title": "THE WORLDMENDER",
+          "text": "You are Jarv. {pool:jarvMoods:0}\n\n{pool:throneDesc:2}"
+        },
+        {
+          "title": "THE VIGIL KING",
+          "text": "{pool:vigilkingDesc:0}"
+        }
+      ]
+    }
+  ],
+  "intro": [
+    {
+      "title": "QUEEN'S CANDLE",
+      "text": "The Vigil Queen's light stood down at your back, and her candle still burns in your hand, never quite guttering. Past the city's dimming wards, a single stair climbs toward the vigil chamber at the heart of the capital — the last room in Amarath that has never once been opened to anyone outside the Court.",
+      "image": "cutscenes/c2finale-intro-1.svg"
+    },
+    {
+      "title": "THE THRONE OF THE UNREMEMBERED",
+      "text": "This is not a room built to impress a visitor. It is a room built to hold a rite steady, whatever the cost to the man reciting it. Every candle in this chamber burns for the same reason every candle in the city below it burns: because the King decided, once, that going dark was unacceptable, and never revisited the decision.",
+      "image": "cutscenes/c2finale-intro-2.svg"
+    },
+    {
+      "title": "THE VIGIL KING",
+      "text": "The monarch whose vigil-rite has held Amarath together in the void for three centuries has never once asked to be relieved of it. He does not command the Court the way the Queen commanded her city. He holds the entire kingdom in his own mind, memory by memory, so that none of it is ever fully lost. He has not yet decided what the Worldmender's arrival means for a vigil he has never once been asked to end.",
+      "image": "cutscenes/c2finale-intro-3.svg"
+    }
+  ],
+  "outro": [
+    {
+      "title": "THE RITE ENDS",
+      "text": "The Vigil King does not fall so much as finally set something down. The chamber's thousand candles gutter all at once, and for the first time in three centuries, the silence in the room is not part of the rite. \"I held this kingdom in my own mind because no one else's would hold it,\" he says. \"Tell me you have a better place to put it, Worldmender. Tell me remembering doesn't have to mean one man, alone, forever.\"",
+      "image": "cutscenes/c2finale-outro-1.svg"
+    },
+    {
+      "title": "CROWN OF THE REMEMBERED",
+      "text": "He presses his crown into your hands — not a weapon, not a relic of war, but the plain, worn circlet of someone who spent three centuries being the only witness to his own kingdom. Wearing it, you understand: the rite was never about holding Amarath apart from the world. It was about making sure that when the world was ready to remember, there would still be something left to remember.",
+      "image": "cutscenes/c2finale-outro-2.svg"
+    },
+    {
+      "title": "THE KINGDOM REMEMBERED",
+      "text": "Word travels faster than any road: Amarath is written back onto every map in the Dominion, its border towns, its candle-lit capital, its King who no longer has to hold the whole of it alone. The Fracture took a kingdom and gave it back changed. Somewhere, in ledgers nobody has opened yet, other maps still show other blank quarters — other things the Fracture erased, still waiting to be found. But that is a crossing for another day. Today, Amarath is remembered.",
+      "image": "cutscenes/c2finale-outro-3.svg"
+    }
+  ],
+  "nodes": {
+    "throne-approach": {
+      "id": "throne-approach",
+      "type": "battle",
+      "label": "The Throne Approach",
+      "description": "Where the city's last dimming ward gives way to the single stair leading to the vigil chamber.",
+      "row": 0,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [
+        "the-last-stair"
+      ],
+      "handicap": 52,
+      "opponentIntervalMs": 2900,
+      "opponentBaseHp": 378,
+      "environment": "vault",
+      "enemyDeck": [
+        "Throne Runner",
+        "Rite Sentry",
+        "Diadem Bearer",
+        "Throne Sconce"
+      ]
+    },
+    "the-last-stair": {
+      "id": "the-last-stair",
+      "type": "battle",
+      "label": "The Last Stair",
+      "description": "A stair worn smooth by three centuries of the same rite climbing it, alone.",
+      "row": 1,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [
+        "the-vigil-archive",
+        "the-hall-of-recitation",
+        "the-sealed-chamber-gate"
+      ],
+      "handicap": 54,
+      "opponentIntervalMs": 2800,
+      "opponentBaseHp": 386,
+      "environment": "vault",
+      "enemyDeck": [
+        "Throne Runner",
+        "Rite Sentry",
+        "Throne Barricade",
+        "Rite Guard",
+        "Rite Step"
+      ]
+    },
+    "the-vigil-archive": {
+      "id": "the-vigil-archive",
+      "type": "event",
+      "label": "The Vigil Archive",
+      "description": "A landing archive tallying every climb made toward a chamber that has never once turned a visitor away alive.",
+      "row": 2,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-reliquary-hearth"
+      ],
+      "eventConfig": {
+        "title": "The Vigil Archive",
+        "description": "The archive at the landing keeps no clerk — only a ledger that fills itself, marking every climb against a vigil three centuries deep. It does not ask why you're climbing. It only asks whether you intend to be recorded.",
+        "pools": [
+          [
+            {
+              "label": "Read the vigil archive (lose 6 HP, gain a rare card)",
+              "consequence": "Every climb recorded costs a little of your own breath. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the archive's wax stipend (gain 60 crystals)",
+              "consequence": "Wax set aside for a vigil that never quite runs short. You gain 60 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 60
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest at the landing's brazier (heal 10 HP)",
+              "consequence": "The brazier holds the stair's chill back better than it has any right to. You heal 10 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 10
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the archive uncounted",
+              "consequence": "You leave the ledger to fill itself.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-hall-of-recitation": {
+      "id": "the-hall-of-recitation",
+      "type": "battle",
+      "label": "The Hall of Recitation",
+      "description": "A hall where the vigil-rite is spoken aloud in shifts, so the King never has to say it alone.",
+      "row": 2,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-reliquary-hearth",
+        "the-regalia-cart"
+      ],
+      "handicap": 54,
+      "opponentIntervalMs": 2800,
+      "opponentBaseHp": 386,
+      "environment": "vault",
+      "enemyDeck": [
+        "Diadem Chanter",
+        "Rite Guard",
+        "Choir of the Remembered",
+        "Rite Lens",
+        "Throne Archer"
+      ]
+    },
+    "the-sealed-chamber-gate": {
+      "id": "the-sealed-chamber-gate",
+      "type": "event",
+      "label": "The Sealed Chamber Gate",
+      "description": "A gate posting vigil orders that read like they were never meant for a stair this ordinary.",
+      "row": 2,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "the-regalia-cart"
+      ],
+      "eventConfig": {
+        "title": "The Sealed Chamber Gate",
+        "description": "The writ nailed to the gate names every hour of the rite and the verse it is due to hold. It is signed by the King himself, countersigned by nobody the chamber has ever met, and dated the same day the Court first sealed this stair.",
+        "pools": [
+          [
+            {
+              "label": "Read the sealed chamber writ (lose 6 HP, gain a rare card)",
+              "consequence": "Every verse named costs you something to read past. You receive a rare card.",
+              "effect": {
+                "type": "compound",
+                "effects": [
+                  {
+                    "type": "damageHp",
+                    "amount": 6
+                  },
+                  {
+                    "type": "gainCard",
+                    "rarity": "rare"
+                  }
+                ]
+              }
+            }
+          ],
+          [
+            {
+              "label": "Take the gate's reliquary cache (gain 70 crystals)",
+              "consequence": "A cache nobody on this stair was ever going to collect. You gain 70 crystals.",
+              "effect": {
+                "type": "gainCrystals",
+                "amount": 70
+              }
+            }
+          ],
+          [
+            {
+              "label": "Rest behind the chamber's seals (heal 8 HP)",
+              "consequence": "Quieter than a sealed stair has any right to be. You heal 8 HP.",
+              "effect": {
+                "type": "healHp",
+                "amount": 8
+              }
+            }
+          ],
+          [
+            {
+              "label": "Leave the writ unread",
+              "consequence": "Some orders are better left uncounted. You move on.",
+              "effect": {
+                "type": "nothing"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "the-reliquary-hearth": {
+      "id": "the-reliquary-hearth",
+      "type": "rest",
+      "label": "The Reliquary Hearth",
+      "description": "A hearth kept for rite-keepers coming off a long recitation.",
+      "row": 3,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "the-rite-company",
+        "mem-c2finale-1"
+      ],
+      "restHeal": 11
+    },
+    "the-regalia-cart": {
+      "id": "the-regalia-cart",
+      "type": "merchant",
+      "label": "The Regalia Cart",
+      "description": "A trading cart parked on a stair that hasn't seen open trade in centuries.",
+      "row": 3,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "the-diadem-line"
+      ]
+    },
+    "the-rite-company": {
+      "id": "the-rite-company",
+      "type": "elite",
+      "label": "The Rite Company",
+      "description": "A file of Court soldiers holding the last stair in the same formation for three centuries.",
+      "row": 4,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-stair"
+      ],
+      "handicap": 58,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 404,
+      "environment": "vault",
+      "enemyDeck": [
+        "Rite Guard",
+        "Rite Vanguard",
+        "Sealed Reliquary",
+        "Diadem Toll",
+        "Diadem Foundry",
+        "Choir of the Remembered"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "mem-c2finale-1": {
+      "id": "mem-c2finale-1",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A founding charter of the vigil-rite itself, the first day the King decided to hold it alone.",
+      "row": 4,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-final-stair",
+        "the-last-vigil-hall"
+      ],
+      "fragmentId": "c2finale-frag-1",
+      "environment": "vault"
+    },
+    "the-diadem-line": {
+      "id": "the-diadem-line",
+      "type": "elite",
+      "label": "The Diadem Line",
+      "description": "A line of courtiers who never got new orders when the rite outlasted every reason for it.",
+      "row": 4,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "the-last-vigil-hall",
+        "the-outer-stair"
+      ],
+      "handicap": 58,
+      "opponentIntervalMs": 2600,
+      "opponentBaseHp": 404,
+      "environment": "vault",
+      "enemyDeck": [
+        "Diadem Chanter",
+        "Rite Automaton",
+        "Throne Sentry",
+        "Regalia Writ",
+        "Choir of the Remembered",
+        "Throne Archer"
+      ],
+      "bossAI": "pale-elite"
+    },
+    "the-final-stair": {
+      "id": "the-final-stair",
+      "type": "battle",
+      "label": "The Final Stair",
+      "description": "The last stretch of stair before the chamber's own threshold.",
+      "row": 5,
+      "col": 0,
+      "rowCols": 3,
+      "childIds": [
+        "the-threshold-of-remembrance"
+      ],
+      "handicap": 60,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 414,
+      "environment": "vault",
+      "enemyDeck": [
+        "Rite Guard",
+        "Throne Barricade",
+        "Throne Watchtower",
+        "Regalia Courier",
+        "Diadem Toll",
+        "Throne Archer"
+      ]
+    },
+    "the-last-vigil-hall": {
+      "id": "the-last-vigil-hall",
+      "type": "battle",
+      "label": "The Last Vigil Hall",
+      "description": "The final hall before the King's own chamber, where even the candles burn steadier.",
+      "row": 5,
+      "col": 1,
+      "rowCols": 3,
+      "childIds": [
+        "the-threshold-of-remembrance",
+        "mem-c2finale-2"
+      ],
+      "handicap": 60,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 414,
+      "environment": "vault",
+      "enemyDeck": [
+        "Regalia Courier",
+        "Choir of the Remembered",
+        "Diadembound Knight",
+        "Regalia Writ",
+        "Throne Sentry",
+        "Diadem Chanter"
+      ]
+    },
+    "the-outer-stair": {
+      "id": "the-outer-stair",
+      "type": "battle",
+      "label": "The Outer Stair",
+      "description": "A lesser stair winding around the chamber, guarded the same as the main climb.",
+      "row": 5,
+      "col": 2,
+      "rowCols": 3,
+      "childIds": [
+        "mem-c2finale-2"
+      ],
+      "handicap": 60,
+      "opponentIntervalMs": 2500,
+      "opponentBaseHp": 414,
+      "environment": "vault",
+      "enemyDeck": [
+        "Rite Vanguard",
+        "Throne Watchtower",
+        "Regalia Writ",
+        "Throne Archer",
+        "Rite Guard"
+      ]
+    },
+    "the-threshold-of-remembrance": {
+      "id": "the-threshold-of-remembrance",
+      "type": "rest",
+      "label": "The Threshold of Remembrance",
+      "description": "The last threshold before the chamber proper. Someone has already lit its candles.",
+      "row": 6,
+      "col": 0,
+      "rowCols": 2,
+      "childIds": [
+        "vigilking-node"
+      ],
+      "restHeal": 12
+    },
+    "mem-c2finale-2": {
+      "id": "mem-c2finale-2",
+      "type": "memory",
+      "label": "Memory Fragment",
+      "description": "A rite-keeper's log from the night the King first spoke of an ending.",
+      "row": 6,
+      "col": 1,
+      "rowCols": 2,
+      "childIds": [
+        "vigilking-node"
+      ],
+      "fragmentId": "c2finale-frag-2",
+      "environment": "vault"
+    },
+    "vigilking-node": {
+      "id": "vigilking-node",
+      "type": "boss",
+      "label": "The Vigil King",
+      "description": "Three centuries of holding a kingdom alone end here, before the monarch who never once asked to be relieved of it.",
+      "row": 7,
+      "col": 0,
+      "rowCols": 1,
+      "childIds": [],
+      "handicap": 62,
+      "opponentIntervalMs": 5000,
+      "opponentBaseHp": 436,
+      "environment": "vault",
+      "enemyDeck": [
+        "The Vigil King",
+        "Rite Vanguard",
+        "Diadembound Knight",
+        "The Last Rite",
+        "Choir of the Remembered",
+        "Throne Sentry",
+        "Regalia Writ"
+      ],
+      "bossAI": "vigilking",
+      "bossDialogue": [
+        "You crossed the City of Vigils, Worldmender. The Queen kept it lit. I have kept this entire kingdom, in my own mind, for three centuries — every name, every candle, every mile of every road you have already walked.",
+        "The Court never asked me to hold Amarath alone. I decided that a kingdom remembered by one man was still a kingdom, and I have never once revisited that decision. You are the first thing in three hundred years to make me revisit anything.",
+        "The rite does not end because I decide to end it. It ends because someone else finally has somewhere to put what I've been holding. Let's find out if that someone is you."
+      ],
+      "bossCard": "The Vigil King"
+    }
+  }
+}

--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -2762,5 +2762,103 @@
         ]
       }
     ]
+  },
+  {
+    "id": "vigilqueen",
+    "intervalMs": 4700,
+    "idleMessage": "Every window in the city still holds a candle she has never once let gutter…",
+    "maxPlaysPerTurn": 3,
+    "openingLog": [
+      "THE VIGIL QUEEN rises above her own city, a capital's worth of grief made weather.",
+      "\"You crossed the Crown Reaches, Worldmender. The Marshal gave you a baton that outlasted his own line. I give you a capital that has never once let a window go dark, and I intend to keep it that way.\""
+    ],
+    "trait": {
+      "name": "The Queen's Descent",
+      "implemented": true,
+      "trigger": "periodic",
+      "triggerIntervalMs": 42000,
+      "type": "fly",
+      "description": "Every 42 seconds the Vigil Queen rises above the field and comes down in a heavy landing over the player's densest cluster, dealing 11 AOE damage in a 2-tile radius and silencing survivors for 1.8 seconds.",
+      "mechanics": {
+        "invulnerableDurationMs": 2500,
+        "landingDamage": 11,
+        "landingRadiusTiles": 2,
+        "stunDurationMs": 1800,
+        "landingTarget": "player_densest_cluster"
+      },
+      "announceText": "THE VIGIL QUEEN takes flight — the sky over your line goes dark with her ascent!",
+      "landText": "THE QUEEN DESCENDS — grief made weather, come down all at once."
+    },
+    "phases": [
+      {
+        "condition": {
+          "gameTimeLt": 30000
+        },
+        "priorities": [
+          {
+            "cardType": "structure",
+            "isWall": true
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "mana"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_asc"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      },
+      {
+        "condition": {
+          "gameTimeGte": 30000,
+          "gameTimeLt": 75000
+        },
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "costGte": 4,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ],
+        "announceOnce": "\"Three centuries of keeping this city lit, and not one ward under my crown has ever asked why we're the last capital standing. The Marshal decided which reach still deserved holding. I decide whether the Court gets a capital left at all.\""
+      },
+      {
+        "condition": null,
+        "manaOverride": 9,
+        "maxPlaysOverride": 4,
+        "announceOnce": "\"THE COURT DOES NOT ASK ME TO WIN THIS CITY. IT ONLY ASKS THAT I KEEP IT LIT.\"",
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/web/src/data/bossAIs.json
+++ b/web/src/data/bossAIs.json
@@ -2860,5 +2860,103 @@
         ]
       }
     ]
+  },
+  {
+    "id": "vigilking",
+    "intervalMs": 4600,
+    "idleMessage": "The rite does not end because someone wishes it would…",
+    "maxPlaysPerTurn": 3,
+    "openingLog": [
+      "THE VIGIL KING rises from a throne that has held one occupant for three centuries.",
+      "\"You crossed the City of Vigils, Worldmender. The Queen kept it lit. I have kept this entire kingdom, in my own mind, for three centuries — every name, every candle, every mile of every road you have already walked.\""
+    ],
+    "trait": {
+      "name": "The Vigil Reignites",
+      "implemented": true,
+      "trigger": "hp_pct_multi",
+      "triggerHpPcts": [66, 33],
+      "type": "fly",
+      "description": "At 66% and again at 33% HP, the Vigil King vanishes into the rite itself for 4 seconds, then reignites every candle in the chamber at once, dealing 10 damage and silencing every friendly unit on the field for 2.2 seconds.",
+      "mechanics": {
+        "invulnerableDurationMs": 4000,
+        "landingDamage": 10,
+        "landingRadiusTiles": 14,
+        "stunDurationMs": 2200,
+        "repositionTarget": "battlefield_centre"
+      },
+      "announceText": "THE VIGIL KING VANISHES INTO THE RITE — the chamber's candles all go dark at once!",
+      "landText": "THE VIGIL REIGNITES — every candle in the chamber catches at the same instant."
+    },
+    "phases": [
+      {
+        "condition": {
+          "gameTimeLt": 30000
+        },
+        "priorities": [
+          {
+            "cardType": "structure",
+            "isWall": true
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "mana"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_asc"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      },
+      {
+        "condition": {
+          "gameTimeGte": 30000,
+          "gameTimeLt": 75000
+        },
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "costGte": 4,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "unit",
+            "isWall": false
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ],
+        "announceOnce": "\"The Court never asked me to hold Amarath alone. I decided that a kingdom remembered by one man was still a kingdom, and I have never once revisited that decision.\""
+      },
+      {
+        "condition": null,
+        "manaOverride": 10,
+        "maxPlaysOverride": 5,
+        "announceOnce": "\"THE RITE DOES NOT END BECAUSE I DECIDE TO END IT. IT ENDS WHEN SOMEONE ELSE HAS SOMEWHERE TO PUT WHAT I'VE BEEN HOLDING.\"",
+        "priorities": [
+          {
+            "cardType": "unit",
+            "isWall": false,
+            "sortBy": "cost_desc"
+          },
+          {
+            "cardType": "structure",
+            "structureEffect": "spawn"
+          },
+          {
+            "cardType": "upgrade"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -15966,6 +15966,99 @@
       "strengths": ["melee", "small"],
       "weaknesses": ["ranged", "flying"],
       "size": "large"
+    },
+    "candle-runner": {
+      "name": "Candle Runner", "attack": 4, "maxHp": 14, "isWall": false, "bypassWall": false,
+      "moveSpeed": 60, "attackRange": 5, "attackCooldownMs": 1050, "flying": false,
+      "tags": ["fast", "small"], "strengths": ["fast", "melee"], "weaknesses": ["armored", "ranged"], "size": "small"
+    },
+    "window-sentry": {
+      "name": "Window Sentry", "attack": 6, "maxHp": 19, "isWall": false, "bypassWall": false,
+      "moveSpeed": 46, "attackRange": 5, "attackCooldownMs": 1200, "flying": false,
+      "tags": ["melee"], "strengths": ["fast"], "weaknesses": ["ranged"], "size": "small"
+    },
+    "ward-herald": {
+      "name": "Ward Herald", "attack": 5, "maxHp": 22, "isWall": false, "bypassWall": false,
+      "moveSpeed": 24, "attackRange": 120, "attackCooldownMs": 1650, "flying": false,
+      "tags": ["ranged"], "strengths": ["flying"], "weaknesses": ["melee", "fast"], "size": "small"
+    },
+    "candle-sconce": {
+      "name": "Candle Sconce", "attack": 5, "maxHp": 25, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 130, "attackCooldownMs": 1750, "tags": ["ranged"]
+    },
+    "ward-guard": {
+      "name": "Ward Guard", "attack": 8, "maxHp": 30, "isWall": false, "bypassWall": false,
+      "moveSpeed": 36, "attackRange": 5, "attackCooldownMs": 1350, "flying": false,
+      "tags": ["melee", "armored"], "strengths": ["fast"], "weaknesses": ["magic"], "size": "medium"
+    },
+    "window-chanter": {
+      "name": "Window Chanter", "attack": 7, "maxHp": 34, "isWall": false, "bypassWall": false,
+      "moveSpeed": 30, "attackRange": 5, "attackCooldownMs": 1350, "flying": false,
+      "tags": ["melee"], "strengths": ["ranged"], "weaknesses": ["fast"], "size": "medium"
+    },
+    "candle-archer": {
+      "name": "Candle Archer", "attack": 7, "maxHp": 20, "isWall": false, "bypassWall": false,
+      "moveSpeed": 40, "attackRange": 140, "attackCooldownMs": 1550, "flying": false,
+      "tags": ["ranged"], "strengths": ["flying"], "weaknesses": ["melee", "fast"], "size": "small"
+    },
+    "ward-courier": {
+      "name": "Ward Courier", "attack": 10, "maxHp": 32, "isWall": false, "bypassWall": false,
+      "moveSpeed": 46, "attackRange": 5, "attackCooldownMs": 1250, "flying": false,
+      "tags": ["fast", "melee"], "strengths": ["armored"], "weaknesses": ["ranged"], "size": "medium"
+    },
+    "ward-barricade": {
+      "name": "Ward Barricade", "attack": 0, "maxHp": 66, "isWall": true, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 0, "tags": ["forgotten"]
+    },
+    "candle-foundry": {
+      "name": "Candle Foundry", "attack": 0, "maxHp": 22, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 0,
+      "structureEffect": {"type": "mana", "amount": 1}, "tags": ["forgotten"]
+    },
+    "ward-automaton": {
+      "name": "Ward Automaton", "attack": 0, "maxHp": 33, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 99999,
+      "structureEffect": {"type": "spawn", "unitTemplateRef": "candle-runner", "intervalMs": 11500}, "tags": ["forgotten"]
+    },
+    "candle-watchtower": {
+      "name": "Candle Watchtower", "attack": 6, "maxHp": 40, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 180, "attackCooldownMs": 2000, "tags": ["ranged"]
+    },
+    "sealed-chantry": {
+      "name": "Sealed Chantry", "attack": 0, "maxHp": 94, "isWall": true, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 0, "tags": ["forgotten"]
+    },
+    "ward-vanguard": {
+      "name": "Ward Vanguard", "attack": 13, "maxHp": 50, "isWall": false, "bypassWall": false,
+      "moveSpeed": 34, "attackRange": 5, "attackCooldownMs": 1400, "flying": false,
+      "tags": ["melee", "armored"], "strengths": ["fast"], "weaknesses": ["magic"], "size": "large"
+    },
+    "choir-of-the-candles": {
+      "name": "Choir of the Candles", "attack": 9, "maxHp": 34, "isWall": false, "bypassWall": false,
+      "moveSpeed": 28, "attackRange": 160, "attackCooldownMs": 2000, "flying": false,
+      "tags": ["ranged", "magic"], "strengths": ["armored"], "weaknesses": ["fast", "melee"], "size": "medium"
+    },
+    "candle-sentry": {
+      "name": "Candle Sentry", "attack": 0, "maxHp": 50, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 99999,
+      "structureEffect": {"type": "spawn", "unitTemplateRef": "candle-runner", "intervalMs": 9500}, "tags": ["forgotten"]
+    },
+    "candlebound-knight": {
+      "name": "Candlebound Knight", "attack": 17, "maxHp": 70, "isWall": false, "bypassWall": false,
+      "moveSpeed": 30, "attackRange": 5, "attackCooldownMs": 1550, "flying": false,
+      "tags": ["melee", "armored", "large"], "strengths": ["melee", "small"], "weaknesses": ["magic", "flying"],
+      "size": "large", "unitTrait": {"guardBase": true, "baseGuardRange": 95, "engageRange": 195}
+    },
+    "the-last-vigil": {
+      "name": "The Last Vigil", "attack": 12, "maxHp": 47, "isWall": false, "bypassWall": true,
+      "moveSpeed": 55, "attackRange": 65, "attackCooldownMs": 1650, "flying": true,
+      "tags": ["flying", "magic"], "strengths": ["melee", "armored"], "weaknesses": ["ranged"], "size": "large"
+    },
+    "the-vigil-queen": {
+      "name": "The Vigil Queen", "attack": 20, "maxHp": 98, "isWall": false, "bypassWall": false,
+      "moveSpeed": 26, "attackRange": 5, "attackCooldownMs": 1450, "flying": true,
+      "tags": ["flying", "large", "magic"], "strengths": ["melee", "small"], "weaknesses": ["ranged"],
+      "size": "large"
     }
   },
   "cards": [
@@ -27697,6 +27790,281 @@
       "deckCount": 0,
       "tags": ["forgotten", "reaches"],
       "lore": "The Court gave him the last army it had. He has never once needed reminding which reach still needs holding."
+    },
+    {
+      "name": "Candle Runner",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "candle-runner",
+      "description": "A quick-footed courier who crosses the City of Vigils by the candlelit back-ways the Court never mapped.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "She has run the same back-way three centuries running and never once let her candle gutter out."
+    },
+    {
+      "name": "Window Sentry",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "window-sentry",
+      "description": "A watcher posted at a window that has held the same candle since before the Fracture.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "He has never once let the candle behind him go dark, and he does not intend to start tonight."
+    },
+    {
+      "name": "Ward Herald",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "ward-herald",
+      "description": "A crier who carries the Queen's word from ward to ward, one lit window at a time.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "Every ward has a herald and every herald has the same word: hold, and keep holding."
+    },
+    {
+      "name": "Candle Sconce",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "structure",
+      "unitRef": "candle-sconce",
+      "description": "A sconce mounted at a ward gate, its flame doubling as a watch-light for the city's vigil.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has burned since the Return and has never once needed relighting."
+    },
+    {
+      "name": "Wick Balm",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffHeal", "amount": 7},
+      "description": "Heals all friendly units by 7.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "Rendered from candle-wax kept warm by a city that has never once let its own light go out."
+    },
+    {
+      "name": "Candle Step",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffSpeed", "amount": 11},
+      "description": "All friendly units move faster, crossing the city at the vigil's own pace.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "A charm cut from a window-sconce, carried at a pace that outlasts the candle it was cut from."
+    },
+    {
+      "name": "Ward Guard",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "ward-guard",
+      "description": "A guard who has held the same ward gate for three centuries, never once needing to be relieved.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "The Queen never asked him to hold this gate forever. He decided that himself."
+    },
+    {
+      "name": "Window Chanter",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "window-chanter",
+      "description": "A chanter who keeps the vigil-rite audible from every lit window in the ward.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "She has sung the same rite from the same window for three centuries and never once lost the tune."
+    },
+    {
+      "name": "Candle Archer",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "candle-archer",
+      "description": "An archer who shoots by candlelight, trained to hit what the dark would otherwise hide.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "She has never once needed a second candle to find her mark."
+    },
+    {
+      "name": "Ward Courier",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "ward-courier",
+      "description": "A courier who carries the Queen's orders faster than the candles can be relit behind her.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "She has outrun every messenger the Court ever fielded against her, and never once been caught carrying the wrong word."
+    },
+    {
+      "name": "Ward Barricade",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "ward-barricade",
+      "description": "A barricade raised at a ward's border, built to hold long after the candles behind it gutter.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has held its ward for three centuries and never once needed to be told why."
+    },
+    {
+      "name": "Candle Foundry",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "candle-foundry",
+      "description": "A foundry that casts candles by the thousand, one flame for every window the city still keeps lit.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has never once run short, not in three centuries of asking."
+    },
+    {
+      "name": "Ward Automaton",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "ward-automaton",
+      "description": "A clockwork sentinel that walks a ward's rounds so the living watch never has to sleep.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has walked the same rounds for three centuries and never once needed reminding of the route."
+    },
+    {
+      "name": "Candle Watchtower",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "candle-watchtower",
+      "description": "A watchtower whose beacon is visible from every ward in the city, a candle the size of a building.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has burned in sight of every ward for three centuries and never once been allowed to gutter."
+    },
+    {
+      "name": "Sealed Chantry",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "sealed-chantry",
+      "description": "A chantry sealed against everything but the vigil-rite itself, its candles burning behind locked doors.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "The Court sealed it three centuries ago and has never once needed to unseal it since."
+    },
+    {
+      "name": "Ward Draught",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffMaxHp", "amount": 9},
+      "description": "All friendly units gain +9 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "Brewed in every ward-house in the city, from a recipe that has never once needed changing."
+    },
+    {
+      "name": "Candle Lens",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffRange", "amount": 16},
+      "description": "All friendly ranged units gain +16 range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "A lens ground to catch every candle's light across the width of the city, and lose none of it."
+    },
+    {
+      "name": "Window Toll",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "aoe", "damage": 7, "range": 105},
+      "description": "Deals 7 damage to all enemies within range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "The toll a lit window charges anything that tries to cross the ward beneath it uninvited."
+    },
+    {
+      "name": "Ward Vanguard",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "ward-vanguard",
+      "description": "An armored vanguard who leads every ward's answer to the Worldmender's crossing.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "She has led the same ward's line for three centuries and never once needed to be told to fall back."
+    },
+    {
+      "name": "Choir of the Candles",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "choir-of-the-candles",
+      "description": "A choir that sings the vigil-rite by every lit window in the city at once, one voice to a candle.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has sung the same rite from the same thousand windows for three centuries and never once gone silent."
+    },
+    {
+      "name": "Candle Sentry",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "candle-sentry",
+      "description": "A sentry post that lights a fresh runner from its own candle every watch, never letting the ward go uncovered.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It has kept the same watch for three centuries and never once let the flame gutter between runners."
+    },
+    {
+      "name": "Ward Writ",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffMaxHp", "amount": 13},
+      "description": "All friendly units gain +13 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "A writ signed by the Queen and sealed by every ward-captain in the city, promising no candle stands alone."
+    },
+    {
+      "name": "Candlebound Knight",
+      "rarity": "epic",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "candlebound-knight",
+      "description": "A knight sworn to a single candle, and to the ward that candle has watched over for three centuries.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "He was sworn to a candle once, and only a candle. Something in three centuries of watching taught him to want more."
+    },
+    {
+      "name": "The Last Vigil",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "the-last-vigil",
+      "description": "The city's oldest watch given wings, flying its rounds over a capital that answers only to the Queen it was raised for.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "It was a candle once, and only a candle. Something in the long watch taught it to fly."
+    },
+    {
+      "name": "The Vigil Queen",
+      "rarity": "legendary",
+      "cost": 7,
+      "cardType": "unit",
+      "unitRef": "the-vigil-queen",
+      "description": "The Court's own sovereign of the vigil-rite — every window in her capital lit, and every one of them hers to command.",
+      "deckCount": 0,
+      "tags": ["forgotten", "vigilcity"],
+      "lore": "The Court gave her a capital to keep. She has never once needed reminding which city still needs holding."
     }
   ],
   "heroCards": [
@@ -28463,6 +28831,31 @@
       "heroEffect": { "type": "buffAttack", "amount": 5 },
       "description": "HERO: Deploys the Reach Breaker — a line-breaker who found the one gap in the Court's last fortified reach. All units gain +5 attack.",
       "lore": "She broke a line the Marshal swore couldn't be broken, and the reach has never once closed the gap she made. She breaks lines for Jarv now the same way."
+    },
+    {
+      "id": "hero-vigil-knight",
+      "name": "Vigil Knight",
+      "rarity": "legendary",
+      "cost": 5,
+      "cardType": "unit",
+      "isHero": true,
+      "unit": {
+        "name": "Vigil Knight",
+        "attack": 11,
+        "maxHp": 55,
+        "isWall": false,
+        "bypassWall": false,
+        "moveSpeed": 32,
+        "attackRange": 5,
+        "attackCooldownMs": 1300,
+        "flying": false,
+        "tags": ["melee", "armored"],
+        "size": "medium",
+        "unitTrait": { "guardBase": true, "baseGuardRange": 90, "engageRange": 185 }
+      },
+      "heroEffect": { "type": "buffMaxHp", "amount": 15 },
+      "description": "HERO: Deploys the Vigil Knight — a knight who has kept watch over the City of Vigils for three centuries and never once let a candle go dark. All units gain +15 max HP.",
+      "lore": "He has stood the same watch since before the Fracture, and outlasted every reason the Court gave him for standing it. He stands watch for Jarv now the same way."
     }
   ]
 }

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -16059,6 +16059,99 @@
       "moveSpeed": 26, "attackRange": 5, "attackCooldownMs": 1450, "flying": true,
       "tags": ["flying", "large", "magic"], "strengths": ["melee", "small"], "weaknesses": ["ranged"],
       "size": "large"
+    },
+    "throne-runner": {
+      "name": "Throne Runner", "attack": 5, "maxHp": 16, "isWall": false, "bypassWall": false,
+      "moveSpeed": 62, "attackRange": 5, "attackCooldownMs": 1050, "flying": false,
+      "tags": ["fast", "small"], "strengths": ["fast", "melee"], "weaknesses": ["armored", "ranged"], "size": "small"
+    },
+    "rite-sentry": {
+      "name": "Rite Sentry", "attack": 7, "maxHp": 21, "isWall": false, "bypassWall": false,
+      "moveSpeed": 46, "attackRange": 5, "attackCooldownMs": 1200, "flying": false,
+      "tags": ["melee"], "strengths": ["fast"], "weaknesses": ["ranged"], "size": "small"
+    },
+    "diadem-bearer": {
+      "name": "Diadem Bearer", "attack": 6, "maxHp": 24, "isWall": false, "bypassWall": false,
+      "moveSpeed": 24, "attackRange": 120, "attackCooldownMs": 1650, "flying": false,
+      "tags": ["ranged"], "strengths": ["flying"], "weaknesses": ["melee", "fast"], "size": "small"
+    },
+    "throne-sconce": {
+      "name": "Throne Sconce", "attack": 6, "maxHp": 27, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 130, "attackCooldownMs": 1750, "tags": ["ranged"]
+    },
+    "rite-guard": {
+      "name": "Rite Guard", "attack": 9, "maxHp": 32, "isWall": false, "bypassWall": false,
+      "moveSpeed": 36, "attackRange": 5, "attackCooldownMs": 1350, "flying": false,
+      "tags": ["melee", "armored"], "strengths": ["fast"], "weaknesses": ["magic"], "size": "medium"
+    },
+    "diadem-chanter": {
+      "name": "Diadem Chanter", "attack": 8, "maxHp": 36, "isWall": false, "bypassWall": false,
+      "moveSpeed": 30, "attackRange": 5, "attackCooldownMs": 1350, "flying": false,
+      "tags": ["melee"], "strengths": ["ranged"], "weaknesses": ["fast"], "size": "medium"
+    },
+    "throne-archer": {
+      "name": "Throne Archer", "attack": 8, "maxHp": 22, "isWall": false, "bypassWall": false,
+      "moveSpeed": 40, "attackRange": 140, "attackCooldownMs": 1550, "flying": false,
+      "tags": ["ranged"], "strengths": ["flying"], "weaknesses": ["melee", "fast"], "size": "small"
+    },
+    "regalia-courier": {
+      "name": "Regalia Courier", "attack": 11, "maxHp": 34, "isWall": false, "bypassWall": false,
+      "moveSpeed": 46, "attackRange": 5, "attackCooldownMs": 1250, "flying": false,
+      "tags": ["fast", "melee"], "strengths": ["armored"], "weaknesses": ["ranged"], "size": "medium"
+    },
+    "throne-barricade": {
+      "name": "Throne Barricade", "attack": 0, "maxHp": 70, "isWall": true, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 0, "tags": ["forgotten"]
+    },
+    "diadem-foundry": {
+      "name": "Diadem Foundry", "attack": 0, "maxHp": 24, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 0,
+      "structureEffect": {"type": "mana", "amount": 1}, "tags": ["forgotten"]
+    },
+    "rite-automaton": {
+      "name": "Rite Automaton", "attack": 0, "maxHp": 35, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 99999,
+      "structureEffect": {"type": "spawn", "unitTemplateRef": "throne-runner", "intervalMs": 11500}, "tags": ["forgotten"]
+    },
+    "throne-watchtower": {
+      "name": "Throne Watchtower", "attack": 7, "maxHp": 42, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 180, "attackCooldownMs": 2000, "tags": ["ranged"]
+    },
+    "sealed-reliquary": {
+      "name": "Sealed Reliquary", "attack": 0, "maxHp": 98, "isWall": true, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 0, "tags": ["forgotten"]
+    },
+    "rite-vanguard": {
+      "name": "Rite Vanguard", "attack": 14, "maxHp": 53, "isWall": false, "bypassWall": false,
+      "moveSpeed": 34, "attackRange": 5, "attackCooldownMs": 1400, "flying": false,
+      "tags": ["melee", "armored"], "strengths": ["fast"], "weaknesses": ["magic"], "size": "large"
+    },
+    "choir-of-the-remembered": {
+      "name": "Choir of the Remembered", "attack": 10, "maxHp": 36, "isWall": false, "bypassWall": false,
+      "moveSpeed": 28, "attackRange": 160, "attackCooldownMs": 2000, "flying": false,
+      "tags": ["ranged", "magic"], "strengths": ["armored"], "weaknesses": ["fast", "melee"], "size": "medium"
+    },
+    "throne-sentry": {
+      "name": "Throne Sentry", "attack": 0, "maxHp": 53, "isWall": false, "bypassWall": false,
+      "moveSpeed": 0, "attackRange": 0, "attackCooldownMs": 99999,
+      "structureEffect": {"type": "spawn", "unitTemplateRef": "throne-runner", "intervalMs": 9500}, "tags": ["forgotten"]
+    },
+    "diadembound-knight": {
+      "name": "Diadembound Knight", "attack": 18, "maxHp": 74, "isWall": false, "bypassWall": false,
+      "moveSpeed": 30, "attackRange": 5, "attackCooldownMs": 1550, "flying": false,
+      "tags": ["melee", "armored", "large"], "strengths": ["melee", "small"], "weaknesses": ["magic", "flying"],
+      "size": "large", "unitTrait": {"guardBase": true, "baseGuardRange": 95, "engageRange": 195}
+    },
+    "the-last-rite": {
+      "name": "The Last Rite", "attack": 13, "maxHp": 50, "isWall": false, "bypassWall": true,
+      "moveSpeed": 55, "attackRange": 65, "attackCooldownMs": 1650, "flying": true,
+      "tags": ["flying", "magic"], "strengths": ["melee", "armored"], "weaknesses": ["ranged"], "size": "large"
+    },
+    "the-vigil-king": {
+      "name": "The Vigil King", "attack": 22, "maxHp": 108, "isWall": false, "bypassWall": false,
+      "moveSpeed": 24, "attackRange": 5, "attackCooldownMs": 1500, "flying": true,
+      "tags": ["flying", "large", "magic"], "strengths": ["melee", "small"], "weaknesses": ["ranged"],
+      "size": "large"
     }
   },
   "cards": [
@@ -28065,6 +28158,281 @@
       "deckCount": 0,
       "tags": ["forgotten", "vigilcity"],
       "lore": "The Court gave her a capital to keep. She has never once needed reminding which city still needs holding."
+    },
+    {
+      "name": "Throne Runner",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "throne-runner",
+      "description": "A courier who carries word up the last stair to the vigil chamber faster than the rite can renew itself.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "She has run the same stair three centuries running and never once arrived a name behind."
+    },
+    {
+      "name": "Rite Sentry",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "rite-sentry",
+      "description": "A watcher posted where the vigil-rite is loudest, listening for the one voice that might finally stop reciting it.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "He has never once missed a word of the rite, and he does not intend to start on the day it finally ends."
+    },
+    {
+      "name": "Diadem Bearer",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "unit",
+      "unitRef": "diadem-bearer",
+      "description": "A bearer who carries a spare diadem for a King who has never once needed a second one.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "She has carried the same spare crown for three centuries and never once been asked to hand it over."
+    },
+    {
+      "name": "Throne Sconce",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "structure",
+      "unitRef": "throne-sconce",
+      "description": "A sconce mounted at the chamber's threshold, its flame the last one the rite still answers to.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has burned since the Return and has never once needed relighting."
+    },
+    {
+      "name": "Remembrance Balm",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffHeal", "amount": 7},
+      "description": "Heals all friendly units by 7.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "Rendered from the same wax that has kept the chamber's memory lit for three centuries."
+    },
+    {
+      "name": "Rite Step",
+      "rarity": "common",
+      "cost": 1,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffSpeed", "amount": 11},
+      "description": "All friendly units move faster, crossing the chamber at the rite's own pace.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "A charm cut from the King's own step, worn smooth by three centuries of the same vigil."
+    },
+    {
+      "name": "Rite Guard",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "rite-guard",
+      "description": "A guard who has held the last stair for three centuries, never once needing to be relieved.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "The King never asked him to hold this stair forever. He decided that himself."
+    },
+    {
+      "name": "Diadem Chanter",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "diadem-chanter",
+      "description": "A chanter who keeps the vigil-rite audible from the chamber's every corner.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "She has sung the same rite in the same chamber for three centuries and never once lost the tune."
+    },
+    {
+      "name": "Throne Archer",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "throne-archer",
+      "description": "An archer trained to shoot by the chamber's single flame, trusting the rite to hold the light steady.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "She has never once needed a second flame to find her mark."
+    },
+    {
+      "name": "Regalia Courier",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "unit",
+      "unitRef": "regalia-courier",
+      "description": "A courier who carries the King's regalia faster than the rite can be recited behind her.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "She has outrun every messenger the Court ever fielded against her, and never once dropped the crown she carried."
+    },
+    {
+      "name": "Throne Barricade",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "throne-barricade",
+      "description": "A barricade raised at the chamber's border, built to hold long after the rite itself falls silent.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has held this chamber for three centuries and never once needed to be told why."
+    },
+    {
+      "name": "Diadem Foundry",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "diadem-foundry",
+      "description": "A foundry that casts diadems for a King who has never once needed to replace the one he wears.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has never once run short, not in three centuries of asking."
+    },
+    {
+      "name": "Rite Automaton",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "rite-automaton",
+      "description": "A clockwork sentinel that recites its own fragment of the rite so the King never has to repeat it twice.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has recited the same fragment for three centuries and never once needed reminding of the words."
+    },
+    {
+      "name": "Throne Watchtower",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "throne-watchtower",
+      "description": "A watchtower whose beacon is visible from every stair leading to the chamber, a candle the size of a spire.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has burned in sight of every stair for three centuries and never once been allowed to gutter."
+    },
+    {
+      "name": "Sealed Reliquary",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "structure",
+      "unitRef": "sealed-reliquary",
+      "description": "A reliquary sealed against everything but the vigil-rite itself, holding what the King still remembers.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "The Court sealed it three centuries ago and has never once needed to unseal it since."
+    },
+    {
+      "name": "Regalia Draught",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffMaxHp", "amount": 9},
+      "description": "All friendly units gain +9 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "Brewed from a recipe the regalia-keepers have never once needed to change."
+    },
+    {
+      "name": "Rite Lens",
+      "rarity": "uncommon",
+      "cost": 2,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffRange", "amount": 16},
+      "description": "All friendly ranged units gain +16 range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "A lens ground to catch the chamber's single flame across the width of the last stair, and lose none of it."
+    },
+    {
+      "name": "Diadem Toll",
+      "rarity": "uncommon",
+      "cost": 3,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "aoe", "damage": 7, "range": 105},
+      "description": "Deals 7 damage to all enemies within range.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "The toll the diadem charges anything that tries to cross the chamber uninvited."
+    },
+    {
+      "name": "Rite Vanguard",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "rite-vanguard",
+      "description": "An armored vanguard who leads the chamber's answer to the Worldmender's final crossing.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "She has led the same stair for three centuries and never once needed to be told to fall back."
+    },
+    {
+      "name": "Choir of the Remembered",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "unit",
+      "unitRef": "choir-of-the-remembered",
+      "description": "A choir that sings the vigil-rite in the King's own voice, one verse for every name he still holds.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has sung the same rite in the same chamber for three centuries and never once gone silent."
+    },
+    {
+      "name": "Throne Sentry",
+      "rarity": "rare",
+      "cost": 3,
+      "cardType": "structure",
+      "unitRef": "throne-sentry",
+      "description": "A sentry post that lights a fresh runner from the chamber's own flame every watch.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It has kept the same watch for three centuries and never once let the flame gutter between runners."
+    },
+    {
+      "name": "Regalia Writ",
+      "rarity": "rare",
+      "cost": 4,
+      "cardType": "upgrade",
+      "upgradeEffect": {"type": "buffMaxHp", "amount": 13},
+      "description": "All friendly units gain +13 max HP.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "A writ signed by the King and sealed by every ward-captain the Court still remembers, promising no name stands alone."
+    },
+    {
+      "name": "Diadembound Knight",
+      "rarity": "epic",
+      "cost": 5,
+      "cardType": "unit",
+      "unitRef": "diadembound-knight",
+      "description": "A knight sworn to the diadem itself, and to the last stair that diadem has watched over for three centuries.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "He was sworn to a crown once, and only a crown. Something in three centuries of watching taught him to want more."
+    },
+    {
+      "name": "The Last Rite",
+      "rarity": "epic",
+      "cost": 6,
+      "cardType": "unit",
+      "unitRef": "the-last-rite",
+      "description": "The chamber's oldest recitation given wings, flying its rounds over a rite that answers only to the King who started it.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "It was a rite once, and only a rite. Something in three centuries of reciting taught it to fly."
+    },
+    {
+      "name": "The Vigil King",
+      "rarity": "legendary",
+      "cost": 8,
+      "cardType": "unit",
+      "unitRef": "the-vigil-king",
+      "description": "The monarch whose vigil-rite has kept Amarath alive in the void for three centuries — a kingdom held together by will alone.",
+      "deckCount": 0,
+      "tags": ["forgotten", "throne"],
+      "lore": "He does not hate the Dominion. He simply cannot allow it to keep the centuries Amarath lost. He has not yet decided if the Worldmender changes that math."
     }
   ],
   "heroCards": [

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -362,5 +362,19 @@
     "nodeId": "mem-c2act13-2",
     "title": "Fragment: The Ward That Nearly Dimmed",
     "body": "A WARD-GUARD'S LOG, RECOVERED FROM A GATEHOUSE WATCH-POST\n\n'Third watch, and the seventh ward's candle guttered for the first time in three centuries — not out, not fully, just low enough that the ward-captain relit it with her own hand before anyone else noticed. She told me not to write this down. I am writing it down anyway. If a single candle can nearly go out after three hundred years of not going out, then the Court's promise that this capital would never go dark is not the guarantee it claims to be, and somebody above my rank ought to know that before the Worldmender's people find it out for themselves.\n\nThe ward-captain relit the candle a second time before the log closed. It held until the next watch. I do not know if a city that nearly dims is still the last capital, or just a grief that has finally started to tire of being remembered.'"
+  },
+  {
+    "id": "c2finale-frag-1",
+    "actId": "c2finale",
+    "nodeId": "mem-c2finale-1",
+    "title": "Fragment: The First Vigil",
+    "body": "FOUNDING CHARTER OF THE VIGIL-RITE — YEAR ONE OF THE RETURN\n\n'The King did not ask the Court to help him hold Amarath together. He told them, once, plainly, that he intended to hold it himself — every name, every road, every candle, in his own mind, for as long as it took the Dominion to remember what it had erased. Nobody on the Court believed one man could carry a kingdom's whole memory alone. He did not ask them to believe it. He simply began.\n\nThree hundred years on, I am told the King has never once set the rite down, not for a night, not for an hour. I believe it. A man who spent three centuries being nowhere does not get to decide the remembering is finished just because the carrying is heavy.\n\nI do not know what happens to a rite like this when it finally ends. I do not think the King knows either. I think that is precisely why he has never once tried.'"
+  },
+  {
+    "id": "c2finale-frag-2",
+    "actId": "c2finale",
+    "nodeId": "mem-c2finale-2",
+    "title": "Fragment: The Night the King Spoke of an Ending",
+    "body": "A RITE-KEEPER'S LOG, RECOVERED FROM THE VIGIL CHAMBER\n\n'Third watch, and for the first time in three centuries the King spoke the word \"ending\" aloud in the chamber, not as a threat and not as a fear, just as a question he had apparently been turning over since word came of the Worldmender's crossing. He did not finish the thought. He told me not to write this down. I am writing it down anyway.\n\nIf the King is asking whether the rite can end, then he is asking whether Amarath can be remembered by more than one mind at last — and I do not think a kingdom that has spent three centuries as one man's private grief knows how to answer that question honestly.\n\nHe did not speak of ending again before the log closed. I do not know if a King who finally asks the question is still the same King who spent three hundred years refusing to ask it, or something new standing in the same chamber.'"
   }
 ]

--- a/web/src/data/memoryFragments.json
+++ b/web/src/data/memoryFragments.json
@@ -348,5 +348,19 @@
     "nodeId": "mem-c2act12-2",
     "title": "Fragment: The Baton's Provenance",
     "body": "A COURT ARCHIVIST'S NOTE, ATTACHED TO THE MARSHAL'S COMMISSION\n\n'The baton is older than the Marshal who carries it, older than the reach he holds, older by most accounts than the Fracture itself. Every commander of the Crown Reaches has carried the same one, passed hand to hand down three centuries of marshals who each, in turn, were told they were the last.\n\nWhat the baton has never done, in three centuries of provenance, is fall. Every marshal before this one held the reach and handed the baton on. This note exists because, for the first time, the archivist charged with tracking it could not say with confidence there would be a next hand to receive it.\n\nI record this not because I believe the reach will fall, but because the ledger requires an answer for every object it tracks, and for the first time in three centuries, I do not have one.'"
+  },
+  {
+    "id": "c2act13-frag-1",
+    "actId": "c2act13",
+    "nodeId": "mem-c2act13-1",
+    "title": "Fragment: The First Ward Charter",
+    "body": "FOUNDING CHARTER OF THE CITY WARDS — YEAR ONE OF THE RETURN\n\n'When the Court decided the capital would never go dark again, it did not ask the wards to build walls. It asked them to keep candles — one to a window, every window in the city, lit and re-lit until the lighting became a duty nobody living remembered choosing.\n\nWe lit the first ward ourselves, and the charter says we did not stop to ask how many windows the city would need before it stopped counting as vigilance and started counting as habit. We lit it anyway, because a capital held together by candlelight does not get to decide when the candlelight is finished.\n\nThree centuries on, I am told no ward in this city has ever gone fully dark, not for a night, not for an hour. I believe it. A kingdom that spent three centuries being nowhere does not let its own capital's light go out, no matter how many windows the keeping costs.'"
+  },
+  {
+    "id": "c2act13-frag-2",
+    "actId": "c2act13",
+    "nodeId": "mem-c2act13-2",
+    "title": "Fragment: The Ward That Nearly Dimmed",
+    "body": "A WARD-GUARD'S LOG, RECOVERED FROM A GATEHOUSE WATCH-POST\n\n'Third watch, and the seventh ward's candle guttered for the first time in three centuries — not out, not fully, just low enough that the ward-captain relit it with her own hand before anyone else noticed. She told me not to write this down. I am writing it down anyway. If a single candle can nearly go out after three hundred years of not going out, then the Court's promise that this capital would never go dark is not the guarantee it claims to be, and somebody above my rank ought to know that before the Worldmender's people find it out for themselves.\n\nThe ward-captain relit the candle a second time before the log closed. It held until the next watch. I do not know if a city that nearly dims is still the last capital, or just a grief that has finally started to tire of being remembered.'"
   }
 ]

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -430,5 +430,22 @@
         "amount": 3
       }
     ]
+  },
+  {
+    "name": "Queen's Candle",
+    "icon": "🕯️",
+    "desc": "All friendly units gain +4 max HP and heal 2 HP every 6 seconds in battle — a candle that has never once been allowed to gutter out.",
+    "lore": "The last flame of a capital that decided, three centuries ago, that going dark was the one thing it would never do again. It does not just burn. It mends what stands near it, the same way the city mended itself after the Fracture.",
+    "effects": [
+      {
+        "type": "unitHp",
+        "amount": 4
+      },
+      {
+        "type": "tickHeal",
+        "amount": 2,
+        "intervalMs": 6000
+      }
+    ]
   }
 ]

--- a/web/src/data/relics.json
+++ b/web/src/data/relics.json
@@ -447,5 +447,29 @@
         "intervalMs": 6000
       }
     ]
+  },
+  {
+    "name": "Crown of the Remembered",
+    "icon": "👑",
+    "desc": "The mark of the one who remembered a kingdom back. Your base gains +30 max HP, all units gain +6 ATK and +8 max HP, and your maximum mana is increased by 2.",
+    "lore": "The plain, worn circlet of a King who spent three centuries as the only witness to his own kingdom. The rite was never about holding Amarath apart from the world — it was about making sure there would still be something left to remember when the world was ready.",
+    "effects": [
+      {
+        "type": "baseHp",
+        "amount": 30
+      },
+      {
+        "type": "unitAtk",
+        "amount": 6
+      },
+      {
+        "type": "unitHp",
+        "amount": 8
+      },
+      {
+        "type": "maxMana",
+        "amount": 2
+      }
+    ]
   }
 ]

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -1244,6 +1244,41 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 2,
   },
 
+  // Campaign 2, Act 13 — The City of Vigils
+  {
+    id: 'campaign:c2act13:1',
+    name: 'First Ward',
+    description: 'Complete Campaign 2 Act 13 — The City of Vigils',
+    category: 'campaign',
+    progressKey: 'campaign:c2act13',
+    target: 1,
+    reward: { type: 'crystals', crystals: 800 },
+    tier: 1,
+  },
+  {
+    id: 'campaign:c2act13:10',
+    name: 'Recorded in the Ward Registry',
+    description: 'Complete Campaign 2 Act 13 ten times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act13',
+    target: 10,
+    reward: { type: 'crystals', crystals: 3800 },
+    tier: 2,
+  },
+  {
+    id: 'campaign:c2act13:100',
+    name: 'The City Remembers Your Name',
+    description: 'Complete Campaign 2 Act 13 one hundred times',
+    category: 'campaign',
+    progressKey: 'campaign:c2act13',
+    target: 100,
+    reward: {
+      type: 'item',
+      item: { id: 'queens_unfailing_wick', name: "Queen's Unfailing Wick", icon: '🕯️', desc: 'A wick from a hundred vigils. It has never once agreed to gutter.' },
+    },
+    tier: 2,
+  },
+
   // ── Boss avatar unlocks (one per act, triggered on first act completion) ─
 
   { id: 'campaign:act1:boss',  name: 'Face of the Thornlord',       description: 'Defeat Act 1 to unlock the Thornlord avatar',       category: 'campaign', progressKey: 'campaign:act1',  target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thornlord' },       tier: 1 },
@@ -1272,6 +1307,7 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
   { id: 'campaign:c2act10:boss',   name: 'Face of the Orchard Keeper', description: 'Defeat Campaign 2 Act 10 to unlock the Orchard Keeper avatar', category: 'campaign', progressKey: 'campaign:c2act10', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-orchardkeeper' }, tier: 1 },
   { id: 'campaign:c2act11:boss',   name: 'Face of the Procession Master', description: 'Defeat Campaign 2 Act 11 to unlock the Procession Master avatar', category: 'campaign', progressKey: 'campaign:c2act11', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-processionmaster' }, tier: 1 },
   { id: 'campaign:c2act12:boss',   name: 'Face of the Pale Marshal', description: 'Defeat Campaign 2 Act 12 to unlock the Pale Marshal avatar', category: 'campaign', progressKey: 'campaign:c2act12', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-palemarshal' }, tier: 1 },
+  { id: 'campaign:c2act13:boss',   name: 'Face of the Vigil Queen', description: 'Defeat Campaign 2 Act 13 to unlock the Vigil Queen avatar', category: 'campaign', progressKey: 'campaign:c2act13', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-vigilqueen' }, tier: 1 },
 
   // ── Boss Cards — earned by repeat boss completions (10/20/30/40 runs) ────
   // Act 1 — Thornlord

--- a/web/src/game/achievements.ts
+++ b/web/src/game/achievements.ts
@@ -1279,6 +1279,41 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
     tier: 2,
   },
 
+  // Campaign 2, Finale — The Throne of the Unremembered
+  {
+    id: 'campaign:c2finale:1',
+    name: 'The Rite Ends',
+    description: 'Complete Campaign 2 Finale — The Throne of the Unremembered',
+    category: 'campaign',
+    progressKey: 'campaign:c2finale',
+    target: 1,
+    reward: { type: 'crystals', crystals: 1000 },
+    tier: 1,
+  },
+  {
+    id: 'campaign:c2finale:10',
+    name: 'Recorded in the Vigil Archive',
+    description: 'Complete Campaign 2 Finale ten times',
+    category: 'campaign',
+    progressKey: 'campaign:c2finale',
+    target: 10,
+    reward: { type: 'crystals', crystals: 4200 },
+    tier: 2,
+  },
+  {
+    id: 'campaign:c2finale:100',
+    name: 'The Kingdom Remembers Your Name',
+    description: 'Complete Campaign 2 Finale one hundred times',
+    category: 'campaign',
+    progressKey: 'campaign:c2finale',
+    target: 100,
+    reward: {
+      type: 'item',
+      item: { id: 'kings_unbroken_vigil', name: "King's Unbroken Vigil", icon: '👑', desc: 'A vigil kept a hundred times over. It has never once needed carrying alone.' },
+    },
+    tier: 2,
+  },
+
   // ── Boss avatar unlocks (one per act, triggered on first act completion) ─
 
   { id: 'campaign:act1:boss',  name: 'Face of the Thornlord',       description: 'Defeat Act 1 to unlock the Thornlord avatar',       category: 'campaign', progressKey: 'campaign:act1',  target: 1, reward: { type: 'avatar', avatarSlug: 'boss-thornlord' },       tier: 1 },
@@ -1308,6 +1343,7 @@ export const ACHIEVEMENT_DEFS: AchievementDef[] = [
   { id: 'campaign:c2act11:boss',   name: 'Face of the Procession Master', description: 'Defeat Campaign 2 Act 11 to unlock the Procession Master avatar', category: 'campaign', progressKey: 'campaign:c2act11', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-processionmaster' }, tier: 1 },
   { id: 'campaign:c2act12:boss',   name: 'Face of the Pale Marshal', description: 'Defeat Campaign 2 Act 12 to unlock the Pale Marshal avatar', category: 'campaign', progressKey: 'campaign:c2act12', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-palemarshal' }, tier: 1 },
   { id: 'campaign:c2act13:boss',   name: 'Face of the Vigil Queen', description: 'Defeat Campaign 2 Act 13 to unlock the Vigil Queen avatar', category: 'campaign', progressKey: 'campaign:c2act13', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-vigilqueen' }, tier: 1 },
+  { id: 'campaign:c2finale:boss',  name: 'Face of the Vigil King', description: 'Defeat Campaign 2 Finale to unlock the Vigil King avatar', category: 'campaign', progressKey: 'campaign:c2finale', target: 1, reward: { type: 'avatar', avatarSlug: 'boss-vigilking' }, tier: 1 },
 
   // ── Boss Cards — earned by repeat boss completions (10/20/30/40 runs) ────
   // Act 1 — Thornlord

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -961,6 +961,7 @@ const ACT_LOADERS: Record<string, () => Promise<{ default: unknown }>> = {
   c2act10:   () => import('../data/acts/c2act10.json'),
   c2act11:   () => import('../data/acts/c2act11.json'),
   c2act12:   () => import('../data/acts/c2act12.json'),
+  c2act13:   () => import('../data/acts/c2act13.json'),
   /** Standalone battles launched from the world map — never part of campaign progression. */
   world:     () => import('../data/acts/worldbattles.json'),
 }

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -962,6 +962,7 @@ const ACT_LOADERS: Record<string, () => Promise<{ default: unknown }>> = {
   c2act11:   () => import('../data/acts/c2act11.json'),
   c2act12:   () => import('../data/acts/c2act12.json'),
   c2act13:   () => import('../data/acts/c2act13.json'),
+  c2finale:  () => import('../data/acts/c2finale.json'),
   /** Standalone battles launched from the world map — never part of campaign progression. */
   world:     () => import('../data/acts/worldbattles.json'),
 }


### PR DESCRIPTION
Implements sub-issues #1998 (Act 13) and #1999 (Finale) — completing the Campaign 2 ("The Forgotten Kingdom") 13-act story arc — plus a campaign-wide follow-up fixing a design gap the user flagged mid-session: every Campaign 2 act map (including the 8 built before this session) used the identical 15-node, 7-row template, unlike Campaign 1's acts which vary from 15 to 34 nodes with genuinely different branch shapes.

## Act 13 — The City of Vigils
- 25 new `"vigilcity"`-tagged cards + hero card **Vigil Knight**.
- New act map, boss **The Vigil Queen** (`vigilqueen`, trait `fly` — "The Queen's Descent"), relic **Queen's Candle**, 2 memory fragments.
- Full sprite set + 6 cutscene panels. Wired into `questline.ts`; `c2act12.json` → `nextActId: "c2act13"`.

## Finale — The Throne of the Unremembered
- 25 new `"throne"`-tagged cards (no hero card, per the story bible's finale row).
- New act map, boss **The Vigil King** (`vigilking`, trait `hp_pct_multi` at 66/33 — "The Vigil Reignites," a full-field version of the periodic fly/landing traits used earlier in the arc).
- Relic **Crown of the Remembered** — a campaign trophy mirroring **Worldmender's Crest**'s exact scale (+30 base HP, +6 unit ATK, +8 unit HP, +2 max mana), per the issue's instruction.
- 2 memory fragments. Full sprite set + 6 cutscene panels.
- `c2act13.json` → `nextActId: "c2finale"`. `codex.ts` and `CampaignAdminScreen` need no changes — both already derive their act lists generically from `ACT_LOADERS`/`ACT_IDS`.
- **`CampaignVictoryScreen`** now takes a `campaignId` prop and looks up campaign-specific victory copy (title + body lines) instead of hardcoding Campaign 1's text; `App.tsx` passes `getCampaignForAct(run.actId).id` through. Campaign 2's copy follows the story bible: Amarath is written back onto the Dominion's maps, with a hook that other blank quarters may still exist.
- The "TO BE CONTINUED" vs. campaign-victory branching required no code changes — `CAMPAIGNS` in `questline.ts` already had `finaleActId: 'c2finale'` set, so `getCampaignForAct` + the existing `currentRun.actId === campaign.finaleActId` check in `App.tsx` now resolves correctly now that the act exists.

## Campaign-wide node-map variety pass
All 13 Campaign 2 acts (`c2act1.json`–`c2act13.json`) had their `nodes` graphs redesigned for shape and size variety, mirroring Campaign 1's per-act escalation. Each act's boss node, relic, memory-fragment content, and end-of-act handicap/HP values were preserved exactly (continuity into the next act's opening difficulty is untouched) — only intermediate node count, branching shape, and enemy-deck distribution changed, reusing each act's own existing 25-card pool.

| Act | Nodes (before → after) | Shape |
|---|---|---|
| 1 | 15 → 17 | fan-out + convergence |
| 2 | 15 → 17 | bottleneck + parallel branches |
| 3 | 15 → 19 | 4-wide parallel rows |
| 4 | 15 → 20 | hourglass, double-elite chokepoint |
| 5 | 15 → 19 | long single-file opening + 5-wide finale |
| 6 | 15 → 15 | double-diamond convergence |
| 7 | 15 → 19 | 3-way start + mid-path convergence |
| 8 | 15 → 27 | two-wave Outer/Inner Court gauntlet (biggest act) |
| 9 | 15 → 21 | braided cross-linked branches |
| 10 | 15 → 27 | two-wave Outer/Inner Grove gauntlet (biggest act) |
| 11 | 15 → 17 | cross-linked lanes + outer detour |
| 12 | 15 → 16 | immediate 3-way fan-out |
| 13 | new, 17 | chained double-elite chokepoint gauntlet |
| Finale | new, 16 | single-spine climb, one mid-branch |

## Verification
- `npm run build` — clean, for every commit in this PR.
- `npm run test` — 1901 tests passed (54 files); the Playwright headless-shell launch error is a pre-existing environment quirk, not a real failure.
- For every act (including the Finale): scripted reachability check (100% of nodes reachable from `startNodeIds`) and a full `enemyDeck` → `cards.json` name-resolution check.
- Verified zero duplicate card/template names across the full `cards.json`.
- Verified every new unit/structure/hero card resolves to an existing sprite file.
- Verified the full campaign chain: `c2act1` → … → `c2act13` → `c2finale` (no further `nextActId`, as required for the victory flow).

Closes #1998. Closes #1999.