### PR TITLE
fix(campaign): stop relic HP bonus from leaking into persisted run HP

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1896,10 +1896,17 @@ export default function App() {
     }
     campaignPlayCountsRef.current = {}
 
-    // Update run HP and counts from battle result
+    // Update run HP and counts from battle result.
+    // gameState.playerBase is scaled to include any equipped relic's HP bonus (applied
+    // fresh each battle — see relics.ts), which run.maxHp deliberately excludes. Carrying
+    // gameState.playerBase.hp straight into run.playerHp would permanently bank that relic
+    // bonus into the persisted HP pool without run.maxHp ever growing to match, drifting
+    // the two out of sync over repeated battles. Instead, carry forward the damage taken
+    // relative to the relic-inflated pool, applied against the relic-free run.maxHp.
+    const dmgTaken = gameState.playerBase.maxHp - gameState.playerBase.hp
     const updatedRun: RunState = {
       ...currentRun,
-      playerHp: gameState.playerBase.hp,
+      playerHp: Math.max(0, currentRun.maxHp - dmgTaken),
       completedNodeIds: [...currentRun.completedNodeIds, nodeId],
       pendingNodeId: null,
       cardPlayCounts: mergedCounts,


### PR DESCRIPTION
## Summary

Fixes a bug reported for players with high permanent max HP (via campaign completion stat upgrades) equipped with **Worldmender's Crest**: the campaign map/stats screen shows the correct max HP, but entering a battle shows a much lower, inconsistent current HP.

**Root cause:** `handleCampaignWin` in `App.tsx` copied `gameState.playerBase.hp` straight into `run.playerHp` after a win. That value includes any equipped relic's flat HP bonus (e.g. Worldmender's Crest's `+30 max HP`), which `relics.ts`'s `applyToGame` re-applies to *both* `hp` and `maxHp` fresh at the start of every single battle — while `run.maxHp` (the persisted, displayed value) deliberately excludes the relic's contribution, since the relic is meant to be a transient per-battle bonus, not a permanent stat.

Because only the inflated `hp` was banked back into `run.playerHp` (never `run.maxHp`), each battle played with the relic equipped silently baked in another dose of "free" HP into the persisted pool without the displayed ceiling ever growing to match — drifting the two out of sync over a long session, and producing exactly the reported symptom (displayed max HP correct, in-battle HP wildly off).

**Fix:** persist *damage taken* relative to the relic-inflated pool, applied against the relic-free `run.maxHp`, instead of the absolute relic-inflated `hp`. This keeps `run.playerHp` and `run.maxHp` on the same scale regardless of which relic (if any) is equipped, while the relic still fully cushions the player during the fight itself.

## Test plan
- [x] `npm run build` — passes clean
- [x] `npm run test` — 1901/1901 tests pass
- [ ] Manual: equip Worldmender's Crest, win several campaign battles, confirm the node-map HP display stays consistent with in-battle HP across multiple fights

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018ZfMaKWX8X9ZCd1rbuh6aK

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZfMaKWX8X9ZCd1rbuh6aK)_