### PR TITLE
fix(battlefield): merge touching water and terrain patches into one shape

### DIFF
--- a/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.stories.tsx
+++ b/web/src/components/battle/battlefield/BattlefieldTerrainCanvas.stories.tsx
@@ -29,3 +29,23 @@ export const Coast:    Story = { args: { environment: 'coast',    id: 'coast-tes
 export const Frost:    Story = { args: { environment: 'frost',    id: 'frost-test'    } }
 export const Reef:     Story = { args: { environment: 'reef',     id: 'reef-test'     } }
 export const Sky:      Story = { args: { environment: 'sky',      id: 'sky-test'      } }
+
+// A chain of deliberately overlapping obstacles — the case authored rivers and
+// tree lines produce (see expandTerrainPathsToObstacles). Each type must render
+// as ONE continuous shape with a single outer edge and no interior holes; if the
+// water shows internal shorelines or grass gaps, the tileset grouping in
+// utils/terrainPatchPlan.ts has regressed.
+export const MergedWater: Story = {
+  args: {
+    environment: 'farmland',
+    id: 'merged-water',
+    terrain: [
+      { id: 't1', type: 'water', x: 140, y: -30, radius: 26 },
+      { id: 't2', type: 'water', x: 190, y: -10, radius: 26 },
+      { id: 't3', type: 'water', x: 240, y:  10, radius: 26 },
+      { id: 't4', type: 'water', x: 290, y:  10, radius: 26 },
+      { id: 't5', type: 'tree',  x: 340, y: -40, radius: 24 },
+      { id: 't6', type: 'tree',  x: 370, y: -20, radius: 24 },
+    ],
+  },
+}

--- a/web/src/data/tiles/worldTileIndex.ts
+++ b/web/src/data/tiles/worldTileIndex.ts
@@ -90,20 +90,20 @@ export const WORLD_DECOR = {
 // Each obstacle renders a SCENERY/PATH tile ring (via TERRAIN_PATCH_MAP) with a
 // single WORLD_DECOR tile placed in the center cell — they must not share a cell.
 // Multiple IDs → pick one deterministically via idNum % length.
+// Water is intentionally absent: water patches fill their center cell so merged
+// pools read as one solid body of water, leaving nowhere for a center icon.
 export const TERRAIN_DECOR_MAP: Record<string, Partial<Record<string, number[]>>> = {
   _default: {
     tree:  [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree, WORLD_DECOR.singleTree],
     rock:  [WORLD_DECOR.pileOfRocks, WORLD_DECOR.rock],
-    water: [WORLD_DECOR.pond],
     ruin:  [WORLD_DECOR.graveStone, WORLD_DECOR.signpost],
   },
   forest:  { tree: [WORLD_DECOR.bigTree, WORLD_DECOR.groupOfTrees] },
   ashen:   { tree: [WORLD_DECOR.rock], ruin: [WORLD_DECOR.graveStone] },
-  sand:    { water: [WORLD_DECOR.sandSinkhole], rock: [WORLD_DECOR.rock], ruin: [WORLD_DECOR.signpost] },
-  volcano: { rock: [WORLD_DECOR.pileOfRocks], water: [WORLD_DECOR.waterWhirlpool], ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
+  sand:    { rock: [WORLD_DECOR.rock], ruin: [WORLD_DECOR.signpost] },
+  volcano: { rock: [WORLD_DECOR.pileOfRocks], ruin: [WORLD_DECOR.volcanoCaveBottomLeft] },
   citadel: { ruin: [WORLD_DECOR.house], rock: [WORLD_DECOR.pileOfRocks] },
-  frost:   { water: [WORLD_DECOR.pond], rock: [WORLD_DECOR.pileOfRocks] },
-  coast:   { water: [WORLD_DECOR.pond] },
+  frost:   { rock: [WORLD_DECOR.pileOfRocks] },
   fungal:  { tree: [WORLD_DECOR.groupOfTrees, WORLD_DECOR.bigTree] },
 }
 

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -1,7 +1,8 @@
 import * as PIXI from 'pixi.js'
 import { ENV_TILES, BASE_GROUND, TILESET_IMAGE, TILESET_COLUMNS, TILE_SIZE, EnvTileDef, SCENERY } from '../data/tiles/tileIndex'
-import { WORLD_DECOR_FILE, WORLD_DECOR, TERRAIN_DECOR_MAP, TERRAIN_PATCH_MAP } from '../data/tiles/worldTileIndex'
+import { WORLD_DECOR_FILE, WORLD_DECOR, TERRAIN_DECOR_MAP } from '../data/tiles/worldTileIndex'
 import { loadTileTexture } from './pixiHelpers'
+import { planTerrainPatches } from './terrainPatchPlan'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
 import { renderPathTiles } from './tileLookup'
@@ -411,6 +412,12 @@ async function renderSceneryPatch(
  * are organic rather than single scaled tiles. Ruins fall back to a single
  * WORLD_DECOR tile (gravestone, house, etc.).
  *
+ * Obstacles sharing a tileset are unioned into one tile set by
+ * planTerrainPatches() and autotiled together, so touching patches render as
+ * one continuous shape — a chain of overlapping water circles becomes a single
+ * lake with one shoreline, rather than each circle edging against its
+ * neighbours. This mirrors what buildRoadGfx does for overlapping roads.
+ *
  * Game coords → canvas px via gameToPixel() (see above).
  */
 export async function buildTerrainDecorGfx(
@@ -423,83 +430,40 @@ export async function buildTerrainDecorGfx(
   if (terrain.length === 0) return
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   const env = opts.environment ?? ''
-  const envPatchMap = TERRAIN_PATCH_MAP[env] ?? {}
   const envDecorMap = TERRAIN_DECOR_MAP[env] ?? {}
 
   const toTile = (obs: TerrainObstacle) => {
     const { px, py } = gameToPixel(obs.x, obs.y, w, h)
     return { tcx: Math.round(px / TILE_SIZE), tcy: Math.round(py / TILE_SIZE) }
   }
+  const tileRadiusOf = (obs: TerrainObstacle) =>
+    Math.max(1, Math.round(obs.radius * h / (TILE_RADIUS_SCALE * TILE_SIZE)))
 
-  // terrain.ts only guarantees a minimum *game-unit* separation between obstacle
-  // centers, but the canvas projection below doesn't scale 1:1 with tile distance —
-  // so two obstacles' tile-rings can still end up overlapping (more often than not,
-  // across types too — confirmed by brute-force search across seeds). Reserve every
-  // obstacle's center cell up front so a neighboring ring can never swallow its decor
-  // icon, then have each ring claim cells first-come so overlapping rings carve cleanly
-  // around each other (and around centers) instead of later obstacles' tiles
-  // overwriting earlier ones into a single illegible blob.
-  const claimedCells = new Set<string>()
-  for (const obs of terrain) {
-    const { tcx, tcy } = toTile(obs)
-    claimedCells.add(`${tcx},${tcy}`)
+  const { groups, decor } = planTerrainPatches(terrain, toTile, tileRadiusOf, env)
+
+  // ── TYPE3 adjacency-tiled patches (tree / rock / water), one draw per tileset ──
+  for (const group of groups) {
+    if (container.destroyed) return
+    const patchContainer = new PIXI.Container()
+    container.addChild(patchContainer)
+    if (group.isPathTiles) {
+      await renderPathTiles(patchContainer, group.tiles, undefined, group.patchFile)
+    } else {
+      await renderSceneryPatch(patchContainer, group.tiles, group.patchFile)
+    }
   }
 
-  for (const obs of terrain) {
+  // ── WORLD_DECOR icons (tree/rock centres, ruins) — drawn last so they sit on top ──
+  const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
+  for (const { type, idNum, tcx, tcy } of decor) {
     if (container.destroyed) return
-    const { tcx, tcy } = toTile(obs)
-    const idNum = parseInt(obs.id.replace('t', ''), 10)
-
-    // ── TYPE3 adjacency-tiled patch (tree / rock / water) ───────────────────
-    // SCENERY/PATH tiles fill the ring; center cell is reserved for WORLD_DECOR.
-    const patchFile = envPatchMap[obs.type] ?? TERRAIN_PATCH_MAP._default?.[obs.type]
-    if (patchFile) {
-      const tileRadius = Math.max(1, Math.round(obs.radius * h / (TILE_RADIUS_SCALE * TILE_SIZE)))
-      const ringSet = new Set<string>()
-      for (let dr = -tileRadius; dr <= tileRadius; dr++) {
-        for (let dc = -tileRadius; dc <= tileRadius; dc++) {
-          if (dr * dr + dc * dc > tileRadius * tileRadius) continue
-          const key = `${tcx + dc},${tcy + dr}`
-          if (claimedCells.has(key)) continue
-          ringSet.add(key)
-        }
-      }
-      for (const key of ringSet) claimedCells.add(key)
-
-      const patchContainer = new PIXI.Container()
-      container.addChild(patchContainer)
-      if (obs.type === 'water') {
-        await renderPathTiles(patchContainer, ringSet, undefined, patchFile)
-      } else {
-        await renderSceneryPatch(patchContainer, ringSet, patchFile)
-      }
-      if (container.destroyed) return
-
-      // Place WORLD_DECOR tile in the center cell (separate from SCENERY/PATH ring)
-      const tileIds = (envDecorMap[obs.type] ?? TERRAIN_DECOR_MAP._default?.[obs.type]) as number[] | undefined
-      if (tileIds?.length) {
-        const tileId = tileIds[idNum % tileIds.length]
-        const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
-        const tex = await loadTileTexture(decorUrl, tileId, 8)
-        if (container.destroyed) return
-        const s = new PIXI.Sprite(tex)
-        s.position.set(tcx * TILE_SIZE, tcy * TILE_SIZE)
-        container.addChild(s)
-      }
-      continue
-    }
-
-    // ── Ruin: single WORLD_DECOR tile (gravestone, house, …) ────────────────
-    if (obs.type === 'ruin') {
-      const tileIds = (envDecorMap['ruin'] ?? TERRAIN_DECOR_MAP._default?.['ruin']) as number[] | undefined ?? []
-      if (tileIds.length === 0) continue
-      const tileId = tileIds[idNum % tileIds.length]
-      const decorUrl = `${base}${WORLD_DECOR_FILE.slice(1)}`
-      const tex = await loadTileTexture(decorUrl, tileId, 8)
-      if (container.destroyed) return
-      const s = new PIXI.Sprite(tex)
-      s.position.set(tcx * TILE_SIZE, tcy * TILE_SIZE)
-      container.addChild(s)
-    }
+    const tileIds = (envDecorMap[type] ?? TERRAIN_DECOR_MAP._default?.[type]) as number[] | undefined
+    if (!tileIds?.length) continue
+    const tileId = tileIds[idNum % tileIds.length]
+    const tex = await loadTileTexture(decorUrl, tileId, 8)
+    if (container.destroyed) return
+    const s = new PIXI.Sprite(tex)
+    s.position.set(tcx * TILE_SIZE, tcy * TILE_SIZE)
+    container.addChild(s)
   }
 }

--- a/web/src/utils/terrainPatchPlan.test.ts
+++ b/web/src/utils/terrainPatchPlan.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { planTerrainPatches } from './terrainPatchPlan'
+import type { TerrainObstacle, TerrainType } from '../game/engine/terrain'
+
+/** Obstacle whose game coords double as tile coords via the toTile stub below. */
+function obs(id: string, type: TerrainType, x: number, y: number): TerrainObstacle {
+  return { id, type, x, y, radius: 20 }
+}
+
+const toTile = (o: TerrainObstacle) => ({ tcx: o.x, tcy: o.y })
+const radius2 = () => 2
+
+describe('planTerrainPatches', () => {
+  it('merges overlapping water into one group with no interior shoreline', () => {
+    const { groups } = planTerrainPatches(
+      [obs('t1', 'water', 10, 10), obs('t2', 'water', 13, 10)],
+      toTile, radius2, 'forest',
+    )
+
+    expect(groups).toHaveLength(1)
+    const { tiles } = groups[0]
+    expect(groups[0].isPathTiles).toBe(true)
+
+    // The seam column between the two discs is fully surrounded, so the
+    // autotiler sees interior water there rather than two facing shorelines.
+    for (const [tx, ty] of [[11, 10], [12, 10]]) {
+      expect(tiles.has(`${tx},${ty}`)).toBe(true)
+      expect(tiles.has(`${tx},${ty - 1}`)).toBe(true)
+      expect(tiles.has(`${tx},${ty + 1}`)).toBe(true)
+      expect(tiles.has(`${tx - 1},${ty}`)).toBe(true)
+      expect(tiles.has(`${tx + 1},${ty}`)).toBe(true)
+    }
+  })
+
+  it('fills water centre cells and places no centre icon there', () => {
+    const { groups, decor } = planTerrainPatches(
+      [obs('t1', 'water', 10, 10), obs('t2', 'water', 13, 10)],
+      toTile, radius2, 'forest',
+    )
+
+    expect(groups[0].tiles.has('10,10')).toBe(true)
+    expect(groups[0].tiles.has('13,10')).toBe(true)
+    expect(decor).toHaveLength(0)
+  })
+
+  it('keeps mismatched tilesets in separate, non-overlapping groups', () => {
+    const { groups, decor } = planTerrainPatches(
+      [obs('t1', 'water', 10, 10), obs('t2', 'tree', 12, 10)],
+      toTile, radius2, 'forest',
+    )
+
+    expect(groups).toHaveLength(2)
+    const [water, tree] = groups
+    for (const key of water.tiles) expect(tree.tiles.has(key)).toBe(false)
+
+    // The tree's centre cell is reserved for its sprite — in neither tile set.
+    expect(tree.tiles.has('12,10')).toBe(false)
+    expect(water.tiles.has('12,10')).toBe(false)
+    expect(decor).toEqual([{ type: 'tree', idNum: 2, tcx: 12, tcy: 10 }])
+  })
+
+  it('emits an icon-only entry for ruins, which have no patch tileset', () => {
+    const { groups, decor } = planTerrainPatches([obs('t7', 'ruin', 4, 4)], toTile, radius2, 'forest')
+
+    expect(groups).toHaveLength(0)
+    expect(decor).toEqual([{ type: 'ruin', idNum: 7, tcx: 4, tcy: 4 }])
+  })
+})

--- a/web/src/utils/terrainPatchPlan.ts
+++ b/web/src/utils/terrainPatchPlan.ts
@@ -1,0 +1,110 @@
+import { TERRAIN_PATCH_MAP } from '../data/tiles/worldTileIndex'
+import type { TerrainObstacle, TerrainType } from '../game/engine/terrain'
+
+/**
+ * A set of tiles that autotile together as one shape. Obstacles sharing a
+ * tileset are unioned into a single group so touching patches render as one
+ * continuous body (one outer shoreline / tree line) instead of each obstacle
+ * drawing its own edge against its neighbour — the same grouping buildRoadGfx
+ * applies to roads.
+ */
+export interface TerrainPatchGroup {
+  patchFile: string
+  /** true → renderPathTiles (water); false → renderSceneryPatch (tree/rock). */
+  isPathTiles: boolean
+  tiles: Set<string>
+}
+
+/** A single WORLD_DECOR icon placed at an obstacle's centre tile. */
+export interface TerrainPatchDecor {
+  type: TerrainType
+  /** Numeric part of the obstacle id — picks the tile variant (idNum % tileIds.length). */
+  idNum: number
+  tcx: number
+  tcy: number
+}
+
+export interface TerrainPatchPlan {
+  groups: TerrainPatchGroup[]
+  decor: TerrainPatchDecor[]
+}
+
+/** Water fills its centre tile; every other type reserves it for a decor sprite. */
+function hasCentreDecor(type: TerrainType): boolean {
+  return type !== 'water'
+}
+
+/**
+ * Turns battlefield terrain obstacles into autotile-ready tile sets, without
+ * touching PixiJS — buildTerrainDecorGfx (utils/terrainLayer.ts) renders the
+ * result, and this stays pure so the tiling rules are unit-testable.
+ *
+ * Obstacles are walked in array order and claim ring cells first-come, so
+ * patches drawn from *different* tilesets carve cleanly around each other
+ * rather than overwriting one another into an illegible blob. Cells within the
+ * same tileset group simply union — that union is what makes overlapping water
+ * read as one lake.
+ *
+ * @param toTile        obstacle → its centre tile coords (canvas projection)
+ * @param tileRadiusOf  obstacle → disc radius in tiles
+ * @param env           act environment, selecting the per-type tileset
+ */
+export function planTerrainPatches(
+  terrain: TerrainObstacle[],
+  toTile: (obs: TerrainObstacle) => { tcx: number; tcy: number },
+  tileRadiusOf: (obs: TerrainObstacle) => number,
+  env: string,
+): TerrainPatchPlan {
+  const envPatchMap = TERRAIN_PATCH_MAP[env] ?? {}
+  const patchFileOf = (type: TerrainType) => envPatchMap[type] ?? TERRAIN_PATCH_MAP._default?.[type]
+
+  // Centre cells of decor-bearing obstacles are reserved up front so no ring —
+  // not even a neighbouring one from the same group — can swallow the cell the
+  // icon sits on. Water has no centre icon, so its centre stays fillable.
+  const reservedCentres = new Set<string>()
+  for (const obs of terrain) {
+    if (!hasCentreDecor(obs.type)) continue
+    const { tcx, tcy } = toTile(obs)
+    reservedCentres.add(`${tcx},${tcy}`)
+  }
+
+  const groups = new Map<string, TerrainPatchGroup>()
+  const cellOwner = new Map<string, string>()
+  const decor: TerrainPatchDecor[] = []
+
+  for (const obs of terrain) {
+    const { tcx, tcy } = toTile(obs)
+    const idNum = parseInt(obs.id.replace('t', ''), 10)
+    const patchFile = patchFileOf(obs.type)
+
+    if (patchFile) {
+      const isPathTiles = obs.type === 'water'
+      const groupKey = `${isPathTiles}|${patchFile}`
+      let group = groups.get(groupKey)
+      if (!group) {
+        group = { patchFile, isPathTiles, tiles: new Set() }
+        groups.set(groupKey, group)
+      }
+
+      const tileRadius = tileRadiusOf(obs)
+      for (let dr = -tileRadius; dr <= tileRadius; dr++) {
+        for (let dc = -tileRadius; dc <= tileRadius; dc++) {
+          if (dr * dr + dc * dc > tileRadius * tileRadius) continue
+          const key = `${tcx + dc},${tcy + dr}`
+          if (reservedCentres.has(key)) continue
+          const owner = cellOwner.get(key)
+          if (owner !== undefined && owner !== groupKey) continue
+          cellOwner.set(key, groupKey)
+          group.tiles.add(key)
+        }
+      }
+    }
+
+    // Ruins have no patch tileset — they are the icon alone.
+    if (patchFile ? hasCentreDecor(obs.type) : obs.type === 'ruin') {
+      decor.push({ type: obs.type, idNum, tcx, tcy })
+    }
+  }
+
+  return { groups: Array.from(groups.values()), decor }
+}


### PR DESCRIPTION
## Problem

Battlefield water rendered as a chain of colliding puddles — each pool drew its own shoreline through the middle of what should be one lake, with a grass hole and pond icon at every blob's centre.

`buildTerrainDecorGfx` rendered each `TerrainObstacle` **on its own**: it built a circular tile ring and autotiled just that ring, so the autotiler never saw the neighbouring pool and drew a shore edge at every seam. Two things compounded it:

- `claimedCells` made each ring carve around cells an earlier obstacle had claimed, producing scalloped bite-outs.
- Every obstacle reserved its centre cell for a `WORLD_DECOR` icon, leaving an island of grass inside each pool.

Overlaps are the norm, not the exception: `generateTerrain` only enforces a minimum *game-unit* separation while `gameToPixel` squashes the lateral axis, and `expandTerrainPathsToObstacles` deliberately emits chains of overlapping circles for authored rivers and tree lines.

## Fix

Apply the grouping `buildRoadGfx` already uses for overlapping roads — union tiles first, autotile once.

- **`web/src/utils/terrainPatchPlan.ts`** (new, Pixi-free so it is testable without mocks) — `planTerrainPatches()` unions obstacles that share a tileset into a single tile set, reserves only decor-bearing centres, and carves first-come *across* tilesets only. Water centres are no longer reserved, so merged pools are solid.
- **`web/src/utils/terrainLayer.ts`** — `buildTerrainDecorGfx` now draws one patch per tileset group instead of one per obstacle, and draws decor icons last so they stay on top. `renderPathTiles`/`renderSceneryPatch` are unchanged; they already autotile whatever set they are handed.
- **`web/src/data/tiles/worldTileIndex.ts`** — dropped the now-unreachable `water` entries from `TERRAIN_DECOR_MAP` and updated the comment above it.
- **Tests** — `terrainPatchPlan.test.ts` covers merged seams (interior tiles, not facing shorelines), filled water centres, disjoint mismatched tilesets, and icon-only ruins. `BattlefieldTerrainCanvas` gained a `MergedWater` story rendering a deliberately overlapping obstacle chain; the existing stories passed no terrain, so nothing covered this visually.

Purely a renderer change — no act/node JSON edits, and `TerrainObstacle` avoidance is untouched, so unit collision behaviour is identical. `BattlefieldEditorCanvas` calls the same function, so the editor stays WYSIWYG with the live battlefield.

## Verification

- `npm run build` — clean.
- `npm run test` — 1929 unit tests pass, including the 4 new ones. (The Storybook browser project cannot launch in this container: it pins Playwright chromium build 1217 and only 1194 is installed — pre-existing, unrelated to this change.)
- Visual: rendered the new `MergedWater` story in Storybook — the four overlapping water obstacles form one continuous lake with a single shoreline, no interior grass holes and no pond icons; the tree obstacles merge into one forest patch the same way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPm1WWGX2Mf84xRLXVkNAn)_