### PR TITLE
Match editor and in-game battlefield tile grids by row count

### DIFF
--- a/web/src/components/battle/BattlefieldCanvas.tsx
+++ b/web/src/components/battle/BattlefieldCanvas.tsx
@@ -8,7 +8,7 @@ import {
 import { WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../data/tiles/tileIndex'
 import { TERRAIN_AVOID_SHAPE } from '../../game/engine/terrain'
-import { GRID_REF_WIDTH } from '../../game/engine/terrainGrid'
+import { GRID_REF_HEIGHT } from '../../game/engine/terrainGrid'
 import { isDebugMode } from '../../game/debug'
 import { LANE_WIDTH, GameState, Unit, Card } from '../../game/types'
 import { buildScene } from './battlefieldCanvas/scene'
@@ -34,11 +34,15 @@ interface LiveProps extends Props {
 // Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
 function CanvasInner(props: LiveProps) {
   const { w, h } = props
-  // Reuses the fixed reference resolution the deterministic collision grid is
-  // built against (see game/engine/terrainGrid.ts) so rendered tile density
-  // stays viewport-invariant instead of just revealing more fixed-size tiles
-  // on a bigger screen.
-  const tileScale = w / GRID_REF_WIDTH
+  // Tile size is derived from the lane's HEIGHT against the reference grid's
+  // height (see game/engine/terrainGrid.ts), so the lane always spans the same
+  // fixed number of tile ROWS and each tile simply scales to fit — a 250px-tall
+  // lane gets ~10px tiles, a 500px-tall one ~20px. Height (not width) is the
+  // anchor because the battlefield editor previews the full 9:19.5 frame while
+  // the live lane is that frame minus the reserved HUD bands: matching on rows
+  // keeps forward-axis (game x) layout identical between the two, so authored
+  // scenes aren't vertically squashed or pushed off the bottom edge in game.
+  const tileScale = h / GRID_REF_HEIGHT
   const containerRef = useRef<HTMLDivElement>(null)
   const propsRef = useRef(props)
   propsRef.current = props

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../utils/terrainLayer'
 import { TILE_SIZE, EnvTileDef } from '../../data/tiles/tileIndex'
 import { TERRAIN_CLEAR_Y, expandTerrainPathsToObstacles } from '../../game/engine/terrain'
+import { GRID_REF_HEIGHT } from '../../game/engine/terrainGrid'
 import { BATTLEFIELD_ASPECT_RATIO } from '../../game/types'
 import { getBattlefieldBundleById } from '../../data/bundles/battlefieldBundleLoader'
 import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity, BattlefieldDecorItem, TerrainPathDef } from './battlefieldEditorTypes'
@@ -139,29 +140,35 @@ function EditorPixi(props: Props & { w: number; h: number }) {
     stage.addChild(base, bg, border, decorLayer, decorObstacles, road, world, guides, editOverlay)
 
     const { environment, envDef, id, roads, terrain, decor, terrainPaths } = props
-    buildTerrainGfx(base, new PIXI.Container(), world, { environment, envDef, id, rivers: [], terrainItems: [] }, w, h)
-    buildBgTileGfx(bg, { environment, envDef }, w, h)
-    buildRoadGfx(road, roads, { environment, envDef }, w, h)
-    buildBorderGfx(border, { environment, envDef }, w, h)
-    if (decor.length > 0) buildManualDecorGfx(decorLayer, decor, w, h)
-    else buildDecorGfx(decorLayer, { environment, envDef, id }, w, h)
+    // WYSIWYG: same height-anchored tile scale BattlefieldCanvas.tsx uses, so the
+    // editor lays out the same fixed number of tile rows the live game will,
+    // regardless of how large the editor window happens to be (see
+    // GRID_REF_HEIGHT in game/engine/terrainGrid.ts).
+    const tileScale = h / GRID_REF_HEIGHT
+    buildTerrainGfx(base, new PIXI.Container(), world, { environment, envDef, id, rivers: [], terrainItems: [] }, w, h, tileScale)
+    buildBgTileGfx(bg, { environment, envDef }, w, h, tileScale)
+    buildRoadGfx(road, roads, { environment, envDef }, w, h, tileScale)
+    buildBorderGfx(border, { environment, envDef }, w, h, tileScale)
+    if (decor.length > 0) buildManualDecorGfx(decorLayer, decor, w, h, tileScale)
+    else buildDecorGfx(decorLayer, { environment, envDef, id }, w, h, tileScale)
     // WYSIWYG: terrainPaths expand into the exact same TerrainObstacle circles
     // the engine adds at battle start, so drawn paths render (and dedup edges
     // against hand-placed obstacles) identically here and in the live game.
-    buildTerrainDecorGfx(decorObstacles, [...terrain, ...expandTerrainPathsToObstacles(terrainPaths)], { environment, envDef }, w, h)
+    buildTerrainDecorGfx(decorObstacles, [...terrain, ...expandTerrainPathsToObstacles(terrainPaths)], { environment, envDef }, w, h, tileScale)
 
-    if (props.showGuides) drawGuides(guides, w, h)
-    drawEditOverlay(editOverlay, props, w, h, dragRef)
+    if (props.showGuides) drawGuides(guides, w, h, tileScale)
+    drawEditOverlay(editOverlay, props, w, h, dragRef, tileScale)
   })
 
   return <div ref={containerRef} style={{ width: w, height: h }} />
 }
 
-function drawGuides(g: PIXI.Graphics, w: number, h: number) {
-  const cols = Math.ceil(w / TILE_SIZE)
-  const rows = Math.ceil(h / TILE_SIZE)
-  for (let c = 0; c <= cols; c++) g.moveTo(c * TILE_SIZE, 0).lineTo(c * TILE_SIZE, h)
-  for (let r = 0; r <= rows; r++) g.moveTo(0, r * TILE_SIZE).lineTo(w, r * TILE_SIZE)
+function drawGuides(g: PIXI.Graphics, w: number, h: number, tileScale: number = 1) {
+  const T = TILE_SIZE * tileScale
+  const cols = Math.ceil(w / T)
+  const rows = Math.ceil(h / T)
+  for (let c = 0; c <= cols; c++) g.moveTo(c * T, 0).lineTo(c * T, h)
+  for (let r = 0; r <= rows; r++) g.moveTo(0, r * T).lineTo(w, r * T)
   g.stroke({ color: 0xffffff, width: 1, alpha: 0.06 })
 
   // TERRAIN_CLEAR_Y corridors are lateral (y-axis) positions procedural terrain
@@ -198,7 +205,9 @@ function drawEditOverlay(
   w: number,
   h: number,
   dragRef: React.MutableRefObject<Drag | null>,
+  tileScale: number = 1,
 ) {
+  const T = TILE_SIZE * tileScale
   const {
     roads, terrain, decor, terrainPaths, selectedEntities, tool, onSelectEntities,
     onDeleteRoad, onDeleteRoadPoint, onDeleteObstacle, onDeleteDecor, onDeletePath, onDeletePathPoint,
@@ -268,18 +277,18 @@ function drawEditOverlay(
     const selected = isDecorSelected(selectedEntities, index)
     const bundle = item.bundleId ? getBattlefieldBundleById(item.bundleId) : undefined
     const origin = gameToPixel(item.x, item.y, w, h)
-    const tcx0 = Math.round(origin.px / TILE_SIZE)
-    const tcy0 = Math.round(origin.py / TILE_SIZE)
+    const tcx0 = Math.round(origin.px / T)
+    const tcy0 = Math.round(origin.py / T)
     const tileOffsets = bundle ? bundle.tiles.map(t => ({ dtx: t.dtx, dty: t.dty })) : [{ dtx: 0, dty: 0 }]
     for (const { dtx, dty } of tileOffsets) {
       const handle = new PIXI.Graphics()
-      handle.rect(0, 0, TILE_SIZE, TILE_SIZE).fill({ color: 0x000000, alpha: 0.001 })
-      handle.rect(1, 1, TILE_SIZE - 2, TILE_SIZE - 2)
+      handle.rect(0, 0, T, T).fill({ color: 0x000000, alpha: 0.001 })
+      handle.rect(1, 1, T - 2, T - 2)
         .stroke({ color: selected ? SELECTED_COLOR : DECOR_COLOR, width: selected ? 2 : 1, alpha: selected ? 0.95 : 0.55 })
-      handle.position.set((tcx0 + dtx) * TILE_SIZE, (tcy0 + dty) * TILE_SIZE)
+      handle.position.set((tcx0 + dtx) * T, (tcy0 + dty) * T)
       handle.eventMode = 'static'
       handle.cursor = 'pointer'
-      handle.hitArea = new PIXI.Rectangle(0, 0, TILE_SIZE, TILE_SIZE)
+      handle.hitArea = new PIXI.Rectangle(0, 0, T, T)
       handle.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
         e.stopPropagation()
         if (tool === 'delete') { onDeleteDecor(index); return }


### PR DESCRIPTION
## Summary

Scenes authored in the battlefield editor rendered noticeably differently in game — vertically squashed, with decor pushed off the bottom edge.

**Root cause:** the editor previews the full `BATTLEFIELD_ASPECT_RATIO` (9:19.5) frame, but the live `.lane` is that frame *minus* the reserved HUD bands (80px top / 230px bottom). With a fixed 32px tile, the editor showed ~26 tile rows where the game showed only ~17. Since game-x 0–500 maps across the full height of whichever box it lands in, everything authored was compressed ~1.45× vertically in game, and multi-tile decor bundles — whose tile footprint is a fixed count — grew proportionally taller and spilled past the edge.

**Fix:** derive `tileScale` from the canvas **height** against `GRID_REF_HEIGHT` rather than the width, so both surfaces always span the same fixed number of tile *rows* and each tile scales to fit the available height:

| | box | tile | grid |
|---|---|---|---|
| editor | 369×800 | 30.3px | 12.2 cols × **26.4 rows** |
| game lane | 369×550 | 20.8px | 17.7 cols × **26.4 rows** |

The editor now also threads that same `tileScale` through its `build*Gfx` calls, its guide grid, and its decor-bundle drag handles, so the forward axis lays out identically in both on every device. Obstacle patch radii and decor row coords stay viewport-invariant and continue to match the deterministic collision grid in `game/engine/terrainGrid.ts`.

## Known residual

The lane is a wider aspect than the editor frame, so with square tiles the two still differ on the **horizontal** axis (17.7 vs 12.2 columns for the same lateral game span). This is far more benign than the vertical mismatch it replaces — decor renders slightly narrower relative to the field rather than overflowing — but it is not yet pixel-exact WYSIWYG. Closing that gap fully would need either non-square (anisotropically stretched) tiles or making the two boxes share an aspect ratio; happy to follow up if it's visible in practice.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 1962 tests across 59 files pass.
- [ ] Manual: open a scene in the battlefield editor, then play that node — confirm the vertical layout matches and nothing sits off the bottom edge.
- [ ] Manual: check the editor's guide grid and decor-bundle handles still line up with the rendered tiles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg4sPgYK93sAJC8XwChpp)_