### PR TITLE
Lock the lane's shape so collision tiles are the tiles that are drawn

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react'
 import { BattlefieldCanvas } from './BattlefieldCanvas'
-import { GameState, Unit, BATTLEFIELD_ASPECT_RATIO, Card } from '../../game/types'
+import { GameState, Unit, BATTLEFIELD_ASPECT_RATIO, LANE_ASPECT_RATIO, Card } from '../../game/types'
 import { CardTile } from '../cards/CardTile'
 import { useCardDetail } from '../cards/useCardDetail'
 import { spriteSlug } from '../../game/sprites'
@@ -138,6 +138,13 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const [pendingAoeCard, setPendingAoeCard] = useState<Card | null>(null)
   const stageRef = useRef<HTMLDivElement>(null)
   const frameSize = useLetterboxSize(stageRef, BATTLEFIELD_ASPECT_RATIO)
+  // The lane is letterboxed inside the slot the HUD bands leave, just as the
+  // frame is letterboxed inside the stage. Those bands are fixed pixel heights,
+  // so the slot's shape drifts with the frame's; locking the lane's shape is
+  // what keeps the terrain art's tile grid identical to the engine's collision
+  // grid on every screen (see LANE_ASPECT_RATIO in game/types.ts).
+  const laneSlotRef = useRef<HTMLDivElement>(null)
+  const laneSize = useLetterboxSize(laneSlotRef, LANE_ASPECT_RATIO)
   const playerName   = loadPlayerName()
   const playerAvatar = loadPlayerAvatar()
 
@@ -229,6 +236,12 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   // back to filling the stage until the first ResizeObserver measurement lands.
   const frameStyle: React.CSSProperties = frameSize
     ? { width: frameSize.width, height: frameSize.height }
+    : { width: '100%', height: '100%' }
+  // Rounded to whole pixels: BattlefieldCanvas measures its own box with
+  // Math.ceil, so a fractional size would land the canvas a pixel off the ratio
+  // and reintroduce a small collision/art drift across the lane's 17 columns.
+  const laneStyle: React.CSSProperties = laneSize
+    ? { width: Math.round(laneSize.width), height: Math.round(laneSize.height) }
     : { width: '100%', height: '100%' }
   const isCompactFrame = !!frameSize && frameSize.width <= 480
   const isTinyFrame = !!frameSize && frameSize.width <= 380
@@ -336,11 +349,16 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       </div>
       </div>
 
-      {/* The Lane — vertical, fills remaining space */}
+      {/* The Lane — letterboxed to LANE_ASPECT_RATIO inside the slot the HUD
+          bands leave, so its shape (and therefore its tile grid) is the same on
+          every device. The slot is the absolutely-positioned box; the lane is
+          the play area centred within it. */}
       {(() => {
         return (
+      <div className="lane-slot" ref={laneSlotRef}>
       <div
         className={`lane${pendingAoeCard ? ' lane--aoe-targeting' : ''}`}
+        style={laneStyle}
       >
         <BattlefieldCanvas
           state={state}
@@ -396,6 +414,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
             </>
           )
         })()}
+      </div>
       </div>
         )
       })()}

--- a/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
+++ b/web/src/components/battlefieldEditor/BattlefieldEditorCanvas.tsx
@@ -8,7 +8,8 @@ import {
 } from '../../utils/terrainLayer'
 import { TILE_SIZE, EnvTileDef } from '../../data/tiles/tileIndex'
 import { TERRAIN_CLEAR_Y, expandTerrainPathsToObstacles } from '../../game/engine/terrain'
-import { BATTLEFIELD_ASPECT_RATIO } from '../../game/types'
+import { LANE_ASPECT_RATIO } from '../../game/types'
+import { GRID_REF_HEIGHT } from '../../game/engine/terrainGrid'
 import { getBattlefieldBundleById } from '../../data/bundles/battlefieldBundleLoader'
 import type { RoadDef, TerrainObstacle, TerrainType, ToolMode, SelectedEntity, BattlefieldDecorItem, TerrainPathDef } from './battlefieldEditorTypes'
 
@@ -142,24 +143,27 @@ function EditorPixi(props: Props & { w: number; h: number }) {
     stage.addChild(base, bg, border, decorObstacles, road, decorLayer, world, guides, editOverlay)
 
     const { environment, envDef, id, roads, terrain, decor, terrainPaths } = props
-    // WYSIWYG: tiles render at native size (tileScale defaults to 1 in every
-    // build*Gfx helper), exactly like BattlefieldTerrainCanvas.tsx — the live
-    // battlefield never passes a tileScale either. Scaling tiles to a fixed
-    // reference resolution here would make the editor's tile density diverge
-    // from what players actually see (GRID_REF_HEIGHT in game/engine/terrainGrid.ts
-    // is a logical grid for pathing/reachability math only, not a rendering size).
-    buildTerrainGfx(base, new PIXI.Container(), world, { environment, envDef, id, rivers: [], terrainItems: [] }, w, h)
-    buildBgTileGfx(bg, { environment, envDef }, w, h)
-    buildRoadGfx(road, roads, { environment, envDef }, w, h)
-    buildBorderGfx(border, { environment, envDef }, w, h)
-    if (decor.length > 0) buildManualDecorGfx(decorLayer, decor, w, h)
-    else buildDecorGfx(decorLayer, { environment, envDef, id }, w, h)
+    // WYSIWYG: the canvas is letterboxed to LANE_ASPECT_RATIO — the same shape
+    // the live lane is locked to — and tiles are scaled off its height against
+    // the same reference the live battlefield uses (see tileScale in
+    // components/battle/BattlefieldCanvas.tsx). That gives the editor exactly
+    // the tile grid players get: GRID_REF_HEIGHT/32 rows by GRID_REF_WIDTH/32
+    // columns, at any canvas size. Drawing at a native 32px instead would put a
+    // different number of tiles across the same authored area than the game
+    // shows, which is what made authored scenes render differently in battle.
+    const tileScale = h / GRID_REF_HEIGHT
+    buildTerrainGfx(base, new PIXI.Container(), world, { environment, envDef, id, rivers: [], terrainItems: [] }, w, h, tileScale)
+    buildBgTileGfx(bg, { environment, envDef }, w, h, tileScale)
+    buildRoadGfx(road, roads, { environment, envDef }, w, h, tileScale)
+    buildBorderGfx(border, { environment, envDef }, w, h, tileScale)
+    if (decor.length > 0) buildManualDecorGfx(decorLayer, decor, w, h, tileScale)
+    else buildDecorGfx(decorLayer, { environment, envDef, id }, w, h, tileScale)
     // WYSIWYG: terrainPaths expand into the exact same TerrainObstacle circles
     // the engine adds at battle start, so drawn paths render (and dedup edges
     // against hand-placed obstacles) identically here and in the live game.
-    buildTerrainDecorGfx(decorObstacles, [...terrain, ...expandTerrainPathsToObstacles(terrainPaths)], { environment, envDef }, w, h)
+    buildTerrainDecorGfx(decorObstacles, [...terrain, ...expandTerrainPathsToObstacles(terrainPaths)], { environment, envDef }, w, h, tileScale)
 
-    if (props.showGuides) drawGuides(guides, w, h)
+    if (props.showGuides) drawGuides(guides, w, h, tileScale)
     drawEditOverlay(editOverlay, props, w, h, dragRef)
   })
 
@@ -348,7 +352,7 @@ function drawEditOverlay(
  */
 export function BattlefieldEditorCanvas(props: Props) {
   const stageRef = useRef<HTMLDivElement>(null)
-  const rawSize = useLetterboxSize(stageRef, BATTLEFIELD_ASPECT_RATIO)
+  const rawSize = useLetterboxSize(stageRef, LANE_ASPECT_RATIO)
   const dims = rawSize ? { w: Math.floor(rawSize.width), h: Math.floor(rawSize.height) } : null
 
   return (

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -12687,8 +12687,8 @@
     },
     "prism-wyrm": {
       "name": "Prism Wyrm",
-      "attack": 55,
-      "maxHp": 220,
+      "attack": 26,
+      "maxHp": 130,
       "isWall": false,
       "bypassWall": true,
       "flying": true,

--- a/web/src/game/dailyChallenge.test.ts
+++ b/web/src/game/dailyChallenge.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { getDailyPlayerDeck, getDailyOpponentDeck } from './dailyChallenge'
+import { newGame } from './engine'
+import { SECRET_RARITIES } from './types'
+
+// Nobody picks the daily challenge's decks — the game deals both sides. So the
+// same rule generated opponent decks follow (maxRarityForHandicap in engine.ts
+// caps at legendary) and Quick Play follows (App.tsx filters SECRET_RARITIES
+// out of its opponent pool) has to hold here too. It didn't: buildChallengeCards
+// shuffled the whole catalog, so a mythic could be dealt to either side.
+
+describe('daily challenge decks', () => {
+  const decks = { player: getDailyPlayerDeck(), opponent: getDailyOpponentDeck() }
+
+  it.each(Object.entries(decks))('the %s deck contains no secret-rarity cards', (_side, deck) => {
+    expect(deck.length).toBeGreaterThan(0)
+    expect(deck.filter(c => SECRET_RARITIES.has(c.rarity)).map(c => c.name)).toEqual([])
+  })
+
+  it.each(Object.entries(decks))('no card in the %s deck can one-shot a starting commander', (_side, deck) => {
+    // A unit's attack lands with no counterplay — unlike an enemy spell, which
+    // the Counter QTE caps at a fraction of commander max HP (resolveSpellCast
+    // in engine/cards.ts). A single hit ending the battle is therefore only ever
+    // something a player should be able to opt into with a card they earned.
+    const startingCommanderHp = newGame({}).playerBase.maxHp
+    const oneShotters = deck
+      .filter(c => (c.unit?.attack ?? 0) >= startingCommanderHp)
+      .map(c => `${c.name} (${c.unit?.attack} atk vs ${startingCommanderHp} hp)`)
+    expect(oneShotters).toEqual([])
+  })
+})

--- a/web/src/game/dailyChallenge.ts
+++ b/web/src/game/dailyChallenge.ts
@@ -7,7 +7,7 @@
 import { logError } from '../logger'
 import { getCardCatalog } from './cards'
 import { hashStr, makeSeededRng, seededShuffle } from './seededRandom'
-import { Card } from './types'
+import { Card, SECRET_RARITIES } from './types'
 import {
   doc, setDoc, getDocs, collection, query, orderBy, limit, where, Timestamp,
 } from 'firebase/firestore'
@@ -70,7 +70,15 @@ function isDeckPlayable(cards: Card[]): boolean {
  *  the deck passes playability checks. Attempt 0 is identical to the original
  *  algorithm, so valid days remain unchanged. */
 function buildChallengeCards(xorSeed: number): Card[] {
-  const catalog       = getCardCatalog()
+  // Secret rarities are excluded, matching Quick Play's opponent pool (App.tsx)
+  // and generated opponent decks (maxRarityForHandicap in engine.ts caps at
+  // legendary). Both decks here are dealt by the game, not chosen by anyone, so
+  // a mythic landing in either is an ambush: mythic units sit 3-4x above the
+  // strongest card of the same cost, and unlike an enemy mythic SPELL — which
+  // the Counter QTE caps at a survivable fraction of commander HP — a unit's
+  // attack has no such safety valve. Mythics belong to the player who finished
+  // the quest chain for them (data/quests.json).
+  const catalog       = getCardCatalog().filter(c => !SECRET_RARITIES.has(c.rarity))
   const BASE_MAX_MANA = 5
   let firstResult: Card[] | null = null
 

--- a/web/src/game/engine/proceduralTerrain.test.ts
+++ b/web/src/game/engine/proceduralTerrain.test.ts
@@ -65,11 +65,11 @@ describe('generatePassableTerrain', () => {
 
 describe('generateTerrain tuning for the collision tile grid', () => {
   it('never emits an obstacle wide enough to span the lane on its own', () => {
-    // The lane's whole lateral span is only 10 collision tile columns, and an
+    // The lane's whole lateral span is 14 collision tile columns, and an
     // obstacle rasterizes to a disc of tile-radius round(radius * 0.12). Once
     // that radius grows enough to cover every column, a single obstacle seals
     // the lane no matter where it lands. The widest the generator currently
-    // emits spans 7 of the 10.
+    // emits spans 7 of the 14.
     const laneWidth = LANE_COLUMNS.hi - LANE_COLUMNS.lo + 1
     for (const env of ENVIRONMENTS) {
       for (const seed of SEEDS) {
@@ -81,11 +81,12 @@ describe('generateTerrain tuning for the collision tile grid', () => {
   })
 
   it('leaves scatters traversable before any pruning is needed', { timeout: 30_000 }, () => {
-    // Currently 100% of seeds: once collision covers the band a tile is drawn
-    // over rather than one shifted half a tile off it, the lane is a full 10
-    // columns wide and the widest obstacle spans 7. Threshold left slightly
-    // under that so a small generator retune isn't an automatic failure, but
-    // well above the 0.7 this sat at while the grid was misaligned.
+    // Currently 100% of seeds: once collision tiles are the same pixels as the
+    // tiles actually drawn — same band vertically, same width horizontally —
+    // the lane is a full 14 columns wide and the widest obstacle spans 7.
+    // Threshold left slightly under that so a small generator retune isn't an
+    // automatic failure, but well above the 0.7 this sat at while the grid was
+    // misaligned.
     const passing = SEEDS.filter(seed => isPassable(generateTerrain(seed, undefined))).length
     expect(passing / SEEDS.length).toBeGreaterThan(0.95)
   })

--- a/web/src/game/engine/terrainGrid.test.ts
+++ b/web/src/game/engine/terrainGrid.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest'
 import {
   gameToTile, gameToContainingTile, tileToGame, buildObstacleTileMap, buildRoadTileMap,
   isTilePassable, checkReachability, checkAllProfilesReachable, laneTileBounds,
+  GRID_REF_WIDTH, GRID_REF_HEIGHT,
 } from './terrainGrid'
+import { LANE_ASPECT_RATIO } from '../types'
 import type { TerrainObstacle, RoadDef } from './terrain'
 
 describe('buildObstacleTileMap', () => {
@@ -125,16 +127,65 @@ describe('obstacle tile footprint matches what is drawn', () => {
   })
 })
 
+describe('a collision tile is the same pixels as a drawn tile', () => {
+  // The reason the lane is letterboxed to a fixed shape (LANE_ASPECT_RATIO, see
+  // components/battle/Battlefield.tsx). Terrain art draws SQUARE tiles sized off
+  // the lane's height — TILE_SIZE * h/GRID_REF_HEIGHT, the tileScale in
+  // BattlefieldCanvas.tsx — while a collision tile spans TILE_SIZE * w/GRID_REF_WIDTH.
+  // Those are only equal when the lane's own w/h is GRID_REF_WIDTH/GRID_REF_HEIGHT.
+  // While the lane's shape was free to drift (fixed-px HUD bands over a fixed-ratio
+  // frame), collision tiles were up to 1.55x wider than the rock actually drawn.
+  const TILE = 32
+
+  it('the reference grid is the shape the lane is letterboxed to', () => {
+    expect(GRID_REF_WIDTH / GRID_REF_HEIGHT).toBeCloseTo(LANE_ASPECT_RATIO, 10)
+  })
+
+  it('collision tile width equals drawn tile size at every lane size', () => {
+    for (const h of [318, 446, 567, 654, 766, 886]) {
+      const w = h * LANE_ASPECT_RATIO
+      const drawnTileSize = TILE * (h / GRID_REF_HEIGHT) // tileScale in BattlefieldCanvas.tsx
+      expect(TILE * (w / GRID_REF_WIDTH)).toBeCloseTo(drawnTileSize, 10)
+      expect(TILE * (h / GRID_REF_HEIGHT)).toBeCloseTo(drawnTileSize, 10)
+    }
+  })
+
+  it('a point resolves to the same tile index through either grid', () => {
+    // Rendering converts game -> live canvas px with the lane's real w/h
+    // (utils/terrainLayer.ts's gameToPixel) and snaps by the drawn tile size;
+    // collision converts against the reference grid and snaps by TILE_SIZE.
+    // Same index, or an obstacle's art and its blocking disc are a tile apart.
+    const h = 567
+    const w = h * LANE_ASPECT_RATIO
+    const drawnTileSize = TILE * (h / GRID_REF_HEIGHT)
+    for (let i = 0; i < 2000; i++) {
+      const x = Math.random() * 500
+      const y = Math.random() * 160 - 80
+      const livePx = (0.5 + (y / 80) * 0.36) * w
+      const livePy = (1 - x / 500) * h
+      expect(gameToTile(x, y)).toEqual({
+        tcx: Math.round(livePx / drawnTileSize),
+        tcy: Math.round(livePy / drawnTileSize),
+      })
+      expect(gameToContainingTile(x, y)).toEqual({
+        tcx: Math.floor(livePx / drawnTileSize),
+        tcy: Math.floor(livePy / drawnTileSize),
+      })
+    }
+  })
+})
+
 describe('tile containment matches the band a tile is drawn over', () => {
   // A tile sprite is drawn top-left at c*TILE_SIZE, so tile c covers
   // [c*T, (c+1)*T). Resolving a position by rounding instead put every
   // containment test half a tile off the art — units stopped short of a rock on
   // one side and walked into it on the other.
   const TILE = 32
-  const GRID_REF_W = 390
+  const GRID_REF_H = 845
+  const GRID_REF_W = Math.round(GRID_REF_H * (544 / 845)) // LANE_ASPECT_RATIO
   const gameToPx = (x: number, y: number) => ({
     px: (0.5 + (y / 80) * 0.36) * GRID_REF_W,
-    py: (1 - x / 500) * Math.round(GRID_REF_W / (9 / 19.5)),
+    py: (1 - x / 500) * GRID_REF_H,
   })
 
   it('a point always lies inside the pixel band of its containing tile', () => {

--- a/web/src/game/engine/terrainGrid.ts
+++ b/web/src/game/engine/terrainGrid.ts
@@ -1,28 +1,37 @@
 import type { TerrainObstacle, RoadDef, TerrainType } from './terrain'
 import { generateTerrain } from './terrain'
-import { LANE_WIDTH } from '../types'
+import { LANE_WIDTH, LANE_ASPECT_RATIO } from '../types'
 import { LANE_MIN_Y, LANE_MAX_Y } from './helpers'
 
 // ─── Reference tile grid ──────────────────────────────────────────────────
 //
 // Gameplay-critical blocking must be deterministic across every client
 // regardless of screen size, so this grid is computed against a FIXED
-// reference resolution rather than the actual on-screen canvas (which
+// reference size for the LANE rather than the actual on-screen canvas (which
 // utils/terrainLayer.ts's rendering-side gameToPixel/pixelToGame use, sized
-// to whatever the player's viewport happens to be). Any (w,h) pair on
-// BATTLEFIELD_ASPECT_RATIO produces an identical grid in game-unit space —
-// this only picks a concrete tile density, not a different result.
+// to whatever the player's viewport happens to be).
 //
-// The two coordinate-conversion formulas below are intentionally duplicated
-// from utils/terrainLayer.ts's gameToPixel/pixelToGame (not imported) — that
-// file pulls in pixi.js, which game/engine code must stay free of. Keep
-// these in sync with that file if the lane's coordinate mapping ever changes.
+// The reference is the lane box, not the whole battlefield frame, and its
+// shape is LANE_ASPECT_RATIO — the ratio components/battle/Battlefield.tsx
+// letterboxes the lane to. That is what makes a collision tile and a drawn
+// tile the same pixels: terrain art draws square tiles of
+// `TILE_SIZE * h/GRID_REF_HEIGHT` (see tileScale in BattlefieldCanvas.tsx),
+// a collision tile spans `TILE_SIZE * w/GRID_REF_WIDTH`, and the two are
+// equal exactly when `w/h == GRID_REF_WIDTH/GRID_REF_HEIGHT`. Before the lane
+// had a locked shape those disagreed by up to 1.55x horizontally, so an
+// obstacle blocked a visibly wider band than the rock that was drawn.
+//
+// The coordinate-conversion formula below is intentionally duplicated from
+// utils/terrainLayer.ts's gameToPixel (not imported) — that file pulls in
+// pixi.js, which game/engine code must stay free of. Keep it in sync with
+// that file if the lane's coordinate mapping ever changes.
 
-const BATTLEFIELD_ASPECT_RATIO = 9 / 19.5 // mirrors game/types.ts's constant of the same name
 const TILE_SIZE = 32 // mirrors data/tiles/tileIndex.ts's TILE_SIZE
 
-export const GRID_REF_WIDTH = 390
-export const GRID_REF_HEIGHT = Math.round(GRID_REF_WIDTH / BATTLEFIELD_ASPECT_RATIO)
+/** Reference lane height in px. Also the divisor BattlefieldCanvas.tsx's
+ *  tileScale uses, so the lane always spans this many tile ROWS. */
+export const GRID_REF_HEIGHT = 845
+export const GRID_REF_WIDTH = Math.round(GRID_REF_HEIGHT * LANE_ASPECT_RATIO) // 544 = 17 columns
 
 function gameToPixel(x: number, y: number): { px: number; py: number } {
   return { px: (0.5 + (y / 80) * 0.36) * GRID_REF_WIDTH, py: (1 - x / 500) * GRID_REF_HEIGHT }

--- a/web/src/game/types.ts
+++ b/web/src/game/types.ts
@@ -421,6 +421,20 @@ export const LANE_WIDTH = 500
  *  to fill wider/shorter containers. See web/src/hooks/useLetterboxSize.ts. */
 export const BATTLEFIELD_ASPECT_RATIO = 9 / 19.5
 
+/** Fixed width/height ratio the LANE — the play area between the frame's reserved
+ *  HUD bands — is letterboxed to, the same way the frame itself is. The bands are
+ *  fixed pixel heights, so without this the lane's shape would drift with the
+ *  frame's (0.62 tall-desktop .. 0.72 small-phone), and terrain art (square tiles
+ *  sized from lane HEIGHT) would lay a different number of tile columns across the
+ *  lane on every device than the collision grid assumes. Locking the shape is what
+ *  lets a collision tile and a drawn tile be the exact same pixels — see
+ *  GRID_REF_WIDTH in game/engine/terrainGrid.ts, which derives from this.
+ *
+ *  544/845 = exactly 17 tile columns, chosen by measuring the letterbox loss over
+ *  frame heights 700-1400: ~10% of width at the smallest, ~8% of height at the
+ *  tallest, and near zero through the phone range. */
+export const LANE_ASPECT_RATIO = 544 / 845
+
 /** In endless mode, player structures may not be placed beyond this forward x-coordinate (3 rows from base). */
 export const ENDLESS_STRUCTURE_MAX_X = 60
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -235,11 +235,11 @@ body {
 /* Narrower-frame tuning — keyed off the letterboxed frame's own computed width
    (set as classes from Battlefield.tsx), not the device viewport: a wide desktop
    window letterboxed down to a phone-width frame needs the same phone tuning a
-   real phone gets, which a viewport @media query alone could never detect. */
+   real phone gets, which a viewport @media query alone could never detect.
+   The lane has no min-height override here: it is letterboxed to a fixed ratio
+   (see .lane below), and a minimum on one axis would silently break that ratio. */
 .battlefield-frame--compact { --bf-top-buffer: 74px; --bf-bottom-buffer: 200px; }
-.battlefield-frame--compact .lane { min-height: 120px; }
 .battlefield-frame--tiny { --bf-top-buffer: 68px; --bf-bottom-buffer: 182px; }
-.battlefield-frame--tiny .lane { min-height: 90px; }
 
 /* Floating bar clusters: absolutely positioned in the reserved bands above/below
    the lane. Their content can grow/wrap without ever resizing or reflowing the lane. */
@@ -476,15 +476,33 @@ body {
 
 /* ─── The Lane (vertical — fills remaining space) ────── */
 
-.lane {
-  /* Absolute fill between the reserved buffer bands — size is viewport-driven only.
-     Still establishes the positioning context + rect source for %-placed units. */
+/* The slot the lane lives in: absolute fill between the reserved buffer bands.
+   Its shape drifts with the frame's (the bands are fixed pixel heights), so the
+   lane itself is letterboxed inside it to a fixed LANE_ASPECT_RATIO and centred —
+   see Battlefield.tsx. Dead space either side (small frames) or above/below
+   (tall frames) shows the frame background. */
+.lane-slot {
   position: absolute;
   top: var(--bf-top-buffer);
   bottom: var(--bf-bottom-buffer);
   left: 0;
   right: 0;
-  border: 2px solid var(--game-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lane {
+  /* Size comes from Battlefield.tsx's letterbox measurement. Establishes the
+     positioning context + rect source for everything placed inside it.
+     The border is an OUTLINE deliberately: box-sizing is border-box globally, so
+     a real border would eat 4px out of that measured size and put the play area
+     ~1% off the locked ratio — visible as collision/art drift across 17 tile
+     columns. An outline takes no layout space and renders identically here. */
+  position: relative;
+  flex-shrink: 0;
+  outline: 2px solid var(--game-border);
+  outline-offset: -2px;
   border-radius: 3px;
   background:
     repeating-linear-gradient(
@@ -6458,7 +6476,7 @@ body {
       #080f08 75%,
       #050f05 100%
     );
-  border-color: #1a3a1a;
+  outline-color: #1a3a1a;
 }
 
 .battlefield--act1 .top-bar { border-color: #1a3a1a; }
@@ -6475,7 +6493,7 @@ body {
       transparent 4px
     ),
     linear-gradient(180deg, #0a0a0c 0%, #0d0d10 40%, #0a0a0c 100%);
-  border-color: #2a2a38;
+  outline-color: #2a2a38;
 }
 .battlefield--act2 .top-bar { border-color: #2a2a38; }
 .battlefield--act2 .base-bar--opponent { border-color: #884422; }
@@ -6491,7 +6509,7 @@ body {
       transparent 4px
     ),
     linear-gradient(180deg, #0a0604 0%, #0e0a06 40%, #0a0604 100%);
-  border-color: #2a1a0a;
+  outline-color: #2a1a0a;
 }
 .battlefield--act3 .top-bar { border-color: #2a1a0a; }
 .battlefield--act3 .base-bar--opponent { border-color: #6a2288; }
@@ -6507,7 +6525,7 @@ body {
       transparent 4px
     ),
     linear-gradient(180deg, #040812 0%, #060c18 40%, #040812 100%);
-  border-color: #0a1a3a;
+  outline-color: #0a1a3a;
 }
 .battlefield--act4 .top-bar { border-color: #0a1a3a; }
 .battlefield--act4 .base-bar--opponent { border-color: #2244aa; }

--- a/web/src/utils/laneGrid.ts
+++ b/web/src/utils/laneGrid.ts
@@ -1,0 +1,63 @@
+import { TILE_SIZE } from '../data/tiles/tileIndex'
+import { gameToTile, GRID_REF_HEIGHT } from '../game/engine/terrainGrid'
+
+// ─── Lane coordinate + tile math ──────────────────────────────────────────
+//
+// Deliberately free of pixi.js so it can be imported by anything, including
+// node-side tests: utils/terrainLayer.ts (which re-exports the two coordinate
+// helpers for its existing callers) pulls in pixi, and pixi touches `navigator`
+// at import time, which does not exist in Node 20.
+
+// Divisor controlling how obstacle radius (game units) maps to tile-ring radius (tiles).
+// Tuned against the realistic range of obstacle radius (20-32) and lane CSS height (~318-842px)
+// so clusters show real size variety instead of always rounding to a single uniform "plus" shape.
+export const TILE_RADIUS_SCALE = 220
+
+/**
+ * Battlefield lane coordinate mapping: game units (x: 0–500 forward base→base,
+ * y: -80..80 lateral) → canvas pixels, and back. buildRoadGfx/buildTerrainDecorGfx
+ * derive their tile coordinates from gameToPixel below; the battlefield editor uses
+ * pixelToGame to turn a pointer click into a game-unit waypoint/obstacle position —
+ * sharing this single definition keeps the two forever in lockstep.
+ */
+export function gameToPixel(x: number, y: number, w: number, h: number): { px: number; py: number } {
+  return { px: (0.5 + (y / 80) * 0.36) * w, py: (1 - x / 500) * h }
+}
+
+export function pixelToGame(px: number, py: number, w: number, h: number): { x: number; y: number } {
+  return { x: 500 * (1 - py / h), y: 80 * ((px / w - 0.5) / 0.36) }
+}
+
+/**
+ * The tile index a game position anchors to, for art that snaps to the tile grid.
+ *
+ * Callers drawing the battlefield lane pass a tileScale (h / GRID_REF_HEIGHT),
+ * and for them the index comes straight from the engine's reference grid rather
+ * than being re-derived from measured canvas pixels. A lane canvas is an
+ * integer-pixel approximation of that grid — its width rounds to a whole pixel —
+ * so rounding px/T on it flips the index for anything sitting exactly on a
+ * half-tile boundary. The lane's centre line (game y = 0, the most common
+ * authored y there is) sits precisely there: the engine computes 8.5 and rounds
+ * up, a 366px-wide lane computes 8.493 and rounds down, and the obstacle's art
+ * lands a whole tile away from the disc that actually blocks units. Asking the
+ * engine removes the second computation rather than trying to match it.
+ *
+ * Canvases that are not the lane (no tileScale — the hub, the node map, the
+ * scenery preview) have no engine grid to agree with, and keep resolving
+ * against their own pixels, which is the only thing that means anything there.
+ */
+export function anchorTile(
+  x: number, y: number, w: number, h: number, T: number, tileScale: number,
+): { tcx: number; tcy: number } {
+  if (tileScale !== 1) return gameToTile(x, y)
+  const { px, py } = gameToPixel(x, y, w, h)
+  return { tcx: Math.round(px / T), tcy: Math.round(py / T) }
+}
+
+/** Tile radius an obstacle's patch is drawn at — the same disc
+ *  game/engine/terrainGrid.ts blocks. Lane callers resolve it against the
+ *  reference grid for the reason anchorTile does. */
+export function patchTileRadius(radius: number, h: number, T: number, tileScale: number): number {
+  const scale = tileScale === 1 ? h / T : GRID_REF_HEIGHT / TILE_SIZE
+  return Math.max(1, Math.round(radius * scale / TILE_RADIUS_SCALE))
+}

--- a/web/src/utils/terrainAlignment.test.ts
+++ b/web/src/utils/terrainAlignment.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { anchorTile, patchTileRadius } from './terrainLayer'
+import { planTerrainPatches } from './terrainPatchPlan'
+import { buildObstacleTileMap, gameToTile, GRID_REF_HEIGHT, GRID_REF_WIDTH } from '../game/engine/terrainGrid'
+import { generateTerrain } from '../game/engine/terrain'
+import type { TerrainObstacle } from '../game/engine/terrain'
+
+// The battlefield debug overlay exists to answer one question: is a tile that
+// blocks a unit the same tile the player can see a rock on? These pin that the
+// answer is yes — that the tiles buildTerrainDecorGfx PLANS to draw are exactly
+// the tiles terrainGrid BLOCKS, for the same terrain.
+
+const TILE_SIZE = 32
+/** Lane heights across the device range; T is derived from each (see tileScale
+ *  in components/battle/BattlefieldCanvas.tsx). */
+const LANE_HEIGHTS = [318, 446, 529, 569, 654, 766, 886]
+
+/** The tile set buildTerrainDecorGfx draws for `terrain` on a lane of height h. */
+function drawnTiles(terrain: TerrainObstacle[], env: string, h: number): Set<string> {
+  const tileScale = h / GRID_REF_HEIGHT
+  const T = TILE_SIZE * tileScale
+  const plan = planTerrainPatches(
+    terrain,
+    obs => anchorTile(obs.x, obs.y, h * (GRID_REF_WIDTH / GRID_REF_HEIGHT), h, T, tileScale),
+    obs => patchTileRadius(obs.radius, h, T, tileScale),
+    env,
+  )
+  const tiles = new Set<string>()
+  for (const group of plan.groups) for (const t of group.tiles) tiles.add(t)
+  for (const d of plan.decor) tiles.add(`${d.tcx},${d.tcy}`)
+  return tiles
+}
+
+describe('drawn terrain tiles are the blocked terrain tiles', () => {
+  const authored: TerrainObstacle[] = [
+    { id: 'r1', type: 'rock', x: 380, y: -60, radius: 26 },
+    { id: 'r2', type: 'rock', x: 380, y: 60, radius: 26 },
+    // y = 0 is the case that used to break: on the reference grid this lands on
+    // an exact half-tile boundary, so the engine rounded it up to one column
+    // while the lane canvas's integer pixel width rounded it down to another.
+    { id: 'w1', type: 'water', x: 250, y: 0, radius: 28 },
+    { id: 't1', type: 'tree', x: 130, y: -50, radius: 24 },
+    { id: 't2', type: 'tree', x: 130, y: 50, radius: 24 },
+    { id: 'u1', type: 'ruin', x: 300, y: 0, radius: 24 },
+  ]
+
+  it.each(LANE_HEIGHTS)('authored terrain lines up at lane height %ipx', h => {
+    expect([...drawnTiles(authored, 'forest', h)].sort())
+      .toEqual([...buildObstacleTileMap(authored).keys()].sort())
+  })
+
+  it('procedural scatter lines up too', () => {
+    for (let i = 0; i < 60; i++) {
+      const terrain = generateTerrain(`align-${i}`, 'forest')
+      expect([...drawnTiles(terrain, 'forest', 569)].sort())
+        .toEqual([...buildObstacleTileMap(terrain).keys()].sort())
+    }
+  })
+
+  it('an obstacle on the lane centre line anchors to the same column either way', () => {
+    // The specific half-tile tie that made every centre-line obstacle's art sit
+    // a whole column away from its blocking disc.
+    for (const h of LANE_HEIGHTS) {
+      const T = TILE_SIZE * (h / GRID_REF_HEIGHT)
+      const w = Math.round(h * (GRID_REF_WIDTH / GRID_REF_HEIGHT)) // lanes are whole pixels
+      expect(anchorTile(250, 0, w, h, T, h / GRID_REF_HEIGHT)).toEqual(gameToTile(250, 0))
+    }
+  })
+})

--- a/web/src/utils/terrainAlignment.test.ts
+++ b/web/src/utils/terrainAlignment.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { anchorTile, patchTileRadius } from './terrainLayer'
+// From ./laneGrid, not ./terrainLayer: the latter imports pixi, which touches
+// `navigator` at import time and so cannot load under Node 20 (which CI runs).
+// These are the exact helpers buildTerrainDecorGfx uses to choose its tiles.
+import { anchorTile, patchTileRadius } from './laneGrid'
 import { planTerrainPatches } from './terrainPatchPlan'
 import { buildObstacleTileMap, gameToTile, GRID_REF_HEIGHT, GRID_REF_WIDTH } from '../game/engine/terrainGrid'
 import { generateTerrain } from '../game/engine/terrain'

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -7,6 +7,7 @@ import { planTerrainPatches } from './terrainPatchPlan'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
 import { renderPathTiles } from './tileLookup'
+import { gameToTile, GRID_REF_HEIGHT } from '../game/engine/terrainGrid'
 import type { TerrainObstacle, RoadDef, BattlefieldDecorItem } from '../game/engine/terrain'
 
 // Divisor controlling how obstacle radius (game units) maps to tile-ring radius (tiles).
@@ -27,6 +28,40 @@ export function gameToPixel(x: number, y: number, w: number, h: number): { px: n
 
 export function pixelToGame(px: number, py: number, w: number, h: number): { x: number; y: number } {
   return { x: 500 * (1 - py / h), y: 80 * ((px / w - 0.5) / 0.36) }
+}
+
+/**
+ * The tile index a game position anchors to, for art that snaps to the tile grid.
+ *
+ * Callers drawing the battlefield lane pass a tileScale (h / GRID_REF_HEIGHT),
+ * and for them the index comes straight from the engine's reference grid rather
+ * than being re-derived from measured canvas pixels. A lane canvas is an
+ * integer-pixel approximation of that grid — its width rounds to a whole pixel —
+ * so rounding px/T on it flips the index for anything sitting exactly on a
+ * half-tile boundary. The lane's centre line (game y = 0, the most common
+ * authored y there is) sits precisely there: the engine computes 8.5 and rounds
+ * up, a 366px-wide lane computes 8.493 and rounds down, and the obstacle's art
+ * lands a whole tile away from the disc that actually blocks units. Asking the
+ * engine removes the second computation rather than trying to match it.
+ *
+ * Canvases that are not the lane (no tileScale — the hub, the node map, the
+ * scenery preview) have no engine grid to agree with, and keep resolving
+ * against their own pixels, which is the only thing that means anything there.
+ */
+export function anchorTile(
+  x: number, y: number, w: number, h: number, T: number, tileScale: number,
+): { tcx: number; tcy: number } {
+  if (tileScale !== 1) return gameToTile(x, y)
+  const { px, py } = gameToPixel(x, y, w, h)
+  return { tcx: Math.round(px / T), tcy: Math.round(py / T) }
+}
+
+/** Tile radius an obstacle's patch is drawn at — the same disc
+ *  game/engine/terrainGrid.ts blocks. Lane callers resolve it against the
+ *  reference grid for the reason anchorTile does. */
+export function patchTileRadius(radius: number, h: number, T: number, tileScale: number): number {
+  const scale = tileScale === 1 ? h / T : GRID_REF_HEIGHT / TILE_SIZE
+  return Math.max(1, Math.round(radius * scale / TILE_RADIUS_SCALE))
 }
 
 export interface TerrainLayerOptions {
@@ -289,9 +324,7 @@ export async function buildManualDecorGfx(
   const sortedDecorItems = [...decorItems].sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0))
   for (const item of sortedDecorItems) {
     if (container.destroyed) return
-    const { px, py } = gameToPixel(item.x, item.y, mapWidth, mapHeight)
-    const tcx0 = Math.round(px / T)
-    const tcy0 = Math.round(py / T)
+    const { tcx: tcx0, tcy: tcy0 } = anchorTile(item.x, item.y, mapWidth, mapHeight, T, tileScale)
     if (item.bundleId) {
       const bundle = getBattlefieldBundleById(item.bundleId)
       if (!bundle) continue
@@ -342,10 +375,7 @@ export async function buildRoadGfx(
   const def = opts.envDef ?? ENV_TILES[opts.environment ?? '']
   const T = TILE_SIZE * tileScale
 
-  const toTile = (x: number, y: number) => {
-    const { px, py } = gameToPixel(x, y, w, h)
-    return { tcx: Math.round(px / T), tcy: Math.round(py / T) }
-  }
+  const toTile = (x: number, y: number) => anchorTile(x, y, w, h, T, tileScale)
 
   // Group by effective tileFile only — every road sharing a tileFile is treated
   // as one continuous material and merges into a single autotiled shape
@@ -493,12 +523,8 @@ export async function buildTerrainDecorGfx(
   const envDecorMap = TERRAIN_DECOR_MAP[env] ?? {}
   const T = TILE_SIZE * tileScale
 
-  const toTile = (obs: TerrainObstacle) => {
-    const { px, py } = gameToPixel(obs.x, obs.y, w, h)
-    return { tcx: Math.round(px / T), tcy: Math.round(py / T) }
-  }
-  const tileRadiusOf = (obs: TerrainObstacle) =>
-    Math.max(1, Math.round(obs.radius * h / (TILE_RADIUS_SCALE * T)))
+  const toTile = (obs: TerrainObstacle) => anchorTile(obs.x, obs.y, w, h, T, tileScale)
+  const tileRadiusOf = (obs: TerrainObstacle) => patchTileRadius(obs.radius, h, T, tileScale)
 
   const { groups, decor } = planTerrainPatches(terrain, toTile, tileRadiusOf, env)
 

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -7,62 +7,13 @@ import { planTerrainPatches } from './terrainPatchPlan'
 import { drawTerrainItem } from './terrainGfx'
 import { seededRand, hashStr, getTerrainItems, type TerrainItem } from './mapUtils'
 import { renderPathTiles } from './tileLookup'
-import { gameToTile, GRID_REF_HEIGHT } from '../game/engine/terrainGrid'
+import { anchorTile, patchTileRadius, gameToPixel, TILE_RADIUS_SCALE } from './laneGrid'
 import type { TerrainObstacle, RoadDef, BattlefieldDecorItem } from '../game/engine/terrain'
 
-// Divisor controlling how obstacle radius (game units) maps to tile-ring radius (tiles).
-// Tuned against the realistic range of obstacle radius (20-32) and lane CSS height (~318-842px)
-// so clusters show real size variety instead of always rounding to a single uniform "plus" shape.
-export const TILE_RADIUS_SCALE = 220
-
-/**
- * Battlefield lane coordinate mapping: game units (x: 0–500 forward base→base,
- * y: -80..80 lateral) → canvas pixels, and back. buildRoadGfx/buildTerrainDecorGfx
- * derive their tile coordinates from gameToPixel below; the battlefield editor uses
- * pixelToGame to turn a pointer click into a game-unit waypoint/obstacle position —
- * sharing this single definition keeps the two forever in lockstep.
- */
-export function gameToPixel(x: number, y: number, w: number, h: number): { px: number; py: number } {
-  return { px: (0.5 + (y / 80) * 0.36) * w, py: (1 - x / 500) * h }
-}
-
-export function pixelToGame(px: number, py: number, w: number, h: number): { x: number; y: number } {
-  return { x: 500 * (1 - py / h), y: 80 * ((px / w - 0.5) / 0.36) }
-}
-
-/**
- * The tile index a game position anchors to, for art that snaps to the tile grid.
- *
- * Callers drawing the battlefield lane pass a tileScale (h / GRID_REF_HEIGHT),
- * and for them the index comes straight from the engine's reference grid rather
- * than being re-derived from measured canvas pixels. A lane canvas is an
- * integer-pixel approximation of that grid — its width rounds to a whole pixel —
- * so rounding px/T on it flips the index for anything sitting exactly on a
- * half-tile boundary. The lane's centre line (game y = 0, the most common
- * authored y there is) sits precisely there: the engine computes 8.5 and rounds
- * up, a 366px-wide lane computes 8.493 and rounds down, and the obstacle's art
- * lands a whole tile away from the disc that actually blocks units. Asking the
- * engine removes the second computation rather than trying to match it.
- *
- * Canvases that are not the lane (no tileScale — the hub, the node map, the
- * scenery preview) have no engine grid to agree with, and keep resolving
- * against their own pixels, which is the only thing that means anything there.
- */
-export function anchorTile(
-  x: number, y: number, w: number, h: number, T: number, tileScale: number,
-): { tcx: number; tcy: number } {
-  if (tileScale !== 1) return gameToTile(x, y)
-  const { px, py } = gameToPixel(x, y, w, h)
-  return { tcx: Math.round(px / T), tcy: Math.round(py / T) }
-}
-
-/** Tile radius an obstacle's patch is drawn at — the same disc
- *  game/engine/terrainGrid.ts blocks. Lane callers resolve it against the
- *  reference grid for the reason anchorTile does. */
-export function patchTileRadius(radius: number, h: number, T: number, tileScale: number): number {
-  const scale = tileScale === 1 ? h / T : GRID_REF_HEIGHT / TILE_SIZE
-  return Math.max(1, Math.round(radius * scale / TILE_RADIUS_SCALE))
-}
+// Lane coordinate/tile math lives in ./laneGrid (pixi-free so tests can import
+// it); re-exported here because most callers reach for it alongside the
+// build*Gfx helpers.
+export { gameToPixel, pixelToGame, TILE_RADIUS_SCALE } from './laneGrid'
 
 export interface TerrainLayerOptions {
   environment?: string


### PR DESCRIPTION
## The problem

With the passability overlay on, blocked tiles still didn't sit under the terrain art. The previous PR fixed the **vertical** half-tile offset; this is the **horizontal** axis, which was never right.

The two systems disagreed about how many tile **columns** the lane is:

- Terrain art draws **square** tiles of `32 * h / GRID_REF_HEIGHT`, so the lane holds `w / T` columns — **16.4 → 18.9** across the device range.
- The collision grid used a fixed `GRID_REF_WIDTH = 390`, so it always assumed `390/32` = **12.19** columns.

Rows agreed (both derive from `h / GRID_REF_HEIGHT`); columns never did. Every blocking disc was 1.35–1.55× wider on screen than the rock drawn under it, and the two grids slid past each other across the lane. Measured on a 390×845 frame (lane 386×567, art tile 21.5px, collision tile 31.7px):

```
y=-60   art tile spans [ 86,107]   collision tile spans [ 95,127]   +14px
y=-30   art tile spans [150,172]   collision tile spans [127,158]   -19px
y=+30   art tile spans [236,258]   collision tile spans [253,285]   +22px
```

Three things couldn't all hold at once: square height-derived art tiles, a fixed collision grid, and a lane whose aspect ratio drifts with the frame (fixed-pixel HUD bands over a fixed-ratio frame give 0.62–0.72).

## The fix

**The lane's shape gives way.** It is now letterboxed to a fixed `LANE_ASPECT_RATIO` inside the slot the HUD bands leave — the same way the frame is already letterboxed inside the stage, reusing `useLetterboxSize` — and the collision grid's reference width derives from that ratio.

`544/845` = exactly 17 tile columns, picked by measuring the letterbox loss across frame heights 700–1400: ~10% of width at the smallest, ~8% of height at the tallest, near zero through the phone range.

A second, subtler bug surfaced once the shapes matched: the renderer re-derived tile indices from **measured canvas pixels**. A lane canvas is an integer-pixel approximation of the reference grid, so rounding `px/T` on it flips the index for anything on a half-tile boundary — and the lane's centre line (game `y = 0`, the most common authored value there is) sits on one exactly. The engine computed 8.5 and rounded up, a 366px lane computed 8.493 and rounded down, and every centre-line obstacle's art landed a whole column from its blocking disc. Lane callers now ask the engine for the index rather than recomputing it; canvases that aren't the lane (hub, node map, scenery preview) keep resolving against their own pixels.

### Knock-on effects

- The playable lateral span goes from ~8.8 to ~13 tile columns with obstacle radii unchanged, so obstacles block the smaller share of the lane they were always *drawing*. Procedural scatters stay 100% traversable with nothing pruned.
- The **battlefield editor** now previews the lane's shape and tile density instead of the frame's, so an authored scene renders in battle the way it looks in the editor. (This re-applies work that `77dbd8f` added and a later commit reverted on the grounds that "the live battlefield never passes a tileScale either" — it does, at `BattlefieldCanvas.tsx:105`.)
- `.lane`'s border became an `outline`: `box-sizing` is `border-box` globally, so a real border would eat 4px out of the letterboxed size and put the play area ~1% off the locked ratio.
- Small dead margins now appear at the lane's sides on small frames and above/below on tall ones — under 9% either way.

## Verification

- Full suite green: 245 files / 2694 tests, including the Storybook browser project. `tsc --noEmit` and a production build clean.
- Stuck sweep re-run: **336 battle nodes × 7 spawn positions plus 150 procedural seeds — 3402 units, 0 stuck.**
- New `terrainAlignment.test.ts` asserts the tiles the renderer *plans to draw* are exactly the tiles the engine *blocks*, for authored and procedural terrain across seven lane heights — including the centre-line case that used to break.
- Checked visually in a headless browser with the overlay on: blocked tiles now hug the drawn patches on every side, and a ruin gets exactly one tile under its icon.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg4sPgYK93sAJC8XwChpp)_