### PR TITLE
test(campaign): cover HP persistence across relics, upgrades, and events

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo, useReducer, lazy, Suspense } from 'react'
 import { ScreenLoadingFallback } from './components/ScreenLoadingFallback'
-import { resolvedNodeOpts, loadHandicap, HANDICAP_KEY, buildQuickBattleOpts, loadCurrentDeckInfo } from './game/campaignHelpers'
+import { resolvedNodeOpts, loadHandicap, HANDICAP_KEY, buildQuickBattleOpts, loadCurrentDeckInfo, carryHpAfterBattle, applyRestHeal, applyEventHeal } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
 import { getGlStats } from './utils/pixiTelemetry'
@@ -1655,7 +1655,7 @@ export default function App() {
 
     for (const effect of effects) {
       if (effect.type === 'healHp') {
-        updatedRun = { ...updatedRun, playerHp: Math.min(updatedRun.maxHp, updatedRun.playerHp + effect.amount) }
+        updatedRun = { ...updatedRun, playerHp: applyEventHeal(updatedRun.playerHp, updatedRun.maxHp, effect.amount) }
       } else if (effect.type === 'damageHp') {
         if (!isNoDamageMode()) {
           updatedRun = { ...updatedRun, playerHp: Math.max(1, updatedRun.playerHp - effect.amount) }
@@ -1896,17 +1896,12 @@ export default function App() {
     }
     campaignPlayCountsRef.current = {}
 
-    // Update run HP and counts from battle result.
-    // gameState.playerBase is scaled to include any equipped relic's HP bonus (applied
-    // fresh each battle — see relics.ts), which run.maxHp deliberately excludes. Carrying
-    // gameState.playerBase.hp straight into run.playerHp would permanently bank that relic
-    // bonus into the persisted HP pool without run.maxHp ever growing to match, drifting
-    // the two out of sync over repeated battles. Instead, carry forward the damage taken
-    // relative to the relic-inflated pool, applied against the relic-free run.maxHp.
-    const dmgTaken = gameState.playerBase.maxHp - gameState.playerBase.hp
+    // Update run HP and counts from battle result (see carryHpAfterBattle for why this
+    // isn't a straight copy of gameState.playerBase.hp — that value can include a
+    // relic's transient HP bonus, which run.maxHp deliberately excludes).
     const updatedRun: RunState = {
       ...currentRun,
-      playerHp: Math.max(0, currentRun.maxHp - dmgTaken),
+      playerHp: carryHpAfterBattle(currentRun.maxHp, gameState.playerBase),
       completedNodeIds: [...currentRun.completedNodeIds, nodeId],
       pendingNodeId: null,
       cardPlayCounts: mergedCounts,
@@ -2014,14 +2009,9 @@ export default function App() {
     let resultMessage = ''
 
     if (choice === 'heal') {
-      if (updatedRun.playerHp >= updatedRun.maxHp) {
-        updatedRun.playerHp = updatedRun.playerHp + healAmount
-        resultMessage = `Already at full health — gained +${healAmount} bonus HP above your maximum!`
-      } else {
-        const gained = Math.min(healAmount, updatedRun.maxHp - updatedRun.playerHp)
-        updatedRun.playerHp = Math.min(updatedRun.playerHp + healAmount, updatedRun.maxHp)
-        resultMessage = `Healed ${gained} HP. (${currentRun.playerHp} → ${updatedRun.playerHp})`
-      }
+      const healed = applyRestHeal(updatedRun.playerHp, updatedRun.maxHp, healAmount)
+      updatedRun.playerHp = healed.hp
+      resultMessage = healed.message
       playRestHeal()
     } else if (choice === 'rest') {
       const fatigued = loadFatigued()

--- a/web/src/game/campaignHelpers.ts
+++ b/web/src/game/campaignHelpers.ts
@@ -163,3 +163,50 @@ export function resolvedNodeOpts(
     bossSpawnKillPct,
   }
 }
+
+// ─── Campaign HP carry-forward ─────────────────────────────────────────────
+
+/**
+ * Computes the run's persisted current HP after a campaign battle win.
+ *
+ * `playerBase` (from the just-finished GameState) may be scaled up by an
+ * equipped relic's flat HP bonus — relics.ts applies that bonus fresh to
+ * both `hp` and `maxHp` at the start of every battle, and it is deliberately
+ * excluded from `run.maxHp` (the relic is meant to be a transient per-battle
+ * cushion, not a permanent stat). Carrying `playerBase.hp` straight into
+ * `run.playerHp` would silently bank that bonus into the persisted pool
+ * without `run.maxHp` ever growing to match, drifting the two apart over
+ * repeated battles. Instead, measure damage taken against the (possibly
+ * relic-inflated) battle pool and re-apply it to the relic-free run.maxHp,
+ * so run.playerHp and run.maxHp always stay on the same scale.
+ */
+export function carryHpAfterBattle(runMaxHp: number, playerBase: { hp: number; maxHp: number }): number {
+  const dmgTaken = playerBase.maxHp - playerBase.hp
+  return Math.max(0, runMaxHp - dmgTaken)
+}
+
+/**
+ * Applies a node-map event's `healHp` effect. Unlike the rest-node heal
+ * choice, event healing always clamps to maxHp — events never grant an
+ * overheal above the player's maximum.
+ */
+export function applyEventHeal(playerHp: number, maxHp: number, amount: number): number {
+  return Math.min(maxHp, playerHp + amount)
+}
+
+/**
+ * Applies a rest-node "heal" choice. Normally clamps to maxHp, but if the
+ * player is already at full health, grants the heal as bonus HP above their
+ * maximum instead of wasting it — this is an intentional overheal, not a bug.
+ */
+export function applyRestHeal(playerHp: number, maxHp: number, healAmount: number): { hp: number; message: string } {
+  if (playerHp >= maxHp) {
+    return {
+      hp: playerHp + healAmount,
+      message: `Already at full health — gained +${healAmount} bonus HP above your maximum!`,
+    }
+  }
+  const gained = Math.min(healAmount, maxHp - playerHp)
+  const hp = Math.min(playerHp + healAmount, maxHp)
+  return { hp, message: `Healed ${gained} HP. (${playerHp} → ${hp})` }
+}

--- a/web/src/game/campaignHp.test.ts
+++ b/web/src/game/campaignHp.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Coverage for the campaign HP-carry-forward bug (max HP display drifting from
+ * in-battle HP when a relic with a flat HP bonus is equipped) and the
+ * surrounding HP-persistence surface: permanent stat upgrades, relic
+ * equip/swap/break, node-map events, rest-node overheal, and archetype
+ * selection (which should have no effect on base HP at all).
+ *
+ * sound.ts and debug.ts are stubbed so engine.ts's newGame() runs in Node
+ * without a DOM (same pattern as engine.test.ts).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('./sound', () => ({
+  playUnitDeath: vi.fn(),
+  playBuildingDestroyed: vi.fn(),
+  playCardPlay: vi.fn(),
+  playUpgrade: vi.fn(),
+  playBaseHit: vi.fn(),
+  playVictory: vi.fn(),
+  playDefeat: vi.fn(),
+}))
+
+vi.mock('./debug', () => ({
+  isNoDamageMode: () => false,
+}))
+
+// Minimal in-memory localStorage for the Node test environment.
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem:    (k: string) => storage.get(k) ?? null,
+  setItem:    (k: string, v: string) => { storage.set(k, String(v)) },
+  removeItem: (k: string) => { storage.delete(k) },
+  clear:      () => { storage.clear() },
+})
+
+import { newGame } from './engine'
+import type { GameState, Archetype } from './types'
+import { newRun, type RunState } from './questline'
+import { loadPlayerStats, savePlayerStats, applyStatUpgrade, type PlayerStats } from './playerStats'
+import { getRelicDef } from './relics'
+import { carryHpAfterBattle, applyRestHeal, applyEventHeal } from './campaignHelpers'
+
+beforeEach(() => storage.clear())
+
+const DEFAULT_STATS: PlayerStats = {
+  maxHp: 50, maxMana: 5, maxDeckSize: 30, maxLives: 3, manaRegenMs: 3000,
+}
+
+/** Builds a battle GameState the way App.tsx does when entering a campaign node. */
+function enterBattle(run: RunState): GameState {
+  const state = newGame()
+  state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
+  if (run.activeRelic) getRelicDef(run.activeRelic)?.applyToGame(state)
+  if (run.archetype) state.archetypePassive = run.archetype
+  return state
+}
+
+/** Simulates a battle ending with `damage` taken off the (possibly relic-inflated) pool, then carries HP back into the run — mirrors handleCampaignWin. */
+function winBattle(run: RunState, state: GameState, damage: number): RunState {
+  state.playerBase.hp = Math.max(0, state.playerBase.hp - damage)
+  return { ...run, playerHp: carryHpAfterBattle(run.maxHp, state.playerBase) }
+}
+
+// ─── Permanent stat upgrades → new runs ────────────────────────────────────
+
+describe('permanent maxHp upgrades feed into newRun()', () => {
+  it('a fresh run starts at full health, matching the current pStats.maxHp', () => {
+    savePlayerStats({ ...DEFAULT_STATS })
+    const run = newRun('act1')
+    expect(run.maxHp).toBe(50)
+    expect(run.playerHp).toBe(50)
+  })
+
+  it('three completed-campaign upgrades (+10 each) raise a subsequent run to 80', () => {
+    savePlayerStats({ ...DEFAULT_STATS })
+    applyStatUpgrade('maxHp')
+    applyStatUpgrade('maxHp')
+    applyStatUpgrade('maxHp')
+    expect(loadPlayerStats().maxHp).toBe(80)
+
+    const run = newRun('act1')
+    expect(run.maxHp).toBe(80)
+    expect(run.playerHp).toBe(80)
+  })
+})
+
+// ─── The reported scenario: 80 max HP + Worldmender's Crest ────────────────
+
+describe('80 max HP + Worldmender’s Crest at battle start', () => {
+  it('goes into battle at full 80 current HP, with a 110 relic-inflated ceiling', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    const state = enterBattle(run)
+
+    // Worldmender's Crest adds +30 base HP — applied to both hp and maxHp so a
+    // fresh, undamaged run enters battle at full health on the new ceiling.
+    expect(state.playerBase.maxHp).toBe(110)
+    expect(state.playerBase.hp).toBe(110)
+    // The player's actual current HP going in (relative to their real 80 max) is
+    // the full 80 — never something lower, regardless of the relic.
+    expect(state.playerBase.hp - (state.playerBase.maxHp - run.maxHp)).toBe(80)
+  })
+})
+
+// ─── Regression: relic bonus must not leak into persisted run HP ──────────
+
+describe('carryHpAfterBattle — relic HP bonus never leaks into run.maxHp', () => {
+  it('with no relic, HP carries forward as plain damage taken', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+
+    const state = enterBattle(run)
+    run = winBattle(run, state, 22)
+
+    expect(run.maxHp).toBe(80)
+    expect(run.playerHp).toBe(58)
+  })
+
+  it('with Worldmender’s Crest equipped, run.maxHp never drifts across many battles', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    // Fight five battles in a row, taking damage each time, without ever
+    // reloading from localStorage (the only place the old code's drift got
+    // silently papered over). run.maxHp must stay exactly 80 throughout, and
+    // the displayed current HP must always be <= 80.
+    const damagePerBattle = [10, 15, 5, 20, 8]
+    for (const dmg of damagePerBattle) {
+      const state = enterBattle(run)
+      // Confirm the relic really did cushion this battle before applying damage.
+      expect(state.playerBase.maxHp).toBe(run.maxHp + 30)
+      run = winBattle(run, state, dmg)
+      expect(run.maxHp).toBe(80)
+      expect(run.playerHp).toBeLessThanOrEqual(80)
+    }
+
+    const totalDamage = damagePerBattle.reduce((a, b) => a + b, 0)
+    expect(run.playerHp).toBe(80 - totalDamage)
+  })
+
+  it('a full-health battle with the relic leaves the run at full health, not reduced', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    const state = enterBattle(run)
+    // No damage taken this battle.
+    run = winBattle(run, state, 0)
+
+    expect(run.maxHp).toBe(80)
+    expect(run.playerHp).toBe(80)
+  })
+})
+
+// ─── Relic swapped or broken mid-run ───────────────────────────────────────
+
+describe('relic swap / break between battles', () => {
+  it('swapping to a different relic does not carry over the old relic’s HP bonus', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    // Battle 1: take some damage under Worldmender's Crest (+30 base HP).
+    let state = enterBattle(run)
+    run = winBattle(run, state, 25)
+    expect(run.maxHp).toBe(80)
+    expect(run.playerHp).toBe(55)
+
+    // Swap to Bark Shield (+10 base HP) between battles — as happens at act-end
+    // relic selection.
+    run = { ...run, activeRelic: 'Bark Shield' }
+    state = enterBattle(run)
+    expect(state.playerBase.maxHp).toBe(90) // 80 + 10, not 80 + 30 + 10
+    expect(state.playerBase.hp).toBe(65)    // 55 + 10, not 55 + 30 + 10
+
+    run = winBattle(run, state, 0)
+    expect(run.maxHp).toBe(80)
+    expect(run.playerHp).toBe(55) // unchanged — no damage this battle
+  })
+
+  it('breaking/unequipping a relic entirely drops its bonus cleanly', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    let state = enterBattle(run)
+    run = winBattle(run, state, 10)
+    expect(run.playerHp).toBe(70)
+
+    // Relic breaks — no longer equipped.
+    run = { ...run, activeRelic: null }
+    state = enterBattle(run)
+    expect(state.playerBase.maxHp).toBe(80) // no relic bonus at all
+    expect(state.playerBase.hp).toBe(70)
+
+    run = winBattle(run, state, 15)
+    expect(run.maxHp).toBe(80)
+    expect(run.playerHp).toBe(55)
+  })
+})
+
+// ─── Archetype has no effect on base HP ────────────────────────────────────
+
+describe('archetype/subclass selection does not affect base HP', () => {
+  const archetypes: Archetype[] = ['siege_commander', 'swarm_tactician', 'arcane_scholar']
+
+  it.each(archetypes)('%s leaves playerBase hp/maxHp identical to no archetype', (archetype) => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    const baseRun = newRun('act1')
+
+    const withoutArchetype = enterBattle(baseRun)
+    const withArchetype = enterBattle({ ...baseRun, archetype })
+
+    expect(withArchetype.playerBase.hp).toBe(withoutArchetype.playerBase.hp)
+    expect(withArchetype.playerBase.maxHp).toBe(withoutArchetype.playerBase.maxHp)
+  })
+})
+
+// ─── Node-map events: healHp clamps, rest-node heal can overheal ──────────
+
+describe('applyEventHeal — node-map event healHp effect', () => {
+  it('clamps to maxHp — events never grant an overheal', () => {
+    expect(applyEventHeal(70, 80, 25)).toBe(80)
+  })
+
+  it('does not clamp below the target when already under max', () => {
+    expect(applyEventHeal(50, 80, 10)).toBe(60)
+  })
+
+  it('a full-health player gains nothing from an event heal (unlike the rest-node choice)', () => {
+    expect(applyEventHeal(80, 80, 15)).toBe(80)
+  })
+})
+
+describe('applyRestHeal — rest-node heal choice', () => {
+  it('clamps a normal heal to maxHp', () => {
+    const result = applyRestHeal(70, 80, 15)
+    expect(result.hp).toBe(80)
+    expect(result.message).toContain('Healed 10 HP')
+  })
+
+  it('grants bonus HP above maxHp when already at full health', () => {
+    const result = applyRestHeal(80, 80, 5)
+    expect(result.hp).toBe(85)
+    expect(result.message).toContain('bonus HP above your maximum')
+  })
+
+  it('an overheal carries forward correctly on the player’s next battle', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 80 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    const healed = applyRestHeal(run.playerHp, run.maxHp, 5)
+    run = { ...run, playerHp: healed.hp }
+    expect(run.playerHp).toBe(85) // 5 HP above the 80 max
+
+    // Entering battle: the relic adds its +30 to both hp and maxHp, so the
+    // overheal buffer is preserved relative to the new ceiling too.
+    const state = enterBattle(run)
+    expect(state.playerBase.maxHp).toBe(110)
+    expect(state.playerBase.hp).toBe(115)
+
+    // Ending the battle undamaged carries the overheal back through untouched.
+    run = winBattle(run, state, 0)
+    expect(run.playerHp).toBe(85)
+    expect(run.maxHp).toBe(80)
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #2044 (merged), which fixed a bug where an equipped relic's flat HP bonus (e.g. Worldmender's Crest) leaked into the persisted run HP, drifting it out of sync with the displayed max HP over repeated battles. This PR adds regression coverage and extends it to the surrounding HP-persistence surface.

- Extracts the campaign HP math that previously lived inline in `App.tsx` into pure, testable helpers in `campaignHelpers.ts` (no behavior change):
  - `carryHpAfterBattle` — the relic-drift fix from #2044
  - `applyEventHeal` — node-map event `healHp` clamp (never overheals)
  - `applyRestHeal` — rest-node heal choice (can overheal above max when already at full health, by design)
- Adds `campaignHp.test.ts` covering:
  - Permanent `maxHp` stat upgrades (earned from completing campaigns) feeding correctly into a fresh `newRun()`
  - The exact reported scenario: a run with 80 max HP + Worldmender's Crest genuinely enters battle at full 80 current HP (110 relic-inflated ceiling)
  - Regression: `run.maxHp` never drifts and HP never silently inflates across many consecutive relic-equipped battles
  - Relic swapped for a different one, or broken/unequipped, mid-run — no leftover "ghost" bonus from the old relic
  - Archetype/subclass selection has no effect on base HP (regression guard)
  - Node-map event healing always clamps to max HP, while the rest-node heal choice intentionally grants bonus HP above max when already full

## Test plan
- [x] `npm run build` — passes clean
- [x] `npm run test` — 1918/1918 tests pass (17 new)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018ZfMaKWX8X9ZCd1rbuh6aK

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZfMaKWX8X9ZCd1rbuh6aK)_