### PR TITLE
Battlefield editor: manual decor, path-drawn blocking terrain, seamless road merging

### DIFF
--- a/web/src/components/battle/BattlefieldCanvas.tsx
+++ b/web/src/components/battle/BattlefieldCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useState, useCallback } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import {
-  buildTerrainGfx, buildBgTileGfx, buildRoadGfx, buildBorderGfx, buildDecorGfx,
+  buildTerrainGfx, buildBgTileGfx, buildRoadGfx, buildBorderGfx, buildDecorGfx, buildManualDecorGfx,
   buildTerrainDecorGfx, gameToPixel, pixelToGame,
 } from '../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
@@ -115,7 +115,8 @@ function CanvasInner(props: LiveProps) {
     buildBgTileGfx(scene.bg, { environment: state.environment, envDef }, w, h)
     buildRoadGfx(scene.road, state.roads ?? [], { environment: state.environment, envDef }, w, h)
     buildBorderGfx(scene.border, { environment: state.environment, envDef }, w, h)
-    buildDecorGfx(scene.decor, { environment: state.environment, envDef, id: state.environment }, w, h)
+    if (state.decor?.length) buildManualDecorGfx(scene.decor, state.decor, w, h)
+    else buildDecorGfx(scene.decor, { environment: state.environment, envDef, id: state.environment }, w, h)
     buildTerrainDecorGfx(scene.decorObstacles, state.terrain ?? [], { environment: state.environment, envDef }, w, h)
   }, [w, h, envDef]))
 

--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useEffect, useState } from 'react'
 import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx, buildTerrainDecorGfx, buildRoadGfx } from '../../../utils/terrainLayer'
+import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildManualDecorGfx, buildBorderGfx, buildTerrainDecorGfx, buildRoadGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
-import type { TerrainObstacle, RoadDef } from '../../../game/engine/terrain'
+import type { TerrainObstacle, RoadDef, BattlefieldDecorItem } from '../../../game/engine/terrain'
 
 export interface Props {
   environment?: string
@@ -13,10 +13,12 @@ export interface Props {
   terrain?: TerrainObstacle[]
   /** Act/node-authored road paths. Rendered only — does not affect unit movement. */
   roads?: RoadDef[]
+  /** Act/node-authored manual decor placements. When non-empty, replaces the procedural decor scatter. */
+  decor?: BattlefieldDecorItem[]
 }
 
 // Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
-function TerrainPixi({ environment, id, terrain, roads, w, h }: Props & { w: number; h: number }) {
+function TerrainPixi({ environment, id, terrain, roads, decor: decorItems, w, h }: Props & { w: number; h: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const envDef = WORLD_ENV_TILES[environment ?? ''] ?? ENV_TILES[environment ?? '']
 
@@ -36,7 +38,8 @@ function TerrainPixi({ environment, id, terrain, roads, w, h }: Props & { w: num
     buildBgTileGfx(bg, { environment, envDef }, w, h)
     buildRoadGfx(road, roads ?? [], { environment, envDef }, w, h)
     buildBorderGfx(border, { environment, envDef }, w, h)
-    buildDecorGfx(decor, { environment, envDef, id }, w, h)
+    if (decorItems?.length) buildManualDecorGfx(decor, decorItems, w, h)
+    else buildDecorGfx(decor, { environment, envDef, id }, w, h)
     buildTerrainDecorGfx(decorObstacles, terrain ?? [], { environment, envDef }, w, h)
   })
 
@@ -48,7 +51,7 @@ function TerrainPixi({ environment, id, terrain, roads, w, h }: Props & { w: num
  * Measures its container after mount, then renders a PixiJS tile scene.
  * Replaces the SVG layer approach of BattlefieldBackground.
  */
-export function BattlefieldTerrainCanvas({ environment, id, terrain, roads }: Props) {
+export function BattlefieldTerrainCanvas({ environment, id, terrain, roads, decor }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
 
@@ -85,7 +88,7 @@ export function BattlefieldTerrainCanvas({ environment, id, terrain, roads }: Pr
       {/* Re-key on size/environment/id so the Pixi scene remounts and rebuilds — usePixiApp's
           onReady closure only runs once per mount, so changing terrain/environment/id alone
           (with the same dimensions) would otherwise silently keep rendering the stale scene. */}
-      {dims && <TerrainPixi key={`${dims.w}x${dims.h}-${environment}-${id}`} environment={environment} id={id} terrain={terrain} roads={roads} w={dims.w} h={dims.h} />}
+      {dims && <TerrainPixi key={`${dims.w}x${dims.h}-${environment}-${id}`} environment={environment} id={id} terrain={terrain} roads={roads} decor={decor} w={dims.w} h={dims.h} />}
     </div>
   )
 }

--- a/web/src/components/battlefieldEditor/BattlefieldDecorPalette.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldDecorPalette.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useMemo } from 'react'
+import { WORLD_DECOR, WORLD_DECOR_FILE } from '../../data/tiles/worldTileIndex'
+
+const T = 32
+const COLS = 8
+
+export interface Props {
+  activeTileId: number
+  onSelectTile: (tileId: number) => void
+}
+
+function DecorCell({
+  tileKey,
+  tileId,
+  isSelected,
+  onClick,
+}: {
+  tileKey: string
+  tileId: number
+  isSelected: boolean
+  onClick: () => void
+}) {
+  const col = tileId % COLS
+  const row = Math.floor(tileId / COLS)
+  return (
+    <div
+      title={tileKey}
+      onClick={onClick}
+      style={{
+        width:              T,
+        height:             T,
+        backgroundImage:    `url("${WORLD_DECOR_FILE}")`,
+        backgroundPosition: `-${col * T}px -${row * T}px`,
+        backgroundRepeat:   'no-repeat',
+        imageRendering:     'pixelated',
+        cursor:             'pointer',
+        outline:            isSelected ? '2px solid #f0c040' : '1px solid transparent',
+        outlineOffset:      '-1px',
+        flexShrink:         0,
+      }}
+    />
+  )
+}
+
+/**
+ * Decor tile picker for the battlefield editor — a scoped-down sibling of
+ * mapEditor/TilePalette.tsx sourcing from WORLD_DECOR (nodemap/32x32/decor.png)
+ * instead of BASE_CHIP_TILES. No tabs/bundles/z-layer (out of scope for
+ * battlefield decor); every WORLD_DECOR entry is shown flat, including
+ * composite-object halves (castles, mountains, bridges) — pairing them
+ * correctly is left to the artist.
+ */
+export function BattlefieldDecorPalette({ activeTileId, onSelectTile }: Props) {
+  const [search, setSearch] = useState('')
+
+  const entries = useMemo(() => Object.entries(WORLD_DECOR) as Array<[string, number]>, [])
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return entries
+    const q = search.toLowerCase()
+    return entries.filter(([key]) => key.toLowerCase().includes(q))
+  }, [entries, search])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#1a1a2e', color: '#ccc', fontSize: 12 }}>
+      <div style={{ padding: '6px 8px', borderBottom: '1px solid #333' }}>
+        <input
+          type="text"
+          placeholder="Search decor…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{
+            width: '100%', padding: '4px 6px', background: '#111', border: '1px solid #444',
+            color: '#ccc', borderRadius: 3, fontSize: 12, boxSizing: 'border-box',
+          }}
+        />
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto', display: 'flex', flexWrap: 'wrap', padding: 4, gap: 2, alignContent: 'flex-start' }}>
+        {filtered.map(([key, tileId]) => (
+          <DecorCell
+            key={key}
+            tileKey={key}
+            tileId={tileId}
+            isSelected={activeTileId === tileId}
+            onClick={() => onSelectTile(tileId)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/battlefieldEditor/BattlefieldEditor.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditor.tsx
@@ -3,6 +3,7 @@ import { useBattlefieldEditorState } from './useBattlefieldEditorState'
 import { BattlefieldEditorCanvas } from './BattlefieldEditorCanvas'
 import { BattlefieldEditorInspector } from './BattlefieldEditorInspector'
 import { BattlefieldEditorToolbar } from './BattlefieldEditorToolbar'
+import { BattlefieldDecorPalette } from './BattlefieldDecorPalette'
 import { WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../data/tiles/tileIndex'
 
@@ -27,9 +28,13 @@ export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
   const envDef = WORLD_ENV_TILES[environment] ?? ENV_TILES[environment]
   const roads = editor.resolveRoadsForTarget(state.actData, state.nodeId)
   const terrain = editor.resolveTerrainForTarget(state.actData, state.nodeId)
+  const decor = editor.resolveDecorForTarget(state.actData, state.nodeId)
+  const terrainPaths = editor.resolveTerrainPathsForTarget(state.actData, state.nodeId)
   const roadFollowing = editor.resolveRoadFollowingForTarget(state.actData, state.nodeId)
   const hasNodeRoadsOverride = state.nodeId !== 'act-default' && node?.roads !== undefined
   const hasNodeTerrainOverride = state.nodeId !== 'act-default' && node?.terrain !== undefined
+  const hasNodeDecorOverride = state.nodeId !== 'act-default' && node?.decor !== undefined
+  const hasNodeTerrainPathsOverride = state.nodeId !== 'act-default' && node?.terrainPaths !== undefined
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: '#111', color: '#eee' }}>
@@ -39,7 +44,9 @@ export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
         nodeId={state.nodeId}
         tool={state.tool}
         activeObstacleType={state.activeObstacleType}
+        activePathType={state.activePathType}
         inProgressRoadIndex={state.inProgressRoadIndex}
+        inProgressPathIndex={state.inProgressPathIndex}
         showGuides={showGuides}
         environment={environment}
         roadFollowing={roadFollowing}
@@ -50,7 +57,9 @@ export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
         onSetNodeId={editor.setNodeId}
         onSetTool={editor.setTool}
         onSetActiveObstacleType={editor.setActiveObstacleType}
+        onSetActivePathType={editor.setActivePathType}
         onFinishRoad={editor.finishRoad}
+        onFinishPath={editor.finishPath}
         onToggleGuides={() => setShowGuides(g => !g)}
         onToggleRoadFollowing={() => editor.setRoadFollowing(!roadFollowing)}
         onUndo={editor.undo}
@@ -58,6 +67,14 @@ export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
         onSaved={editor.markSaved}
       />
       <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        {state.tool === 'decor' && (
+          <div style={{ width: 192, flexShrink: 0, borderRight: '1px solid #333', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+            <BattlefieldDecorPalette
+              activeTileId={state.activeDecorTileId}
+              onSelectTile={editor.setActiveDecorTileId}
+            />
+          </div>
+        )}
         <div style={{ flex: 1, position: 'relative' }}>
           <BattlefieldEditorCanvas
             environment={environment}
@@ -65,28 +82,44 @@ export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
             id={`${state.actId}-${state.nodeId}`}
             roads={roads}
             terrain={terrain}
+            decor={decor}
+            terrainPaths={terrainPaths}
             tool={state.tool}
             activeObstacleType={state.activeObstacleType}
+            activeDecorTileId={state.activeDecorTileId}
+            activePathType={state.activePathType}
             inProgressRoadIndex={state.inProgressRoadIndex}
+            inProgressPathIndex={state.inProgressPathIndex}
             selectedEntities={state.selectedEntities}
             showGuides={showGuides}
             onSelectEntities={editor.selectEntities}
             onRoadClick={editor.clickRoadTool}
             onObstacleClick={(x, y) => editor.addObstacle(x, y, state.activeObstacleType)}
+            onDecorClick={(x, y) => editor.addDecor(x, y, state.activeDecorTileId)}
+            onPathClick={editor.clickPathTool}
             onMoveRoadPoint={editor.moveRoadPoint}
             onMoveObstacle={editor.moveObstacle}
+            onMoveDecor={editor.moveDecor}
+            onMovePathPoint={editor.movePathPoint}
             onDeleteRoad={editor.deleteRoad}
             onDeleteRoadPoint={editor.deleteRoadPoint}
             onDeleteObstacle={editor.deleteObstacle}
+            onDeleteDecor={editor.deleteDecor}
+            onDeletePath={editor.deletePath}
+            onDeletePathPoint={editor.deletePathPoint}
           />
         </div>
         <BattlefieldEditorInspector
           selectedEntities={state.selectedEntities}
           roads={roads}
           terrain={terrain}
+          decor={decor}
+          terrainPaths={terrainPaths}
           nodeId={state.nodeId}
           hasNodeRoadsOverride={hasNodeRoadsOverride}
           hasNodeTerrainOverride={hasNodeTerrainOverride}
+          hasNodeDecorOverride={hasNodeDecorOverride}
+          hasNodeTerrainPathsOverride={hasNodeTerrainPathsOverride}
           onUpdateRoad={editor.updateRoad}
           onMoveRoadPoint={editor.moveRoadPoint}
           onDeleteRoad={editor.deleteRoad}
@@ -94,8 +127,17 @@ export function BattlefieldEditor({ initialActId = 'act1' }: Props) {
           onUpdateObstacle={editor.updateObstacle}
           onMoveObstacle={editor.moveObstacle}
           onDeleteObstacle={editor.deleteObstacle}
+          onUpdateDecorTile={editor.updateDecorTile}
+          onMoveDecor={editor.moveDecor}
+          onDeleteDecor={editor.deleteDecor}
+          onUpdatePath={editor.updatePath}
+          onMovePathPoint={editor.movePathPoint}
+          onDeletePath={editor.deletePath}
+          onDeletePathPoint={editor.deletePathPoint}
           onRevertRoads={() => editor.revertToActDefault('roads')}
           onRevertTerrain={() => editor.revertToActDefault('terrain')}
+          onRevertDecor={() => editor.revertToActDefault('decor')}
+          onRevertTerrainPaths={() => editor.revertToActDefault('terrainPaths')}
         />
       </div>
     </div>

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -3,13 +3,13 @@ import * as PIXI from 'pixi.js'
 import { usePixiApp } from '../../hooks/usePixiApp'
 import { useLetterboxSize } from '../../hooks/useLetterboxSize'
 import {
-  buildTerrainGfx, buildBgTileGfx, buildBorderGfx, buildDecorGfx,
+  buildTerrainGfx, buildBgTileGfx, buildBorderGfx, buildDecorGfx, buildManualDecorGfx,
   buildRoadGfx, buildTerrainDecorGfx, gameToPixel, pixelToGame,
 } from '../../utils/terrainLayer'
 import { TILE_SIZE, EnvTileDef } from '../../data/tiles/tileIndex'
-import { TERRAIN_CLEAR_Y } from '../../game/engine/terrain'
+import { TERRAIN_CLEAR_Y, expandTerrainPathsToObstacles } from '../../game/engine/terrain'
 import { BATTLEFIELD_ASPECT_RATIO } from '../../game/types'
-import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity } from './battlefieldEditorTypes'
+import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity, BattlefieldDecorItem, TerrainPathDef } from './battlefieldEditorTypes'
 
 export interface Props {
   environment: string
@@ -18,29 +18,45 @@ export interface Props {
   id: string
   roads: RoadDef[]
   terrain: TerrainObstacle[]
+  decor: BattlefieldDecorItem[]
+  terrainPaths: TerrainPathDef[]
   tool: ToolMode
   activeObstacleType: TerrainType
+  activeDecorTileId: number
+  activePathType: TerrainType
   inProgressRoadIndex: number | null
+  inProgressPathIndex: number | null
   selectedEntities: SelectedEntity[]
   showGuides: boolean
   onSelectEntities: (entities: SelectedEntity[]) => void
   onRoadClick: (x: number, y: number) => void
   onObstacleClick: (x: number, y: number) => void
+  onDecorClick: (x: number, y: number) => void
+  onPathClick: (x: number, y: number) => void
   onMoveRoadPoint: (roadIndex: number, pointIndex: number, x: number, y: number) => void
   onMoveObstacle: (index: number, x: number, y: number) => void
+  onMoveDecor: (index: number, x: number, y: number) => void
+  onMovePathPoint: (pathIndex: number, pointIndex: number, x: number, y: number) => void
   onDeleteRoad: (roadIndex: number) => void
   onDeleteRoadPoint: (roadIndex: number, pointIndex: number) => void
   onDeleteObstacle: (index: number) => void
+  onDeleteDecor: (index: number) => void
+  onDeletePath: (pathIndex: number) => void
+  onDeletePathPoint: (pathIndex: number, pointIndex: number) => void
 }
 
 const HANDLE_RADIUS = 8
 const SELECTED_COLOR = 0xffcc33
 const HANDLE_COLOR = 0x33ccff
 const OBSTACLE_COLOR = 0xff5566
+const DECOR_COLOR = 0x66ffcc
+const PATH_COLOR = 0xcc99ff
 
 type Drag =
   | { kind: 'roadPoint'; roadIndex: number; pointIndex: number }
   | { kind: 'obstacle'; index: number }
+  | { kind: 'decor'; index: number }
+  | { kind: 'pathPoint'; pathIndex: number; pointIndex: number }
 
 // Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
 function EditorPixi(props: Props & { w: number; h: number }) {
@@ -56,11 +72,13 @@ function EditorPixi(props: Props & { w: number; h: number }) {
     stage.hitArea = new PIXI.Rectangle(0, 0, w, h)
 
     stage.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-      const { tool, onRoadClick, onObstacleClick, onSelectEntities } = propsRef.current
+      const { tool, onRoadClick, onObstacleClick, onDecorClick, onPathClick, onSelectEntities } = propsRef.current
       const pos = e.getLocalPosition(stage)
       const { x, y } = pixelToGame(pos.x, pos.y, w, h)
       if (tool === 'road') { onRoadClick(x, y); return }
       if (tool === 'obstacle') { onObstacleClick(x, y); return }
+      if (tool === 'decor') { onDecorClick(x, y); return }
+      if (tool === 'path') { onPathClick(x, y); return }
       if (tool === 'select') { onSelectEntities([]) }
     })
 
@@ -70,7 +88,9 @@ function EditorPixi(props: Props & { w: number; h: number }) {
       const pos = e.getLocalPosition(stage)
       const { x, y } = pixelToGame(pos.x, pos.y, w, h)
       if (drag.kind === 'roadPoint') propsRef.current.onMoveRoadPoint(drag.roadIndex, drag.pointIndex, x, y)
-      else propsRef.current.onMoveObstacle(drag.index, x, y)
+      else if (drag.kind === 'obstacle') propsRef.current.onMoveObstacle(drag.index, x, y)
+      else if (drag.kind === 'decor') propsRef.current.onMoveDecor(drag.index, x, y)
+      else propsRef.current.onMovePathPoint(drag.pathIndex, drag.pointIndex, x, y)
     })
 
     const endDrag = () => { dragRef.current = null }
@@ -99,20 +119,24 @@ function EditorPixi(props: Props & { w: number; h: number }) {
     const bg             = new PIXI.Container()
     const road           = new PIXI.Container()
     const border         = new PIXI.Container()
-    const decor          = new PIXI.Container()
+    const decorLayer     = new PIXI.Container()
     const decorObstacles = new PIXI.Container()
     const world          = new PIXI.Container()
     const guides         = new PIXI.Graphics()
     const editOverlay    = new PIXI.Container()
-    stage.addChild(base, bg, road, border, decor, decorObstacles, world, guides, editOverlay)
+    stage.addChild(base, bg, road, border, decorLayer, decorObstacles, world, guides, editOverlay)
 
-    const { environment, envDef, id, roads, terrain } = props
+    const { environment, envDef, id, roads, terrain, decor, terrainPaths } = props
     buildTerrainGfx(base, new PIXI.Container(), world, { environment, envDef, id, rivers: [], terrainItems: [] }, w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
     buildRoadGfx(road, roads, { environment, envDef }, w, h)
     buildBorderGfx(border, { environment, envDef }, w, h)
-    buildDecorGfx(decor, { environment, envDef, id }, w, h)
-    buildTerrainDecorGfx(decorObstacles, terrain, { environment, envDef }, w, h)
+    if (decor.length > 0) buildManualDecorGfx(decorLayer, decor, w, h)
+    else buildDecorGfx(decorLayer, { environment, envDef, id }, w, h)
+    // WYSIWYG: terrainPaths expand into the exact same TerrainObstacle circles
+    // the engine adds at battle start, so drawn paths render (and dedup edges
+    // against hand-placed obstacles) identically here and in the live game.
+    buildTerrainDecorGfx(decorObstacles, [...terrain, ...expandTerrainPathsToObstacles(terrainPaths)], { environment, envDef }, w, h)
 
     if (props.showGuides) drawGuides(guides, w, h)
     drawEditOverlay(editOverlay, props, w, h, dragRef)
@@ -146,6 +170,15 @@ function isPointSelected(sel: SelectedEntity[], roadIndex: number, pointIndex: n
 function isObstacleSelected(sel: SelectedEntity[], index: number): boolean {
   return sel.some(s => s.type === 'obstacle' && s.index === index)
 }
+function isDecorSelected(sel: SelectedEntity[], index: number): boolean {
+  return sel.some(s => s.type === 'decor' && s.index === index)
+}
+function isPathSelected(sel: SelectedEntity[], pathIndex: number): boolean {
+  return sel.some(s => (s.type === 'terrainPath' && s.index === pathIndex) || (s.type === 'terrainPathPoint' && s.pathIndex === pathIndex))
+}
+function isPathPointSelected(sel: SelectedEntity[], pathIndex: number, pointIndex: number): boolean {
+  return sel.some(s => s.type === 'terrainPathPoint' && s.pathIndex === pathIndex && s.pointIndex === pointIndex)
+}
 
 function drawEditOverlay(
   container: PIXI.Container,
@@ -154,7 +187,10 @@ function drawEditOverlay(
   h: number,
   dragRef: React.MutableRefObject<Drag | null>,
 ) {
-  const { roads, terrain, selectedEntities, tool, onSelectEntities, onDeleteRoad, onDeleteRoadPoint, onDeleteObstacle } = props
+  const {
+    roads, terrain, decor, terrainPaths, selectedEntities, tool, onSelectEntities,
+    onDeleteRoad, onDeleteRoadPoint, onDeleteObstacle, onDeleteDecor, onDeletePath, onDeletePathPoint,
+  } = props
 
   // Road strokes + waypoint handles
   roads.forEach((road, roadIndex) => {
@@ -210,6 +246,62 @@ function drawEditOverlay(
       dragRef.current = { kind: 'obstacle', index }
     })
     container.addChild(handle)
+  })
+
+  // Decor drag handles
+  decor.forEach((item, index) => {
+    const { px, py } = gameToPixel(item.x, item.y, w, h)
+    const selected = isDecorSelected(selectedEntities, index)
+    const handle = new PIXI.Graphics()
+    handle.circle(0, 0, HANDLE_RADIUS).stroke({ color: selected ? SELECTED_COLOR : DECOR_COLOR, width: 3, alpha: 0.95 })
+    handle.position.set(px, py)
+    handle.eventMode = 'static'
+    handle.cursor = 'pointer'
+    handle.hitArea = new PIXI.Circle(0, 0, HANDLE_RADIUS * 2)
+    handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+      e.stopPropagation()
+      if (tool === 'delete') { onDeleteDecor(index); return }
+      onSelectEntities([{ type: 'decor', index }])
+      dragRef.current = { kind: 'decor', index }
+    })
+    container.addChild(handle)
+  })
+
+  // Terrain-path strokes + waypoint handles (mirrors road strokes/handles above)
+  terrainPaths.forEach((path, pathIndex) => {
+    const pts = path.points.map(p => gameToPixel(p.x, p.y, w, h))
+    if (pts.length >= 2) {
+      const line = new PIXI.Graphics()
+      line.moveTo(pts[0].px, pts[0].py)
+      for (let i = 1; i < pts.length; i++) line.lineTo(pts[i].px, pts[i].py)
+      line.stroke({ color: isPathSelected(selectedEntities, pathIndex) ? SELECTED_COLOR : PATH_COLOR, width: 3, alpha: 0.85 })
+      line.eventMode = 'static'
+      line.cursor = 'pointer'
+      line.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        if (tool === 'delete') { onDeletePath(pathIndex); return }
+        onSelectEntities([{ type: 'terrainPath', index: pathIndex }])
+      })
+      container.addChild(line)
+    }
+
+    path.points.forEach((_, pointIndex) => {
+      const { px, py } = pts[pointIndex]
+      const handle = new PIXI.Graphics()
+      const selected = isPathPointSelected(selectedEntities, pathIndex, pointIndex)
+      handle.circle(0, 0, HANDLE_RADIUS).fill({ color: selected ? SELECTED_COLOR : PATH_COLOR, alpha: 0.95 })
+      handle.position.set(px, py)
+      handle.eventMode = 'static'
+      handle.cursor = 'pointer'
+      handle.hitArea = new PIXI.Circle(0, 0, HANDLE_RADIUS * 2)
+      handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
+        e.stopPropagation()
+        if (tool === 'delete') { onDeletePathPoint(pathIndex, pointIndex); return }
+        onSelectEntities([{ type: 'terrainPathPoint', pathIndex, pointIndex }])
+        dragRef.current = { kind: 'pathPoint', pathIndex, pointIndex }
+      })
+      container.addChild(handle)
+    })
   })
 }
 

--- a/web/src/components/battlefieldEditor/BattlefieldEditorInspector.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorInspector.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import type { SelectedEntity, RoadDef, TerrainObstacle, TerrainType, EditTarget } from './battlefieldEditorTypes'
-import { WORLD_PATH_TILE } from '../../data/tiles/worldTileIndex'
+import type { SelectedEntity, RoadDef, TerrainObstacle, TerrainType, EditTarget, BattlefieldDecorItem, TerrainPathDef } from './battlefieldEditorTypes'
+import { WORLD_PATH_TILE, WORLD_DECOR, WORLD_DECOR_FILE } from '../../data/tiles/worldTileIndex'
 
 const TERRAIN_TYPES: TerrainType[] = ['rock', 'tree', 'water', 'ruin']
 const ROAD_TILE_OPTIONS = Object.entries(WORLD_PATH_TILE)
+const DECOR_TILE_OPTIONS = Object.entries(WORLD_DECOR) as Array<[string, number]>
+const DECOR_COLS = 8
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -103,13 +105,105 @@ function ObstacleInspector({ index, obstacle, onUpdateObstacle, onMoveObstacle, 
   )
 }
 
+interface DecorInspectorProps {
+  index: number
+  item: BattlefieldDecorItem
+  onUpdateDecorTile: (index: number, tileId: number) => void
+  onMoveDecor: (index: number, x: number, y: number) => void
+  onDeleteDecor: (index: number) => void
+}
+
+function DecorInspector({ index, item, onUpdateDecorTile, onMoveDecor, onDeleteDecor }: DecorInspectorProps) {
+  const col = item.tileId % DECOR_COLS
+  const row = Math.floor(item.tileId / DECOR_COLS)
+  return (
+    <div>
+      <h4 style={{ margin: '0 0 8px' }}>Decor #{index + 1}</h4>
+      <Field label="Preview">
+        <div
+          style={{
+            width: 32, height: 32,
+            backgroundImage: `url("${WORLD_DECOR_FILE}")`,
+            backgroundPosition: `-${col * 32}px -${row * 32}px`,
+            backgroundRepeat: 'no-repeat',
+            imageRendering: 'pixelated',
+            border: '1px solid #444',
+          }}
+        />
+      </Field>
+      <Field label="Type">
+        <select
+          value={item.tileId}
+          onChange={e => onUpdateDecorTile(index, parseInt(e.target.value, 10))}
+          style={{ width: '100%' }}
+        >
+          {DECOR_TILE_OPTIONS.map(([key, tileId]) => <option key={key} value={tileId}>{key}</option>)}
+        </select>
+      </Field>
+      <Field label="Position (x, y)">
+        <div style={{ display: 'flex', gap: 4 }}>
+          {numInput(Math.round(item.x), v => onMoveDecor(index, v, item.y))}
+          {numInput(Math.round(item.y), v => onMoveDecor(index, item.x, v))}
+        </div>
+      </Field>
+      <button onClick={() => onDeleteDecor(index)}>Delete Decor</button>
+    </div>
+  )
+}
+
+interface TerrainPathInspectorProps {
+  pathIndex: number
+  path: TerrainPathDef
+  onUpdatePath: (pathIndex: number, patch: Partial<Pick<TerrainPathDef, 'type' | 'radius'>>) => void
+  onMovePathPoint: (pathIndex: number, pointIndex: number, x: number, y: number) => void
+  onDeletePath: (pathIndex: number) => void
+  onDeletePathPoint: (pathIndex: number, pointIndex: number) => void
+}
+
+function TerrainPathInspector({ pathIndex, path, onUpdatePath, onMovePathPoint, onDeletePath, onDeletePathPoint }: TerrainPathInspectorProps) {
+  return (
+    <div>
+      <h4 style={{ margin: '0 0 8px' }}>Path #{pathIndex + 1}</h4>
+      <Field label="Type">
+        <select
+          value={path.type}
+          onChange={e => onUpdatePath(pathIndex, { type: e.target.value as TerrainType })}
+          style={{ width: '100%' }}
+        >
+          {TERRAIN_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </Field>
+      <Field label="Radius (chain spacing)">
+        {numInput(path.radius ?? 20, v => onUpdatePath(pathIndex, { radius: Math.max(1, v) }))}
+      </Field>
+      <Field label={`Waypoints (${path.points.length})`}>
+        <div style={{ maxHeight: 180, overflowY: 'auto' }}>
+          {path.points.map((p, i) => (
+            <div key={i} style={{ display: 'flex', gap: 4, marginBottom: 4, alignItems: 'center' }}>
+              <span style={{ fontSize: 10, opacity: 0.6, width: 14 }}>{i + 1}</span>
+              {numInput(Math.round(p.x), v => onMovePathPoint(pathIndex, i, v, p.y))}
+              {numInput(Math.round(p.y), v => onMovePathPoint(pathIndex, i, p.x, v))}
+              <button onClick={() => onDeletePathPoint(pathIndex, i)} disabled={path.points.length <= 1} title="Delete waypoint">×</button>
+            </div>
+          ))}
+        </div>
+      </Field>
+      <button onClick={() => onDeletePath(pathIndex)}>Delete Path</button>
+    </div>
+  )
+}
+
 export interface InspectorProps {
   selectedEntities: SelectedEntity[]
   roads: RoadDef[]
   terrain: TerrainObstacle[]
+  decor: BattlefieldDecorItem[]
+  terrainPaths: TerrainPathDef[]
   nodeId: EditTarget
   hasNodeRoadsOverride: boolean
   hasNodeTerrainOverride: boolean
+  hasNodeDecorOverride: boolean
+  hasNodeTerrainPathsOverride: boolean
   onUpdateRoad: RoadInspectorProps['onUpdateRoad']
   onMoveRoadPoint: RoadInspectorProps['onMoveRoadPoint']
   onDeleteRoad: RoadInspectorProps['onDeleteRoad']
@@ -117,21 +211,40 @@ export interface InspectorProps {
   onUpdateObstacle: ObstacleInspectorProps['onUpdateObstacle']
   onMoveObstacle: ObstacleInspectorProps['onMoveObstacle']
   onDeleteObstacle: ObstacleInspectorProps['onDeleteObstacle']
+  onUpdateDecorTile: DecorInspectorProps['onUpdateDecorTile']
+  onMoveDecor: DecorInspectorProps['onMoveDecor']
+  onDeleteDecor: DecorInspectorProps['onDeleteDecor']
+  onUpdatePath: TerrainPathInspectorProps['onUpdatePath']
+  onMovePathPoint: TerrainPathInspectorProps['onMovePathPoint']
+  onDeletePath: TerrainPathInspectorProps['onDeletePath']
+  onDeletePathPoint: TerrainPathInspectorProps['onDeletePathPoint']
   onRevertRoads: () => void
   onRevertTerrain: () => void
+  onRevertDecor: () => void
+  onRevertTerrainPaths: () => void
 }
 
 export function BattlefieldEditorInspector(props: InspectorProps) {
-  const { selectedEntities, roads, terrain, nodeId, hasNodeRoadsOverride, hasNodeTerrainOverride, onRevertRoads, onRevertTerrain } = props
+  const {
+    selectedEntities, roads, terrain, decor, terrainPaths, nodeId,
+    hasNodeRoadsOverride, hasNodeTerrainOverride, hasNodeDecorOverride, hasNodeTerrainPathsOverride,
+    onRevertRoads, onRevertTerrain, onRevertDecor, onRevertTerrainPaths,
+  } = props
   const sel = selectedEntities[0]
 
-  let body: React.ReactNode = <p style={{ opacity: 0.6, fontSize: 12 }}>Select a road or obstacle to edit it.</p>
+  let body: React.ReactNode = <p style={{ opacity: 0.6, fontSize: 12 }}>Select a road, obstacle, decor item, or path to edit it.</p>
   if (sel?.type === 'road' && roads[sel.index]) {
     body = <RoadInspector roadIndex={sel.index} road={roads[sel.index]} onUpdateRoad={props.onUpdateRoad} onMoveRoadPoint={props.onMoveRoadPoint} onDeleteRoad={props.onDeleteRoad} onDeleteRoadPoint={props.onDeleteRoadPoint} />
   } else if (sel?.type === 'roadPoint' && roads[sel.roadIndex]) {
     body = <RoadInspector roadIndex={sel.roadIndex} road={roads[sel.roadIndex]} onUpdateRoad={props.onUpdateRoad} onMoveRoadPoint={props.onMoveRoadPoint} onDeleteRoad={props.onDeleteRoad} onDeleteRoadPoint={props.onDeleteRoadPoint} />
   } else if (sel?.type === 'obstacle' && terrain[sel.index]) {
     body = <ObstacleInspector index={sel.index} obstacle={terrain[sel.index]} onUpdateObstacle={props.onUpdateObstacle} onMoveObstacle={props.onMoveObstacle} onDeleteObstacle={props.onDeleteObstacle} />
+  } else if (sel?.type === 'decor' && decor[sel.index]) {
+    body = <DecorInspector index={sel.index} item={decor[sel.index]} onUpdateDecorTile={props.onUpdateDecorTile} onMoveDecor={props.onMoveDecor} onDeleteDecor={props.onDeleteDecor} />
+  } else if (sel?.type === 'terrainPath' && terrainPaths[sel.index]) {
+    body = <TerrainPathInspector pathIndex={sel.index} path={terrainPaths[sel.index]} onUpdatePath={props.onUpdatePath} onMovePathPoint={props.onMovePathPoint} onDeletePath={props.onDeletePath} onDeletePathPoint={props.onDeletePathPoint} />
+  } else if (sel?.type === 'terrainPathPoint' && terrainPaths[sel.pathIndex]) {
+    body = <TerrainPathInspector pathIndex={sel.pathIndex} path={terrainPaths[sel.pathIndex]} onUpdatePath={props.onUpdatePath} onMovePathPoint={props.onMovePathPoint} onDeletePath={props.onDeletePath} onDeletePathPoint={props.onDeletePathPoint} />
   }
 
   return (
@@ -142,9 +255,17 @@ export function BattlefieldEditorInspector(props: InspectorProps) {
             Roads: {hasNodeRoadsOverride ? 'node override' : 'inherited from act'}
             {hasNodeRoadsOverride && <button style={{ marginLeft: 6 }} onClick={onRevertRoads}>Clear</button>}
           </div>
-          <div>
+          <div style={{ marginBottom: 4 }}>
             Terrain: {hasNodeTerrainOverride ? 'node override' : 'inherited / procedural'}
             {hasNodeTerrainOverride && <button style={{ marginLeft: 6 }} onClick={onRevertTerrain}>Clear</button>}
+          </div>
+          <div style={{ marginBottom: 4 }}>
+            Decor: {hasNodeDecorOverride ? 'node override' : 'inherited from act'}
+            {hasNodeDecorOverride && <button style={{ marginLeft: 6 }} onClick={onRevertDecor}>Clear</button>}
+          </div>
+          <div>
+            Paths: {hasNodeTerrainPathsOverride ? 'node override' : 'inherited from act'}
+            {hasNodeTerrainPathsOverride && <button style={{ marginLeft: 6 }} onClick={onRevertTerrainPaths}>Clear</button>}
           </div>
         </div>
       )}

--- a/web/src/components/battlefieldEditor/BattlefieldEditorToolbar.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorToolbar.tsx
@@ -8,10 +8,13 @@ const TOOLS: { tool: ToolMode; label: string }[] = [
   { tool: 'select', label: 'Select' },
   { tool: 'road', label: 'Road' },
   { tool: 'obstacle', label: 'Obstacle' },
+  { tool: 'decor', label: 'Decor' },
+  { tool: 'path', label: 'Path' },
   { tool: 'delete', label: 'Delete' },
 ]
 
 const OBSTACLE_TYPES: TerrainType[] = ['rock', 'tree', 'water', 'ruin']
+const PATH_TYPES: TerrainType[] = ['rock', 'tree', 'water', 'ruin']
 
 export interface Props {
   actId: string
@@ -19,7 +22,9 @@ export interface Props {
   nodeId: EditTarget
   tool: ToolMode
   activeObstacleType: TerrainType
+  activePathType: TerrainType
   inProgressRoadIndex: number | null
+  inProgressPathIndex: number | null
   showGuides: boolean
   environment: string
   roadFollowing: boolean
@@ -30,7 +35,9 @@ export interface Props {
   onSetNodeId: (nodeId: EditTarget) => void
   onSetTool: (tool: ToolMode) => void
   onSetActiveObstacleType: (type: TerrainType) => void
+  onSetActivePathType: (type: TerrainType) => void
   onFinishRoad: () => void
+  onFinishPath: () => void
   onToggleGuides: () => void
   onToggleRoadFollowing: () => void
   onUndo: () => void
@@ -40,9 +47,9 @@ export interface Props {
 
 export function BattlefieldEditorToolbar(props: Props) {
   const {
-    actId, actData, nodeId, tool, activeObstacleType, inProgressRoadIndex, showGuides,
+    actId, actData, nodeId, tool, activeObstacleType, activePathType, inProgressRoadIndex, inProgressPathIndex, showGuides,
     environment, roadFollowing, canUndo, canRedo, isDirty,
-    onSetActId, onSetNodeId, onSetTool, onSetActiveObstacleType, onFinishRoad,
+    onSetActId, onSetNodeId, onSetTool, onSetActiveObstacleType, onSetActivePathType, onFinishRoad, onFinishPath,
     onToggleGuides, onToggleRoadFollowing, onUndo, onRedo, onSaved,
   } = props
 
@@ -107,8 +114,21 @@ export function BattlefieldEditorToolbar(props: Props) {
         </label>
       )}
 
+      {tool === 'path' && (
+        <label>
+          Type:{' '}
+          <select value={activePathType} onChange={e => onSetActivePathType(e.target.value as TerrainType)}>
+            {PATH_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </label>
+      )}
+
       {tool === 'road' && inProgressRoadIndex !== null && (
         <button onClick={onFinishRoad}>Finish road</button>
+      )}
+
+      {tool === 'path' && inProgressPathIndex !== null && (
+        <button onClick={onFinishPath}>Finish path</button>
       )}
 
       <label style={{ fontSize: 11 }}>

--- a/web/src/components/battlefieldEditor/battlefieldEditorTypes.ts
+++ b/web/src/components/battlefieldEditor/battlefieldEditorTypes.ts
@@ -1,12 +1,15 @@
 import type { Act } from '../../game/questline'
-import type { RoadDef, TerrainObstacle, TerrainType } from '../../game/engine/terrain'
+import type { RoadDef, TerrainObstacle, TerrainType, BattlefieldDecorItem, TerrainPathDef } from '../../game/engine/terrain'
 
-export type ToolMode = 'select' | 'road' | 'obstacle' | 'delete'
+export type ToolMode = 'select' | 'road' | 'obstacle' | 'decor' | 'path' | 'delete'
 
 export type SelectedEntity =
   | { type: 'road'; index: number }
   | { type: 'roadPoint'; roadIndex: number; pointIndex: number }
   | { type: 'obstacle'; index: number }
+  | { type: 'decor'; index: number }
+  | { type: 'terrainPath'; index: number }
+  | { type: 'terrainPathPoint'; pathIndex: number; pointIndex: number }
 
 /** 'act-default' edits the act-level roads/terrain; otherwise a specific node id. */
 export type EditTarget = 'act-default' | string
@@ -17,12 +20,16 @@ export interface BattlefieldEditorState {
   actData: Act
   tool: ToolMode
   activeObstacleType: TerrainType
+  activeDecorTileId: number
+  activePathType: TerrainType
   /** Index into the current target's roads array while a road is being drawn point-by-point. */
   inProgressRoadIndex: number | null
+  /** Index into the current target's terrainPaths array while a path is being drawn point-by-point. */
+  inProgressPathIndex: number | null
   selectedEntities: SelectedEntity[]
   undoStack: Act[]
   redoStack: Act[]
   isDirty: boolean
 }
 
-export type { Act, RoadDef, TerrainObstacle, TerrainType }
+export type { Act, RoadDef, TerrainObstacle, TerrainType, BattlefieldDecorItem, TerrainPathDef }

--- a/web/src/components/battlefieldEditor/useBattlefieldEditorState.ts
+++ b/web/src/components/battlefieldEditor/useBattlefieldEditorState.ts
@@ -1,7 +1,8 @@
 import { useState, useCallback } from 'react'
-import type { Act, RoadDef, TerrainObstacle, TerrainType, ToolMode, EditTarget, SelectedEntity, BattlefieldEditorState } from './battlefieldEditorTypes'
+import type { Act, RoadDef, TerrainObstacle, TerrainType, ToolMode, EditTarget, SelectedEntity, BattlefieldEditorState, BattlefieldDecorItem, TerrainPathDef } from './battlefieldEditorTypes'
 import { generateTerrain } from '../../game/engine/terrain'
 import { isSelfSave } from '../../utils/hotReloadGuard'
+import { WORLD_DECOR } from '../../data/tiles/worldTileIndex'
 
 import act1 from '../../data/acts/act1.json'
 import act2 from '../../data/acts/act2.json'
@@ -143,6 +144,41 @@ function nextObstacleId(existing: TerrainObstacle[]): string {
   return `t${n}`
 }
 
+/** Like roads, a node without its own `terrainPaths` inherits the act-level
+ *  default (or an empty array) — no procedural fallback. */
+function resolveTerrainPathsForTarget(act: Act, nodeId: EditTarget): TerrainPathDef[] {
+  if (nodeId === 'act-default') return act.terrainPaths ?? []
+  return act.nodes[nodeId]?.terrainPaths ?? act.terrainPaths ?? []
+}
+
+function withTerrainPaths(act: Act, nodeId: EditTarget, terrainPaths: TerrainPathDef[]): Act {
+  if (nodeId === 'act-default') return { ...act, terrainPaths }
+  const node = act.nodes[nodeId]
+  if (!node) return act
+  return { ...act, nodes: { ...act.nodes, [nodeId]: { ...node, terrainPaths } } }
+}
+
+/** Decor has no procedural fallback — like roads, a node without its own
+ *  `decor` inherits the act-level default (or an empty array). */
+function resolveDecorForTarget(act: Act, nodeId: EditTarget): BattlefieldDecorItem[] {
+  if (nodeId === 'act-default') return act.decor ?? []
+  return act.nodes[nodeId]?.decor ?? act.decor ?? []
+}
+
+function withDecor(act: Act, nodeId: EditTarget, decor: BattlefieldDecorItem[]): Act {
+  if (nodeId === 'act-default') return { ...act, decor }
+  const node = act.nodes[nodeId]
+  if (!node) return act
+  return { ...act, nodes: { ...act.nodes, [nodeId]: { ...node, decor } } }
+}
+
+function nextDecorId(existing: BattlefieldDecorItem[]): string {
+  const ids = new Set(existing.map(o => o.id))
+  let n = existing.length + 1
+  while (ids.has(`d${n}`)) n++
+  return `d${n}`
+}
+
 export function useBattlefieldEditorState(initialActId: string = 'act1') {
   const [state, setState] = useState<BattlefieldEditorState>(() => ({
     actId:               initialActId,
@@ -150,7 +186,10 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
     nodeId:              'act-default',
     tool:                'select',
     activeObstacleType:  'rock',
+    activeDecorTileId:   WORLD_DECOR.singleTree,
+    activePathType:      'tree',
     inProgressRoadIndex: null,
+    inProgressPathIndex: null,
     selectedEntities:    [],
     undoStack:           [],
     redoStack:           [],
@@ -165,6 +204,7 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
       nodeId:              'act-default',
       tool:                'select',
       inProgressRoadIndex: null,
+      inProgressPathIndex: null,
       selectedEntities:    [],
       undoStack:           [],
       redoStack:           [],
@@ -173,15 +213,28 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
   }, [])
 
   const setNodeId = useCallback((nodeId: EditTarget) => {
-    setState(s => ({ ...s, nodeId, inProgressRoadIndex: null, selectedEntities: [] }))
+    setState(s => ({ ...s, nodeId, inProgressRoadIndex: null, inProgressPathIndex: null, selectedEntities: [] }))
   }, [])
 
   const setTool = useCallback((tool: ToolMode) => {
-    setState(s => ({ ...s, tool, inProgressRoadIndex: tool === 'road' ? s.inProgressRoadIndex : null }))
+    setState(s => ({
+      ...s,
+      tool,
+      inProgressRoadIndex: tool === 'road' ? s.inProgressRoadIndex : null,
+      inProgressPathIndex: tool === 'path' ? s.inProgressPathIndex : null,
+    }))
   }, [])
 
   const setActiveObstacleType = useCallback((activeObstacleType: TerrainType) => {
     setState(s => ({ ...s, activeObstacleType }))
+  }, [])
+
+  const setActivePathType = useCallback((activePathType: TerrainType) => {
+    setState(s => ({ ...s, activePathType }))
+  }, [])
+
+  const setActiveDecorTileId = useCallback((activeDecorTileId: number) => {
+    setState(s => ({ ...s, activeDecorTileId }))
   }, [])
 
   const selectEntities = useCallback((entities: SelectedEntity[]) => {
@@ -359,6 +412,177 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
     })
   }, [])
 
+  // ── Decor ─────────────────────────────────────────────────────────────
+
+  const addDecor = useCallback((x: number, y: number, tileId: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveDecorForTarget(prevAct, s.nodeId)
+      const item: BattlefieldDecorItem = { id: nextDecorId(current), tileId, x, y }
+      const newDecor = [...current, item]
+      return {
+        ...s,
+        actData:          withDecor(prevAct, s.nodeId, newDecor),
+        selectedEntities: [{ type: 'decor' as const, index: newDecor.length - 1 }],
+        undoStack:        [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:        [],
+        isDirty:          true,
+      }
+    })
+  }, [])
+
+  const moveDecor = useCallback((index: number, x: number, y: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveDecorForTarget(prevAct, s.nodeId)
+      if (!current[index]) return s
+      const newDecor = current.map((d, i) => i === index ? { ...d, x, y } : d)
+      return {
+        ...s,
+        actData:   withDecor(prevAct, s.nodeId, newDecor),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const updateDecorTile = useCallback((index: number, tileId: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveDecorForTarget(prevAct, s.nodeId)
+      if (!current[index]) return s
+      const newDecor = current.map((d, i) => i === index ? { ...d, tileId } : d)
+      return {
+        ...s,
+        actData:   withDecor(prevAct, s.nodeId, newDecor),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const deleteDecor = useCallback((index: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveDecorForTarget(prevAct, s.nodeId)
+      if (!current[index]) return s
+      const newDecor = current.filter((_, i) => i !== index)
+      return {
+        ...s,
+        actData:          withDecor(prevAct, s.nodeId, newDecor),
+        selectedEntities: [],
+        undoStack:        [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:        [],
+        isDirty:          true,
+      }
+    })
+  }, [])
+
+  // ── Terrain paths ─────────────────────────────────────────────────────
+
+  /** 'path' tool click: extends the in-progress path, or starts a new one. */
+  const clickPathTool = useCallback((x: number, y: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainPathsForTarget(prevAct, s.nodeId)
+      const inProgress = s.inProgressPathIndex !== null && current[s.inProgressPathIndex]
+      const pathIndex = inProgress ? s.inProgressPathIndex! : current.length
+      const newPaths = inProgress
+        ? current.map((p, i) => i === pathIndex ? { ...p, points: [...p.points, { x, y }] } : p)
+        : [...current, { type: s.activePathType, points: [{ x, y }] }]
+      const newAct = withTerrainPaths(prevAct, s.nodeId, newPaths)
+      return {
+        ...s,
+        actData:             newAct,
+        inProgressPathIndex: pathIndex,
+        selectedEntities:    [{ type: 'terrainPath' as const, index: pathIndex }],
+        undoStack:           [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:           [],
+        isDirty:             true,
+      }
+    })
+  }, [])
+
+  const finishPath = useCallback(() => {
+    setState(s => s.inProgressPathIndex === null ? s : { ...s, inProgressPathIndex: null })
+  }, [])
+
+  const movePathPoint = useCallback((pathIndex: number, pointIndex: number, x: number, y: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainPathsForTarget(prevAct, s.nodeId)
+      if (!current[pathIndex]?.points[pointIndex]) return s
+      const newPaths = current.map((p, i) => i !== pathIndex ? p : {
+        ...p, points: p.points.map((pt, j) => j === pointIndex ? { x, y } : pt),
+      })
+      return {
+        ...s,
+        actData:   withTerrainPaths(prevAct, s.nodeId, newPaths),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const updatePath = useCallback((pathIndex: number, patch: Partial<Pick<TerrainPathDef, 'type' | 'radius'>>) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainPathsForTarget(prevAct, s.nodeId)
+      if (!current[pathIndex]) return s
+      const newPaths = current.map((p, i) => i === pathIndex ? { ...p, ...patch } : p)
+      return {
+        ...s,
+        actData:   withTerrainPaths(prevAct, s.nodeId, newPaths),
+        undoStack: [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty:   true,
+      }
+    })
+  }, [])
+
+  const deletePathPoint = useCallback((pathIndex: number, pointIndex: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainPathsForTarget(prevAct, s.nodeId)
+      const path = current[pathIndex]
+      if (!path?.points[pointIndex]) return s
+      const points = path.points.filter((_, j) => j !== pointIndex)
+      const newPaths = points.length >= 1
+        ? current.map((p, i) => i === pathIndex ? { ...p, points } : p)
+        : current.filter((_, i) => i !== pathIndex)
+      return {
+        ...s,
+        actData:             withTerrainPaths(prevAct, s.nodeId, newPaths),
+        selectedEntities:    [],
+        inProgressPathIndex: s.inProgressPathIndex === pathIndex ? null : s.inProgressPathIndex,
+        undoStack:           [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:           [],
+        isDirty:             true,
+      }
+    })
+  }, [])
+
+  const deletePath = useCallback((pathIndex: number) => {
+    setState(s => {
+      const prevAct = s.actData
+      const current = resolveTerrainPathsForTarget(prevAct, s.nodeId)
+      if (!current[pathIndex]) return s
+      const newPaths = current.filter((_, i) => i !== pathIndex)
+      return {
+        ...s,
+        actData:             withTerrainPaths(prevAct, s.nodeId, newPaths),
+        selectedEntities:    [],
+        inProgressPathIndex: s.inProgressPathIndex === pathIndex ? null : s.inProgressPathIndex,
+        undoStack:           [...s.undoStack, prevAct].slice(-MAX_UNDO),
+        redoStack:           [],
+        isDirty:             true,
+      }
+    })
+  }, [])
+
   // ── Road following ────────────────────────────────────────────────────
 
   const setRoadFollowing = useCallback((roadFollowing: boolean) => {
@@ -376,7 +600,7 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
 
   // ── Inheritance ───────────────────────────────────────────────────────
 
-  const revertToActDefault = useCallback((field: 'roads' | 'terrain') => {
+  const revertToActDefault = useCallback((field: 'roads' | 'terrain' | 'decor' | 'terrainPaths') => {
     setState(s => {
       if (s.nodeId === 'act-default') return s
       const prevAct = s.actData
@@ -430,12 +654,16 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
     state,
     resolveRoadsForTarget,
     resolveTerrainForTarget,
+    resolveDecorForTarget,
+    resolveTerrainPathsForTarget,
     resolveRoadFollowingForTarget,
     setRoadFollowing,
     setActId,
     setNodeId,
     setTool,
     setActiveObstacleType,
+    setActiveDecorTileId,
+    setActivePathType,
     selectEntities,
     clickRoadTool,
     finishRoad,
@@ -447,6 +675,16 @@ export function useBattlefieldEditorState(initialActId: string = 'act1') {
     moveObstacle,
     updateObstacle,
     deleteObstacle,
+    addDecor,
+    moveDecor,
+    updateDecorTile,
+    deleteDecor,
+    clickPathTool,
+    finishPath,
+    movePathPoint,
+    updatePath,
+    deletePathPoint,
+    deletePath,
     revertToActDefault,
     undo,
     redo,

--- a/web/src/game/campaignHelpers.ts
+++ b/web/src/game/campaignHelpers.ts
@@ -157,6 +157,8 @@ export function resolvedNodeOpts(
     roads: node.roads ?? act?.roads,
     roadFollowing: node.roadFollowing ?? act?.roadFollowing ?? false,
     terrain: node.terrain ?? act?.terrain,
+    decor: node.decor ?? act?.decor,
+    terrainPaths: node.terrainPaths ?? act?.terrainPaths,
     opponentIntervalMs: adjustedInterval,
     opponentBaseHp: adjustedHp,
     opponentStartCards: handBonus,

--- a/web/src/game/engine.ts
+++ b/web/src/game/engine.ts
@@ -14,8 +14,8 @@ import { MAX_UPGRADE_LEVEL, resolveSpellCast } from './engine/cards'
 import { unitDist } from './engine/targeting'
 import { opponentAI } from './engine/opponentAI'
 import { triggerBattleEvent, BATTLE_EVENT_BASE_MS } from './engine/battleEvents'
-import { generateTerrain } from './engine/terrain'
-import type { RoadDef, TerrainObstacle } from './engine/terrain'
+import { generateTerrain, expandTerrainPathsToObstacles } from './engine/terrain'
+import type { RoadDef, TerrainObstacle, BattlefieldDecorItem, TerrainPathDef } from './engine/terrain'
 import { processEndlessModeAdditions, triggerNextEndlessWave, spawnEndlessCommander } from './engine/endlessMode'
 import { handleSuddentDeath } from './engine/suddenDeath'
 
@@ -126,6 +126,10 @@ export interface NewGameOptions {
   roadFollowing?: boolean
   /** Act/node-authored terrain obstacles for the battlefield. When present, replaces the procedurally-generated default. */
   terrain?: TerrainObstacle[]
+  /** Act/node-authored manual decor placements for the battlefield. When present and non-empty, replaces the procedural decor scatter. */
+  decor?: BattlefieldDecorItem[]
+  /** Act/node-authored path-drawn blocking terrain. Expands into extra TerrainObstacle circles alongside `terrain`. */
+  terrainPaths?: TerrainPathDef[]
   /** Override opponent play interval (ms). Defined per-node in act JSON. */
   opponentIntervalMs?: number
   /** Override opponent base HP. Defined per-node in act JSON. */
@@ -180,6 +184,8 @@ export function newGame(
     roads,
     roadFollowing,
     terrain: authoredTerrain,
+    decor,
+    terrainPaths,
     opponentIntervalMs: intervalOverride,
     opponentBaseHp: hpOverride,
     bossSpawnKillPct,
@@ -330,10 +336,14 @@ export function newGame(
       traitFired: false,
       baseInvulnerableUntilMs: 0,
     } : undefined,
-    terrain: authoredTerrain ?? generateTerrain(terrainSeed, environment),
+    terrain: [
+      ...(authoredTerrain ?? generateTerrain(terrainSeed, environment)),
+      ...expandTerrainPathsToObstacles(terrainPaths ?? []),
+    ],
     roads,
     roadFollowing,
     environment,
+    decor,
     battleStats: { cardsPlayed: {}, playerKills: 0, playerUnitsLost: 0 },
     animEvents: [],
     bloodPools: [],

--- a/web/src/game/engine/terrain.ts
+++ b/web/src/game/engine/terrain.ts
@@ -37,6 +37,72 @@ export interface RoadDef {
   tileFile?: string
 }
 
+/**
+ * Act/node-authored blocking terrain drawn as a path rather than placed one
+ * circle at a time — a line of trees, a river, a mountain ridge. Expands (via
+ * expandTerrainPathsToObstacles below) into a chain of overlapping
+ * TerrainObstacle circles along the waypoints, so it gets full unit avoidance
+ * and the exact same per-type rendering (ring autotile for rock/tree/water,
+ * icon for ruin — see buildTerrainDecorGfx in utils/terrainLayer.ts) as
+ * individually hand-placed obstacles, for free.
+ */
+export interface TerrainPathDef {
+  type: TerrainType
+  /** Waypoints in game-unit coords — same space as TerrainObstacle: x 0–500 (forward, base→base), y -80..80 (lateral). */
+  points: Array<{ x: number; y: number }>
+  /** Avoidance radius of each chained obstacle (game units). Also controls chain spacing — consecutive circles are spaced at `radius` apart so the chain has continuous coverage. Default 20. */
+  radius?: number
+}
+
+/**
+ * Expands TerrainPathDef waypoint chains into TerrainObstacle circles spaced
+ * `radius` apart along each path's polyline, so a drawn path is just sugar
+ * for "a lot of hand-placed obstacles in a row" — reuses 100% of the existing
+ * avoidance (TERRAIN_AVOID_SHAPE) and rendering (buildTerrainDecorGfx) code,
+ * no new terrain-shape logic needed anywhere else in the engine/renderer.
+ * IDs are plain digit strings (pathIndex*1000 + n) so they stay compatible
+ * with buildTerrainDecorGfx's `parseInt(obs.id.replace('t', ''))` tile-variant
+ * picker (a no-op replace on a string with no 't' in it).
+ */
+export function expandTerrainPathsToObstacles(paths: TerrainPathDef[]): TerrainObstacle[] {
+  const obstacles: TerrainObstacle[] = []
+  paths.forEach((path, pathIndex) => {
+    if (path.points.length === 0) return
+    const radius = path.radius ?? 20
+    let n = 0
+    const place = (x: number, y: number) => {
+      obstacles.push({ id: String(pathIndex * 1000 + n++), type: path.type, x, y, radius })
+    }
+    place(path.points[0].x, path.points[0].y)
+    for (let i = 1; i < path.points.length; i++) {
+      const a = path.points[i - 1]
+      const b = path.points[i]
+      const dist = Math.hypot(b.x - a.x, b.y - a.y)
+      const steps = Math.max(1, Math.round(dist / radius))
+      for (let s = 1; s <= steps; s++) {
+        place(a.x + (b.x - a.x) * (s / steps), a.y + (b.y - a.y) * (s / steps))
+      }
+    }
+  })
+  return obstacles
+}
+
+/**
+ * Act/node-authored decor placement — a single WORLD_DECOR sprite (see
+ * data/tiles/worldTileIndex.ts) placed at a fixed point. Purely visual: does
+ * NOT affect unit avoidance (unlike TerrainObstacle) and is not an autotiled
+ * patch (unlike scenery/border tiles). When an act/node defines a non-empty
+ * `decor` array, it replaces buildDecorGfx's procedural scatter for that
+ * act/node (see terrainLayer.ts).
+ */
+export interface BattlefieldDecorItem {
+  id: string
+  /** Index into WORLD_DECOR (data/tiles/worldTileIndex.ts). */
+  tileId: number
+  x: number // forward axis, same coords/range as TerrainObstacle (0–500)
+  y: number // lateral axis, same coords/range as TerrainObstacle (-80..80)
+}
+
 // ─── Terrain Generation ───────────────────────────────────
 //
 // Scatter rocks, trees, water, and ruins across the mid-field.

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -1,5 +1,5 @@
 import { CardRarity, Archetype } from './types'
-import type { RoadDef, TerrainObstacle } from './engine/terrain'
+import type { RoadDef, TerrainObstacle, BattlefieldDecorItem, TerrainPathDef } from './engine/terrain'
 import { loadPlayerStats } from './playerStats'
 import { logError } from '../logger'
 import { getCardCatalog } from './cards'
@@ -169,6 +169,10 @@ export interface QuestNode {
   roadFollowing?: boolean
   /** Battlefield terrain obstacles for this node, overriding the act's `terrain` and replacing the procedurally-generated default. Affects unit avoidance, same as procedural terrain. */
   terrain?: TerrainObstacle[]
+  /** Manually-authored decor sprite placements for this node's battlefield, overriding the act's `decor`. When non-empty, replaces the procedural decor scatter. */
+  decor?: BattlefieldDecorItem[]
+  /** Path-drawn blocking terrain (rivers, tree lines, mountain ridges) for this node, overriding the act's `terrainPaths`. Expands into extra TerrainObstacle circles at battle start — see expandTerrainPathsToObstacles. */
+  terrainPaths?: TerrainPathDef[]
   /** Override opponent play interval (ms). Replaces handicap-derived default. */
   opponentIntervalMs?: number
   /** Override opponent base HP. Replaces engine default (95 for bosses, 82 for others). */
@@ -328,6 +332,22 @@ export interface WorldMap {
    * Affects unit avoidance, same as procedural terrain.
    */
   terrain?: TerrainObstacle[]
+
+  /**
+   * Default manually-authored decor sprite placements for battles in this act
+   * (see BattlefieldDecorItem). When present and non-empty, replaces the
+   * procedural decor scatter (buildDecorGfx) for battles in this act; a
+   * QuestNode's own `decor` overrides this per-node.
+   */
+  decor?: BattlefieldDecorItem[]
+
+  /**
+   * Default path-drawn blocking terrain for battles in this act (see
+   * TerrainPathDef). Expands into extra TerrainObstacle circles alongside
+   * `terrain` at battle start; a QuestNode's own `terrainPaths` overrides this
+   * per-node.
+   */
+  terrainPaths?: TerrainPathDef[]
 
 }
 

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -374,11 +374,12 @@ export interface BattleEventState {
 // Types and constants owned by engine/terrain.ts; re-exported here for
 // consumers that import from the top-level types module.
 
-import type { TerrainObstacle as _TerrainObstacle, RoadDef as _RoadDef } from './engine/terrain'
-export type { TerrainType, TerrainObstacle, RoadDef } from './engine/terrain'
+import type { TerrainObstacle as _TerrainObstacle, RoadDef as _RoadDef, BattlefieldDecorItem as _BattlefieldDecorItem } from './engine/terrain'
+export type { TerrainType, TerrainObstacle, RoadDef, BattlefieldDecorItem } from './engine/terrain'
 export { TERRAIN_AVOID_SHAPE } from './engine/terrain'
 type TerrainObstacle = _TerrainObstacle
 type RoadDef = _RoadDef
+type BattlefieldDecorItem = _BattlefieldDecorItem
 
 // ─── Game ────────────────────────────────────────────────
 
@@ -448,6 +449,7 @@ export interface GameState {
   roads?: RoadDef[]          // act/node-authored road paths for the battlefield
   roadFollowing?: boolean    // when true, mobile units path onto and follow `roads` toward the enemy base (see engine/units.ts)
   environment?: string       // battlefield background theme ('forest' | 'ruins' | 'camp' | 'citadel' | 'ashen')
+  decor?: BattlefieldDecorItem[]  // act/node-authored manual decor placements; replaces the procedural decor scatter when non-empty
   unitReviveHp?: 'half' | 'full' | number      // pending one-time unit revive at this HP value (set by Soulstone/Salvage Hook relics)
   relicManaBonus?: number             // passive +N to maxMana cap (set by Prism Lens relic)
   playerAtkMult?: number              // ATK multiplier applied to all player units, incl. later deploys (Glass Cannon Protocol exotic)

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -5,7 +5,7 @@ import { loadTileTexture } from './pixiHelpers'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
 import { renderPathTiles } from './tileLookup'
-import type { TerrainObstacle, RoadDef } from '../game/engine/terrain'
+import type { TerrainObstacle, RoadDef, BattlefieldDecorItem } from '../game/engine/terrain'
 
 // Divisor controlling how obstacle radius (game units) maps to tile-ring radius (tiles).
 // Tuned against the realistic range of obstacle radius (20-32) and lane CSS height (~318-842px)
@@ -248,9 +248,48 @@ export async function buildDecorGfx(
 }
 
 /**
+ * Renders act/node-authored decor placements (see BattlefieldDecorItem) — a
+ * fixed list of WORLD_DECOR sprites, as opposed to buildDecorGfx's random
+ * scatter. Callers should use this INSTEAD of buildDecorGfx when a non-empty
+ * manual decor array is present for the act/node (manual placement replaces
+ * the procedural scatter, it doesn't layer on top of it).
+ *
+ * Game coords → tile coords via gameToPixel() (see above), snapped to the tile
+ * grid the same way buildTerrainDecorGfx does, so manually-placed items line
+ * up with the rest of the battlefield's tile-aligned art.
+ */
+export async function buildManualDecorGfx(
+  container: PIXI.Container,
+  decorItems: BattlefieldDecorItem[],
+  mapWidth: number,
+  mapHeight: number,
+): Promise<void> {
+  if (decorItems.length === 0) return
+  const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
+  const tileUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
+  for (const item of decorItems) {
+    if (container.destroyed) return
+    const { px, py } = gameToPixel(item.x, item.y, mapWidth, mapHeight)
+    const tcx = Math.round(px / TILE_SIZE)
+    const tcy = Math.round(py / TILE_SIZE)
+    const tex = await loadTileTexture(tileUrl, item.tileId, 8)
+    if (container.destroyed) return
+    const s = new PIXI.Sprite(tex)
+    s.position.set(tcx * TILE_SIZE, tcy * TILE_SIZE)
+    container.addChild(s)
+  }
+}
+
+/**
  * Renders act/node-authored road paths on the battlefield lane, using the same
  * renderPathTiles() autotiler as hub streets and battlefield water patches.
  * Visual only — does not affect unit movement/avoidance.
+ *
+ * Roads sharing the same effective tileset (tileFile + canal-width class) are
+ * unioned into a single tile set before autotiling, so overlapping/touching
+ * roads render as one seamless shape (the autotiler picks interior tiles at
+ * the seam) instead of each road drawing its own independently-edged patch —
+ * two separate roads sharing an edge would otherwise double-draw that edge.
  *
  * Game coords → tile coords via gameToPixel() (see above), divided by TILE_SIZE.
  */
@@ -269,8 +308,12 @@ export async function buildRoadGfx(
     return { tcx: Math.round(px / TILE_SIZE), tcy: Math.round(py / TILE_SIZE) }
   }
 
+  // Group by effective tileFile + canal-width class so mismatched-style roads
+  // still render with their own art, while same-style roads merge into one
+  // autotiled shape (grouping key uses '' for the default/undefined tileFile).
+  const groups = new Map<string, { tileFile: string | undefined; isCanal: boolean; tiles: Set<string> }>()
+
   for (const road of roads) {
-    if (container.destroyed) return
     if (road.points.length < 2) continue
 
     // Rasterize the centerline tile-by-tile between consecutive waypoints.
@@ -296,20 +339,29 @@ export async function buildRoadGfx(
     // approximate (not exact-integer) tile width.
     const width = road.width ?? 2
     const tileRadius = Math.max(0, Math.floor(width / 2))
-    const roadSet = new Set<string>()
-    for (const key of centerline) {
-      const [c, r] = key.split(',').map(Number)
+    const isCanal = width > 1
+    const key = `${road.tileFile ?? ''}|${isCanal}`
+    let group = groups.get(key)
+    if (!group) {
+      group = { tileFile: road.tileFile, isCanal, tiles: new Set() }
+      groups.set(key, group)
+    }
+    for (const centerKey of centerline) {
+      const [c, r] = centerKey.split(',').map(Number)
       for (let dr = -tileRadius; dr <= tileRadius; dr++) {
         for (let dc = -tileRadius; dc <= tileRadius; dc++) {
           if (dr * dr + dc * dc > tileRadius * tileRadius) continue
-          roadSet.add(`${c + dc},${r + dr}`)
+          group.tiles.add(`${c + dc},${r + dr}`)
         }
       }
     }
+  }
 
+  for (const group of groups.values()) {
+    if (container.destroyed) return
     const roadContainer = new PIXI.Container()
     container.addChild(roadContainer)
-    await renderPathTiles(roadContainer, roadSet, opts.environment, road.tileFile, width > 1, def)
+    await renderPathTiles(roadContainer, group.tiles, opts.environment, group.tileFile, group.isCanal, def)
     if (container.destroyed) return
   }
 }


### PR DESCRIPTION
## Summary
- **Decor tool**: place `WORLD_DECOR` sprites (`nodemap/32x32/decor.png`) by hand via a new `BattlefieldDecorPalette`, following the same pattern as `mapEditor/TilePalette.tsx`. A non-empty manual decor list replaces the procedural scatter (`buildDecorGfx`) for that act/node — in both the editor and real battles (`GameState.decor`, plumbed through `engine.ts`/`campaignHelpers.ts`).
- **Path tool**: draw blocking terrain (rock/tree/water/ruin) as a waypoint path instead of placing one obstacle circle at a time. `TerrainPathDef` expands into a chain of overlapping `TerrainObstacle` circles (`expandTerrainPathsToObstacles`), so it gets full unit avoidance and per-type rendering (ring autotile for rock/tree/water, icon for ruin) entirely for free — no new pathfinding or rendering code. The existing single-click Obstacle tool is untouched and still works alongside it.
- **Seamless road merging**: `buildRoadGfx` now unions roads that share the same effective tileset into one tile set before autotiling, so overlapping/touching roads render as one continuous shape instead of two independently-edged patches that double-draw their shared boundary.

## Test plan
- [x] `tsc --noEmit` clean (only a pre-existing unrelated `HubWeather.stories.tsx` casing error remains)
- [ ] Storybook `Battlefield Editor / BattlefieldEditor`: place decor, drag/edit/delete it, confirm procedural scatter is replaced once any decor exists
- [ ] Draw a terrain path (each of the 4 types), confirm it renders as a chain of ring-tiled obstacles and units avoid it in a real battle
- [ ] Draw two overlapping roads with the same tileset, confirm they render as one seamless shape
- [ ] Save via the editor and confirm `decor`/`terrainPaths` round-trip through the act JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)