### PR TITLE
Passability overlay, per-unit lateral lanes, and DEFEND interception

### DIFF
--- a/web/src/components/admin/DevMenu.tsx
+++ b/web/src/components/admin/DevMenu.tsx
@@ -246,6 +246,27 @@ export function DevMenu({ onCrystalsChanged, onHandicapChanged, onSceneryPreview
         </button>
       </div>
 
+      {/* Battlefield passability overlay */}
+      <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+        <div>
+          <div className="settings-label">Battlefield passability overlay</div>
+          <div className="settings-sublabel">
+            Shades every collision tile green (walkable) or red (blocked) and draws the tile grid.
+            Pause and tap a unit to project the route it will take.
+          </div>
+        </div>
+        <button
+          className={`action-btn${config.battlefieldDebugOverlay ? ' action-btn--gold' : ''}`}
+          onClick={() => {
+            const next = patchDevConfig({ battlefieldDebugOverlay: !config.battlefieldDebugOverlay })
+            setConfig(next)
+            flash(next.battlefieldDebugOverlay ? 'Passability overlay on.' : 'Passability overlay off.')
+          }}
+        >
+          {config.battlefieldDebugOverlay ? 'ON' : 'OFF'}
+        </button>
+      </div>
+
       {/* Clear dev config */}
       <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
         <div>

--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -18,7 +18,8 @@ import { loadBattlePopups } from '../screens/SettingsScreen'
 import { TutorialOverlay } from '../modals/TutorialOverlay'
 import { hasSeen, markSeen } from '../../game/tutorial'
 import { useLetterboxSize } from '../../hooks/useLetterboxSize'
-import { loadDevConfig } from '../../game/devStore'
+import { loadDevConfig, patchDevConfig } from '../../game/devStore'
+import { isDevMode } from '../../game/debug'
 
 const modalAutoDismissTime = 2000
 const BATTLE_TUTORIAL_ID = 'gameplay'
@@ -119,9 +120,10 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const [importantMsgQueue, setImportantMsgQueue] = useState<string[]>([])
   const lastLogLenRef = useRef(0)
   const [inspectedUnit, setInspectedUnit] = useState<Unit | null>(null)
-  // Read once per mount — the dev toggle is set in Settings, so it can't change
-  // mid-battle, and re-reading localStorage every render would be wasteful.
-  const [debugOverlay] = useState(() => loadDevConfig().battlefieldDebugOverlay)
+  // Seeded from the persisted dev config, but also flippable from the pause
+  // menu so the overlay can be compared against a live battle without leaving
+  // it. BattlefieldCanvas reads this every frame, so it takes effect at once.
+  const [debugOverlay, setDebugOverlay] = useState(() => loadDevConfig().battlefieldDebugOverlay)
   const [showDeckViewer, setShowDeckViewer] = useState(false)
   const [confirmGiveUp, setConfirmGiveUp] = useState(false)
   const [showBattleTutorial, setShowBattleTutorial] = useState(
@@ -636,6 +638,18 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
                   <Button size="md" onClick={() => setShowDeckViewer(true)}>📋 My Deck</Button>
                   {onGiveUp && (
                     <Button size="md" variant="danger" onClick={() => setConfirmGiveUp(true)}>✕ Give Up</Button>
+                  )}
+                  {isDevMode() && (
+                    <Button
+                      size="md"
+                      onClick={() => {
+                        const next = !debugOverlay
+                        setDebugOverlay(next)
+                        patchDevConfig({ battlefieldDebugOverlay: next })
+                      }}
+                    >
+                      {debugOverlay ? '🟩 Tiles ON' : '⬛ Tiles OFF'}
+                    </Button>
                   )}
                 </div>
               </>

--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -18,6 +18,7 @@ import { loadBattlePopups } from '../screens/SettingsScreen'
 import { TutorialOverlay } from '../modals/TutorialOverlay'
 import { hasSeen, markSeen } from '../../game/tutorial'
 import { useLetterboxSize } from '../../hooks/useLetterboxSize'
+import { loadDevConfig } from '../../game/devStore'
 
 const modalAutoDismissTime = 2000
 const BATTLE_TUTORIAL_ID = 'gameplay'
@@ -118,6 +119,9 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const [importantMsgQueue, setImportantMsgQueue] = useState<string[]>([])
   const lastLogLenRef = useRef(0)
   const [inspectedUnit, setInspectedUnit] = useState<Unit | null>(null)
+  // Read once per mount — the dev toggle is set in Settings, so it can't change
+  // mid-battle, and re-reading localStorage every render would be wasteful.
+  const [debugOverlay] = useState(() => loadDevConfig().battlefieldDebugOverlay)
   const [showDeckViewer, setShowDeckViewer] = useState(false)
   const [confirmGiveUp, setConfirmGiveUp] = useState(false)
   const [showBattleTutorial, setShowBattleTutorial] = useState(
@@ -339,6 +343,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           pendingAoeCard={pendingAoeCard}
           onPlayAoeCard={onPlayAoeCard}
           onAoeCancel={() => setPendingAoeCard(null)}
+          debugOverlay={debugOverlay}
+          selectedUnitId={inspectedUnit?.id ?? null}
         />
 
         {/* AoE targeting overlay */}

--- a/web/src/components/battle/BattlefieldCanvas.tsx
+++ b/web/src/components/battle/BattlefieldCanvas.tsx
@@ -8,7 +8,11 @@ import {
 import { WORLD_ENV_TILES } from '../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../data/tiles/tileIndex'
 import { TERRAIN_AVOID_SHAPE } from '../../game/engine/terrain'
-import { GRID_REF_HEIGHT } from '../../game/engine/terrainGrid'
+import {
+  GRID_REF_HEIGHT, GRID_REF_WIDTH, laneTileBounds, buildObstacleTileMap, buildRoadTileMap,
+  isTilePassable, type MovementProfile,
+} from '../../game/engine/terrainGrid'
+import { projectUnitRoute } from '../../game/engine/projectRoute'
 import { isDebugMode } from '../../game/debug'
 import { LANE_WIDTH, GameState, Unit, Card } from '../../game/types'
 import { buildScene } from './battlefieldCanvas/scene'
@@ -24,11 +28,67 @@ export interface Props {
   pendingAoeCard: Card | null
   onPlayAoeCard?: (cardId: string, cx: number, cy: number) => void
   onAoeCancel: () => void
+  /** Dev-only: shade collision tiles green/red, draw the tile grid, and project
+   *  the selected unit's route while paused. See DevMenu's toggle. */
+  debugOverlay?: boolean
+  /** Unit currently tapped in the inspect panel — the one whose route is drawn. */
+  selectedUnitId?: string | null
 }
 
 interface LiveProps extends Props {
   w: number
   h: number
+}
+
+const TILE_REF_SIZE = 32   // mirrors terrainGrid.ts's private TILE_SIZE
+
+/**
+ * Shades every collision tile and draws the tile grid.
+ *
+ * Tiles are drawn where the COLLISION grid puts them, not where the terrain art
+ * is: `gameToTile` rounds, so tile `tcx` owns reference pixels
+ * `[tcx*32 - 16, tcx*32 + 16)` and is centred on `tcx*32`. Reference pixels
+ * scale linearly to screen pixels because both coordinate systems share the
+ * same form (see gameToPixel in terrainGrid.ts vs utils/terrainLayer.ts), so a
+ * plain ratio converts them. Any visible mismatch against the drawn terrain is
+ * therefore a real discrepancy, which is the entire point of this overlay.
+ */
+function drawPassabilityTiles(
+  g: PIXI.Graphics, state: GameState, w: number, h: number, profile: MovementProfile, swims: boolean,
+): void {
+  g.clear()
+  const obstacleTiles = state.terrainGridCache?.obstacleTiles ?? buildObstacleTileMap(state.terrain ?? [])
+  const roadTiles = state.terrainGridCache?.roadTiles ?? buildRoadTileMap(state.roads ?? [])
+  const { tcxLo, tcxHi, tcyLo, tcyHi } = laneTileBounds()
+  const sx = w / GRID_REF_WIDTH
+  const sy = h / GRID_REF_HEIGHT
+  const half = TILE_REF_SIZE / 2
+
+  for (let tcy = tcyLo; tcy <= tcyHi; tcy++) {
+    for (let tcx = tcxLo; tcx <= tcxHi; tcx++) {
+      const passable = isTilePassable(obstacleTiles, roadTiles, tcx, tcy, profile, swims)
+      const x = (tcx * TILE_REF_SIZE - half) * sx
+      const y = (tcy * TILE_REF_SIZE - half) * sy
+      g.rect(x, y, TILE_REF_SIZE * sx, TILE_REF_SIZE * sy)
+        .fill({ color: passable ? 0x33ff66 : 0xff3333, alpha: passable ? 0.15 : 0.30 })
+        .stroke({ color: 0xffffff, width: 1, alpha: 0.15 })
+    }
+  }
+}
+
+/** Strokes a projected route (game coords) as a white polyline with an end dot. */
+function drawRoute(g: PIXI.Graphics, route: Array<{ x: number; y: number }>, w: number, h: number): void {
+  g.clear()
+  if (route.length < 2) return
+  const first = gameToPixel(route[0].x, route[0].y, w, h)
+  g.moveTo(first.px, first.py)
+  for (let i = 1; i < route.length; i++) {
+    const { px, py } = gameToPixel(route[i].x, route[i].y, w, h)
+    g.lineTo(px, py)
+  }
+  g.stroke({ color: 0xffffff, width: 2, alpha: 0.9 })
+  const end = gameToPixel(route[route.length - 1].x, route[route.length - 1].y, w, h)
+  g.circle(end.px, end.py, 4).fill({ color: 0xffffff, alpha: 0.9 })
 }
 
 // Inner component — only mounts once dimensions are known so usePixiApp gets the right size.
@@ -48,6 +108,9 @@ function CanvasInner(props: LiveProps) {
   propsRef.current = props
   const sceneRef = useRef<ReturnType<typeof buildScene> | null>(null)
   const hoverPxRef = useRef<{ x: number; y: number } | null>(null)
+  // Cache keys so the dev overlay redraws on change rather than every frame.
+  const tileOverlayKeyRef = useRef<string | null>(null)
+  const routeKeyRef = useRef<string | null>(null)
 
   const envDef = WORLD_ENV_TILES[props.state.environment ?? ''] ?? ENV_TILES[props.state.environment ?? '']
 
@@ -115,6 +178,33 @@ function CanvasInner(props: LiveProps) {
         }
       } else {
         s.debugLayer.clear()
+      }
+
+      // ── Dev passability overlay ───────────────────────────────────────────
+      // Terrain never changes mid-battle, so the tile shading is redrawn only
+      // when the toggle flips or the terrain identity changes — not per frame
+      // like the ellipses above, which would be hundreds of rects every tick.
+      const overlayOn = !!cur.debugOverlay
+      const selected = overlayOn && cur.paused && cur.selectedUnitId
+        ? cur.state.field.find(u => u.id === cur.selectedUnitId && u.hp > 0)
+        : undefined
+      const profile: MovementProfile = selected?.flying ? 'flying'
+        : selected?.tags?.includes('burrowing') ? 'burrowing' : 'ground'
+      const swims = selected?.tags?.includes('swim') ?? false
+      const tileKey = overlayOn ? `${profile}|${swims}|${cur.state.terrain?.length ?? 0}` : null
+      if (tileKey !== tileOverlayKeyRef.current) {
+        tileOverlayKeyRef.current = tileKey
+        if (tileKey) drawPassabilityTiles(s.tileDebugLayer, cur.state, w, h, profile, swims)
+        else s.tileDebugLayer.clear()
+      }
+
+      // Route projection runs the real engine forward, so recompute it only when
+      // the selection changes — never every frame.
+      const routeKey = selected ? `${selected.id}|${Math.round(selected.x)}|${Math.round(selected.y)}` : null
+      if (routeKey !== routeKeyRef.current) {
+        routeKeyRef.current = routeKey
+        if (selected) drawRoute(s.routeLayer, projectUnitRoute(cur.state, selected.id), w, h)
+        else s.routeLayer.clear()
       }
     })
 

--- a/web/src/components/battle/battlefieldCanvas/scene.ts
+++ b/web/src/components/battle/battlefieldCanvas/scene.ts
@@ -74,6 +74,9 @@ export interface Scene {
   decorObstacles: PIXI.Container
   world: PIXI.Container
   // Battle content layers (bottom → top).
+  /** Dev-only passability shading + tile grid. Sits under units so sprites stay
+   *  readable on top of it; drawn once per battle, not per frame. */
+  tileDebugLayer: PIXI.Graphics
   debugLayer: PIXI.Graphics
   bloodLayer: PIXI.Container
   hazardLayer: PIXI.Container
@@ -82,6 +85,8 @@ export interface Scene {
   unitLayer: PIXI.Container
   effectLayer: PIXI.Container
   overlayLayer: PIXI.Container   // AoE reticle + spell-cast glow
+  /** Dev-only projected-route polyline. Above units, or unit sprites would hide it. */
+  routeLayer: PIXI.Graphics
   // Pools.
   unitPool: Map<string, UnitEntry>
   wallGroupPool: Map<string, UnitEntry>   // keyed by `${owner}:${roundedX}` — one composite strip per group
@@ -101,6 +106,8 @@ export function buildScene(app: PIXI.Application): Scene {
   const decor = new PIXI.Container()
   const decorObstacles = new PIXI.Container()
   const world = new PIXI.Container()
+  const tileDebugLayer = new PIXI.Graphics()
+  const routeLayer = new PIXI.Graphics()
   const debugLayer = new PIXI.Graphics()
   const bloodLayer = new PIXI.Container()
   const hazardLayer = new PIXI.Container()
@@ -116,20 +123,21 @@ export function buildScene(app: PIXI.Application): Scene {
   spellGlow.visible = false
   overlayLayer.addChild(spellGlow, aoeReticle)
 
-  // z-order: terrain (base→world) → debug → blood → hazards → moats → walls →
-  // units → effects → overlays (reticle/glow), matching AGENTS.md's documented
-  // background→grid→buildings→units→effects→HUD convention.
+  // z-order: terrain (base→world) → tile debug → debug → blood → hazards →
+  // moats → walls → units → effects → overlays (reticle/glow) → route, matching
+  // AGENTS.md's documented background→grid→buildings→units→effects→HUD
+  // convention. routeLayer is last so the projected line draws over sprites.
   app.stage.addChild(
     base, bg, road, border, decor, decorObstacles, world,
-    debugLayer, bloodLayer, hazardLayer, moatLayer, wallLayer, unitLayer,
-    effectLayer, overlayLayer,
+    tileDebugLayer, debugLayer, bloodLayer, hazardLayer, moatLayer, wallLayer, unitLayer,
+    effectLayer, overlayLayer, routeLayer,
   )
 
   return {
     app,
     base, bg, road, border, decor, decorObstacles, world,
-    debugLayer, bloodLayer, hazardLayer, moatLayer, wallLayer, unitLayer,
-    effectLayer, overlayLayer,
+    tileDebugLayer, debugLayer, bloodLayer, hazardLayer, moatLayer, wallLayer, unitLayer,
+    effectLayer, overlayLayer, routeLayer,
     unitPool: new Map(),
     wallGroupPool: new Map(),
     bloodPool: new Map(),

--- a/web/src/game/devStore.ts
+++ b/web/src/game/devStore.ts
@@ -14,6 +14,10 @@ export interface DevConfig {
   crystalBonus:      number | null
   handicapOverride:  number | null
   grantAllCards:     boolean
+  /** Shade every battlefield collision tile green (walkable) or red (blocked),
+   *  draw the tile grid, and project a tapped unit's route while paused.
+   *  See BattlefieldCanvas.tsx. */
+  battlefieldDebugOverlay: boolean
 }
 
 const DEFAULT_CONFIG: DevConfig = {
@@ -21,6 +25,7 @@ const DEFAULT_CONFIG: DevConfig = {
   crystalBonus:     null,
   handicapOverride: null,
   grantAllCards:    false,
+  battlefieldDebugOverlay: false,
 }
 
 export function loadDevConfig(): DevConfig {

--- a/web/src/game/engine/projectRoute.test.ts
+++ b/web/src/game/engine/projectRoute.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { newGame } from '../engine'
+import { spawnUnit } from './helpers'
+import { projectUnitRoute } from './projectRoute'
+import { LANE_WIDTH } from '../types'
+import { LANE_MIN_Y, LANE_MAX_Y } from './helpers'
+
+const UNIT = {
+  name: 'Goblin', maxHp: 25, attack: 6, moveSpeed: 32, attackRange: 35,
+  attackCooldownMs: 1000, isWall: false, bypassWall: false,
+}
+
+/** A battle with one player unit and a rock straight ahead of it. */
+function battleWithObstacle() {
+  const s = newGame({
+    terrain: [{ id: 'rock', type: 'rock', x: 250, y: 0, radius: 26 }],
+    terrainValidated: true,
+  } as never)
+  const u = spawnUnit(UNIT as never, 'player')
+  u.x = 20
+  u.y = 0
+  u.spawnGrowTimer = 0
+  s.field = [u]
+  s.opponentBase.hp = 9999
+  return { s, unitId: u.id }
+}
+
+describe('projectUnitRoute', () => {
+  it('returns an empty route for an unknown unit', () => {
+    const { s } = battleWithObstacle()
+    expect(projectUnitRoute(s, 'no-such-unit')).toEqual([])
+  })
+
+  it('projects a route that advances toward the goal', () => {
+    const { s, unitId } = battleWithObstacle()
+    const route = projectUnitRoute(s, unitId)
+    expect(route.length).toBeGreaterThan(1)
+    expect(route[route.length - 1].x).toBeGreaterThan(route[0].x)
+  })
+
+  it('keeps every projected point inside the lane', () => {
+    const { s, unitId } = battleWithObstacle()
+    for (const p of projectUnitRoute(s, unitId)) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.x).toBeLessThanOrEqual(LANE_WIDTH)
+      expect(p.y).toBeGreaterThanOrEqual(LANE_MIN_Y)
+      expect(p.y).toBeLessThanOrEqual(LANE_MAX_Y)
+    }
+  })
+
+  it('routes around the obstacle rather than through it', () => {
+    const { s, unitId } = battleWithObstacle()
+    const route = projectUnitRoute(s, unitId)
+    // The unit starts dead centre with a rock dead ahead, so getting past it
+    // requires leaving the centre line at some point.
+    expect(Math.max(...route.map(p => Math.abs(p.y)))).toBeGreaterThan(5)
+  })
+
+  it('does not mutate the live battle state', () => {
+    const { s, unitId } = battleWithObstacle()
+    const before = s.field.map(u => ({ x: u.x, y: u.y, hp: u.hp, wp: u.roadWaypoints?.length ?? -1 }))
+    projectUnitRoute(s, unitId)
+    const after = s.field.map(u => ({ x: u.x, y: u.y, hp: u.hp, wp: u.roadWaypoints?.length ?? -1 }))
+    expect(after).toEqual(before)
+  })
+})

--- a/web/src/game/engine/projectRoute.ts
+++ b/web/src/game/engine/projectRoute.ts
@@ -1,0 +1,70 @@
+import type { GameState } from '../types'
+import { moveUnits } from './units'
+
+export interface RoutePoint { x: number; y: number }
+
+/** Game-units of movement below which a step isn't worth its own polyline vertex. */
+const MIN_STEP = 0.5
+/** Consecutive near-stationary steps after which the unit is treated as parked. */
+const STALL_STEPS = 12
+
+/**
+ * Projects where a unit will actually go, by running the real movement code
+ * forward on a throwaway copy of the battle.
+ *
+ * Deliberately not a flow-field trace: the flow field is only consulted when a
+ * unit is blocked, so a grid path would show a tidy route the unit may never
+ * take — it ignores enemy chasing, road following and detour hysteresis. Since
+ * the point of this is debugging movement, the projection has to be able to
+ * show the unit doing something wrong.
+ *
+ * The whole field is simulated, not just the tracked unit, so targets keep
+ * moving and the projection stays realistic.
+ *
+ * Caveats worth knowing when reading the line:
+ *  - `moveUnits` seeds `guardY` from `Math.random()` on a unit's first tick, so
+ *    a projection taken before that fires isn't perfectly reproducible.
+ *  - Only movement is simulated. Combat, spawns and card play are not, so the
+ *    further out the line goes the more it diverges from what will really
+ *    happen — it answers "where is this unit heading right now", not "where
+ *    will it be in 12 seconds".
+ */
+export function projectUnitRoute(
+  state: GameState,
+  unitId: string,
+  steps = 120,
+  dtMs = 100,
+): RoutePoint[] {
+  const index = state.field.findIndex(u => u.id === unitId)
+  if (index < 0) return []
+
+  // Copy everything moveUnits writes to (unit position//state and each unit's
+  // waypoint queue) so the live battle is untouched. terrainGridCache is shared
+  // deliberately: moveUnits only reads its tile maps and memoises flow fields
+  // into it, so sharing is safe and skips rebuilding the BFS.
+  const sim: GameState = {
+    ...state,
+    field: state.field.map(u => ({
+      ...u,
+      roadWaypoints: u.roadWaypoints?.map(p => ({ ...p })),
+    })),
+  }
+
+  const tracked = sim.field[index]
+  const route: RoutePoint[] = [{ x: tracked.x, y: tracked.y }]
+  let last = route[0]
+  let stalled = 0
+
+  for (let i = 0; i < steps; i++) {
+    moveUnits(sim, dtMs)
+    if (tracked.hp <= 0) break
+    if (Math.hypot(tracked.x - last.x, tracked.y - last.y) < MIN_STEP) {
+      if (++stalled >= STALL_STEPS) break
+      continue
+    }
+    stalled = 0
+    last = { x: tracked.x, y: tracked.y }
+    route.push(last)
+  }
+  return route
+}

--- a/web/src/game/engine/terrainGrid.ts
+++ b/web/src/game/engine/terrainGrid.ts
@@ -175,8 +175,9 @@ export function isTilePassable(
 /** Tile key -> BFS step distance to the goal edge. Absent = unreachable. */
 export type FlowField = Map<string, number>
 
-/** Tile-grid bounds of the playable lane, shared by reachability and flow fields. */
-function laneTileBounds() {
+/** Tile-grid bounds of the playable lane, shared by reachability, flow fields
+ *  and the battlefield passability overlay. */
+export function laneTileBounds() {
   const minTile = gameToTile(0, LANE_MIN_Y)
   const maxTile = gameToTile(LANE_WIDTH, LANE_MAX_Y)
   return {

--- a/web/src/game/engine/terrainGrid.ts
+++ b/web/src/game/engine/terrainGrid.ts
@@ -237,24 +237,41 @@ export function buildFlowField(
 }
 
 /**
- * The neighbouring tile that gets closest to the goal — i.e. one step downhill
- * on the flow field. Returns null when the unit's tile isn't on the field (it's
- * already sealed off) or nothing adjacent is strictly closer.
+ * One step downhill on the flow field — a neighbouring tile strictly closer to
+ * the goal. Returns null when nothing adjacent improves (already at the goal, or
+ * sealed in).
+ *
+ * `preferTcx` breaks the choice toward a lateral column the caller favours.
+ * Without it every unit reads the same field and therefore takes the same route,
+ * so an entire army funnels around terrain on one side while the other flank
+ * goes unused. Candidates are still restricted to tiles that strictly reduce the
+ * remaining distance, so honouring a preference can't cause a unit to loop or
+ * stall — it only chooses between routes that all make real progress.
  */
-export function flowFieldStep(field: FlowField, tcx: number, tcy: number): TileKey | null {
+export function flowFieldStep(
+  field: FlowField, tcx: number, tcy: number, preferTcx?: number,
+): TileKey | null {
   const here = field.get(tileKeyStr(tcx, tcy))
-  // Standing somewhere unreachable (e.g. spawned inside terrain): fall back to
-  // the best neighbour available rather than refusing to move at all.
-  let bestDist = here ?? Infinity
+  // Standing somewhere unreachable (e.g. spawned inside terrain): accept any
+  // neighbour on the field rather than refusing to move at all.
+  const limit = here ?? Infinity
   let best: TileKey | null = null
+  let bestPref = Infinity
+  let bestDist = Infinity
   const deltas = [-1, 0, 1]
   for (const dtx of deltas) {
     for (const dty of deltas) {
       if (dtx === 0 && dty === 0) continue
-      const dist = field.get(tileKeyStr(tcx + dtx, tcy + dty))
-      if (dist === undefined || dist >= bestDist) continue
-      bestDist = dist
-      best = { tcx: tcx + dtx, tcy: tcy + dty }
+      const ntx = tcx + dtx
+      const nty = tcy + dty
+      const dist = field.get(tileKeyStr(ntx, nty))
+      if (dist === undefined || dist >= limit) continue
+      const pref = preferTcx === undefined ? 0 : Math.abs(ntx - preferTcx)
+      if (pref < bestPref || (pref === bestPref && dist < bestDist)) {
+        best = { tcx: ntx, tcy: nty }
+        bestPref = pref
+        bestDist = dist
+      }
     }
   }
   return best

--- a/web/src/game/engine/units.test.ts
+++ b/web/src/game/engine/units.test.ts
@@ -249,3 +249,42 @@ describe('moveUnits — hard terrain blocking (terrainValidated)', () => {
     expect(unit.x).toBeGreaterThan(400)
   })
 })
+
+describe('moveUnits — defend stance', () => {
+  /** A defend-stance battle with one player defender and one enemy position. */
+  function defendBattle(enemyX: number) {
+    const s = newGame()
+    s.terrain = []
+    s.playerStance = 'defend'
+    const defender = spawnUnit(MOBILE_TEMPLATE, 'player')
+    defender.x = 70
+    defender.y = 0
+    defender.advanceY = 0
+    const enemy = spawnUnit(MOBILE_TEMPLATE, 'opponent')
+    enemy.x = enemyX
+    enemy.y = 60
+    s.field = [defender, enemy]
+    return { s, defender, enemy }
+  }
+
+  it('breaks formation to intercept an enemy that has breached the line', () => {
+    // An enemy this deep is on top of the player's spawners and commander.
+    const { s, defender, enemy } = defendBattle(60)
+    const startDist = Math.hypot(defender.x - enemy.x, defender.y - enemy.y)
+
+    for (let i = 0; i < 30; i++) moveUnits(s, 100)
+
+    const endDist = Math.hypot(defender.x - enemy.x, defender.y - enemy.y)
+    expect(endDist).toBeLessThan(startDist)
+  })
+
+  it('holds its assigned slot when no enemy has breached the line', () => {
+    // Far up the lane — not a threat, so the defender should stay on the line
+    // rather than charging out to meet it.
+    const { s, defender } = defendBattle(LANE_WIDTH - 40)
+
+    for (let i = 0; i < 30; i++) moveUnits(s, 100)
+
+    expect(defender.x).toBeLessThan(120)
+  })
+})

--- a/web/src/game/engine/units.test.ts
+++ b/web/src/game/engine/units.test.ts
@@ -26,13 +26,14 @@ describe('moveUnits — road following', () => {
     s.roads = [{ points: [{ x: 0, y: 40 }, { x: LANE_WIDTH, y: 40 }] }]
     const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
     unit.y = 0 // pin — spawnUnit() otherwise picks a random lane from LANE_POSITIONS
+    unit.advanceY = 0 // pin — advancing units otherwise head for a random lateral lane
     s.field = [unit]
 
     moveUnits(s, 100)
 
     expect(unit.roadWaypoints).toBeUndefined()
-    // Straight toward the opponent base (LANE_WIDTH, 0) — y should not have moved toward
-    // the road's y=40.
+    // Straight toward the opponent base at the unit's own lane — y should not have
+    // moved toward the road's y=40.
     expect(unit.y).toBeCloseTo(0)
   })
 
@@ -81,13 +82,14 @@ describe('moveUnits — road following', () => {
     s.roads = roads
     const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
     unit.y = 0
+    unit.advanceY = 0 // pin — advancing units otherwise head for a random lateral lane
     s.field = [unit]
 
     for (let i = 0; i < 100; i++) moveUnits(s, 100)
 
     expect(unit.roadWaypoints).toEqual([])
     // With the road exhausted, the unit should be progressing straight toward the
-    // opponent base (increasing x, y pinned back to 0).
+    // opponent base (increasing x, y pinned back to its lane).
     expect(unit.x).toBeGreaterThan(45)
     expect(unit.y).toBeCloseTo(0)
   })

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -87,8 +87,15 @@ export function moveUnits(s: GameState, deltaMs: number): void {
 
     const nearestAhead = findNearestEnemyByPriority(s.field, unit) ?? findNearestEnemy(s.field, unit)
 
+    // Advancing units head for their own lateral lane rather than dead centre.
+    // Sending everyone to y=0 collapsed the army onto the centre line within
+    // seconds, which wasted the flanks and — because the flow field is shared
+    // and deterministic — meant every blocked unit then detoured round terrain
+    // on the identical side. A per-unit lane fans them out, so they meet
+    // obstacles at different points and naturally split around them.
+    if (unit.advanceY === undefined) unit.advanceY = (Math.random() * 2 - 1) * LANE_MAX_Y
     let tx: number = unit.owner === 'player' ? LANE_WIDTH : 0
-    let ty: number = 0
+    let ty: number = unit.advanceY
     let hasTarget = false
 
     // Road-following: lazily compute this unit's path onto the nearest authored road the
@@ -465,7 +472,10 @@ export function moveUnits(s: GameState, deltaMs: number): void {
         // sub-pixel move. Forward progress was zero, yet the unit never looked
         // stuck to the code; it just ground against the obstacle for the rest
         // of the battle.
-        const next = flowFieldStep(field, here.tcx, here.tcy)
+        // Steer the detour toward this unit's own lane so an army splits around
+        // an obstacle instead of every unit tracing the identical shortest route.
+        const preferTcx = gameToTile(unit.x, unit.advanceY ?? unit.y).tcx
+        const next = flowFieldStep(field, here.tcx, here.tcy, preferTcx)
         if (next) {
           const target = tileToGame(next.tcx, next.tcy)
           const toX = target.x - unit.x

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -75,6 +75,19 @@ export function moveUnits(s: GameState, deltaMs: number): void {
   // Y positions defenders spread across so they don't all converge on a single point.
   const DEFEND_Y_SLOTS = [-64, -40, -20, 0, 20, 40, 64]
 
+  // The line defenders form up on, and how far in front of it an enemy still
+  // counts as an intruder worth breaking formation for.
+  const DEFEND_LINE_X = PLAYER_SPAWN_X + 40
+  const DEFEND_INTERCEPT_PX = 120
+
+  // Enemies that have reached the defensive line or slipped behind it — where
+  // the player's spawners, walls and commander all sit. Without this, defenders
+  // sat on their assigned slot while an enemy chewed through a structure a few
+  // pixels away, since nothing in the defend branch ever looked for a target.
+  const defendThreats = stance === 'defend'
+    ? s.field.filter(u => u.owner === 'opponent' && u.hp > 0 && u.x <= DEFEND_LINE_X + DEFEND_INTERCEPT_PX)
+    : []
+
   for (const unit of s.field) {
     if (unit.moveSpeed === 0) continue
     if (unit.spawnGrowTimer != null && unit.spawnGrowTimer > 0) continue
@@ -130,11 +143,26 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       }
     }
 
-    // Defend: pull back toward spawn, spread across Y slots; overflow units charge forward.
+    // Defend: intercept anything that has breached the line, otherwise hold
+    // formation spread across Y slots. Overflow units charge forward instead.
     if (unit.owner === 'player' && stance === 'defend' && !defendOverflowAttackers.has(unit.id)) {
-      tx = PLAYER_SPAWN_X + 40
-      ty = DEFEND_Y_SLOTS[idNum(unit.id) % DEFEND_Y_SLOTS.length]
-      hasTarget = false
+      let threat: Unit | undefined
+      let threatDist = Infinity
+      for (const other of defendThreats) {
+        const d = unitDist(unit, other)
+        if (d < threatDist) { threatDist = d; threat = other }
+      }
+      if (threat) {
+        // Already engaging it — combat handles the attack, don't crowd closer.
+        if (threatDist <= unit.attackRange) continue
+        tx = threat.x
+        ty = threat.isWall ? unit.y : threat.y
+        hasTarget = true
+      } else {
+        tx = DEFEND_LINE_X
+        ty = DEFEND_Y_SLOTS[idNum(unit.id) % DEFEND_Y_SLOTS.length]
+        hasTarget = false
+      }
     }
 
     // Trait-based movement overrides are suppressed in attack/defend/hold stances

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -217,6 +217,13 @@ export interface Unit extends UnitTemplate {
    *  movement tick when the battle has `roadFollowing` enabled). Empty once the unit has
    *  passed the last waypoint or no road was found; undefined until first computed. */
   roadWaypoints?: Array<{ x: number; y: number }>
+  /** Lateral lane this unit prefers while advancing, picked at random on its
+   *  first movement tick (lazy — spawnUnit has no GameState access). Used as the
+   *  default target's `y` instead of dead centre, so an army fans out across the
+   *  battlefield rather than collapsing onto the centre line and then all
+   *  detouring round terrain on the same side. Overridden by anything with a
+   *  real target: road waypoints, enemy chasing, defend slots. */
+  advanceY?: number
   /** Flow-field distance-to-goal recorded when this unit started routing around
    *  terrain (hard-blocking battles only — see moveUnits). While set, the unit
    *  keeps following the flow field even on ticks when the direct path looks


### PR DESCRIPTION
## Summary

Three related movement changes.

### 1. Admin passability overlay + route projection

A dev-menu toggle (`?dev` → Settings → DEV TOOLS, persisted) that shades every collision tile **green** (walkable) or **red** (blocked), draws the tile grid, and — when paused with a unit tapped — projects that unit's route as a **white polyline**.

The route runs the **real engine** forward on a throwaway copy of the battle rather than tracing the flow field, so it reflects enemy chasing, road following and detour hysteresis. A grid trace would draw a tidy path the unit may never take, and the point is being able to see a unit doing the *wrong* thing. A test asserts the live battle is not mutated.

Tiles are drawn where **collision** puts them, not where the art is. `gameToTile` rounds, so tile `tcx` owns pixels `[tcx*32 − 16, tcx*32 + 16)` centred on `tcx*32`, while every sprite is drawn with its **top-left** at `tcx*T`. The art therefore sits half a tile down-and-right of the region it represents (~10px on a phone). Verified the overlay's own maths against `gameToTile` over 20,000 random points — 0 mismatches — so a visible offset is the bug, not the tool. **Deliberately not fixed here**: confirm on a real screen first.

### 2. Per-unit lateral lanes

Advancing units all targeted dead centre (`ty = 0`), so an army collapsed onto the centre line within seconds and wasted both flanks. Each unit now picks a random lateral lane on its first movement tick and heads for that, mirroring the existing lazy `guardY` pattern. Road waypoints, enemy chasing and defend slots still override it.

`flowFieldStep` also takes an optional lateral preference: the field is shared and deterministic, so every blocked unit previously traced the identical detour. Candidates are still restricted to tiles that strictly reduce remaining distance, so a preference can never cause a loop or stall.

**Note on the "everyone uses one side" symptom:** this change spreads units, but it is mostly *not* a movement bug. Checking which lateral tile columns are clear end-to-end on 10 procedural maps: 8 have exactly **one** open column, so units were correctly taking the only route. Only `qp-5` has both flanks open — and that is the map where units split 12/13. Genuinely opening both flanks needs a terrain-generation change (obstacle tile footprints are 7 of the 9 lane columns, so a small off-centre offset seals one edge); not attempted here.

### 3. DEFEND intercepts breaches

Defenders parked on a fixed Y slot and never looked for a target, so an enemy could stand next to a spawner or the commander — both well behind the line — and destroy it unopposed. They now engage the nearest enemy that has reached or passed the defensive line, and fall back to their slot when nothing has breached. Enemies still up the lane are ignored, so DEFEND stays defensive. CHARGE and ATTACK are unchanged.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 1990 tests across 62 files pass.
- [x] New `projectRoute.test.ts` (route advances, stays in lane, leaves the centre line to pass an obstacle, no mutation of live state) and two new DEFEND tests (breaks formation for a breach; holds the slot otherwise).
- [x] Swept all 336 battle nodes across every act plus 100 procedural seeds: **0 units stuck**.
- [x] Two road-following tests updated to pin `advanceY` — they assumed the default target was the centre line; what they actually test (road ignored when `roadFollowing` is off) is unchanged.
- [ ] Manual: enable the overlay, check whether red tiles align with the rock/tree/water art.
- [ ] Manual: DEFEND with an enemy attacking a spawner — defenders should now break off and engage.