### PR TITLE
Make ruins a one-tile obstacle everywhere

### DIFF
--- a/web/src/game/engine/terrain.ts
+++ b/web/src/game/engine/terrain.ts
@@ -16,6 +16,23 @@ export const TERRAIN_AVOID_SHAPE: Record<TerrainType, { fx: number; fy: number }
   ruin:  { fx: 1.0, fy: 0.9 },  // ruins/farmhouse/watchtower: roughly square
 }
 
+/**
+ * A ruin is a one-tile obstacle, whatever radius its data carries.
+ *
+ * Unlike rock/tree/water it has no patch tileset in any environment, so
+ * utils/terrainPatchPlan.ts draws it as a single WORLD_DECOR icon on one tile
+ * and nothing more. Sizing it by radius therefore blocks — or deflects around —
+ * ground that shows no obstacle at all. Hard blocking handles this by type (see
+ * obstacleTileRadius in ./terrainGrid); this is the same rule for the legacy
+ * soft-avoidance path, so a ruin behaves identically whether or not a node has
+ * been terrain-validated.
+ *
+ * ~5 makes the avoidance ellipse about one tile across: a tile spans ~17.8
+ * game-y laterally and ~18.5 game-x forward, and the ellipse half-extents are
+ * `radius * shape + 4`.
+ */
+export const RUIN_FOOTPRINT_RADIUS = 5
+
 export interface TerrainObstacle {
   id: string
   type: TerrainType

--- a/web/src/game/engine/terrainGrid.test.ts
+++ b/web/src/game/engine/terrainGrid.test.ts
@@ -99,3 +99,28 @@ describe('checkReachability / checkAllProfilesReachable', () => {
     expect(checkReachability(terrain, roads, 'ground', false).reachable).toBe(false)
   })
 })
+
+describe('obstacle tile footprint matches what is drawn', () => {
+  // utils/terrainPatchPlan.ts gives ruins no patch tileset in any environment —
+  // they render as a single WORLD_DECOR icon on their centre tile. Blocking the
+  // patch-sized disc anyway walled off up to 29 tiles behind a one-tile icon.
+  it('a ruin blocks only the tile its icon occupies, at any radius', () => {
+    for (const radius of [18, 22, 26, 28, 32]) {
+      const map = buildObstacleTileMap([{ id: 't1', type: 'ruin', x: 250, y: 0, radius }])
+      expect(map.size).toBe(1)
+      const centre = gameToTile(250, 0)
+      expect(map.get(`${centre.tcx},${centre.tcy}`)?.type).toBe('ruin')
+    }
+  })
+
+  it('patch-drawing types still block the full disc they autotile', () => {
+    // rock/tree/water fill the same disc they block, so their footprint must
+    // keep scaling with radius rather than collapsing to a single tile.
+    for (const type of ['rock', 'tree', 'water'] as const) {
+      const small = buildObstacleTileMap([{ id: 't1', type, x: 250, y: 0, radius: 18 }]).size
+      const large = buildObstacleTileMap([{ id: 't1', type, x: 250, y: 0, radius: 28 }]).size
+      expect(small).toBeGreaterThan(1)
+      expect(large).toBeGreaterThan(small)
+    }
+  })
+})

--- a/web/src/game/engine/terrainGrid.ts
+++ b/web/src/game/engine/terrainGrid.ts
@@ -79,10 +79,22 @@ function tilesInSquare(center: TileKey, width: number): TileKey[] {
 
 export interface ObstacleTile { type: TerrainType; zIndex: number }
 
-/** Same tile-radius formula utils/terrainLayer.ts's buildTerrainDecorGfx uses
- *  (obstacle radius in game units -> tile-ring radius), evaluated against the
- *  fixed reference resolution instead of the actual on-screen canvas. */
-function obstacleTileRadius(radius: number): number {
+/**
+ * How many tile rings out from its centre an obstacle blocks.
+ *
+ * Mirrors the tile-radius formula utils/terrainLayer.ts's buildTerrainDecorGfx
+ * uses, evaluated against the fixed reference resolution rather than the actual
+ * canvas — but only for the types that actually draw that disc.
+ *
+ * Ruins do not. They have no patch tileset in any environment, so
+ * utils/terrainPatchPlan.ts draws them as a single WORLD_DECOR icon on their
+ * centre tile and skips the patch loop entirely. Applying the patch formula to
+ * them blocked up to 29 tiles behind a one-tile icon — a mushroom or gravestone
+ * that reads as scenery while walling off a third of the lane. Ruins block the
+ * tile their icon sits on, which is the whole of what they draw.
+ */
+function obstacleTileRadius(type: TerrainType, radius: number): number {
+  if (type === 'ruin') return 0
   const TILE_RADIUS_SCALE = 220 // mirrors utils/terrainLayer.ts's constant of the same name
   return Math.max(1, Math.round(radius * GRID_REF_HEIGHT / (TILE_RADIUS_SCALE * TILE_SIZE)))
 }
@@ -91,7 +103,7 @@ export function buildObstacleTileMap(terrain: TerrainObstacle[]): Map<string, Ob
   const map = new Map<string, ObstacleTile>()
   for (const obs of terrain) {
     const center = gameToTile(obs.x, obs.y)
-    const tileRadius = obstacleTileRadius(obs.radius)
+    const tileRadius = obstacleTileRadius(obs.type, obs.radius)
     const z = obs.zIndex ?? 0
     for (const { tcx, tcy } of tilesInDisc(center, tileRadius)) {
       const key = tileKeyStr(tcx, tcy)

--- a/web/src/game/engine/units.test.ts
+++ b/web/src/game/engine/units.test.ts
@@ -288,3 +288,41 @@ describe('moveUnits — defend stance', () => {
     expect(defender.x).toBeLessThan(120)
   })
 })
+
+describe('moveUnits — ruins are a one-tile obstacle on the soft-avoidance path too', () => {
+  // Hard blocking sizes ruins by type (obstacleTileRadius in terrainGrid), but
+  // nodes that were never terrain-validated still use lateral avoidance, which
+  // read the authored radius. A ruin drawn as one icon must not shove units
+  // around from 30 game units away just because its data says radius 30.
+  const farOffRuin = (radius: number) => {
+    const s = newGame()
+    s.terrainValidated = false
+    s.terrain = [{ id: 'r1', type: 'ruin', x: 120, y: 40, radius }]
+    const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
+    unit.x = 100
+    unit.y = 0
+    unit.advanceY = 0
+    s.field = [unit]
+    for (let i = 0; i < 10; i++) moveUnits(s, 100)
+    return Math.abs(unit.y)
+  }
+
+  it('does not deflect a unit a whole tile away, whatever radius the data carries', () => {
+    // y=0 vs a ruin at y=40 is more than two tiles clear of a one-tile footprint.
+    expect(farOffRuin(30)).toBeLessThan(1)
+    expect(farOffRuin(18)).toBeLessThan(1)
+  })
+
+  it('a rock of the same radius still deflects, so avoidance itself is intact', () => {
+    const s = newGame()
+    s.terrainValidated = false
+    s.terrain = [{ id: 'r1', type: 'rock', x: 120, y: 40, radius: 30 }]
+    const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
+    unit.x = 100
+    unit.y = 20
+    unit.advanceY = 20
+    s.field = [unit]
+    for (let i = 0; i < 10; i++) moveUnits(s, 100)
+    expect(unit.y).toBeLessThan(20)
+  })
+})

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -1,4 +1,4 @@
-import { GameState, LANE_WIDTH, TERRAIN_AVOID_SHAPE, Unit, UnitTag } from '../types'
+import { GameState, LANE_WIDTH, TERRAIN_AVOID_SHAPE, RUIN_FOOTPRINT_RADIUS, Unit, UnitTag } from '../types'
 import { BASE_STOP_MARGIN, COMMANDER_LEASH_PX, DAMAGE_FLASH_MS, PLAYER_SPAWN_X } from './constants'
 import { LANE_MAX_Y, LANE_MIN_Y } from './helpers'
 import { unitDist, findNearestEnemy, findNearestEnemyByPriority, findEnemyBehind } from './targeting'
@@ -385,8 +385,11 @@ export function moveUnits(s: GameState, deltaMs: number): void {
           const toObsX = obs.x - unit.x
           const toObsY = obs.y - unit.y
           const shape  = TERRAIN_AVOID_SHAPE[obs.type]
-          const ax     = obs.radius * shape.fx + 4
-          const ay     = obs.radius * shape.fy + 4
+          // Ruins draw a single icon, so they deflect over one tile rather than
+          // their authored radius — see RUIN_FOOTPRINT_RADIUS.
+          const radius = obs.type === 'ruin' ? RUIN_FOOTPRINT_RADIUS : obs.radius
+          const ax     = radius * shape.fx + 4
+          const ay     = radius * shape.fy + 4
           const normDist = Math.sqrt((toObsX / ax) ** 2 + (toObsY / ay) ** 2)
           if (normDist < 1 && normDist > 0) {
             const strength = 1 - normDist

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -393,7 +393,7 @@ export interface BattleEventState {
 
 import type { TerrainType as _TerrainType, TerrainObstacle as _TerrainObstacle, RoadDef as _RoadDef, BattlefieldDecorItem as _BattlefieldDecorItem } from './engine/terrain'
 export type { TerrainType, TerrainObstacle, RoadDef, BattlefieldDecorItem } from './engine/terrain'
-export { TERRAIN_AVOID_SHAPE } from './engine/terrain'
+export { TERRAIN_AVOID_SHAPE, RUIN_FOOTPRINT_RADIUS } from './engine/terrain'
 type TerrainType = _TerrainType
 type TerrainObstacle = _TerrainObstacle
 type RoadDef = _RoadDef


### PR DESCRIPTION
## Summary

Found with the new passability overlay: large blocked regions on the daily challenge containing nothing but a single small mushroom.

The collision grid sized every obstacle's footprint with the **rendering side's patch formula** (`obstacleTileRadius`, mirroring `buildTerrainDecorGfx`), on the assumption that an obstacle fills the disc it blocks. Ruins don't. They have no patch tileset in **any** environment, so `utils/terrainPatchPlan.ts` draws them as a single `WORLD_DECOR` icon on their centre tile and skips the patch loop entirely — while `buildObstacleTileMap` still rasterized the full radius.

| obstacle | tiles blocked (before) | tiles drawn |
|---|---|---|
| radius 18 rock | 13 | 13 |
| radius 18 **ruin** | 13 | **1** |
| radius 22–28 **ruin** | 29 | **1** |

In the fungal environment that's a mushroom reading as scenery while walling off a third of the lane.

## Fix

A ruin is a one-tile obstacle whatever radius its data carries, on **both** movement paths:

- **Hard blocking** — `obstacleTileRadius` is now type-aware, so a ruin blocks exactly the tile its icon occupies. Patch-drawing types (rock/tree/water) are untouched; they autotile the same disc they block, so their footprint already matched.
- **Legacy soft avoidance** — 325 act nodes are still on that path and three carry ruins with radii 21–30, so a ruin was deflecting units from well over a tile away. `RUIN_FOOTPRINT_RADIUS` states the rule in one place and sizes the avoidance ellipse from it, so a ruin behaves identically whether or not its node has been terrain-validated.

## Impact

Ruins are **26% of generated obstacles**, so this measurably opens up procedural maps. Across 300 seeds:

| | before | after |
|---|---|---|
| avg fully-clear lateral columns (of 9) | 0.94 | **1.26** |
| maps offering at most one route through | 83% | **65%** |

That also partly explains the earlier "units all traverse on one side" observation — a good share of those single-route maps were single-route because of phantom ruin walls that were never visible on screen.

Shrinking a footprint can only *add* routes, so the reachability guarantees in `actTerrain.test.ts` and `proceduralTerrain.test.ts` still hold.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 2012 tests pass (plus the new ones below).
- [x] `terrainGrid.test.ts`: a ruin blocks exactly one tile at any radius; rock/tree/water still scale with radius, so the fix can't over-apply.
- [x] `units.test.ts`: a ruin no longer deflects a unit a tile away whatever its radius, while a rock of the same radius still does — proving avoidance itself is intact rather than disabled.
- [x] Swept all 336 battle nodes across every act plus 100 procedural seeds: **0 units stuck**.
- [ ] Manual: re-check the daily challenge with the overlay on — the big orange crosses around lone mushrooms should now be single tiles.