### PR TITLE
fix(battlefield): tint unit HP bars by owner again

### DIFF
--- a/web/src/components/battle/battlefieldCanvas/units.ts
+++ b/web/src/components/battle/battlefieldCanvas/units.ts
@@ -228,7 +228,7 @@ function syncMobileOrStructure(scene: Scene, unit: Unit, opts: SyncOneOpts) {
     hpBar.clear()
     const barW = 30
     hpBar.position.set(-barW / 2, topAnchored ? box.h + 4 : 4)
-    drawHpBar(hpBar, 0, 0, barW, unit.hp / unit.maxHp)
+    drawHpBar(hpBar, 0, 0, barW, unit.hp / unit.maxHp, unit.owner)
   }
 
   // ── Buffs ──

--- a/web/src/utils/pixiHelpers.test.ts
+++ b/web/src/utils/pixiHelpers.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const loadMock = vi.fn()
 vi.mock('pixi.js', () => ({ Assets: { load: (url: string) => loadMock(url) } }))
 
-const { loadAnimFramesOrStatic } = await import('./pixiHelpers')
+const { loadAnimFramesOrStatic, drawHpBar } = await import('./pixiHelpers')
 
 /** Resolves `{slug}.svg` only; every `{slug}-N.svg` frame 404s. */
 function staticOnly(...slugs: string[]) {
@@ -46,5 +46,53 @@ describe('loadAnimFramesOrStatic', () => {
   it('rejects when neither the frames nor the static sprite exist', async () => {
     loadMock.mockImplementation(() => Promise.reject(new Error('404')))
     await expect(loadAnimFramesOrStatic('No Such Unit', 3)).rejects.toThrow()
+  })
+})
+
+/** Minimal stand-in for PIXI.Graphics — drawHpBar only chains rect().fill(). */
+function fakeGraphics() {
+  const fills: number[] = []
+  const g = {
+    fills,
+    rect: () => g,
+    fill: (col: number) => { fills.push(col); return g },
+  }
+  return g
+}
+
+/** Fill color of the bar itself (the first fill is the dark backing rect). */
+function fillColor(hpFrac: number, owner?: 'player' | 'opponent'): number | undefined {
+  const g = fakeGraphics()
+  drawHpBar(g as never, 0, 0, 30, hpFrac, owner)
+  return g.fills[1]
+}
+
+describe('drawHpBar', () => {
+  // Enemy bars used to share the player's green at full health, making the two
+  // sides indistinguishable on the battlefield.
+  it('keeps player and opponent bars in different hues at every damage level', () => {
+    for (const frac of [1, 0.4, 0.1]) {
+      expect(fillColor(frac, 'player')).not.toBe(fillColor(frac, 'opponent'))
+    }
+  })
+
+  it('darkens within the owner hue as HP drops', () => {
+    for (const owner of ['player', 'opponent'] as const) {
+      const [healthy, hurt, critical] = [1, 0.4, 0.1].map(f => fillColor(f, owner)!)
+      expect(healthy).toBeGreaterThan(hurt)
+      expect(hurt).toBeGreaterThan(critical)
+    }
+  })
+
+  it('falls back to the neutral ramp when no owner is given', () => {
+    expect(fillColor(1)).toBe(0x44cc44)
+    expect(fillColor(0.4)).toBe(0xddbb00)
+    expect(fillColor(0.1)).toBe(0xcc2222)
+  })
+
+  it('draws only the backing rect at zero HP', () => {
+    const g = fakeGraphics()
+    drawHpBar(g as never, 0, 0, 30, 0, 'opponent')
+    expect(g.fills).toEqual([0x111111])
   })
 })

--- a/web/src/utils/pixiHelpers.ts
+++ b/web/src/utils/pixiHelpers.ts
@@ -93,17 +93,37 @@ export function animateTileSprites(
 }
 
 /**
+ * HP bar fill ramps, as [healthy, hurt, critical].
+ *
+ * Friendly units read green and hostile units read red, restoring the owner tint
+ * the DOM battlefield had (`.lane-unit--player/--opponent .lane-unit-hp-fill`)
+ * before the Pixi migration flattened every bar onto one fraction ramp — which
+ * left full-health enemies looking identical to your own units. Shades darken as
+ * HP drops so injury still reads without either side straying into the other's
+ * hue. `neutral` is the pre-existing owner-agnostic ramp, kept for callers that
+ * have no side to show.
+ */
+const HP_BAR_RAMP: Record<'player' | 'opponent' | 'neutral', readonly [number, number, number]> = {
+  player:   [0x33ff33, 0x28cc28, 0x1f9e1f],
+  opponent: [0xff4444, 0xd12f2f, 0xa32020],
+  neutral:  [0x44cc44, 0xddbb00, 0xcc2222],
+}
+
+/**
  * Draw a health bar into a Graphics object at (x, y) with the given pixel width.
  * Call g.clear() before drawing all bars if you want to redraw each frame.
+ * Pass `owner` to tint the fill by side; omit it for the neutral ramp.
  */
 export function drawHpBar(
   g: PIXI.Graphics,
   x: number, y: number,
   barWidth: number,
   hpFrac: number,
+  owner?: 'player' | 'opponent',
 ): void {
-  const f   = Math.max(0, Math.min(1, hpFrac))
-  const col = f > 0.5 ? 0x44cc44 : f > 0.25 ? 0xddbb00 : 0xcc2222
+  const f = Math.max(0, Math.min(1, hpFrac))
+  const [healthy, hurt, critical] = HP_BAR_RAMP[owner ?? 'neutral']
+  const col = f > 0.5 ? healthy : f > 0.25 ? hurt : critical
   g.rect(x, y, barWidth, 3).fill(0x111111)
   if (f > 0) g.rect(x, y, Math.round(barWidth * f), 3).fill(col)
 }


### PR DESCRIPTION
## Problem

On the battlefield, enemy HP bars render in the same color as friendly ones, so at full health both sides look identical.

This is a regression from the Pixi migration (`ec3aaf9`). The DOM battlefield colored the HP fill by owner:

```css
.lane-unit--player   .lane-unit-hp-fill { background: #33ff33; }
.lane-unit--opponent .lane-unit-hp-fill { background: var(--color-red); }
```

That markup was replaced by `drawHpBar()` in `web/src/utils/pixiHelpers.ts`, which colored purely by HP fraction (green > 50%, yellow > 25%, red below) with no owner input — dropping the side distinction entirely.

## Change

`drawHpBar()` now takes the unit's `owner` and selects its ramp from that, so both signals survive:

| | healthy | hurt | critical |
|---|---|---|---|
| player | `#33ff33` | `#28cc28` | `#1f9e1f` |
| opponent | `#ff4444` | `#d12f2f` | `#a32020` |

Friendly bars stay in the green family and hostile bars in the red family, each darkening as HP drops so injury still reads without either side straying into the other's hue. The `owner` parameter is optional — callers with no side to show keep the previous owner-agnostic ramp unchanged.

The battlefield's only call site (`battlefieldCanvas/units.ts`) now passes `unit.owner`. Walls and moats were already owner-tinted by `drawWall`/`drawMoat` and are untouched; the tower-defence minigame has its own `drawHpBars` and is unaffected.

## Verification

- `npm run build` (typecheck) passes.
- `npm run test` passes — 237 files, 2582 tests.
- Added four `drawHpBar` unit tests: the two sides differ at every damage level, each ramp darkens as HP drops, the no-owner fallback keeps its original colors, and a zero-HP bar draws only its backing rect.
- Checked visually in Storybook with player and opponent units at 100% / 40% / 10% HP: friendly bars render green, enemy bars red, both shading down with damage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwpYY45qdQHuQsFTtmyBeF)_