### PR TITLE
fix(campaign): battle HP bar shows full max (80/80) instead of 58/80

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { useRegisterSW } from 'virtual:pwa-register/react'
 import { GameState, Card, StanceRules, Archetype, SECRET_RARITIES } from './game/types'
 import { newGame, MAX_HANDICAP } from './game/engine'
 import { playCard, playAoeCard } from './game/engine/cards'
+import { syncPlayerCommanderToBase } from './game/engine/helpers'
 import { makeNodeDeck } from './game/cards'
 import { battleReducer, INITIAL_BATTLE_STATE, TICK_MS } from './game/battleReducer'
 import {
@@ -390,6 +391,7 @@ export default function App() {
         const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
         state.playerBase = { hp: savedRun.playerHp, maxHp: savedRun.maxHp }
         if (savedRun.activeRelic) getRelicDef(savedRun.activeRelic)?.applyToGame(state)
+        syncPlayerCommanderToBase(state)
         if (startupArch) state.archetypePassive = startupArch
         return { screen: 'playing' as Screen, gameState: state as GameState | null, run: savedRun, isCampaign: true }
       }
@@ -572,6 +574,7 @@ export default function App() {
           const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
           state.playerBase = { hp: savedRun.playerHp, maxHp: savedRun.maxHp }
           if (savedRun.activeRelic) getRelicDef(savedRun.activeRelic)?.applyToGame(state)
+          syncPlayerCommanderToBase(state)
           if (startupArch) state.archetypePassive = startupArch
           dispatch({ type: 'START', gameState: state })
           setRun(savedRun)
@@ -1327,6 +1330,7 @@ export default function App() {
           const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods) })
           state.playerBase = { hp: activeRun.playerHp, maxHp: activeRun.maxHp }
           if (activeRun.activeRelic) getRelicDef(activeRun.activeRelic)?.applyToGame(state)
+          syncPlayerCommanderToBase(state)
           state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
           startBattle(state)
           rollRareEvent()
@@ -1602,6 +1606,7 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods733) })
     state.playerBase = { hp: updatedRun.playerHp, maxHp: updatedRun.maxHp }
     if (updatedRun.activeRelic) getRelicDef(updatedRun.activeRelic)?.applyToGame(state)
+    syncPlayerCommanderToBase(state)
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
@@ -1632,6 +1637,7 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), mods761) })
     state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
     if (run.activeRelic) getRelicDef(run.activeRelic)?.applyToGame(state)
+    syncPlayerCommanderToBase(state)
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()
@@ -2352,6 +2358,7 @@ export default function App() {
     const state = newGame({ playerCards, ...resolvedNodeOpts(node, act, loadRunCount(), modsRetry) })
     state.playerBase = { hp: withFail.playerHp, maxHp: withFail.maxHp }
     if (withFail.activeRelic) getRelicDef(withFail.activeRelic)?.applyToGame(state)
+    syncPlayerCommanderToBase(state)
     state.stanceRules = STANCE_RULES_BY_NODE_TYPE[node.type]
     startBattle(state)
     rollRareEvent()

--- a/web/src/game/campaignHp.test.ts
+++ b/web/src/game/campaignHp.test.ts
@@ -33,8 +33,9 @@ vi.stubGlobal('localStorage', {
   clear:      () => { storage.clear() },
 })
 
-import { newGame } from './engine'
+import { newGame, tick } from './engine'
 import type { GameState, Archetype } from './types'
+import { syncPlayerCommanderToBase } from './engine/helpers'
 import { newRun, type RunState } from './questline'
 import { loadPlayerStats, savePlayerStats, applyStatUpgrade, type PlayerStats } from './playerStats'
 import { getRelicDef } from './relics'
@@ -51,6 +52,9 @@ function enterBattle(run: RunState): GameState {
   const state = newGame()
   state.playerBase = { hp: run.playerHp, maxHp: run.maxHp }
   if (run.activeRelic) getRelicDef(run.activeRelic)?.applyToGame(state)
+  // The player commander unit is the base avatar; the engine syncs its hp into
+  // playerBase.hp every tick, so App.tsx reconciles it after relic setup.
+  syncPlayerCommanderToBase(state)
   if (run.archetype) state.archetypePassive = run.archetype
   return state
 }
@@ -101,6 +105,61 @@ describe('80 max HP + Worldmender’s Crest at battle start', () => {
     // The player's actual current HP going in (relative to their real 80 max) is
     // the full 80 — never something lower, regardless of the relic.
     expect(state.playerBase.hp - (state.playerBase.maxHp - run.maxHp)).toBe(80)
+  })
+})
+
+// ─── The HP bar after the game loop runs (regression for the 58/80 bug) ────
+//
+// The player "base" on the battlefield is a commander unit in state.field, and
+// every engine tick syncs commander.hp → playerBase.hp. newGame() spawns that
+// commander at a fixed HP, so unless battle setup reconciles it with the run's
+// max HP (+ relic baseHp), the first tick drags the current-HP bar down to the
+// commander's stale value. These tests run a tick so that sync actually fires —
+// the earlier assertions read playerBase before any tick and so missed the bug.
+
+describe('current-HP bar stays correct after the first engine tick', () => {
+  it('50 base HP + Worldmender’s Crest enters battle at 80/80, not 58/80', () => {
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 50 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest" }
+
+    let state = enterBattle(run)
+    // Advance one game loop so the commander → playerBase.hp sync runs.
+    state = tick(state, 16)
+
+    // Base = 50 + 30 (relic baseHp); the +8 unit HP must NOT leak onto the base.
+    expect(state.playerBase.maxHp).toBe(80)
+    expect(state.playerBase.hp).toBe(80)
+  })
+
+  it('a permanent maxHp upgrade to 80 (no relic) enters battle at 80/80, not 50/80', () => {
+    savePlayerStats({ ...DEFAULT_STATS })
+    applyStatUpgrade('maxHp')
+    applyStatUpgrade('maxHp')
+    applyStatUpgrade('maxHp')
+    const run = newRun('act1')
+    expect(run.maxHp).toBe(80)
+
+    let state = enterBattle(run)
+    state = tick(state, 16)
+
+    // The upgraded max HP must reach the commander so it grants real survivability.
+    expect(state.playerBase.maxHp).toBe(80)
+    expect(state.playerBase.hp).toBe(80)
+  })
+
+  it('a partially-damaged run + Crest correctly shows the damaged total, not full', () => {
+    // run at 28/50 (22 damage taken previously) re-entering with the Crest should
+    // read 58/80 — that value is only wrong when the player is actually at full HP.
+    savePlayerStats({ ...DEFAULT_STATS, maxHp: 50 })
+    let run = newRun('act1')
+    run = { ...run, activeRelic: "Worldmender's Crest", playerHp: 28 }
+
+    let state = enterBattle(run)
+    state = tick(state, 16)
+
+    expect(state.playerBase.maxHp).toBe(80)
+    expect(state.playerBase.hp).toBe(58)
   })
 })
 

--- a/web/src/game/engine/helpers.ts
+++ b/web/src/game/engine/helpers.ts
@@ -1,5 +1,5 @@
 import { logError } from '../../logger';
-import { Card, UnitTemplate, Unit, LANE_WIDTH } from '../types';
+import { Card, UnitTemplate, Unit, GameState, LANE_WIDTH } from '../types';
 import { rollSecretRarity, makeShinyVariant, makeHolofoilVariant, makeGlassVariant } from '../secretRarities';
 import { getCardCatalog, COMMANDER_UNIT, WARLORD_UNIT } from '../cards';
 import { PLAYER_SPAWN_X, OPPONENT_SPAWN_X, COMMANDER_HOME_X } from './constants';
@@ -105,4 +105,21 @@ export function spawnCommander(owner: 'player' | 'opponent', hp: number): Unit {
   unit.x              = homeX
   unit.y              = 0
   return unit
+}
+
+/**
+ * The player's on-field commander unit is the base avatar, and the engine syncs
+ * commander.hp → playerBase.hp every tick (see updateGame). newGame() spawns that
+ * commander at a fixed HP, so after campaign battle setup adjusts state.playerBase
+ * (from run HP + permanent maxHp upgrades + relic baseHp bonus), the commander must
+ * be brought in line — otherwise the tick sync pulls the HP bar and game-over check
+ * back down to the commander's stale value. Running this after applyToGame also
+ * discards any army-unit relic bonus (unitHp) that leaked onto the base commander.
+ */
+export function syncPlayerCommanderToBase(state: GameState): void {
+  const cmd = state.field.find(u => u.isCommander && u.owner === 'player')
+  if (cmd) {
+    cmd.maxHp = state.playerBase.maxHp
+    cmd.hp    = state.playerBase.hp
+  }
 }


### PR DESCRIPTION
## Problem

Starting a fresh campaign with 50 base max HP and the **Worldmender's Crest** relic, the first battle displayed health as **58/80** instead of the expected **80/80**.

## Root cause

The player's on-field "base" is actually a **commander unit** in `state.field`, and the engine syncs `commander.hp → playerBase.hp` on every tick (`engine.ts:574-575`). But:

- `newGame()` spawns that commander at a hardcoded **50 HP** (`engine.ts:292`).
- Every campaign battle-entry site in `App.tsx` updated **only** `state.playerBase` (from run HP + relic), never the commander unit.
- The crest's `baseHp +30` lifts `playerBase.maxHp` to **80**, but its `unitHp +8` loops over player field units and lands on the commander (the only one present at battle start), making it **58**.
- The per-tick sync then pins the current-HP bar to the commander's **58** → **58/80**.

The same gap meant **permanent maxHp upgrades** never reached the commander either: an upgraded 80-max run entered battle at **50/80** and actually died at 50 damage (game-over keys off the commander's HP).

## Fix

Add `syncPlayerCommanderToBase(state)` and call it right after `applyToGame` at all six campaign battle-entry sites, so the commander reflects the true base HP (`run.maxHp` + relic `baseHp`). This:

- Shows **80/80** for a fresh 50-HP run + Crest.
- Gives permanent maxHp upgrades real survivability (**80/80**, not 50/80).
- Discards the stray `unitHp` bump that was leaking onto the base (the +8 is meant for army units, per the relic text).

Damaged runs are unaffected — a run already at 28/50 correctly re-enters at 58/80, since damage is still measured against the relic-inflated pool by `carryHpAfterBattle`.

## Tests

The existing `campaignHp.test.ts` missed this because its `enterBattle` helper read `state.playerBase` **before any tick** fired the commander→base sync. Updated it to run an engine tick, and added regression cases for: 50 base + Crest → 80/80, permanent-upgrade → 80/80, and a damaged run + Crest → 58/80.

- `npx vitest run` — **1921 passed**, 0 failures.
- `npx tsc --noEmit` — clean.

## Out of scope

The crest's *"all units gain +6 ATK and +8 max HP"* does not actually reach **deployed** army units (`applyToGame` runs once at battle start when only the commander is present, and unit bonuses aren't re-applied on deploy). That's a separate relic-effectiveness bug and left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113yKnjAxBUaD1YQsFLdxdJ)_