### PR TITLE
Show NPC's own sprite in shop banner instead of role emoji

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -424,7 +424,7 @@ export default function App() {
   const [screen, setScreen]             = useState<Screen>(_startup.screen)
   const [returnScreen, setReturnScreen]  = useState<Screen>('title')
   const [shopBuildingId, setShopBuildingId] = useState<string | undefined>(undefined)
-  const [shopTappedNpc, setShopTappedNpc] = useState<{ name: string; dialogue?: string[] } | undefined>(undefined)
+  const [shopTappedNpc, setShopTappedNpc] = useState<{ name: string; dialogue?: string[]; sprite?: string } | undefined>(undefined)
   // Restore the town the player was last in (persisted in worldState). The saved
   // value is a world-map node id; for town nodes that id equals the hub data's
   // locationRegistry key. Hub data is lazy-loaded (see hubData below), so this

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -72,7 +72,7 @@ interface QuestEvent {
 }
 
 interface NpcTapDef {
-  name?: string; dialogue?: string[]; screen?: string; building?: string
+  name?: string; dialogue?: string[]; screen?: string; building?: string; sprite?: string
   questGive?: string; questReceive?: string | string[]
   innRumours?: Array<{ id: string; text: string }>
   dialogueTree?: string
@@ -211,7 +211,7 @@ function getActiveDialogue(quest: HubQuestDef): string {
 
 export interface Props {
   onBack:             () => void
-  onNavigate?:        (screen: string, buildingId?: string, npc?: { name: string; dialogue?: string[] }) => void
+  onNavigate?:        (screen: string, buildingId?: string, npc?: { name: string; dialogue?: string[]; sprite?: string }) => void
   onCampaign?:        () => void
   /** Launch campaign 2 (The Forgotten Kingdom) — from Elsben in Ironhold Keep. */
   onCampaign2?:       () => void
@@ -636,7 +636,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     el.scrollTop  = py - el.clientHeight / 2
   }, [locationData])
 
-  const handleNodeInteract = useCallback((screen: string, buildingId?: string, npc?: { name: string; dialogue?: string[] }) => {
+  const handleNodeInteract = useCallback((screen: string, buildingId?: string, npc?: { name: string; dialogue?: string[]; sprite?: string }) => {
     if (screen.startsWith('interior:')) {
       const buildingId = screen.slice(9)
       interiorEnterRef.current?.(buildingId)
@@ -1339,7 +1339,7 @@ function hasOfferableQuest(giverId: string): boolean {
       const screen = npcDef.screen
       const enterChoice: DialogueChoice = {
         label: screenEnterLabel(screen),
-        onClick: () => handleNodeInteract(screen, npcDef.building, speakerName ? { name: speakerName, dialogue: npcDef.dialogue } : undefined),
+        onClick: () => handleNodeInteract(screen, npcDef.building, speakerName ? { name: speakerName, dialogue: npcDef.dialogue, sprite: npcDef.sprite } : undefined),
       }
 
       // Build at most one quest choice, in priority order: deliver → turn in →

--- a/web/src/components/screens/ShopScreen.stories.tsx
+++ b/web/src/components/screens/ShopScreen.stories.tsx
@@ -20,3 +20,14 @@ export const Default: Story = {
     onCrystalsChange: fn(),
   },
 };
+
+/** Tapped a specific hub NPC with a known sprite — the banner shows their
+ *  sprite instead of the generic role emoji. */
+export const TappedNpcWithSprite: Story = {
+  args: {
+    ...Default.args,
+    category: 'cards',
+    buildingId: 'card-shop',
+    tappedNpc: { name: 'Vorn', dialogue: ["I only come out at night."], sprite: 'hub-npc-vorn' },
+  },
+};

--- a/web/src/components/screens/ShopScreen.tsx
+++ b/web/src/components/screens/ShopScreen.tsx
@@ -102,7 +102,7 @@ interface Props {
   /** The specific hub NPC the player tapped to get here, if any. When present,
    *  the banner reflects this NPC (by name/dialogue) instead of the random
    *  daily/shift pick. Absent for the plain title-screen 'shop' entry. */
-  tappedNpc?: { name: string; dialogue?: string[] }
+  tappedNpc?: { name: string; dialogue?: string[]; sprite?: string }
 }
 
 const PACK_QUANTITIES = [1, 3, 5, 10]
@@ -254,13 +254,22 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
     wanderer:   '🌍',
   }
 
+  // Only show the tapped NPC's own sprite when the banner is still displaying
+  // that same NPC — a rare traveling seller substitution shows a different
+  // name/role, so their (mismatched) sprite would be misleading.
+  const npcSprite = tappedNpc?.sprite && npc.name === tappedNpc.name ? tappedNpc.sprite : undefined
+
   return (
     <OverlayScreen title={category ? CATEGORY_TITLE[category] : 'SHOP'} onBack={onBack} right={<span className="crystal-count">💎 {crystals.toLocaleString()}</span>}>
       <div className="shop-wrapper">
 
       {/* NPC banner */}
       <div className="shop-npc-banner">
-        <div className="shop-npc-icon">{roleLabel[npc.role] ?? '🏪'}</div>
+        <div className="shop-npc-icon">
+          {npcSprite
+            ? <SpriteImg name={npcSprite} className="shop-npc-sprite" />
+            : (roleLabel[npc.role] ?? '🏪')}
+        </div>
         <div className="shop-npc-info">
           <div className="shop-npc-name">
             {npc.name} <span className="shop-npc-title">— {npc.title}</span>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1764,6 +1764,7 @@ body {
   box-sizing: border-box;
 }
 .shop-npc-icon { font-size: 2.286rem; line-height: 1; flex-shrink: 0; }
+.shop-npc-sprite { width: 2.286rem; height: 2.286rem; image-rendering: pixelated; flex-shrink: 0; }
 .shop-npc-info { display: flex; flex-direction: column; gap: 3px; }
 .shop-npc-name { font-size: var(--font-base); color: var(--color-gold-light); font-weight: bold; letter-spacing: 1px; }
 .shop-npc-title { color: #aa8833; font-weight: normal; }


### PR DESCRIPTION
## Summary

Follow-up to #2058. Now that the shop banner shows the NPC you actually tapped (e.g. "Nox — Nocturnal Curator"), replace the generic role emoji (🏪/🌟/📚/🌍) with that NPC's real sprite when one is available:

- The tapped NPC's `sprite` field (from hub NPC data, e.g. `hub-npc-nox`) is threaded through the same `HubWorld` → `App` → `ShopScreen` chain already carrying `name`/`dialogue`.
- `ShopScreen` renders it via the existing `SpriteImg` component in place of the emoji, sized to match the banner's icon slot.
- Falls back to the role emoji when there's no sprite, or when a rare traveling seller has substituted in for the regular shopkeeper (their sprite would be mismatched with the displayed identity in that case — gated on `npc.name === tappedNpc.name`).
- Added a Storybook story (`TappedNpcWithSprite`) demonstrating the sprite banner.

## Test plan

- [x] `npm run build` (tsc + vite build) — clean
- [x] `npm run test` (vitest, full suite) — 2000/2000 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013biJRGruCw3mBg493zynKr

---
_Generated by [Claude Code](https://claude.ai/code/session_013biJRGruCw3mBg493zynKr)_