### PR TITLE
Let the admin account reach dev tools without ?dev

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -122,6 +122,7 @@ import { getIntegrityViolations, clearIntegrityViolations } from './game/integri
 import { useRareEvents } from './hooks/useRareEvents'
 import { useAchievements } from './hooks/useAchievements'
 import { isNoDamageMode } from './game/debug'
+import { isAdminUser } from './game/admin'
 import { saveBattleState, loadBattleState, clearBattleState } from './game/battleState'
 import { loadCommander, promoteCommander, CommanderState } from './game/commander'
 
@@ -3823,7 +3824,7 @@ export default function App() {
         if (gameState.phase.type === 'celebration') {
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
               <VictoryPanel
                 playerScore={gameState.playerScore}
                 opponentScore={gameState.opponentScore}
@@ -3840,7 +3841,7 @@ export default function App() {
           const fp = gameState.phase as { type: 'fingerSmash'; wave: number; smashedNames: string[]; rewardDue: boolean }
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
               <FingerSmash
                 smashedNames={fingerSmashNames}
                 onDone={() => {
@@ -3902,7 +3903,7 @@ export default function App() {
           />
         ) : (
           <>
-            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} />
+            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
             {showBossShockwave && <BossShockwave onDone={() => dispatch({ type: 'HIDE_BOSS_SHOCKWAVE' })} />}
             {activeRareEvent === 'fakeCrash'   && <FakeCrashEvent   onDone={handleRareEventDone} />}
             {activeRareEvent === 'blackjack'   && <BlackjackEvent   onDone={handleRareEventDone} />}

--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -54,6 +54,12 @@ interface Props {
   speedMultiplier?: 1 | 2 | 4 | 8
   onCycleSpeed?: () => void
   onCounterSpell?: () => void
+  /** True for the game admin. Together with `?dev` this reveals the dev-only
+   *  passability overlay toggle in the pause menu. Passed as a boolean rather
+   *  than resolved here so this component stays free of a Firebase dependency
+   *  (its Storybook story renders without auth) and so useAuth's
+   *  onAuthStateChanged listener isn't duplicated for a cosmetic gate. */
+  isAdmin?: boolean
 }
 
 function ManaBar({ mana, maxMana, manaAccum }: { mana: number; maxMana: number; manaAccum: number }) {
@@ -113,7 +119,7 @@ function opponentPortraitSlug(bossAI: string | undefined, actTheme: string | und
   return 'bandit'
 }
 
-export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign, stance = 'auto', onSetStance, speedMultiplier = 1, onCycleSpeed, onCounterSpell }: Props) {
+export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign, stance = 'auto', onSetStance, speedMultiplier = 1, onCycleSpeed, onCounterSpell, isAdmin = false }: Props) {
   const { openDetail, cardDetailNode } = useCardDetail()
   const [heroLightning, setHeroLightning] = useState<{ owner: 'player' | 'opponent'; key: number } | null>(null)
   const [paused, setPaused] = useState(false)
@@ -639,7 +645,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
                   {onGiveUp && (
                     <Button size="md" variant="danger" onClick={() => setConfirmGiveUp(true)}>✕ Give Up</Button>
                   )}
-                  {isDevMode() && (
+                  {(isDevMode() || isAdmin) && (
                     <Button
                       size="md"
                       onClick={() => {

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -12,6 +12,7 @@ import { uploadSave, applySave, getLastSyncTime, type CloudSave } from '../../ga
 import { isDevMode } from '../../game/debug'
 import { DevMenu } from '../admin/DevMenu'
 import { GIFT_OWNER_UID } from '../../game/gifts'
+import { isAdminUser } from '../../game/admin'
 import { loadPlaytime, formatPlaytime } from '../../game/playtime'
 import { isHubWorldUnlocked, unlockHubWorld, loadHubDefault, saveHubDefault } from '../../game/codex'
 
@@ -742,7 +743,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </Section>
         )}
 
-        {isDevMode() && onDevCrystalsChanged && onDevHandicapChanged && onSceneryPreview && (
+        {(isDevMode() || isAdminUser(user)) && onDevCrystalsChanged && onDevHandicapChanged && onSceneryPreview && (
           <DevMenu
             onCrystalsChanged={onDevCrystalsChanged}
             onHandicapChanged={onDevHandicapChanged}

--- a/web/src/game/admin.test.ts
+++ b/web/src/game/admin.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import type { User } from 'firebase/auth'
+import { isAdminUser } from './admin'
+import { GIFT_OWNER_UID } from './gifts'
+
+const asUser = (uid: string) => ({ uid }) as User
+
+describe('isAdminUser', () => {
+  it('accepts the owner uid', () => {
+    expect(isAdminUser(asUser(GIFT_OWNER_UID))).toBe(true)
+  })
+
+  it('rejects any other account', () => {
+    // Anonymous sign-in always yields a uid (see hooks/useAuth), so "has a
+    // user" must never be mistaken for "is the admin".
+    expect(isAdminUser(asUser('some-other-uid'))).toBe(false)
+  })
+
+  it('rejects a missing user rather than throwing', () => {
+    expect(isAdminUser(null)).toBe(false)
+    expect(isAdminUser(undefined)).toBe(false)
+  })
+})

--- a/web/src/game/admin.ts
+++ b/web/src/game/admin.ts
@@ -1,0 +1,16 @@
+import type { User } from 'firebase/auth'
+import { GIFT_OWNER_UID } from './gifts'
+
+/**
+ * Whether this account is the game's admin.
+ *
+ * The owner UID lives in ./gifts for historical reasons — it started life as
+ * "who owns the gift registry" — but it is really the one admin identity, so
+ * gating reads better through this than through a gifts import.
+ *
+ * Distinct from `isDevMode()` in ./debug, which is a URL opt-in (`?dev`) any
+ * account can use. Dev tooling is gated on either: `isDevMode() || isAdminUser(user)`.
+ */
+export function isAdminUser(user: User | null | undefined): boolean {
+  return !!user && user.uid === GIFT_OWNER_UID
+}


### PR DESCRIPTION
## Summary

The battlefield passability overlay (from #2063) was gated on `isDevMode()` — the presence of `?dev` in the URL. That's a **different gate** from the one granting admin powers, so the admin account, signed in and seeing every ADMIN section in Settings, couldn't find the DEV TOOLS section or the pause-menu overlay toggle, with nothing on screen explaining why.

There were three independent gates:

| Gate | Mechanism | Controlled |
|---|---|---|
| `isDevMode()` | `?dev` in URL | Settings → DEV TOOLS, pause-menu overlay toggle |
| `user?.uid === GIFT_OWNER_UID` | Firebase account UID | ADMIN sections |
| `isDebugMode` (local shadow) | `?debug` in URL | DEBUG section (OR'd with admin UID) |

## Changes

- **`web/src/game/admin.ts`** (new) — `isAdminUser(user)`, the single admin predicate. The owner UID lives in `game/gifts` for historical reasons (it began as "who owns the gift registry") but is really the one admin identity, so gating now reads through `game/admin` instead of a gifts import. Handles `null`/`undefined` explicitly — anonymous sign-in always yields a uid, so "has a user" must never be mistaken for "is the admin".
- **`SettingsScreen.tsx`** — DEV TOOLS gate becomes `isDevMode() || isAdminUser(user)`. `user` was already a prop.
- **`Battlefield.tsx`** — new optional `isAdmin` prop; pause-menu toggle gates on `isDevMode() || isAdmin`. Passed as a plain boolean from `App.tsx` (which already holds auth state) rather than calling `useAuth()` here: the hook subscribes to `onAuthStateChanged`, so a second caller would add a redundant auth listener for a cosmetic gate, and a boolean keeps the component free of Firebase for its Storybook story. **All three** `<Battlefield>` call sites pass it.

`?dev` behaves exactly as before, so this widens the gate rather than replacing it.

## Note on scope

Confirmed with the repo owner that the admin account should unlock the **whole** DEV TOOLS section, not just the overlay row. Worth stating plainly: that section contains game-altering actions — crystal grants, handicap override, forced rare events, skip-to-act, unlock-all-chapters — which now sit one tap away in every ordinary session on the admin account with no URL opt-in. Deliberate, but easy to trip by accident; narrowing it to just the overlay row later is a one-line change if that becomes annoying.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 2010 tests across 63 files pass.
- [x] New `admin.test.ts`: accepts the owner uid, rejects any other account, rejects a missing user without throwing.
- [ ] Manual, admin account, **no** `?dev`: Settings shows DEV TOOLS; pausing a battle shows the 🟩/⬛ Tiles button; toggling flips the overlay immediately and survives a reload.
- [ ] Manual, non-admin account, no `?dev`: neither appears.
- [ ] Manual, any account **with** `?dev`: both appear, as today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg4sPgYK93sAJC8XwChpp)_