### PR TITLE
Fix flame overlay sitting too low on the tile

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -297,6 +297,10 @@ export function HubTownCanvas({
     // alongside decorGlows in the same two decor-building loops below, then spawned
     // once texture loading settles (see spawnFlame).
     interface FlameSource { parent: PIXI.Container; x: number; y: number; type: FlameType; color: FlameColor; sortY?: number }
+    // Vertical anchor point within a tile a flame sits on, as a fraction of tile
+    // height (0 = top, 1 = bottom) — tuned to sit over a tile's fire-pit/hearth
+    // art rather than at the very bottom edge of the tile cell.
+    const FLAME_ANCHOR_Y = 0.72
     const FLAME_PARAMS: Record<FlameType, { scale: number; glowRadius: number; speed: number }> = {
       flicker: { scale: 0.45, glowRadius: 1,   speed: 0.10 },
       low:     { scale: 0.65, glowRadius: 1.5, speed: 0.12 },
@@ -589,7 +593,7 @@ export function HubTownCanvas({
         if (d.glow) decorGlows.push({ x: d.tx * T + T / 2, y: d.ty * T + T / 2, radius: (d.glowRadius ?? 2) * T, pulse: !!d.pulse })
         if (d.flame) {
           const flameParent = d.zlayer === 'below' ? belowAvatarLayer : d.zlayer === 'above' ? aboveAvatarLayer : exteriorDecorLayer
-          const fx = d.tx * T + T / 2, fy = d.ty * T + T * 0.85
+          const fx = d.tx * T + T / 2, fy = d.ty * T + T * FLAME_ANCHOR_Y
           collectFlame(flames, decorGlows, !!d.glow, flameParent, fx, fy, fx, fy, d.flameType, d.flameColor, d.ty)
         }
       }
@@ -754,8 +758,8 @@ export function HubTownCanvas({
           if (d.glow) decorGlows.push({ x: (pos.tx + d.dx) * T + T / 2, y: (pos.ty + d.dy) * T + T / 2, radius: (d.glowRadius ?? 2) * T, pulse: !!d.pulse })
           if (d.flame) {
             collectFlame(flames, decorGlows, !!d.glow, parent,
-              d.dx * T + T / 2, d.dy * T + T * 0.85,
-              (pos.tx + d.dx) * T + T / 2, (pos.ty + d.dy) * T + T * 0.85,
+              d.dx * T + T / 2, d.dy * T + T * FLAME_ANCHOR_Y,
+              (pos.tx + d.dx) * T + T / 2, (pos.ty + d.dy) * T + T * FLAME_ANCHOR_Y,
               d.flameType, d.flameColor, pos.ty + d.dy)
           }
           if (d.spriteId) {


### PR DESCRIPTION
## Summary

- Follow-up to #2060: on Thornwood Camp's campfire, the flame overlay rendered a few pixels too low, sitting close to the tile's bottom edge instead of over the fire-pit art.
- `web/src/components/hub/HubTownCanvas.tsx`: replaced the two hardcoded `T * 0.85` vertical-anchor literals (exterior-decor and interactable-decor flame-collection call sites) with a shared `FLAME_ANCHOR_Y = 0.72` constant. The derived night-glow position, which is offset from the flame's anchor, moves up with it automatically.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Manual: visit Thornwood Camp, confirm the campfire flame now sits closer to the fire-pit art rather than the tile's ground line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEtJuhwEuc8QMoaj5QdGTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEtJuhwEuc8QMoaj5QdGTC)_