### PR TITLE
Sync daily/weekly challenge battlefield terrain across players

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,8 +107,8 @@ const FeedbackAdminScreen = lazy(() => import('./components/admin/FeedbackAdminS
 const TownAccessAdminScreen = lazy(() => import('./components/admin/TownAccessAdminScreen').then(m => ({ default: m.TownAccessAdminScreen })))
 import { DeckSelectorModal } from './components/cards/DeckSelectorModal'
 import { loadDeckSlot } from './game/collection'
-import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
-import { getWeeklyChallenge, getWeeklyPlayerDeck, getWeeklyOpponentDeck, getWeeklyChallengeState, saveWeeklyChallengeResult, grantWeeklyReward, publishWeeklyResult, WeeklyRewardResult } from './game/weeklyChallenge'
+import { getDailyPlayerDeck, getDailyOpponentDeck, getDailyChallengeState, getDailyTerrainSeed, saveDailyChallengeResult, recordDailyWin, publishDailyResult, publishEndlessResult, DailyChallengeState } from './game/dailyChallenge'
+import { getWeeklyChallenge, getWeeklyPlayerDeck, getWeeklyOpponentDeck, getWeeklyChallengeState, getWeeklyTerrainSeed, saveWeeklyChallengeResult, grantWeeklyReward, publishWeeklyResult, WeeklyRewardResult } from './game/weeklyChallenge'
 const WeeklyChallengeScreen = lazy(() => import('./components/screens/WeeklyChallengeScreen').then(m => ({ default: m.WeeklyChallengeScreen })))
 import { getRelicDef, addEarnedRelic, removeEarnedRelic, loadEarnedRelics, addBrokenRelic, rollExoticDrop } from './game/relics'
 import { recordQuestKills, recordQuestWin, recordQuestCardPlayed, recordQuestBossDefeat, QuestChainDef } from './game/quests'
@@ -1135,6 +1135,7 @@ export default function App() {
       opponentHandicap: 0,
       quickStart: true,
       isDailyChallenge: true,
+      terrainSeed: getDailyTerrainSeed(),
     }))
     rollRareEvent()
   }, [])
@@ -1159,6 +1160,7 @@ export default function App() {
       opponentHandicap: 0,
       quickStart: true,
       isDailyChallenge: true,
+      terrainSeed: getDailyTerrainSeed(),
     }))
     rollRareEvent()
   }, [])
@@ -1187,6 +1189,7 @@ export default function App() {
       opponentHandicap: 0,
       quickStart: true,
       isDailyChallenge: true,  // same mana-floor rule: the player can't edit this deck
+      terrainSeed: getWeeklyTerrainSeed(),
     }))
     rollRareEvent()
   }, [])

--- a/web/src/game/dailyChallenge.ts
+++ b/web/src/game/dailyChallenge.ts
@@ -141,6 +141,11 @@ export function getDailyOpponentDeck(): Card[] {
   return buildChallengeCards(0xda110000)
 }
 
+/** Deterministic terrain seed for today — same battlefield layout for every player. */
+export function getDailyTerrainSeed(): string {
+  return `daily-${getDailyDate()}`
+}
+
 export function getDailyChallengeState(): DailyChallengeState {
   try {
     const raw = localStorage.getItem(DC_KEY)

--- a/web/src/game/weeklyChallenge.ts
+++ b/web/src/game/weeklyChallenge.ts
@@ -189,6 +189,11 @@ export function getWeeklyOpponentDeck(): Card[] {
   return buildConstrainedDeck(pool, 0x4ee71000, { allowUnits: true })
 }
 
+/** Deterministic terrain seed for this week — same battlefield layout for every player. */
+export function getWeeklyTerrainSeed(): string {
+  return `weekly-${getISOWeekKey()}`
+}
+
 // ── Local state ───────────────────────────────────────────────────────────────
 
 export function getWeeklyChallengeState(): WeeklyChallengeState {


### PR DESCRIPTION
## Summary
- The daily and weekly challenges already seed the player/opponent decks deterministically (by date / ISO week), but the battlefield terrain scatter was not seeded — `generateTerrain()` falls back to `Math.random()` whenever no `terrainSeed` is passed, and `App.tsx`'s daily/weekly challenge start/retry handlers never passed one. Every player (and every retry) got a different random obstacle layout despite supposedly playing "the same" challenge.
- Added `getDailyTerrainSeed()` (`web/src/game/dailyChallenge.ts`) and `getWeeklyTerrainSeed()` (`web/src/game/weeklyChallenge.ts`), returning stable strings derived from today's date / the current ISO week key.
- Wired these into the three affected `newGame()` calls in `web/src/App.tsx`: `handleStartDailyChallenge`, `handleDailyChallengeRetry`, and `handleStartWeeklyChallenge`.
- Result: terrain generation (`generateTerrain`/`generatePassableTerrain`) is now deterministic per day/week, matching the deck seeding — same battlefield layout for every player, and consistent across retries within the same day/week.

## Test plan
- [x] `npm run build` — passes clean
- [x] `npm run test` — 2000/2000 tests pass (unrelated pre-existing headless-shell binary warning in this sandbox, not caused by this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_0198EH6eDztqEPCu7LbVBFXg)_