### PR TITLE
Fix units walking through trees in Woodland Ambush / Goblin Raiders

### DIFF
--- a/web/src/data/acts/act1.json
+++ b/web/src/data/acts/act1.json
@@ -463,6 +463,7 @@
           "radius": 3
         }
       ],
+      "terrainValidated": true,
       "roads": []
     },
     "camp": {
@@ -526,7 +527,8 @@
             }
           ]
         }
-      ]
+      ],
+      "terrainValidated": true
     },
     "shrine": {
       "id": "shrine",

--- a/web/src/data/acts/actTerrain.test.ts
+++ b/web/src/data/acts/actTerrain.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { generateTerrain, expandTerrainPathsToObstacles } from '../../game/engine/terrain'
+import { checkAllProfilesReachable } from '../../game/engine/terrainGrid'
+import type { Act, QuestNode } from '../../game/questline'
+
+// Every act/node that opts into hard tile-based terrain blocking
+// (terrainValidated: true) must keep its lane traversable — see
+// game/engine/units.ts's terrainValidated branch and the battlefield
+// editor's "validate on save" step (BattlefieldEditorToolbar.tsx), which
+// this test mirrors offline so a bad edit to tree/rock/water lines fails
+// CI instead of silently sealing a battle's lane.
+
+const actModules = import.meta.glob<{ default: Act }>('./*.json', { eager: true })
+
+interface ValidatedTarget {
+  actId: string
+  nodeId: string
+  node: QuestNode
+  act: Act
+}
+
+const validatedTargets: ValidatedTarget[] = []
+for (const [path, mod] of Object.entries(actModules)) {
+  const act = mod.default
+  if (!act?.nodes) continue
+  const actId = path.replace(/^\.\//, '').replace(/\.json$/, '')
+  for (const [nodeId, node] of Object.entries(act.nodes)) {
+    const terrainValidated = node.terrainValidated ?? act.terrainValidated ?? false
+    if (terrainValidated) validatedTargets.push({ actId, nodeId, node, act })
+  }
+}
+
+describe('act terrain reachability', () => {
+  it('found at least one terrainValidated node to check', () => {
+    expect(validatedTargets.length).toBeGreaterThan(0)
+  })
+
+  it.each(validatedTargets)('$actId/$nodeId keeps the lane reachable for ground and burrowing units', ({ node, act }) => {
+    const environment = node.environment ?? act.environment
+    const authoredTerrain = node.terrain ?? act.terrain
+    const terrainPaths = node.terrainPaths ?? act.terrainPaths
+    const roads = node.roads ?? act.roads ?? []
+
+    const terrain = [
+      ...(authoredTerrain ?? generateTerrain(node.id, environment)),
+      ...expandTerrainPathsToObstacles(terrainPaths ?? []),
+    ]
+
+    const report = checkAllProfilesReachable(terrain, roads)
+    expect(report.ground.reachable).toBe(true)
+    expect(report.burrowing.reachable).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- In Act 1, the "Woodland Ambush" (`camp`) and "Goblin Raiders" (`goblin-raid`) battle nodes define tree `terrainPaths` but never set `terrainValidated: true`, so they were stuck on the legacy soft-avoidance movement system, which only nudges units sideways and never blocks forward movement — units could walk straight through the tree line.
- Sets `terrainValidated: true` on both nodes in `web/src/data/acts/act1.json`, switching them to the existing hard tile-based collision system already used by other Act 1 nodes (`ruins`, `deep-crossing`). No engine code changes were needed — `terrainPaths` are already expanded into obstacles unconditionally at battle start; the flag just determines whether movement enforces hard blocking against them.
- Verified via `checkAllProfilesReachable` that neither node's tree line seals the lane for ground or burrowing units (flying is always reachable by definition).
- Adds `web/src/data/acts/actTerrain.test.ts`, a regression test that walks every act JSON file and asserts lane reachability for every node/act that opts into `terrainValidated`, so a future bad edit to tree/rock/water lines fails CI instead of shipping a sealed lane.

## Test plan

- [x] `npx vitest run` — full suite passes (1961 tests across 59 files); new `actTerrain.test.ts` passes for all 6 currently-validated act/node targets.
- [x] `npx tsc --noEmit` — clean type-check.
- [ ] Manual playtest: Act 1 → Woodland Ambush and Goblin Raiders — confirm units now path around the tree lines instead of through them, and that flying units are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg4sPgYK93sAJC8XwChpp)_