### PR TITLE
Align battlefield collision with the tiles that are drawn

### DIFF
--- a/web/src/components/battle/BattlefieldCanvas.tsx
+++ b/web/src/components/battle/BattlefieldCanvas.tsx
@@ -46,12 +46,13 @@ const TILE_REF_SIZE = 32   // mirrors terrainGrid.ts's private TILE_SIZE
  * Shades every collision tile and draws the tile grid.
  *
  * Tiles are drawn where the COLLISION grid puts them, not where the terrain art
- * is: `gameToTile` rounds, so tile `tcx` owns reference pixels
- * `[tcx*32 - 16, tcx*32 + 16)` and is centred on `tcx*32`. Reference pixels
- * scale linearly to screen pixels because both coordinate systems share the
- * same form (see gameToPixel in terrainGrid.ts vs utils/terrainLayer.ts), so a
- * plain ratio converts them. Any visible mismatch against the drawn terrain is
- * therefore a real discrepancy, which is the entire point of this overlay.
+ * is: tile `tcx` owns reference pixels `[tcx*32, (tcx+1)*32)`, the same band a
+ * tile sprite is drawn over (see gameToContainingTile in terrainGrid.ts).
+ * Reference pixels scale linearly to screen pixels because both coordinate
+ * systems share the same form (see gameToPixel in terrainGrid.ts vs
+ * utils/terrainLayer.ts), so a plain ratio converts them. Any visible mismatch
+ * against the drawn terrain is therefore a real discrepancy, which is the
+ * entire point of this overlay.
  */
 function drawPassabilityTiles(
   g: PIXI.Graphics, state: GameState, w: number, h: number, profile: MovementProfile, swims: boolean,
@@ -62,13 +63,12 @@ function drawPassabilityTiles(
   const { tcxLo, tcxHi, tcyLo, tcyHi } = laneTileBounds()
   const sx = w / GRID_REF_WIDTH
   const sy = h / GRID_REF_HEIGHT
-  const half = TILE_REF_SIZE / 2
 
   for (let tcy = tcyLo; tcy <= tcyHi; tcy++) {
     for (let tcx = tcxLo; tcx <= tcxHi; tcx++) {
       const passable = isTilePassable(obstacleTiles, roadTiles, tcx, tcy, profile, swims)
-      const x = (tcx * TILE_REF_SIZE - half) * sx
-      const y = (tcy * TILE_REF_SIZE - half) * sy
+      const x = tcx * TILE_REF_SIZE * sx
+      const y = tcy * TILE_REF_SIZE * sy
       g.rect(x, y, TILE_REF_SIZE * sx, TILE_REF_SIZE * sy)
         .fill({ color: passable ? 0x33ff66 : 0xff3333, alpha: passable ? 0.15 : 0.30 })
         .stroke({ color: 0xffffff, width: 1, alpha: 0.15 })

--- a/web/src/game/engine/proceduralTerrain.test.ts
+++ b/web/src/game/engine/proceduralTerrain.test.ts
@@ -56,17 +56,20 @@ describe('generatePassableTerrain', () => {
       generated += generateTerrain(seed, undefined).length
     }
     // Pruning should be the exception: the generator's own tuning already
-    // leaves most scatters traversable.
-    expect(kept / generated).toBeGreaterThan(0.85)
+    // leaves scatters traversable. Currently nothing is pruned at all for
+    // these seeds — the safety net exists for layouts the tuning misses, not
+    // as a routine step.
+    expect(kept / generated).toBeGreaterThan(0.95)
   })
 })
 
 describe('generateTerrain tuning for the collision tile grid', () => {
   it('never emits an obstacle wide enough to span the lane on its own', () => {
-    // The lane's whole lateral span is only 9 collision tile columns, and an
+    // The lane's whole lateral span is only 10 collision tile columns, and an
     // obstacle rasterizes to a disc of tile-radius round(radius * 0.12). Once
-    // radius reaches ~29 that rounds to 4 — covering all 9 columns — and a
-    // single obstacle seals the lane no matter where it lands.
+    // that radius grows enough to cover every column, a single obstacle seals
+    // the lane no matter where it lands. The widest the generator currently
+    // emits spans 7 of the 10.
     const laneWidth = LANE_COLUMNS.hi - LANE_COLUMNS.lo + 1
     for (const env of ENVIRONMENTS) {
       for (const seed of SEEDS) {
@@ -77,8 +80,13 @@ describe('generateTerrain tuning for the collision tile grid', () => {
     }
   })
 
-  it('leaves most scatters traversable before any pruning is needed', { timeout: 30_000 }, () => {
+  it('leaves scatters traversable before any pruning is needed', { timeout: 30_000 }, () => {
+    // Currently 100% of seeds: once collision covers the band a tile is drawn
+    // over rather than one shifted half a tile off it, the lane is a full 10
+    // columns wide and the widest obstacle spans 7. Threshold left slightly
+    // under that so a small generator retune isn't an automatic failure, but
+    // well above the 0.7 this sat at while the grid was misaligned.
     const passing = SEEDS.filter(seed => isPassable(generateTerrain(seed, undefined))).length
-    expect(passing / SEEDS.length).toBeGreaterThan(0.7)
+    expect(passing / SEEDS.length).toBeGreaterThan(0.95)
   })
 })

--- a/web/src/game/engine/terrainGrid.test.ts
+++ b/web/src/game/engine/terrainGrid.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
-  gameToTile, buildObstacleTileMap, buildRoadTileMap, isTilePassable,
-  checkReachability, checkAllProfilesReachable,
+  gameToTile, gameToContainingTile, tileToGame, buildObstacleTileMap, buildRoadTileMap,
+  isTilePassable, checkReachability, checkAllProfilesReachable, laneTileBounds,
 } from './terrainGrid'
 import type { TerrainObstacle, RoadDef } from './terrain'
 
@@ -121,6 +121,65 @@ describe('obstacle tile footprint matches what is drawn', () => {
       const large = buildObstacleTileMap([{ id: 't1', type, x: 250, y: 0, radius: 28 }]).size
       expect(small).toBeGreaterThan(1)
       expect(large).toBeGreaterThan(small)
+    }
+  })
+})
+
+describe('tile containment matches the band a tile is drawn over', () => {
+  // A tile sprite is drawn top-left at c*TILE_SIZE, so tile c covers
+  // [c*T, (c+1)*T). Resolving a position by rounding instead put every
+  // containment test half a tile off the art — units stopped short of a rock on
+  // one side and walked into it on the other.
+  const TILE = 32
+  const GRID_REF_W = 390
+  const gameToPx = (x: number, y: number) => ({
+    px: (0.5 + (y / 80) * 0.36) * GRID_REF_W,
+    py: (1 - x / 500) * Math.round(GRID_REF_W / (9 / 19.5)),
+  })
+
+  it('a point always lies inside the pixel band of its containing tile', () => {
+    for (let i = 0; i < 2000; i++) {
+      const x = Math.random() * 500
+      const y = Math.random() * 160 - 80
+      const { tcx, tcy } = gameToContainingTile(x, y)
+      const { px, py } = gameToPx(x, y)
+      expect(px).toBeGreaterThanOrEqual(tcx * TILE)
+      expect(px).toBeLessThan((tcx + 1) * TILE)
+      expect(py).toBeGreaterThanOrEqual(tcy * TILE)
+      expect(py).toBeLessThan((tcy + 1) * TILE)
+    }
+  })
+
+  it('tileToGame returns a centre its own tile contains', () => {
+    // The flow field steers units at tileToGame's result and then re-checks the
+    // step with containment, so a corner would sit where four tiles meet.
+    const { tcxLo, tcxHi, tcyLo, tcyHi } = laneTileBounds()
+    for (let tcx = tcxLo; tcx <= tcxHi; tcx++) {
+      for (let tcy = tcyLo; tcy <= tcyHi; tcy++) {
+        const { x, y } = tileToGame(tcx, tcy)
+        expect(gameToContainingTile(x, y)).toEqual({ tcx, tcy })
+      }
+    }
+  })
+
+  it('keeps anchoring on rounding, so art and collision pick the same tile', () => {
+    // utils/terrainLayer.ts chooses an obstacle's patch tile with Math.round;
+    // gameToTile must keep matching it, or an obstacle's art and its blocking
+    // disc land a whole tile apart.
+    for (let i = 0; i < 2000; i++) {
+      const x = 90 + Math.random() * 320
+      const y = Math.random() * 160 - 80
+      const { px, py } = gameToPx(x, y)
+      expect(gameToTile(x, y)).toEqual({ tcx: Math.round(px / TILE), tcy: Math.round(py / TILE) })
+    }
+  })
+
+  it('the lane covers every column a unit can stand in, including the edges', () => {
+    const { tcxLo, tcxHi } = laneTileBounds()
+    for (const y of [-80, -40, 0, 40, 80]) {
+      const { tcx } = gameToContainingTile(250, y)
+      expect(tcx).toBeGreaterThanOrEqual(tcxLo)
+      expect(tcx).toBeLessThanOrEqual(tcxHi)
     }
   })
 })

--- a/web/src/game/engine/terrainGrid.ts
+++ b/web/src/game/engine/terrainGrid.ts
@@ -30,10 +30,33 @@ function gameToPixel(x: number, y: number): { px: number; py: number } {
 
 export interface TileKey { tcx: number; tcy: number }
 
-/** Converts a game-unit position into the reference tile grid's cell coords. */
+/**
+ * The tile an obstacle is ANCHORED on.
+ *
+ * Rounds, which is what utils/terrainLayer.ts's `toTile` helpers do when they
+ * choose the tile to draw an obstacle's patch around. Keeping the two identical
+ * is what makes an obstacle's art and its blocking disc cover the same tile
+ * indices — change one and they diverge by a whole tile.
+ *
+ * For "which tile is this point inside" use gameToContainingTile instead.
+ */
 export function gameToTile(x: number, y: number): TileKey {
   const { px, py } = gameToPixel(x, y)
   return { tcx: Math.round(px / TILE_SIZE), tcy: Math.round(py / TILE_SIZE) }
+}
+
+/**
+ * The tile a point lies INSIDE.
+ *
+ * A tile's sprite is drawn top-left at `c * TILE_SIZE`, so tile `c` covers the
+ * band `[c*T, (c+1)*T)` — this floors where gameToTile rounds. Resolving a
+ * unit's position with the rounding version instead put every containment test
+ * half a tile off the art, so units stopped short of a rock on one side and
+ * walked into it on the other.
+ */
+export function gameToContainingTile(x: number, y: number): TileKey {
+  const { px, py } = gameToPixel(x, y)
+  return { tcx: Math.floor(px / TILE_SIZE), tcy: Math.floor(py / TILE_SIZE) }
 }
 
 function tileKeyStr(tcx: number, tcy: number): string {
@@ -215,8 +238,12 @@ export type FlowField = Map<string, number>
 /** Tile-grid bounds of the playable lane, shared by reachability, flow fields
  *  and the battlefield passability overlay. */
 export function laneTileBounds() {
-  const minTile = gameToTile(0, LANE_MIN_Y)
-  const maxTile = gameToTile(LANE_WIDTH, LANE_MAX_Y)
+  // Containment, not anchoring: these bounds must cover every tile a unit can
+  // stand in. With rounding they stopped at column 2 while a unit at y=-80
+  // resolves to column 1, which would put edge-lane units outside every BFS
+  // range — treated as sealed in, and stuck.
+  const minTile = gameToContainingTile(0, LANE_MIN_Y)
+  const maxTile = gameToContainingTile(LANE_WIDTH, LANE_MAX_Y)
   return {
     tcxLo: Math.min(minTile.tcx, maxTile.tcx),
     tcxHi: Math.max(minTile.tcx, maxTile.tcx),
@@ -244,7 +271,7 @@ export function buildFlowField(
     tcx >= tcxLo && tcx <= tcxHi && tcy >= tcyLo && tcy <= tcyHi &&
     isTilePassable(obstacleTiles, roadTiles, tcx, tcy, profile, swims)
 
-  const goalTcy = gameToTile(goalX, 0).tcy
+  const goalTcy = gameToContainingTile(goalX, 0).tcy
   const queue: TileKey[] = []
   for (let tcx = tcxLo; tcx <= tcxHi; tcx++) {
     if (!passable(tcx, goalTcy)) continue
@@ -314,10 +341,13 @@ export function flowFieldStep(
   return best
 }
 
-/** Centre of a tile, in game units — the point a unit steers toward. */
+/** Centre of a tile, in game units — the point a unit steers toward. Tile `c`
+ *  spans [c*T, (c+1)*T), so its centre is half a tile in from the origin; a
+ *  steering target left on the corner sits where four tiles meet, which is a
+ *  stall risk once the caller re-checks the step against containment. */
 export function tileToGame(tcx: number, tcy: number): { x: number; y: number } {
-  const px = tcx * TILE_SIZE
-  const py = tcy * TILE_SIZE
+  const px = (tcx + 0.5) * TILE_SIZE
+  const py = (tcy + 0.5) * TILE_SIZE
   return { x: 500 * (1 - py / GRID_REF_HEIGHT), y: 80 * ((px / GRID_REF_WIDTH - 0.5) / 0.36) }
 }
 
@@ -351,12 +381,7 @@ export function checkReachability(
   // (tcy) correspond to forward position, and tile COLUMNS (tcx) correspond
   // to lateral position — x=0 (player base) is the LARGEST tcy, x=LANE_WIDTH
   // (opponent base) the smallest, since py = (1 - x/500) * height.
-  const minTile = gameToTile(0, LANE_MIN_Y)
-  const maxTile = gameToTile(LANE_WIDTH, LANE_MAX_Y)
-  const tcxLo = Math.min(minTile.tcx, maxTile.tcx)
-  const tcxHi = Math.max(minTile.tcx, maxTile.tcx)
-  const tcyLo = Math.min(minTile.tcy, maxTile.tcy)
-  const tcyHi = Math.max(minTile.tcy, maxTile.tcy)
+  const { tcxLo, tcxHi, tcyLo, tcyHi } = laneTileBounds()
 
   const passable = (tcx: number, tcy: number) =>
     tcx >= tcxLo && tcx <= tcxHi && tcy >= tcyLo && tcy <= tcyHi &&
@@ -364,8 +389,8 @@ export function checkReachability(
 
   // BFS from every passable tile in the x=0 (player base) row, across the
   // full lateral range, to any tile in the x=LANE_WIDTH (opponent base) row.
-  const startTcy = gameToTile(0, 0).tcy
-  const goalTcy = gameToTile(LANE_WIDTH, 0).tcy
+  const startTcy = gameToContainingTile(0, 0).tcy
+  const goalTcy = gameToContainingTile(LANE_WIDTH, 0).tcy
 
   const visited = new Set<string>()
   const queue: TileKey[] = []

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -4,7 +4,7 @@ import { LANE_MAX_Y, LANE_MIN_Y } from './helpers'
 import { unitDist, findNearestEnemy, findNearestEnemyByPriority, findEnemyBehind } from './targeting'
 import { computeRoadWaypoints } from './roads'
 import {
-  gameToTile, buildObstacleTileMap, buildRoadTileMap, isTilePassable,
+  gameToContainingTile, buildObstacleTileMap, buildRoadTileMap, isTilePassable,
   buildFlowField, flowFieldStep, tileToGame, type MovementProfile,
 } from './terrainGrid'
 
@@ -443,7 +443,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       const profile: MovementProfile = unit.tags?.includes('burrowing') ? 'burrowing' : 'ground'
       const swims = unit.tags?.includes('swim') ?? false
       const canEnter = (x: number, y: number) => {
-        const { tcx, tcy } = gameToTile(x, y)
+        const { tcx, tcy } = gameToContainingTile(x, y)
         return isTilePassable(obstacleTiles, roadTiles, tcx, tcy, profile, swims)
       }
       const movesX = Math.abs(candX - unit.x) > 1e-6
@@ -459,9 +459,9 @@ export function moveUnits(s: GameState, deltaMs: number): void {
         field = buildFlowField(obstacleTiles, roadTiles, profile, swims, goalX)
         s.terrainGridCache.flowFields.set(fieldKey, field)
       }
-      const here = gameToTile(unit.x, unit.y)
+      const here = gameToContainingTile(unit.x, unit.y)
       const hereDist = field.get(`${here.tcx},${here.tcy}`)
-      const dest = gameToTile(candX, candY)
+      const dest = gameToContainingTile(candX, candY)
       const destDist = field.get(`${dest.tcx},${dest.tcy}`)
 
       // A direct move is "productive" only if it actually gets the unit closer
@@ -505,7 +505,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
         // of the battle.
         // Steer the detour toward this unit's own lane so an army splits around
         // an obstacle instead of every unit tracing the identical shortest route.
-        const preferTcx = gameToTile(unit.x, unit.advanceY ?? unit.y).tcx
+        const preferTcx = gameToContainingTile(unit.x, unit.advanceY ?? unit.y).tcx
         const next = flowFieldStep(field, here.tcx, here.tcy, preferTcx)
         if (next) {
           const target = tileToGame(next.tcx, next.tcy)


### PR DESCRIPTION
## Summary

The half-tile offset the passability overlay was built to settle. With the phantom ruin walls gone (#2065), a daily-challenge screenshot showed it cleanly: a lone ruin blocks exactly one tile, and that orange tile sits visibly **up-and-left of its icon**.

A tile index meant two different things depending on who was asking:

- **Anchor** — which tile an obstacle sits on. The renderer (`terrainLayer.ts`) and the collision grid both round, so they **already agreed**: an obstacle's art patch and its blocking disc covered the same indices.
- **Containment** — which tile a point is inside. They did *not* agree. A sprite for index `c` is drawn top-left at `c*T`, covering `[c*T, (c+1)*T)`, but `gameToTile` rounds, so collision treated index `c` as covering `[c*T − T/2, c*T + T/2)`.

Every containment test was half a tile off the art — units stopped short of a rock on one side and walked into it on the other.

## Fix

Add `gameToContainingTile` (floor) for **positions**; keep `gameToTile` (round) for **anchors**.

That distinction matters: the obvious fix — flipping every `Math.round(px/T)` to floor — would also move the renderer's anchors, shifting battlefield road/patch/decor art one tile up-and-left for any object whose `px % T >= T/2`. **No sprite moves here.**

- Unit lookups, flow-field steering and lane bounds → containment.
- Obstacle and road anchors → unchanged.
- `tileToGame` now returns the true centre `(c + 0.5) * T`. It feeds the detour steering target, which the caller re-validates with containment, so a corner would have sat where four tiles meet — a stall risk.
- The overlay draws the corrected band.

**Lane bounds had to move with it.** A unit at `y = −80` is at pixel 54.6, inside column **1**, but the rounded bounds started at column 2 — edge units resolved outside every BFS range and would have read as sealed in.

## Impact

The lane is a full **10** collision columns rather than 9, and the widest obstacle spans 7, so procedural maps open up considerably:

| | before | after |
|---|---|---|
| raw traversable scatters | 75% | **100%** (pruning never needed) |
| maps with more than one route through | 35% | **86%** |

That last row is the "everyone traverses one side" complaint largely resolved — it was mostly the misaligned grid narrowing the usable lane, not the movement code.

Tightened the two ratio thresholds in `proceduralTerrain.test.ts` to match the new reality rather than leaving the old slack, and fixed the comment hardcoding a 9-column lane.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 2018 tests across 63 files pass.
- [x] New tests pin all three invariants: a point always lies inside its containing tile's drawn band; `tileToGame` returns a centre its own tile contains; anchoring still matches the renderer's `Math.round`; and the lane covers every column a unit can stand in, edges included.
- [x] Swept all 336 battle nodes at **7** spawn positions — including the exact lane edges `y = ±80`, the case the old bounds mishandled — plus 150 procedural seeds: **0 units stuck**.
- [ ] Manual: daily challenge with the overlay on — the single-tile ruin's orange square should sit exactly under its icon, and rock clusters' orange should hug the boulders.
- [ ] Manual: confirm terrain art is pixel-identical, on the battlefield and in the editor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg4sPgYK93sAJC8XwChpp)_