### PR TITLE
Give the world-battle nodes real terrain collision

### DIFF
--- a/web/src/data/acts/worldbattles.json
+++ b/web/src/data/acts/worldbattles.json
@@ -85,7 +85,8 @@
           "y": -8.903282030951232,
           "radius": 26.72567148413509
         }
-      ]
+      ],
+      "terrainValidated": true
     },
     "b-south-road": {
       "id": "b-south-road",
@@ -156,6 +157,7 @@
           "radius": 24.44444159977138
         }
       ],
+      "terrainValidated": true,
       "roads": [
         {
           "points": [


### PR DESCRIPTION
## Summary

"Toll Road Ambush" and "Old King's Road" (`worldbattles.json`) were the last two nodes where units walked through rocks, water and ruins. Both define terrain but never set `terrainValidated`, so both stayed on legacy soft avoidance.

Toll Road Ambush was deliberately left alone back in #2054, because enabling it **sealed the lane** for ground and burrowing units. That's no longer true, thanks to two later fixes:

- **#2065** — ruins block one tile instead of a patch-sized disc. Two of this node's seven obstacles are ruins.
- **#2066** — collision covers the band a tile is actually drawn over rather than one shifted half a tile off it, which widened the usable lane from 9 tile columns to 10.

So it benefited twice over. **Re-checked rather than assumed:** both nodes are now reachable on every movement profile, and simulating 7 spawn positions across each (including the exact lane edges `y = ±80`) with collision enabled gets **every unit to the far side**.

| node | obstacles | ground/burrowing reachable | units stuck with collision on |
|---|---|---|---|
| `b-east-road` — Toll Road Ambush | 7 | true / true | 0 / 7 |
| `b-south-road` — Old King's Road | 6 | true / true | 0 / 7 |

`b-south-road` had the identical gap and is fixed in the same change.

Worth noting the shape of Toll Road Ambush: its obstacles cluster centrally, leaving one fully-clear straight column at the far-left edge. Units will favour that flank on this map. For a node themed around bandits blockading a road that reads as a deliberate chokepoint rather than a defect, but flagging it since it's a visible behaviour change.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 2020 tests pass. The generic reachability regression test globs every act JSON, so it picked both nodes up automatically (2018 → 2020) and will now fail if a future edit to their obstacles seals a lane.
- [x] Swept all 336 battle nodes across every act **including `worldbattles.json`** at 7 spawn positions: **0 units stuck** (0/2352).
- [ ] Manual: play both world battles and confirm units path around the terrain instead of through it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg4sPgYK93sAJC8XwChpp)_