### PR TITLE
fix(battlefield): render opponent commander sprite when walk frames are missing

### DIFF
--- a/web/src/components/battle/battlefieldCanvas/units.ts
+++ b/web/src/components/battle/battlefieldCanvas/units.ts
@@ -3,7 +3,7 @@ import type { GameState, Unit } from '../../../game/types'
 import { MAX_UPGRADE_LEVEL } from '../../../game/engine/cards'
 import { DAMAGE_FLASH_MS, SPAWN_GROW_MS } from '../../../game/engine/constants'
 import { DEATH_LINGER_MS, KILL_FLASH_MS } from '../../../game/engine/combat'
-import { loadSpriteTexture, loadAnimFrames, drawHpBar, makeClickable } from '../../../utils/pixiHelpers'
+import { loadSpriteTexture, loadAnimFramesOrStatic, drawHpBar, makeClickable } from '../../../utils/pixiHelpers'
 import { gameToPixel } from '../../../utils/terrainLayer'
 import { drawMoat, drawWall, MOAT_H, WALL_H } from './moatWall'
 import type { Scene, UnitEntry } from './scene'
@@ -85,12 +85,15 @@ function fitScale(tex: PIXI.Texture, box: { w: number; h: number }): number {
 }
 
 async function ensureSprite(entry: UnitEntry, spriteName: string, animated: boolean, box: { w: number; h: number }, anchorY: number): Promise<void> {
-  if (entry.loadedSpriteName === spriteName + (animated ? '#a' : '#s')) return
+  const key = spriteName + (animated ? '#a' : '#s')
+  if (entry.loadedSpriteName === key) return
   const token = ++entry.loadToken
-  entry.loadedSpriteName = spriteName + (animated ? '#a' : '#s')
+  entry.loadedSpriteName = key
   try {
     if (animated) {
-      const frames = await loadAnimFrames(spriteName, 3)
+      // Frame-less units (Warlord — the opponent commander — and Commander) come
+      // back as a single static frame rather than throwing, so they still render.
+      const frames = await loadAnimFramesOrStatic(spriteName, 3)
       if (entry.loadToken !== token) return
       const old = entry.sprite
       const sprite = new PIXI.AnimatedSprite(frames)

--- a/web/src/utils/pixiHelpers.test.ts
+++ b/web/src/utils/pixiHelpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Stub Pixi so the loader can be exercised in the node test env — only Assets.load
+// is reached by the code under test.
+const loadMock = vi.fn()
+vi.mock('pixi.js', () => ({ Assets: { load: (url: string) => loadMock(url) } }))
+
+const { loadAnimFramesOrStatic } = await import('./pixiHelpers')
+
+/** Resolves `{slug}.svg` only; every `{slug}-N.svg` frame 404s. */
+function staticOnly(...slugs: string[]) {
+  return (url: string) => {
+    const hit = slugs.some(s => url.endsWith(`/${s}.svg`))
+    return hit ? Promise.resolve({ url }) : Promise.reject(new Error(`404 ${url}`))
+  }
+}
+
+describe('loadAnimFramesOrStatic', () => {
+  beforeEach(() => { loadMock.mockReset() })
+
+  it('returns the walk frames when they exist', async () => {
+    loadMock.mockImplementation((url: string) => Promise.resolve({ url }))
+    const frames = await loadAnimFramesOrStatic('Goblin', 3)
+    expect(frames.map(f => (f as unknown as { url: string }).url)).toEqual([
+      '/sprites/goblin-1.svg', '/sprites/goblin-2.svg', '/sprites/goblin-3.svg',
+    ])
+  })
+
+  // The opponent commander is the Warlord, which ships only a static sprite. Before
+  // this fallback the rejected frame load left it with no sprite on the battlefield.
+  it('falls back to the static sprite when frame files are missing', async () => {
+    loadMock.mockImplementation(staticOnly('warlord'))
+    const frames = await loadAnimFramesOrStatic('Warlord', 3)
+    expect(frames).toHaveLength(1)
+    expect((frames[0] as unknown as { url: string }).url).toBe('/sprites/warlord.svg')
+  })
+
+  it('does not re-request frame files for a slug already known to lack them', async () => {
+    loadMock.mockImplementation(staticOnly('commander'))
+    await loadAnimFramesOrStatic('Commander', 3)
+    loadMock.mockClear()
+    await loadAnimFramesOrStatic('Commander', 3)
+    expect(loadMock.mock.calls.every(([url]) => url === '/sprites/commander.svg')).toBe(true)
+  })
+
+  it('rejects when neither the frames nor the static sprite exist', async () => {
+    loadMock.mockImplementation(() => Promise.reject(new Error('404')))
+    await expect(loadAnimFramesOrStatic('No Such Unit', 3)).rejects.toThrow()
+  })
+})

--- a/web/src/utils/pixiHelpers.ts
+++ b/web/src/utils/pixiHelpers.ts
@@ -34,6 +34,29 @@ export async function loadAnimFrames(name: string, frameCount: number): Promise<
   )
 }
 
+// Slugs already found to have no `{slug}-N.svg` frames, so repeat callers go
+// straight to the static sprite instead of re-issuing 404s every sync.
+const _noAnimFrames = new Set<string>()
+
+/**
+ * Load a unit's walk frames, falling back to its single static `{slug}.svg`
+ * when the per-frame files don't exist (e.g. Warlord / Commander, which only
+ * ship a static sprite). This mirrors AnimatedSpriteImg's onError fallback in
+ * SpriteImg.tsx — without it a frame-less unit renders as nothing at all.
+ * Rejects only when the static sprite is missing too.
+ */
+export async function loadAnimFramesOrStatic(name: string, frameCount: number): Promise<PIXI.Texture[]> {
+  const slug = spriteSlug(name)
+  if (!_noAnimFrames.has(slug)) {
+    try {
+      return await loadAnimFrames(name, frameCount)
+    } catch {
+      _noAnimFrames.add(slug)
+    }
+  }
+  return [await loadSpriteTexture(name)]
+}
+
 /**
  * Animate a group of sprites that all share one tile-sheet texture source and
  * show the same combo tile at a different animation frame (e.g. a water path


### PR DESCRIPTION
## Problem

The opponent commander was invisible on the battlefield. Its HP bar rendered, it was clickable when paused, and the opponent portrait in the base bar showed correctly — but the unit itself drew nothing.

## Root cause

`ensureSprite()` in `web/src/components/battle/battlefieldCanvas/units.ts` loads every **mobile** unit as an animated sprite:

```ts
const frames = await loadAnimFrames(spriteName, 3)   // slug-1.svg … slug-3.svg
```

`loadAnimFrames` is a `Promise.all` over the three frame files, so it rejects if any one 404s. The surrounding `try/catch` swallows the rejection with `/* leave prior sprite (or none) in place */` — for a freshly spawned unit that means **no sprite at all**.

The opponent commander is the `Warlord` template (`web/src/data/cards.json`), and `web/public/sprites/` only contains `warlord.svg` — there is no `warlord-1/2/3.svg`. So the frame load always rejected and the sprite never appeared. The base-bar portrait kept working because it points at the static `warlord.svg` directly.

The player commander was unaffected: `syncUnits` overrides its sprite with the player avatar slug, and every avatar ships walk frames.

This was a regression from the DOM → Pixi battlefield rewrite. The old DOM path used `AnimatedSpriteImg`, which has an `onError` handler that falls back to the static `SpriteImg` — that fallback was not carried over.

## Fix

Added `loadAnimFramesOrStatic()` to `web/src/utils/pixiHelpers.ts`: it tries the walk frames, and on failure returns a single-frame array containing the static `{slug}.svg`. Frame-less slugs are remembered in a module-level set so repeat callers skip the failing requests instead of re-issuing 404s on every sync. It rejects only when the static sprite is missing too, preserving the existing "leave it alone" behaviour for a genuinely absent sprite.

`ensureSprite()` now uses it. A one-frame `AnimatedSprite` cycles to itself, so the existing ticker frame-advance logic needs no change, and `Commander` (the other frame-less mobile template) is covered by the same path.

## Testing

- `npm run build` — passes (tsc + vite build)
- `npm run test` — 1925 tests pass across 56 files. The Storybook browser project fails to launch Chromium in this sandbox (`chrome-headless-shell` missing); that's a pre-existing environment limitation, not related to this change.
- New `web/src/utils/pixiHelpers.test.ts` covers the loader: normal frames, the static fallback for `Warlord`, the no-repeat-request behaviour, and rejection when neither form exists.

---
_Generated by [Claude Code](https://claude.ai/code/session_0196MvtgPZvvLpHgeLUSCBZp)_