### PR TITLE
Fix shop banner to show the tapped NPC; add rare traveling sellers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ dist/
 *~
 
 .env
+.env.local
+.env.*.local
 
 .claude/
 *storybook.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ DO NOT USE AGENTS - Unless I explicitly state for you to do so.
 ## Verifying Changes
 `npm run build` (typecheck) and `npm run test` are the default way to verify a change — run them and trust them. Only fall back to launching the dev server and driving it in a browser when you are investigating or confirming a **visual** bug (layout, rendering, sprite/animation, canvas interaction) — not for logic/data changes, even ones that touch UI-adjacent code. Browser verification of this hub-world/PixiJS canvas is expensive (no DOM selectors for in-canvas elements, camera/pathfinding makes reaching a specific NPC slow) — don't reach for it by default.
 
+If browser verification is genuinely warranted: the app needs Firebase env vars to render past a blank white screen (`firebase.ts` calls `initializeApp` with `import.meta.env.VITE_FIREBASE_*`, which are unset by default and throw `auth/invalid-api-key` on load). `web/.env.test` has working fake-but-valid-format keys — copy it to `web/.env.local` (gitignored) before `npm run dev`. Don't commit `.env.local` or leave ad hoc driver scripts in the repo.
+
 ## Git Workflow — Avoiding Conflicts
 Before starting any new work, always rebase onto the latest `main`:
 ```bash

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -424,6 +424,7 @@ export default function App() {
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
   const [shopBuildingId, setShopBuildingId] = useState<string | undefined>(undefined)
+  const [shopTappedNpc, setShopTappedNpc] = useState<{ name: string; dialogue?: string[] } | undefined>(undefined)
   // Restore the town the player was last in (persisted in worldState). The saved
   // value is a world-map node id; for town nodes that id equals the hub data's
   // locationRegistry key. Hub data is lazy-loaded (see hubData below), so this
@@ -3121,9 +3122,10 @@ export default function App() {
       {(screen === 'hubworld' || screen === 'location') && hubData && (
         <HubWorld
           onBack={() => setScreen('settings')}
-          onNavigate={(s, buildingId) => {
+          onNavigate={(s, buildingId, npc) => {
             setReturnScreen('hubworld')
             setShopBuildingId(buildingId)
+            setShopTappedNpc(npc)
             const HUB_MINIGAME_IDS: SubScreen[] = ['marble', 'tileflip', 'crystalcatch', 'spinner', 'marblerace', 'regatta', 'higherOrLower', 'fruitMachine', 'videoPoker', 'fishing', 'towerDefence', 'citybuilder', 'prizes']
             if (HUB_MINIGAME_IDS.includes(s as SubScreen)) {
               setHubMiniGameEntry(s as SubScreen)
@@ -3533,6 +3535,7 @@ export default function App() {
         <ShopScreen
           category="cards"
           buildingId={shopBuildingId}
+          tappedNpc={shopTappedNpc}
           crystals={crystals}
           onBuyCrystalPack={handleBuyCrystalPack}
           onCrystalsChange={(n: number) => { saveCrystals(n); setCrystals(n) }}
@@ -3544,6 +3547,7 @@ export default function App() {
         <ShopScreen
           category="augments"
           buildingId={shopBuildingId}
+          tappedNpc={shopTappedNpc}
           crystals={crystals}
           onBuyCrystalPack={handleBuyCrystalPack}
           onCrystalsChange={(n: number) => { saveCrystals(n); setCrystals(n) }}
@@ -3555,6 +3559,7 @@ export default function App() {
         <ShopScreen
           category="supplies"
           buildingId={shopBuildingId}
+          tappedNpc={shopTappedNpc}
           crystals={crystals}
           onBuyCrystalPack={handleBuyCrystalPack}
           onCrystalsChange={(n: number) => { saveCrystals(n); setCrystals(n) }}

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -211,7 +211,7 @@ function getActiveDialogue(quest: HubQuestDef): string {
 
 export interface Props {
   onBack:             () => void
-  onNavigate?:        (screen: string, buildingId?: string) => void
+  onNavigate?:        (screen: string, buildingId?: string, npc?: { name: string; dialogue?: string[] }) => void
   onCampaign?:        () => void
   /** Launch campaign 2 (The Forgotten Kingdom) — from Elsben in Ironhold Keep. */
   onCampaign2?:       () => void
@@ -636,7 +636,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     el.scrollTop  = py - el.clientHeight / 2
   }, [locationData])
 
-  const handleNodeInteract = useCallback((screen: string, buildingId?: string) => {
+  const handleNodeInteract = useCallback((screen: string, buildingId?: string, npc?: { name: string; dialogue?: string[] }) => {
     if (screen.startsWith('interior:')) {
       const buildingId = screen.slice(9)
       interiorEnterRef.current?.(buildingId)
@@ -672,7 +672,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
         return
       }
     }
-    onNavigate?.(screen, buildingId)
+    onNavigate?.(screen, buildingId, npc)
   }, [onNavigate, onCampaign, onCampaign2, onWorldMap, onNavigateTown, onNarratorLog, commander])
 
   const handleReturn = useCallback(() => {
@@ -1339,7 +1339,7 @@ function hasOfferableQuest(giverId: string): boolean {
       const screen = npcDef.screen
       const enterChoice: DialogueChoice = {
         label: screenEnterLabel(screen),
-        onClick: () => handleNodeInteract(screen, npcDef.building),
+        onClick: () => handleNodeInteract(screen, npcDef.building, speakerName ? { name: speakerName, dialogue: npcDef.dialogue } : undefined),
       }
 
       // Build at most one quest choice, in priority order: deliver → turn in →

--- a/web/src/components/screens/ShopScreen.tsx
+++ b/web/src/components/screens/ShopScreen.tsx
@@ -3,6 +3,7 @@ import { CRYSTAL_PACK_COST, addCardsToCollection } from '../../game/collection'
 import { incrementAchievementProgress } from '../../game/achievements'
 import {
   getDailyShopNPC,
+  resolveShopNpcForHubNpc,
   getDailyShopCards,
   getDailyShopSellSlots,
   getDailyShopAugment,
@@ -14,6 +15,7 @@ import {
   isWeekend,
   ShopCardDeal,
   ShopAugmentDeal,
+  ShopNPC,
   recordNPCVisit,
   isShopItemSold,
   markCardBought,
@@ -97,11 +99,15 @@ interface Props {
   /** Which trader's stock this screen represents, for the "already bought today" gate.
    *  Defaults to Ravenwatch's own card-shop/augment-shop ids, preserving legacy behavior. */
   buildingId?: string
+  /** The specific hub NPC the player tapped to get here, if any. When present,
+   *  the banner reflects this NPC (by name/dialogue) instead of the random
+   *  daily/shift pick. Absent for the plain title-screen 'shop' entry. */
+  tappedNpc?: { name: string; dialogue?: string[] }
 }
 
 const PACK_QUANTITIES = [1, 3, 5, 10]
 
-export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBack, category, buildingId }: Props) {
+export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBack, category, buildingId, tappedNpc }: Props) {
   const show = (c: ShopCategory) => !category || category === c
   const cardBuildingId    = buildingId ?? 'card-shop'
   const augmentBuildingId = buildingId ?? 'augment-shop'
@@ -111,8 +117,12 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
   const canBuyPack = crystals >= CRYSTAL_PACK_COST * packQty
   const [pendingPackBuy, setPendingPackBuy] = useState(false)
 
-  const [npc, setNpc] = useState(() => getDailyShopNPC())
-  const [dailyCards, setDailyCards] = useState(() => getDailyShopCards())
+  const resolveNpc = (): ShopNPC => tappedNpc
+    ? resolveShopNpcForHubNpc(buildingId ?? tappedNpc.name, tappedNpc.name, tappedNpc.dialogue)
+    : getDailyShopNPC()
+
+  const [npc, setNpc] = useState(resolveNpc)
+  const [dailyCards, setDailyCards] = useState(() => getDailyShopCards(undefined, undefined, resolveNpc()))
   const [dailyAugment, setDailyAugment] = useState<ShopAugmentDeal>(() => getDailyShopAugment())
   const [sellSlots, setSellSlots] = useState(() => getDailyShopSellSlots())
   const [weekend, setWeekend] = useState(() => isWeekend())
@@ -144,8 +154,9 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
       setCountdown(secs)
       setShiftCountdown(getSecondsUntilShiftEnd())
       if (secs === 0) {
-        setNpc(getDailyShopNPC())
-        setDailyCards(getDailyShopCards())
+        const freshNpc = resolveNpc()
+        setNpc(freshNpc)
+        setDailyCards(getDailyShopCards(undefined, undefined, freshNpc))
         setDailyAugment(getDailyShopAugment())
         setSellSlots(getDailyShopSellSlots())
         setWeekend(isWeekend())

--- a/web/src/game/shopSchedule.test.ts
+++ b/web/src/game/shopSchedule.test.ts
@@ -4,6 +4,7 @@ import {
   markCardBought,
   markAugmentBought,
   getDailyShopCards,
+  resolveShopNpcForHubNpc,
   DailyShopState,
 } from './shopSchedule'
 
@@ -96,6 +97,53 @@ describe('getDailyShopCards filters', () => {
     for (const d of deals) expect(['epic', 'legendary']).toContain(d.rarity)
     const names = deals.map(d => d.cardName)
     expect(new Set(names).size).toBe(names.length)
+  })
+})
+
+describe('resolveShopNpcForHubNpc', () => {
+  const at = new Date('2026-06-30T12:00:00Z') // day shift, 2026-06-30-day
+
+  it('returns the matching roster entry by name, ignoring the rare-visitor roll', () => {
+    const npc = resolveShopNpcForHubNpc('card-shop', 'Vorn', ['some dialogue'], at)
+    expect(npc.name).toBe('Vorn')
+    expect(npc.role).toBe('legendary_dealer')
+    expect(npc.title).toBe('Shadow Merchant')
+  })
+
+  it('falls back to a generic identity built from the hub NPC when there is no roster match and the rare roll misses', () => {
+    // Seeded miss for this building/shift (verified against the resolver's own RNG algorithm).
+    const npc = resolveShopNpcForHubNpc('supplies-vendor-crownhaven', 'Dealer Sloane', ['line1', 'line2'], at)
+    expect(npc.name).toBe('Dealer Sloane')
+    expect(npc.role).toBe('owner')
+    expect(npc.title).toBe('Shopkeeper')
+    expect(npc.greeting).toBe('line1')
+    expect(npc.dialogues).toEqual(['line1', 'line2'])
+  })
+
+  it('substitutes a rare traveling seller when the per-building-per-shift roll hits', () => {
+    // Seeded hit for this building/shift (verified against the resolver's own RNG algorithm) — resolves to Lysandra.
+    const npc = resolveShopNpcForHubNpc('augment-shop', 'Dealer Sloane', ['line1'], at)
+    expect(npc.name).toBe('Lysandra')
+    expect(npc.role).toBe('legendary_dealer')
+    expect(['Aldric', 'Lysandra']).toContain(npc.name)
+  })
+
+  it('is deterministic for the same building and shift, and can differ across buildings', () => {
+    const first  = resolveShopNpcForHubNpc('augment-shop', 'Dealer Sloane', ['line1'], at)
+    const second = resolveShopNpcForHubNpc('augment-shop', 'Dealer Sloane', ['line1'], at)
+    expect(second).toEqual(first)
+
+    const other = resolveShopNpcForHubNpc('card-shop-bldg', 'Dealer Sloane', ['line1'], at)
+    expect(other.name).not.toBe(first.name)
+  })
+})
+
+describe('getDailyShopCards with npcOverride', () => {
+  it('uses the overridden NPC role for the legendary-slot decision instead of the random daily pick', () => {
+    const at = new Date('2026-06-30T12:00:00Z')
+    const legendaryDealer = resolveShopNpcForHubNpc('card-shop', 'Vorn', [], at)
+    const deals = getDailyShopCards(at, undefined, legendaryDealer)
+    expect(deals[2].rarity).toBe('legendary')
   })
 })
 

--- a/web/src/game/shopSchedule.ts
+++ b/web/src/game/shopSchedule.ts
@@ -127,17 +127,23 @@ export function getShiftKey(at?: Date): string {
 
 const DAY_SHIFT_NPCS: ShopNPC[]   = shopNpcsJson.dayShift   as ShopNPC[]
 const NIGHT_SHIFT_NPCS: ShopNPC[] = shopNpcsJson.nightShift as ShopNPC[]
+const ALL_SHOP_NPCS: ShopNPC[]    = [...DAY_SHIFT_NPCS, ...NIGHT_SHIFT_NPCS]
 
-export function getDailyShopNPC(at?: Date): ShopNPC {
-  const shiftKey = getShiftKey(at)
-  const night    = isNightShift(at)
-  const pool     = night ? NIGHT_SHIFT_NPCS : DAY_SHIFT_NPCS
-  const shiftSeed = night ? 0xbaadf00d : 0xdeadbeef
-  const rng      = makeSeededRng(dateHash(shiftKey) ^ shiftSeed)
-  const idx      = Math.floor(rng() * pool.length)
-  const npc      = { ...pool[idx] }
+/** Names with no fixed real-town home in the hub — plausible as a rare
+ *  "someone else is minding the shop today" visitor in any town's shop.
+ *  Deliberately excludes Vorn/Nox/Grix, who are Ravenwatch's own named
+ *  shopkeepers and are matched by name instead (see resolveShopNpcForHubNpc). */
+const RARE_TRAVELING_NAMES = {
+  day:   ['Aldric', 'Lysandra'],
+  night: ['Cass', 'The Stranger'],
+} as const
 
-  // Resolve Pip's dynamic greeting/perk at call time
+/** Chance (per building, per 12h shift) that a hub shop is minded by a rare
+ *  traveling seller instead of its regular shopkeeper. */
+const RARE_TRAVELING_CHANCE = 0.12
+
+// Resolve Pip's dynamic greeting/perk at call time
+function applyDynamicNpcFields(npc: ShopNPC, night: boolean): ShopNPC {
   if (npc.name === 'Pip' && npc.role === 'apprentice') {
     const weekend = isWeekend()
     npc.perk = weekend ? '10% weekend discount · buys select items' : '10% discount on weekends'
@@ -147,8 +153,62 @@ export function getDailyShopNPC(at?: Date): ShopNPC {
         : "Um, hi! I'm looking after the shop today. I think."
     }
   }
-
   return npc
+}
+
+export function getDailyShopNPC(at?: Date): ShopNPC {
+  const shiftKey = getShiftKey(at)
+  const night    = isNightShift(at)
+  const pool     = night ? NIGHT_SHIFT_NPCS : DAY_SHIFT_NPCS
+  const shiftSeed = night ? 0xbaadf00d : 0xdeadbeef
+  const rng      = makeSeededRng(dateHash(shiftKey) ^ shiftSeed)
+  const idx      = Math.floor(rng() * pool.length)
+  const npc      = { ...pool[idx] }
+  return applyDynamicNpcFields(npc, night)
+}
+
+/**
+ * Resolves the ShopNPC identity a hub-town shop screen should display for
+ * the specific NPC the player tapped in the town, instead of the fully
+ * random `getDailyShopNPC()` pick.
+ *
+ * - If the hub NPC's name matches a roster entry (currently only
+ *   Ravenwatch's Vorn/Nox/Grix), that entry is used directly.
+ * - Otherwise, a small deterministic-per-building-per-shift chance
+ *   substitutes one of the roster's rare traveling sellers (offering the
+ *   same legendary-card/discount treats as the title-screen shop).
+ * - Otherwise, a generic fallback identity is synthesized from the hub
+ *   NPC's own name and authored dialogue lines.
+ */
+export function resolveShopNpcForHubNpc(buildingId: string, name: string, dialogue?: string[], at?: Date): ShopNPC {
+  const night = isNightShift(at)
+
+  const matches = ALL_SHOP_NPCS.filter(n => n.name === name)
+  if (matches.length > 0) {
+    const shiftPool = night ? NIGHT_SHIFT_NPCS : DAY_SHIFT_NPCS
+    const preferred = matches.find(n => shiftPool.includes(n)) ?? matches[0]
+    return applyDynamicNpcFields({ ...preferred }, night)
+  }
+
+  const shiftKey = getShiftKey(at)
+  const rng      = makeSeededRng(dateHash(`${buildingId}|${shiftKey}`) ^ 0x5a1e5eed)
+  if (rng() < RARE_TRAVELING_CHANCE) {
+    const names = night ? RARE_TRAVELING_NAMES.night : RARE_TRAVELING_NAMES.day
+    const pickedName = names[Math.floor(rng() * names.length)]
+    const visitor = ALL_SHOP_NPCS.find(n => n.name === pickedName)
+    if (visitor) return applyDynamicNpcFields({ ...visitor }, night)
+  }
+
+  const lines = dialogue && dialogue.length > 0 ? dialogue : ["Welcome — take a look at what I've got."]
+  return {
+    name,
+    title: 'Shopkeeper',
+    role: 'owner',
+    greeting: lines[0],
+    perk: 'Standard prices',
+    shiftEndLine: "I'll be here a while yet — {time}, give or take. No rush.",
+    dialogues: lines,
+  }
 }
 
 /**
@@ -194,12 +254,15 @@ export interface ShopCardFilter {
   slotCount?: number
 }
 
-/** Returns the current stock's card deals (refreshes every 3 hours). */
-export function getDailyShopCards(at?: Date, filter?: ShopCardFilter): ShopCardDeal[] {
+/** Returns the current stock's card deals (refreshes every 3 hours).
+ *  Pass `npcOverride` to base the legendary-slot decision on a specific
+ *  resolved NPC (e.g. from `resolveShopNpcForHubNpc`) instead of the
+ *  independent random daily pick. */
+export function getDailyShopCards(at?: Date, filter?: ShopCardFilter, npcOverride?: ShopNPC): ShopCardDeal[] {
   const slotKey = getShopSlotKey(at)
   const rng     = makeSeededRng(dateHash(slotKey) ^ 0xcafebabe)
   const catalog = getCardCatalog().filter(c => !filter?.cardType || c.cardType === filter.cardType)
-  const npc     = getDailyShopNPC(at)
+  const npc     = npcOverride ?? getDailyShopNPC(at)
 
   const rarityFilter = filter?.rarities ?? (filter?.rarity ? [filter.rarity] : undefined)
   if (rarityFilter) {


### PR DESCRIPTION
## Summary

- Fixes: tapping a shopkeeper NPC on the hub town canvas and choosing "Browse the wares?" opened `ShopScreen` with a banner (name/title/greeting/perk) picked from a fully random global daily/shift roster — unrelated to the NPC actually tapped.
- Threads the tapped NPC's real identity through `HubWorld` → `App` → `ShopScreen` (`onNavigate`/`handleNodeInteract` now carry an optional `{ name, dialogue }`), and adds `resolveShopNpcForHubNpc` in `shopSchedule.ts` to resolve a banner from that identity:
  - Exact name matches against the existing roster (currently Ravenwatch's Vorn/Nox/Grix) use that entry directly, preserving their role-driven mechanics (legendary card slot, weekend discount).
  - Everyone else gets a generic-but-correctly-named fallback banner built from their own authored hub dialogue.
  - A small per-building/per-shift chance (~12%) substitutes one of a "rare traveling seller" pool (Aldric, Lysandra, Cass, The Stranger) — extending the title-screen shop's existing special-seller mechanic (legendary card dealer / weekend-discount apprentice) into hub towns, per follow-up discussion during planning.
- `getDailyShopCards` now accepts an optional `npcOverride` so the legendary-card-slot mechanic stays consistent with whichever NPC is actually shown in the banner.
- The plain title-screen `shop` entry (no tapped-NPC context) is unaffected — it keeps using the original random daily rotation.
- Documented a dev-server gotcha discovered while investigating (Firebase env vars needed to avoid a blank screen) in `AGENTS.md`, and gitignored `.env.local`/`.env.*.local`.

## Test plan

- [x] `npm run build` (tsc + vite build) — clean
- [x] `npm run test` (vitest, full suite) — 2000/2000 passing, including new/extended cases in `shopSchedule.test.ts` covering name-match resolution, the fallback identity, the rare-visitor roll (deterministic per building/shift), and `getDailyShopCards` with `npcOverride`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013biJRGruCw3mBg493zynKr

---
_Generated by [Claude Code](https://claude.ai/code/session_013biJRGruCw3mBg493zynKr)_