### PR TITLE
Fix 5 UI issues: fragment scroll, boss dismissal, resting UI, map connectors, card overlap

### DIFF
--- a/web/src/components/battle/BossDialogueScreen.tsx
+++ b/web/src/components/battle/BossDialogueScreen.tsx
@@ -28,23 +28,25 @@ export function BossDialogueScreen({ bossName, lines, onDone }: Props) {
   const allShown = shownCount >= lines.length
 
   return (
-    <div className="boss-dialogue-screen" onClick={advance}>
-      <div className="boss-dialogue-speaker">[{bossName.toUpperCase()}]</div>
-      <div className="boss-dialogue-lines u-col u-gap-8">
-        {lines.slice(0, shownCount).map((line, i) => (
-          <div
-            key={i}
-            className={`boss-dialogue-line${i === shownCount - 1 ? ' boss-dialogue-line--new' : ''}`}
-          >
-            {line}
-          </div>
-        ))}
-      </div>
-      <div className="boss-dialogue-footer">
-        {allShown
-          ? <span className="boss-dialogue-fight">PRESS ENTER TO FIGHT</span>
-          : <span className="boss-dialogue-continue">CLICK TO CONTINUE ›</span>
-        }
+    <div className="boss-dialogue-backdrop" onClick={advance}>
+      <div className="boss-dialogue-screen">
+        <div className="boss-dialogue-speaker">[{bossName.toUpperCase()}]</div>
+        <div className="boss-dialogue-lines u-col u-gap-8">
+          {lines.slice(0, shownCount).map((line, i) => (
+            <div
+              key={i}
+              className={`boss-dialogue-line${i === shownCount - 1 ? ' boss-dialogue-line--new' : ''}`}
+            >
+              {line}
+            </div>
+          ))}
+        </div>
+        <div className="boss-dialogue-footer">
+          {allShown
+            ? <span className="boss-dialogue-fight">PRESS ENTER TO FIGHT</span>
+            : <span className="boss-dialogue-continue">CLICK TO CONTINUE ›</span>
+          }
+        </div>
       </div>
     </div>
   )

--- a/web/src/components/campaign/BossEpilogueScreen.tsx
+++ b/web/src/components/campaign/BossEpilogueScreen.tsx
@@ -44,28 +44,30 @@ export function BossEpilogueScreen({ panels, onDone }: Props) {
   const paragraphs = panel.text.split('\n\n').filter(Boolean)
 
   return (
-    <div className="cutscene-screen u-col u-just-sb u-pointer u-no-select" onClick={advance}>
-      <div className={`cutscene-content${visible ? ' cutscene-content--visible' : ''}`}>
-        <div className="cutscene-act-label">// {panel.title}</div>
-        {panel.image && (
-          <img src={`${import.meta.env.BASE_URL}${panel.image}`} alt="" className="cutscene-image" />
-        )}
-        <div className="cutscene-body u-col u-gap-7">
-          {paragraphs.map((p, i) => (
-            <p key={i} className="cutscene-paragraph">{p}</p>
-          ))}
+    <div className="boss-epilogue-backdrop" onClick={advance}>
+      <div className="cutscene-screen u-col u-just-sb u-no-select">
+        <div className={`cutscene-content${visible ? ' cutscene-content--visible' : ''}`}>
+          <div className="cutscene-act-label">// {panel.title}</div>
+          {panel.image && (
+            <img src={`${import.meta.env.BASE_URL}${panel.image}`} alt="" className="cutscene-image" />
+          )}
+          <div className="cutscene-body u-col u-gap-7">
+            {paragraphs.map((p, i) => (
+              <p key={i} className="cutscene-paragraph">{p}</p>
+            ))}
+          </div>
         </div>
-      </div>
 
-      <div className="cutscene-footer u-flex u-just-sb u-items-c">
-        <span className="cutscene-progress">{index + 1} / {panels.length}</span>
-        <button
-          className="cutscene-skip-btn"
-          onClick={e => { e.stopPropagation(); onDone() }}
-        >
-          SKIP ›
-        </button>
-        <span className="cutscene-continue">{isLast ? 'PRESS ENTER TO CONTINUE' : 'CLICK TO CONTINUE ›'}</span>
+        <div className="cutscene-footer u-flex u-just-sb u-items-c">
+          <span className="cutscene-progress">{index + 1} / {panels.length}</span>
+          <button
+            className="cutscene-skip-btn"
+            onClick={e => { e.stopPropagation(); onDone() }}
+          >
+            SKIP ›
+          </button>
+          <span className="cutscene-continue">{isLast ? 'PRESS ENTER TO CONTINUE' : 'CLICK TO CONTINUE ›'}</span>
+        </div>
       </div>
     </div>
   )

--- a/web/src/components/campaign/MemoryFragmentScreen.tsx
+++ b/web/src/components/campaign/MemoryFragmentScreen.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export function MemoryFragmentScreen({ fragment, alreadyFound, shardBonus, onCollect }: Props) {
   return (
-    <div className="memory-screen">
+    <div className="overlay-screen memory-screen">
       <div className="memory-type-tag">[MEMORY FRAGMENT]</div>
       <div className="memory-title">{fragment.title}</div>
 

--- a/web/src/components/cards/CardRestSelect.tsx
+++ b/web/src/components/cards/CardRestSelect.tsx
@@ -44,12 +44,13 @@ export function CardRestSelect({ candidates, playCounts, alreadyResting = [], on
       {alreadyResting.length > 0 && (
         <div className="card-rest-already">
           <div className="card-rest-already-label">ALREADY RESTING</div>
-          <div className="card-rest-already-list u-flex u-wrap u-gap-4">
+          <div className="card-rest-already-list u-flex u-wrap u-gap-4 u-just-c">
             {alreadyResting.map(name => (
-              <>
-                <SpriteImg name={name} className="card-sprite" />
-                <span key={name} className="card-rest-already-item">[ZZZ] {name}</span>
-              </>
+              <div key={name} className="card-rest-already-item">
+                <SpriteImg name={name} className="card-sprite card-rest-already-sprite" />
+                <span className="card-rest-already-name">{name}</span>
+                <span className="card-rest-already-tag">ZZZ</span>
+              </div>
             ))}
           </div>
           <div className="card-rest-already-note">

--- a/web/src/components/cards/CardRestSelectCandidate.tsx
+++ b/web/src/components/cards/CardRestSelectCandidate.tsx
@@ -10,24 +10,21 @@ interface Props {
 }
 
 export function CardRestSelectCandidate({ name, playCount, rank, isSelected, onClick }: Props) {
-
-
   return (
-<>
-            <div
-              key={name}
-              className={[
-                'card-rest-candidate',
-                isSelected ? 'card-rest-candidate--selected' : '',
-              ].join(' ')}
-              onClick={() => onClick(name)}
-            >
-              <div className="card-art u-flex u-items-c u-just-c"> {isSelected ?(<span className="card-art-flame">🔥</span>):null}<SpriteImg name={name} className="card-sprite" /></div>
-              <div className="crc-rank">#{rank} most used</div>
-              <div className="crc-name">{name}</div>
-              <div className="crc-count">×{playCount ?? 0} plays this act</div>
-            </div>
-            </>
-          )
-  
-  }
+    <div
+      className={[
+        'card-rest-candidate',
+        isSelected ? 'card-rest-candidate--selected' : '',
+      ].join(' ')}
+      onClick={() => onClick(name)}
+    >
+      <div className="card-art u-flex u-items-c u-just-c">
+        {isSelected ? <span className="card-art-flame">🔥</span> : null}
+        <SpriteImg name={name} className="card-sprite" />
+      </div>
+      <div className="crc-rank">#{rank} most used</div>
+      <div className="crc-name">{name}</div>
+      <div className="crc-count">×{playCount ?? 0} plays this act</div>
+    </div>
+  )
+}

--- a/web/src/components/cards/CardTile.stories.tsx
+++ b/web/src/components/cards/CardTile.stories.tsx
@@ -61,6 +61,13 @@ export const ShowDetails: Story = {
   },
 };
 
+export const GlassRaritySecretBadgeCheck: Story = {
+  args: {
+    card: { ...exampleCard, rarity: 'glass', glassBreakChance: 0.15 },
+    showDetails: true,
+  },
+};
+
 export const AllProps: Story = {
   args: {
     card: { ...exampleCard, isHero: true, upgradeEffect: { type: 'buffAttack', amount: 2 } },

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -192,7 +192,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
 
       <div className="card-cost">{displayCost ?? card.cost}</div>
       {upgradeable && <div className="card-upgrade-badge">UPGRADE</div>}
-      <div className="card-title">{card.name}</div>
+      <div className={`card-title${isSecret ? ' card-title--badge' : ''}`}>{card.name}</div>
       <div className="card-art u-flex u-items-c u-just-c">
         {card.unit
           ? <SpriteImg name={card.unit.name} className="card-sprite" />
@@ -205,21 +205,19 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
       </div>
 
       <div className="card-stats">{stats}</div>
-      <div className="card-bottom-row u-flex u-items-c u-just-sb u-gap-1">
+      <div className="card-bottom-row">
         <div className="card-rarity">{rarityStars(card.rarity)}</div>
         <div className={`card-type-badge card-type-badge--${getCardCategory(card)}`}>
           {CATEGORY_ICON[getCardCategory(card)]}
           <span>{CATEGORY_LABEL[getCardCategory(card)]}</span>
         </div>
         {showDetails && (
-          <div className="cell-footer">
-              <button
-                className="extra-btn cdm-info-btn"
-                onClick={e => { e.stopPropagation(); openDetail(card) }}
-                title="Card details"
-              >ⓘ</button>
-            </div>       
-        )} 
+          <button
+            className="card-bottom-info-btn"
+            onClick={e => { e.stopPropagation(); openDetail(card) }}
+            title="Card details"
+          >ⓘ</button>
+        )}
       </div>
       {heroLocked && (
         <div className="card-hero-lock u-absolute u-col u-items-c u-just-c">

--- a/web/src/components/ui/NodeMap/NodeMapRederer.stories.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.stories.tsx
@@ -31,6 +31,25 @@ export const CampaignMode: Story = {
   },
 }
 
+// Temporary verification story: node-1 connects directly to node-4 (2
+// columns ahead, skipping node-2/node-3's row) to confirm connectors and
+// path tiles render across multi-column gaps, not just adjacent columns.
+export const MultiColumnJumpCheck: Story = {
+  args: {
+    id: exampleAct.id,
+    worldMap: {
+      ...exampleAct,
+      nodes: {
+        ...exampleAct.nodes,
+        'node-1': { ...exampleAct.nodes['node-1'], childIds: ['node-2', 'node-3', 'node-4'] },
+      },
+    },
+    run: exampleRunState,
+    setPeekNode: fn(),
+    showPaths: true,
+  },
+}
+
 export const CampaignFreshRun: Story = {
   args: {
     id: exampleAct.id,

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -250,21 +250,28 @@ async function buildPathTileGfx(
     }
   }
 
-  // Row-to-row connector paths
-  for (let ri = 0; ri < rows.length - 1; ri++) {
-    const prevRow = rows[ri], nextRow = rows[ri + 1]
-    const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
-    const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
-    const parentCenterX = AVATAR_PADDING + ri * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
-    const childCenterX  = AVATAR_PADDING + (ri + 1) * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
-    const xMid = AVATAR_PADDING + (ri + 1) * COL_WIDTH + ri * CONN_W + CONN_W / 2
+  // Row-to-row connector paths. Built from a global id -> row-index lookup
+  // (not just adjacent rows) so a child living 2+ columns ahead of its
+  // parent still gets a path laid all the way to it.
+  const nodeRowIndex = new Map<string, { ri: number; rowCols: number; node: QuestNode }>()
+  for (let ri = 0; ri < rows.length; ri++) {
+    const rowCols = rows[ri][0]?.rowCols ?? rows[ri].length
+    for (const node of rows[ri]) nodeRowIndex.set(node.id, { ri, rowCols, node })
+  }
 
-    for (const parent of prevRow) {
+  for (const row of rows) {
+    for (const parent of row) {
+      const parentEntry = nodeRowIndex.get(parent.id)!
       for (const childId of parent.childIds) {
-        const child = nextRow.find(n => n.id === childId)
-        if (!child) continue
-        const pr = (maxRowCols - prevRowCols) / 2 + parent.col
-        const cr = (maxRowCols - nextRowCols) / 2 + child.col
+        const childEntry = nodeRowIndex.get(childId)
+        if (!childEntry || childEntry.ri <= parentEntry.ri) continue
+
+        const parentCenterX = AVATAR_PADDING + parentEntry.ri * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+        const childCenterX  = AVATAR_PADDING + childEntry.ri  * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+        const xMid = (parentCenterX + COL_WIDTH / 2 + childCenterX - COL_WIDTH / 2) / 2
+
+        const pr = (maxRowCols - parentEntry.rowCols) / 2 + parent.col
+        const cr = (maxRowCols - childEntry.rowCols) / 2 + childEntry.node.col
         const y1 = (pr + 0.5) / maxRowCols * mapHeight
         const y2 = (cr + 0.5) / maxRowCols * mapHeight
 
@@ -341,80 +348,80 @@ function drawConnectorsGfx(
   const priority: Record<LineVariant, number> = { frontier: 3, trail: 2, future: 1, dead: 0 }
   const created: PIXI.Graphics[] = []
 
-  for (let ri = 0; ri < rows.length - 1; ri++) {
-    const prevRow = rows[ri], nextRow = rows[ri + 1]
-    const prevRowCols = prevRow[0]?.rowCols ?? prevRow.length
-    const nextRowCols = nextRow[0]?.rowCols ?? nextRow.length
-    const vrow = (node: QuestNode, rc: number) => (maxRowCols - rc) / 2 + node.col
-    const nextById = new Map(nextRow.map(n => [n.id, n]))
-    const best = new Map<string, { variant: LineVariant; pr: number; cr: number }>()
+  // Global id -> row-index lookup (not just adjacent rows) so a child living
+  // 2+ columns ahead of its parent still gets a connector drawn to it.
+  const nodeIndex = new Map<string, { ri: number; rowCols: number; node: QuestNode }>()
+  for (let ri = 0; ri < rows.length; ri++) {
+    const rowCols = rows[ri][0]?.rowCols ?? rows[ri].length
+    for (const node of rows[ri]) nodeIndex.set(node.id, { ri, rowCols, node })
+  }
+  const vrow = (node: QuestNode, rc: number) => (maxRowCols - rc) / 2 + node.col
 
-    for (const parent of prevRow) {
-      if (hiddenNodeIds.has(parent.id)) continue
-      for (const childId of parent.childIds) {
-        if (hiddenNodeIds.has(childId)) continue
-        const child = nextById.get(childId)
-        if (!child) continue
-        const pr = vrow(parent, prevRowCols), cr = vrow(child, nextRowCols)
-        const key = `${pr}:${cr}`
-        const v = lineVariant(parent.id, childId, statusOf, reachableIds)
-        const ex = best.get(key)
-        if (!ex || priority[v] > priority[ex.variant]) best.set(key, { variant: v, pr, cr })
+  const best = new Map<string, { variant: LineVariant; parentRi: number; childRi: number; pr: number; cr: number }>()
+  for (const { node: parent, ri: parentRi, rowCols: parentRowCols } of nodeIndex.values()) {
+    if (hiddenNodeIds.has(parent.id)) continue
+    for (const childId of parent.childIds) {
+      if (hiddenNodeIds.has(childId)) continue
+      const childEntry = nodeIndex.get(childId)
+      if (!childEntry || childEntry.ri <= parentRi) continue
+      const pr = vrow(parent, parentRowCols), cr = vrow(childEntry.node, childEntry.rowCols)
+      const key = `${parentRi}:${pr}:${childEntry.ri}:${cr}`
+      const v = lineVariant(parent.id, childId, statusOf, reachableIds)
+      const ex = best.get(key)
+      if (!ex || priority[v] > priority[ex.variant]) best.set(key, { variant: v, parentRi, childRi: childEntry.ri, pr, cr })
+    }
+  }
+
+  for (const { variant, parentRi, childRi, pr, cr } of best.values()) {
+    const parentCenterX = AVATAR_PADDING + parentRi * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+    const childCenterX  = AVATAR_PADDING + childRi  * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+    const xStart = parentCenterX + COL_WIDTH / 2
+    const xEnd   = childCenterX  - COL_WIDTH / 2
+    const xMid   = (xStart + xEnd) / 2
+    const y1 = (pr + 0.5) / maxRowCols * mapHeight
+    const y2 = (cr + 0.5) / maxRowCols * mapHeight
+    const gfx = new PIXI.Graphics()
+    gfx.zIndex = (y1 + y2) / 2
+
+    if (variant === 'dead') {
+      gfx.moveTo(parentCenterX, y1).lineTo(xStart, y1)
+        .bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
+        .lineTo(childCenterX, y2)
+        .stroke({ color: 0xffffff, width: 1, alpha: 0.04 })
+    } else if (variant === 'future') {
+      const pts = [
+        { x: parentCenterX,                y: y1 },
+        { x: (parentCenterX + xStart) / 2, y: y1 },
+        ...sampleBezier(xStart, y1, xMid, y1, xMid, y2, xEnd, y2),
+        { x: (xEnd + childCenterX) / 2,    y: y2 },
+        { x: childCenterX,                 y: y2 },
+      ]
+      gfx.poly(bezierBand(pts, 5)).fill({ color: 0x000000, alpha: 0.15 })
+      gfx.poly(bezierBand(pts, 3)).fill({ color: trail.color, alpha: trail.alpha * 0.25 })
+    } else {
+      const pts = [
+        { x: parentCenterX,                y: y1 },
+        { x: (parentCenterX + xStart) / 2, y: y1 },
+        ...sampleBezier(xStart, y1, xMid, y1, xMid, y2, xEnd, y2),
+        { x: (xEnd + childCenterX) / 2,    y: y2 },
+        { x: childCenterX,                 y: y2 },
+      ]
+      const isFront = variant === 'frontier'
+      const halfOuter = isFront ? 9 : 7
+      const halfInner = isFront ? 6 : 4
+      const c = isFront ? frontier : trail
+
+      gfx.poly(bezierBand(pts, halfOuter)).fill({ color: 0x000000, alpha: 0.35 })
+      gfx.poly(bezierBand(pts, halfInner)).fill({ color: c.color, alpha: Math.min(c.alpha, 0.50) })
+
+      if (isFront) {
+        gfx.moveTo(xStart, y1).bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
+          .stroke({ color: c.color, width: 22, alpha: 0.18, cap: 'round' })
       }
     }
 
-    const xStart = AVATAR_PADDING + (ri + 1) * COL_WIDTH + ri * CONN_W
-    const xMid   = xStart + CONN_W / 2
-    const xEnd   = xStart + CONN_W
-    const parentCenterX = AVATAR_PADDING + ri * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
-    const childCenterX  = AVATAR_PADDING + (ri + 1) * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
-
-    for (const { variant, pr, cr } of best.values()) {
-      const y1 = (pr + 0.5) / maxRowCols * mapHeight
-      const y2 = (cr + 0.5) / maxRowCols * mapHeight
-      const gfx = new PIXI.Graphics()
-      gfx.zIndex = (y1 + y2) / 2
-
-      if (variant === 'dead') {
-        gfx.moveTo(parentCenterX, y1).lineTo(xStart, y1)
-          .bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
-          .lineTo(childCenterX, y2)
-          .stroke({ color: 0xffffff, width: 1, alpha: 0.04 })
-      } else if (variant === 'future') {
-        const pts = [
-          { x: parentCenterX,                y: y1 },
-          { x: (parentCenterX + xStart) / 2, y: y1 },
-          ...sampleBezier(xStart, y1, xMid, y1, xMid, y2, xEnd, y2),
-          { x: (xEnd + childCenterX) / 2,    y: y2 },
-          { x: childCenterX,                 y: y2 },
-        ]
-        gfx.poly(bezierBand(pts, 5)).fill({ color: 0x000000, alpha: 0.15 })
-        gfx.poly(bezierBand(pts, 3)).fill({ color: trail.color, alpha: trail.alpha * 0.25 })
-      } else {
-        const pts = [
-          { x: parentCenterX,                y: y1 },
-          { x: (parentCenterX + xStart) / 2, y: y1 },
-          ...sampleBezier(xStart, y1, xMid, y1, xMid, y2, xEnd, y2),
-          { x: (xEnd + childCenterX) / 2,    y: y2 },
-          { x: childCenterX,                 y: y2 },
-        ]
-        const isFront = variant === 'frontier'
-        const halfOuter = isFront ? 9 : 7
-        const halfInner = isFront ? 6 : 4
-        const c = isFront ? frontier : trail
-
-        gfx.poly(bezierBand(pts, halfOuter)).fill({ color: 0x000000, alpha: 0.35 })
-        gfx.poly(bezierBand(pts, halfInner)).fill({ color: c.color, alpha: Math.min(c.alpha, 0.50) })
-
-        if (isFront) {
-          gfx.moveTo(xStart, y1).bezierCurveTo(xMid, y1, xMid, y2, xEnd, y2)
-            .stroke({ color: c.color, width: 22, alpha: 0.18, cap: 'round' })
-        }
-      }
-
-      worldLayer.addChild(gfx)
-      created.push(gfx)
-    }
+    worldLayer.addChild(gfx)
+    created.push(gfx)
   }
 
   return created

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -940,6 +940,11 @@ body {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  min-height: 30px;
+}
+
+.card-title--badge {
+  padding-top: 12px;
 }
 
 .card-stats {
@@ -976,6 +981,35 @@ body {
 .card-type-badge--defensive { color: #ff9955; }
 .card-type-badge--support   { color: #cc88ff; }
 .card-type-badge--buff      { color: #ffee66; }
+
+.card-bottom-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-1);
+}
+
+.card-bottom-info-btn {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  font-size: var(--font-xxs);
+  background: rgba(0, 0, 0, 0.75);
+  border: 1px solid #555;
+  border-radius: 50%;
+  color: var(--game-text-color-dim);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+}
+
+.card-bottom-info-btn:hover {
+  color: var(--game-text-color-muted);
+  border-color: var(--game-text-color-muted);
+}
 
 .card-art {
   height: 42px;
@@ -2201,9 +2235,6 @@ body {
 }
 
 /* Fixed-height card tiles in collection so all cells are uniform */
-.collection-cell .card-title {
-  min-height: 30px; /* always reserve 2 lines */
-}
 .collection-cell .card-stats {
   min-height: 14px; /* always reserve 1 stats line */
 }
@@ -5207,7 +5238,6 @@ body {
   border: 1px solid #333;
   border-radius: 4px;
   padding: 10px 14px;
-  margin-bottom: 16px;
   background: #111;
   width: 100%;
   max-width: 560px;
@@ -5225,12 +5255,33 @@ body {
 }
 
 .card-rest-already-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  border: 1px solid var(--game-border);
+  border-radius: 4px;
+  padding: 8px 12px;
+  min-width: 90px;
+  background: #161616;
+  opacity: 0.75;
+  text-align: center;
+}
+
+.card-rest-already-sprite {
+  max-width: 40px;
+  max-height: 26px;
+}
+
+.card-rest-already-name {
   font-size: var(--font-sm);
-  color: #888;
-  background: #1a1a1a;
-  border: 1px solid #333;
-  padding: 2px 8px;
-  border-radius: 3px;
+  color: #999;
+}
+
+.card-rest-already-tag {
+  font-size: var(--font-xs);
+  letter-spacing: 0.2em;
+  color: #666;
 }
 
 .card-rest-already-note {
@@ -5990,6 +6041,18 @@ body {
   letter-spacing: 0.2em;
 }
 
+.boss-dialogue-backdrop,
+.boss-epilogue-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--game-bg);
+  cursor: pointer;
+}
+
 .boss-dialogue-screen {
   display: flex;
   flex-direction: column;
@@ -5999,7 +6062,6 @@ body {
   max-width: 560px;
   margin: 0 auto;
   padding: 48px 32px;
-  cursor: pointer;
   user-select: none;
   width: 100%;
 }


### PR DESCRIPTION
## Summary

Fixes five UI issues reported from screenshots/testing:

- **Fragment text doesn't scroll** — `MemoryFragmentScreen` now uses the existing `overlay-screen` convention (`flex:1; min-height:0; overflow-y:auto`), so long lore text scrolls instead of being clipped by the fixed-height game container.
- **Boss intro/outro requires tapping a specific small area to dismiss** — `BossDialogueScreen` and `BossEpilogueScreen` are now wrapped in a full-viewport backdrop (matching the existing `.event-card-reveal-backdrop` pattern), so tapping anywhere on screen advances/dismisses instead of only the small centered text box.
- **"Troops Need Rest" screen is messy** — fixed a misplaced `key`/stray fragment in `CardRestSelect`/`CardRestSelectCandidate`, and "ALREADY RESTING" entries now render as small consistent bordered chips (sprite + name + "ZZZ" tag) instead of loose icon/text pairs.
- **Node map road doesn't show the link when an act node skips more than 1 column ahead** — `NodeMapRederer`'s connector-drawing and path-tile code only checked the immediately-next row for a child node. Replaced the adjacent-row lookup with a global row-index map so connectors and ground path tiles render correctly across any column gap.
- **Card component is a mess (e.g. "Glass" fairy)** — `CardTile`'s secret-rarity ribbon (GLASS/MYTHIC/SHINY/HOLO) was overlapping the card title because the title had no reserved top space to clear the absolutely-positioned badge. Also gave the bottom row (rarity stars/type badge/info button) dedicated CSS instead of ad hoc utility classes, and reserved title height at the base level so cards no longer jitter based on name length.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 1929/1929 tests pass
- [x] Verified visually via Storybook + the pre-installed Chromium:
  - `CardTile` glass-rarity story: rarity ribbon no longer overlaps title; bottom row aligned; hero-card ribbon unaffected
  - `CardRestSelect` story: "ALREADY RESTING" now renders as bordered chips matching the candidate cards below
  - `BossDialogueScreen` story: confirmed the new backdrop's bounding box covers the full viewport, so clicks anywhere dismiss it
  - Added a temporary `NodeMapRederer` story with a node skipping 2 columns ahead — confirmed the connector line and path tiles now render across the gap, with no regression to adjacent-column connectors

Two small regression-proofing stories were added alongside the fixes (`CardTile`'s `GlassRaritySecretBadgeCheck`, `NodeMapRederer`'s `MultiColumnJumpCheck`) since neither existing story set covered a secret rarity or a multi-column node jump.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018Vt9S3RxRXSqFoVLBbG32a)_