### PR TITLE
Keep DEFEND-stance units inside the defensive zone

### DIFF
--- a/web/src/game/engine/constants.ts
+++ b/web/src/game/engine/constants.ts
@@ -18,6 +18,16 @@ export const BASE_STOP_MARGIN    = 0                // units may reach the base 
 export const COMMANDER_HOME_X    = 15               // player commander's home position
 export const COMMANDER_LEASH_PX  = 40              // max px a commander can stray from home
 
+// ─── Defend Stance Zone ───────────────────────────────────
+// The DEFEND stance holds a band of the lane in front of the player's base rather
+// than chasing enemies up the field. In moveUnits it bounds both what counts as a
+// threat worth breaking formation for and how far forward a defender may end a
+// tick, so units hold the zone and engage whatever enters it.
+/** Fraction of the lane, measured from the player's base, that DEFEND stance holds. */
+export const DEFEND_ZONE_FRAC   = 0.15
+/** Forward limit of the defend zone — defending units never advance past this. */
+export const DEFEND_ZONE_MAX_X  = LANE_WIDTH * DEFEND_ZONE_FRAC  // 75
+
 // ─── Opponent Spell-Cast Telegraph + Counter QTE ──────────
 export const CAST_WINDUP_MS          = 5000  // windup before an opponent AOE spell resolves
 // A successful counter never fully negates damage — it caps it at a percentage of the

--- a/web/src/game/engine/units.test.ts
+++ b/web/src/game/engine/units.test.ts
@@ -9,6 +9,7 @@ import { moveUnits } from './units'
 import { spawnUnit } from './helpers'
 import { RoadDef, TerrainObstacle } from './terrain'
 import { LANE_WIDTH } from '../types'
+import { DEFEND_ZONE_MAX_X } from './constants'
 
 const MOBILE_TEMPLATE = {
   name: 'Test Runner', maxHp: 30, attack: 5, moveSpeed: 40,
@@ -285,7 +286,112 @@ describe('moveUnits — defend stance', () => {
 
     for (let i = 0; i < 30; i++) moveUnits(s, 100)
 
-    expect(defender.x).toBeLessThan(120)
+    expect(defender.x).toBeLessThanOrEqual(DEFEND_ZONE_MAX_X)
+  })
+
+  it('never leaves the zone to chase an enemy sitting just outside it', () => {
+    // The reported bug: an enemy parked beyond the zone used to drag defenders
+    // out to ~x=190 (38% of the lane) while the base went undefended.
+    const { s, defender } = defendBattle(150)
+
+    for (let i = 0; i < 200; i++) moveUnits(s, 100)
+
+    expect(defender.x).toBeLessThanOrEqual(DEFEND_ZONE_MAX_X)
+  })
+
+  it('returns to its slot once the enemy it engaged is out of the zone', () => {
+    // A defender pushed forward, with an enemy ahead close enough to be within
+    // attackRange. The "already in range, don't move" early-continue used to fire
+    // before the defend branch, pinning the unit up-field for the rest of the battle.
+    const { s, defender, enemy } = defendBattle(200)
+    defender.x = 190
+    enemy.y = 0
+
+    for (let i = 0; i < 200; i++) moveUnits(s, 100)
+
+    expect(defender.x).toBeLessThanOrEqual(DEFEND_ZONE_MAX_X)
+  })
+
+  it('walks home rather than snapping back when DEFEND is tapped up-field', () => {
+    // Units caught beyond the zone when the stance changes must not teleport.
+    const { s, defender } = defendBattle(LANE_WIDTH - 40)
+    defender.x = 300
+
+    moveUnits(s, 100)
+    const afterOneTick = defender.x
+    expect(afterOneTick).toBeLessThan(300)
+    expect(afterOneTick).toBeGreaterThan(DEFEND_ZONE_MAX_X)
+
+    for (let i = 0; i < 200; i++) moveUnits(s, 100)
+    expect(defender.x).toBeLessThanOrEqual(DEFEND_ZONE_MAX_X)
+  })
+
+  it('routes home around terrain instead of marching toward the enemy base', () => {
+    // A terrain-blocked unit is steered by the flow field, and the field's goal used
+    // to be the enemy base regardless of stance — so a defender whose direct path
+    // home was blocked pathed *forward*, ending around x=310 instead of on its slot.
+    // The geometry here is deliberate: the obstacle must block the way home while
+    // leaving the defender itself on free ground, since a unit embedded in terrain
+    // takes the walk-out path and never consults the field at all.
+    const s = newGame()
+    s.playerStance = 'defend'
+    s.terrainValidated = true
+    s.terrain = [{ id: 'block', type: 'rock', x: 130, y: 0, radius: 40 }]
+    const defender = spawnUnit(MOBILE_TEMPLATE, 'player')
+    defender.id = 'u7' // pin — the Y slot is chosen from the id, and geometry matters here
+    defender.x = 200
+    defender.y = 0
+    defender.advanceY = 0
+    s.field = [defender]
+
+    for (let i = 0; i < 300; i++) moveUnits(s, 100)
+
+    expect(defender.x).toBeLessThanOrEqual(DEFEND_ZONE_MAX_X)
+  })
+
+  it('spreads defenders across multiple breachers instead of collapsing onto one', () => {
+    const s = newGame()
+    s.terrain = []
+    s.playerStance = 'defend'
+    // Both defenders sit beside breacher A, so "nearest threat" alone sends both to
+    // A and leaves B free to chew through the base — the claim set is what splits them.
+    const defenders = [-58, -62].map(y => {
+      const u = spawnUnit(MOBILE_TEMPLATE, 'player')
+      u.x = 75; u.y = y; u.advanceY = y
+      return u
+    })
+    const breacherA = spawnUnit(MOBILE_TEMPLATE, 'opponent')
+    breacherA.x = 40; breacherA.y = -60; breacherA.moveSpeed = 0 // pinned: measures defender choice only
+    const breacherB = spawnUnit(MOBILE_TEMPLATE, 'opponent')
+    breacherB.x = 40; breacherB.y = 20; breacherB.moveSpeed = 0
+    s.field = [...defenders, breacherA, breacherB]
+
+    for (let i = 0; i < 40; i++) moveUnits(s, 100)
+
+    // Each breacher should have drawn exactly one defender.
+    for (const b of [breacherA, breacherB]) {
+      const engaged = defenders.filter(d => Math.hypot(d.x - b.x, d.y - b.y) <= d.attackRange)
+      expect(engaged.length).toBe(1)
+    }
+  })
+
+  it('still sends the overflow attackers forward when the army is large', () => {
+    const s = newGame()
+    s.terrain = []
+    s.playerStance = 'defend'
+    const defenders = Array.from({ length: 20 }, (_, i) => {
+      const u = spawnUnit(MOBILE_TEMPLATE, 'player')
+      u.x = 70 + i; u.y = 0; u.advanceY = 0
+      return u
+    })
+    s.field = defenders
+
+    for (let i = 0; i < 100; i++) moveUnits(s, 100)
+
+    // 5 furthest-forward break off and charge; the rest hold the zone.
+    const past = defenders.filter(u => u.x > DEFEND_ZONE_MAX_X)
+    expect(past.length).toBe(5)
+    expect(defenders.filter(u => u.x <= DEFEND_ZONE_MAX_X).length).toBe(15)
   })
 })
 

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -1,5 +1,7 @@
 import { GameState, LANE_WIDTH, TERRAIN_AVOID_SHAPE, RUIN_FOOTPRINT_RADIUS, Unit, UnitTag } from '../types'
-import { BASE_STOP_MARGIN, COMMANDER_LEASH_PX, DAMAGE_FLASH_MS, PLAYER_SPAWN_X } from './constants'
+import {
+  BASE_STOP_MARGIN, COMMANDER_LEASH_PX, DAMAGE_FLASH_MS, DEFEND_ZONE_MAX_X, PLAYER_SPAWN_X,
+} from './constants'
 import { LANE_MAX_Y, LANE_MIN_Y } from './helpers'
 import { unitDist, findNearestEnemy, findNearestEnemyByPriority, findEnemyBehind } from './targeting'
 import { computeRoadWaypoints } from './roads'
@@ -75,18 +77,23 @@ export function moveUnits(s: GameState, deltaMs: number): void {
   // Y positions defenders spread across so they don't all converge on a single point.
   const DEFEND_Y_SLOTS = [-64, -40, -20, 0, 20, 40, 64]
 
-  // The line defenders form up on, and how far in front of it an enemy still
-  // counts as an intruder worth breaking formation for.
+  // The line defenders form up on. Sits just inside DEFEND_ZONE_MAX_X so units
+  // holding formation have room to shuffle without touching the boundary.
   const DEFEND_LINE_X = PLAYER_SPAWN_X + 40
-  const DEFEND_INTERCEPT_PX = 120
 
-  // Enemies that have reached the defensive line or slipped behind it — where
-  // the player's spawners, walls and commander all sit. Without this, defenders
-  // sat on their assigned slot while an enemy chewed through a structure a few
-  // pixels away, since nothing in the defend branch ever looked for a target.
+  // Enemies that have entered the defensive zone — where the player's spawners,
+  // walls and commander all sit. Defenders break formation only for these, and
+  // never leave the zone to reach one. Anything outside is still shot at by
+  // whoever's attackRange covers it; processAttacks is stance-agnostic.
+  // Moats are walked through rather than targeted (see targeting.ts).
   const defendThreats = stance === 'defend'
-    ? s.field.filter(u => u.owner === 'opponent' && u.hp > 0 && u.x <= DEFEND_LINE_X + DEFEND_INTERCEPT_PX)
+    ? s.field.filter(u => u.owner === 'opponent' && u.hp > 0 && !u.isMoat && u.x <= DEFEND_ZONE_MAX_X)
     : []
+
+  // Threats already claimed by a defender this tick. Without this every defender
+  // independently picks the globally nearest intruder, so a single breacher pulls
+  // the whole line off its slots and leaves the other lanes open.
+  const claimedThreats = new Set<string>()
 
   for (const unit of s.field) {
     if (unit.moveSpeed === 0) continue
@@ -97,6 +104,11 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     if (unit.owner === 'player' && stance === 'hold') continue
 
     const anyEnemies = unit.owner === 'player' ? livingOpponentUnits : livingPlayerUnits
+
+    // Defenders steer entirely from the defend branch below. Overflow units are
+    // excluded — they charge like any attacker.
+    const isDefending = unit.owner === 'player' && stance === 'defend'
+      && !defendOverflowAttackers.has(unit.id)
 
     const nearestAhead = findNearestEnemyByPriority(s.field, unit) ?? findNearestEnemy(s.field, unit)
 
@@ -124,9 +136,41 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       ty = unit.roadWaypoints[0].y
     }
 
-    if (nearestAhead) {
+    // Defend runs before the chase block rather than after it. The
+    // "already in range, don't move" early-continue below fires for any enemy
+    // ahead regardless of stance, so while it ran first a defender facing a
+    // steady stream of enemies never reached this branch and never walked back
+    // to its slot — it stayed parked wherever the last intercept left it.
+    if (isDefending) {
+      // Intercept whatever has entered the zone, otherwise hold formation spread
+      // across Y slots. Nearest *unclaimed* threat wins so the line spreads over
+      // several breachers; nearest overall is the fallback once all are claimed.
+      let threat: Unit | undefined
+      let threatDist = Infinity
+      let nearest: Unit | undefined
+      let nearestDist = Infinity
+      for (const other of defendThreats) {
+        const d = unitDist(unit, other)
+        if (d < nearestDist) { nearestDist = d; nearest = other }
+        if (claimedThreats.has(other.id)) continue
+        if (d < threatDist) { threatDist = d; threat = other }
+      }
+      if (!threat) { threat = nearest; threatDist = nearestDist }
+      if (threat) {
+        claimedThreats.add(threat.id)
+        // Already engaging it — combat handles the attack, don't crowd closer.
+        if (threatDist <= unit.attackRange) continue
+        tx = threat.x
+        ty = threat.isWall ? unit.y : threat.y
+        hasTarget = true
+      } else {
+        tx = DEFEND_LINE_X
+        ty = DEFEND_Y_SLOTS[idNum(unit.id) % DEFEND_Y_SLOTS.length]
+        hasTarget = false
+      }
+    } else if (nearestAhead) {
       if (unitDist(unit, nearestAhead) <= unit.attackRange) continue
-      // Attack/defend: don't chase enemies — keep charging toward destination
+      // Attack: don't chase enemies — keep charging toward destination
       if (unit.owner !== 'player' || stance === 'auto') {
         tx = nearestAhead.x
         ty = nearestAhead.isWall ? unit.y : nearestAhead.y
@@ -140,28 +184,6 @@ export function moveUnits(s: GameState, deltaMs: number): void {
         tx = behind.x
         ty = behind.isWall ? unit.y : behind.y
         hasTarget = true
-      }
-    }
-
-    // Defend: intercept anything that has breached the line, otherwise hold
-    // formation spread across Y slots. Overflow units charge forward instead.
-    if (unit.owner === 'player' && stance === 'defend' && !defendOverflowAttackers.has(unit.id)) {
-      let threat: Unit | undefined
-      let threatDist = Infinity
-      for (const other of defendThreats) {
-        const d = unitDist(unit, other)
-        if (d < threatDist) { threatDist = d; threat = other }
-      }
-      if (threat) {
-        // Already engaging it — combat handles the attack, don't crowd closer.
-        if (threatDist <= unit.attackRange) continue
-        tx = threat.x
-        ty = threat.isWall ? unit.y : threat.y
-        hasTarget = true
-      } else {
-        tx = DEFEND_LINE_X
-        ty = DEFEND_Y_SLOTS[idNum(unit.id) % DEFEND_Y_SLOTS.length]
-        hasTarget = false
       }
     }
 
@@ -328,6 +350,11 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       }
     }
 
+    // Position at the start of this tick — the defend clamp below needs it so a
+    // unit already past the zone when the stance was tapped can walk home
+    // instead of being teleported back to the boundary.
+    const xBefore = unit.x
+
     const dx = tx - unit.x
     const dy = ty - unit.y
     const d  = Math.sqrt(dx * dx + dy * dy)
@@ -452,7 +479,10 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       const directOpen = wants && canEnter(candX, candY)
 
       // Flow field toward this unit's goal edge, built lazily per profile/goal.
-      const goalX = unit.owner === 'player' ? LANE_WIDTH : 0
+      // Defenders route toward their own base: the field is what steers a
+      // terrain-blocked unit, and pointing it at the enemy base marched
+      // defenders across the map the moment an obstacle got in the way.
+      const goalX = isDefending ? 0 : (unit.owner === 'player' ? LANE_WIDTH : 0)
       const fieldKey = `${profile}|${swims}|${goalX}`
       let field = s.terrainGridCache.flowFields.get(fieldKey)
       if (!field) {
@@ -533,10 +563,22 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       }
     }
 
+    // Backstop on the zone. Redundant by design: steering can't exceed the
+    // boundary (every defend target is at most DEFEND_ZONE_MAX_X and a step never
+    // overshoots its target), and the detour field points home. It's here because
+    // the branches above write unit.x directly on several paths — the terrain
+    // detour and the walk-out-of-an-obstacle escape hatch — so a future change to
+    // any of them can't quietly put defenders back on the field. Clamping to
+    // xBefore rather than the boundary means a unit caught up-field when DEFEND
+    // is tapped walks home under normal steering instead of teleporting back.
+    if (isDefending) unit.x = Math.min(unit.x, Math.max(DEFEND_ZONE_MAX_X, xBefore))
+
     // Advance past the current road waypoint once reached — gated on !hasTarget so a unit
     // pulled off-path by a higher-priority target this tick isn't credited with "arriving"
-    // just because unrelated movement happened to land it near the waypoint.
-    if (!hasTarget && unit.roadWaypoints && unit.roadWaypoints.length > 0) {
+    // just because unrelated movement happened to land it near the waypoint. Defenders are
+    // excluded outright: holding a slot leaves hasTarget false, so drifting near a waypoint
+    // would silently consume it.
+    if (!hasTarget && !isDefending && unit.roadWaypoints && unit.roadWaypoints.length > 0) {
       const wp = unit.roadWaypoints[0]
       if (Math.hypot(unit.x - wp.x, unit.y - wp.y) <= ROAD_WAYPOINT_ARRIVE_PX) {
         unit.roadWaypoints.shift()


### PR DESCRIPTION
Tapping **DEFEND** sent units charging up the field instead of holding near the base, so the base got destroyed while the army was out of position.

## What was wrong

Defenders formed up on the right line (`DEFEND_LINE_X` = 70, 14% of the lane) but were then allowed to chase anything within 120px of it — out to `x = 190`, **38% of the field**. Four separate things kept them there:

1. **The intercept band reached x=190.** `DEFEND_INTERCEPT_PX = 120` made any enemy at `x ≤ 190` a threat, and `tx = threat.x` was applied raw with nothing bounding the walk. Defenders went the whole way out to meet enemies that had never entered the defended area.
2. **The defend branch ran *after* the chase block.** That block's "already in range, don't move" early-`continue` fires for any enemy ahead regardless of stance, so against a steady stream of enemies the defend branch was skipped every tick — a defender pulled forward once never walked back to its slot.
3. **The terrain flow field's goal was hardcoded to the enemy base.** A defender whose direct path home was blocked pathed *forward* instead, ending around `x = 310` in the geometry the new regression test uses.
4. **All defenders picked the globally nearest intruder.** One breacher pulled the whole line off its slots and left the other lanes open.

## What changed

Replaced the line-plus-band with a real zone. `DEFEND_ZONE_MAX_X` (15% of the lane, `x ≤ 75`) now bounds both what counts as a threat worth breaking formation for and how far forward a defender may end a tick.

- `constants.ts` — new `DEFEND_ZONE_FRAC` / `DEFEND_ZONE_MAX_X`, alongside the other spatial constants.
- `units.ts` — threats are only what's inside the zone (moats excluded, matching `targeting.ts`); the defend decision moves ahead of the chase block; the detour flow field points at the player's base for defenders; each defender claims a distinct threat where one is available; a position backstop bounds forward movement.

Units caught up-field when the stance is tapped **walk home rather than snapping back** — the clamp is against the tick's starting `x`, not the boundary.

Combat is untouched: `processAttacks` is stance-agnostic, so defenders still shoot anything their `attackRange` covers, including an enemy standing just outside the zone.

The ≥15-defender overflow that sends the 5 furthest-forward units charging is deliberate and **unchanged** — there's now a test locking that in.

## Testing

`npm run build` passes; full suite is **2042 tests, 0 failures**.

Seven new cases in `units.test.ts`. Each fix was ablated individually to confirm the tests are load-bearing rather than incidentally green:

| Test | Fails without |
|---|---|
| never leaves the zone to chase an enemy sitting just outside it | zone bound |
| returns to its slot once the enemy it engaged is out of the zone | branch reorder |
| walks home rather than snapping back when DEFEND is tapped up-field | branch reorder |
| routes home around terrain instead of marching toward the enemy base | flow-field goal |
| spreads defenders across multiple breachers instead of collapsing onto one | threat claiming |

The position backstop is deliberately redundant and is commented as such — with the other fixes in place no path can exceed the boundary, so no test can exercise it. It's kept because the terrain-detour and walk-out-of-an-obstacle paths write `unit.x` directly, and a future change to either shouldn't be able to quietly put defenders back on the field.

Existing defend-stance, road-following, terrain-blocking, `pathfinding.test.ts` and `engine.perf.test.ts` cases all still pass, so non-defend movement is unaffected.

## Notes, observed but not changed

- On **sudden death** the game force-sets stance `attack` and disables every other stance button (`App.tsx:912-918`). If a base was lost during sudden death, that's by design and unaffected by this fix.
- The stance bar labels are counter-intuitive: the button reading **ATTACK** sets stance `auto`, and **CHARGE** sets `attack` (`Battlefield.tsx:456`). **DEFEND** maps correctly. Left alone as out of scope — happy to follow up if you want them straightened out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iD3rMrAnYyHfCbtpw2deu

---
_Generated by [Claude Code](https://claude.ai/code/session_015iD3rMrAnYyHfCbtpw2deu)_