### PR TITLE
Make node map labels legible and align nodes with their paths

### DIFF
--- a/web/src/components/ui/NodeMap/NodeMapRederer.stories.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { NodeMapRederer } from './NodeMapRederer'
 import { exampleAct, exampleRunState } from '../../../game/types.sample'
 import { WORLD_MAP } from '../../../data/world/worldMapDef'
+import type { Act } from '../../../game/questline'
+import act6 from '../../../data/acts/act6.json'
 
 const meta = {
   component: NodeMapRederer,
@@ -59,6 +61,20 @@ export const CampaignFreshRun: Story = {
       completedNodeIds: [],
       pendingNodeId: null,
     },
+    setPeekNode: fn(),
+    showPaths: true,
+  },
+}
+
+// Act 6's sky environment is the brightest terrain in the game — a near-white
+// cloud floor — so it is the worst case for node label contrast. Its rows 0, 1
+// and 6 also have a rowCols parity that differs from maxRowCols, the layout that
+// used to render node markers half a tile off their own road.
+export const SkyBrightTerrain: Story = {
+  args: {
+    id: 'act6',
+    worldMap: act6 as unknown as Act,
+    run: { ...exampleRunState, actId: 'act6', completedNodeIds: [], pendingNodeId: null },
     setPeekNode: fn(),
     showPaths: true,
   },

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -23,6 +23,7 @@ import { hashStr, envColors, parseRgba, sampleBezier, bezierBand } from '../../.
 import { renderPathTiles } from '../../../utils/tileLookup'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx } from '../../../utils/terrainLayer'
 import { NODE_ICON, NODE_LABEL, mapLabelStyle } from '../../ui/NodeMap/constants'
+import { COL_WIDTH, ROW_HEIGHT, AVATAR_PADDING, CONN_W, nodeCenter, startPos } from '../../ui/NodeMap/nodeLayout'
 import { getCurrentWorldLocation } from '../../../game/world/worldState'
 import { NodePeekModal } from '../../ui/NodeMap/NodePeekModal'
 
@@ -41,10 +42,6 @@ interface Props {
 
 
 
-const COL_WIDTH      = 128
-const ROW_HEIGHT     = 96
-const AVATAR_PADDING = 80
-const CONN_W         = 32
 const AVATAR_SIZE    = 36
 const WALK_DURATION  = 700
 const NODE_RADIUS    = 22
@@ -194,37 +191,10 @@ function lastCompletedNode(nodes: Record<string, QuestNode>, run: RunState): Que
   return nodes[run.completedNodeIds[run.completedNodeIds.length - 1]] ?? null
 }
 
-// Everything the map draws on the ground — roads, node markers, the avatar — is
-// snapped to the centre of a 32px tile. Without this a row whose rowCols parity
-// differs from maxRowCols gets a half-row offset, landing the node centre on a
-// tile *boundary* while the road tiles under it are laid at floor(y / TILE_SIZE)
-// — a visible 16px gap between the node and its own path. Flooring (rather than
-// rounding) picks the same tile the road already occupies, so the roads stay put
-// and the nodes move onto them.
-export function snapToTile(v: number): number {
-  return Math.floor(v / TILE_SIZE) * TILE_SIZE + TILE_SIZE / 2
-}
-
-// The single source of truth for where a grid-mode node sits. Node markers, road
-// tiles and connector beziers all read from this, so they cannot drift apart.
-export function nodeCenter(
-  rowIndex: number, col: number, rowCols: number, maxRowCols: number,
-): { x: number; y: number } {
-  const vrow = (maxRowCols - rowCols) / 2 + col
-  return {
-    x: snapToTile(AVATAR_PADDING + rowIndex * (COL_WIDTH + CONN_W) + COL_WIDTH / 2),
-    y: snapToTile((vrow + 0.5) * ROW_HEIGHT),
-  }
-}
-
 function nodePosition(
   rowIndex: number, node: QuestNode, rowCols: number, maxRowCols: number,
 ): { x: number; y: number } {
   return nodeCenter(rowIndex, node.col, rowCols, maxRowCols)
-}
-
-function startPos(mapHeight: number) {
-  return { x: AVATAR_PADDING / 2, y: snapToTile(mapHeight / 2) }
 }
 
 // ── Path tile renderer ────────────────────────────────────────────────────────
@@ -545,7 +515,9 @@ async function buildNodeMarker(
           ws.x = Math.sin(t * sx + phase) * WANDER_RANGE
           ws.y = Math.cos(t * sy + phase * 1.414) * WANDER_RANGE
         }
-        app.ticker.add(tick)
+        // The sprite load above is awaited, so the app can already have been
+        // destroyed by the time we get here — its ticker is null then.
+        app.ticker?.add(tick)
       }
     } else {
       // Building enemy — static sprite, no wander

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -22,7 +22,7 @@ import { GIFT_OWNER_UID } from '../../../game/gifts'
 import { hashStr, envColors, parseRgba, sampleBezier, bezierBand } from '../../../utils/mapUtils'
 import { renderPathTiles } from '../../../utils/tileLookup'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx } from '../../../utils/terrainLayer'
-import { NODE_ICON, NODE_LABEL } from '../../ui/NodeMap/constants'
+import { NODE_ICON, NODE_LABEL, mapLabelStyle } from '../../ui/NodeMap/constants'
 import { getCurrentWorldLocation } from '../../../game/world/worldState'
 import { NodePeekModal } from '../../ui/NodeMap/NodePeekModal'
 
@@ -194,16 +194,38 @@ function lastCompletedNode(nodes: Record<string, QuestNode>, run: RunState): Que
   return nodes[run.completedNodeIds[run.completedNodeIds.length - 1]] ?? null
 }
 
-function nodePosition(
-  rowIndex: number, node: QuestNode, rowCols: number, maxRowCols: number,
+// Everything the map draws on the ground — roads, node markers, the avatar — is
+// snapped to the centre of a 32px tile. Without this a row whose rowCols parity
+// differs from maxRowCols gets a half-row offset, landing the node centre on a
+// tile *boundary* while the road tiles under it are laid at floor(y / TILE_SIZE)
+// — a visible 16px gap between the node and its own path. Flooring (rather than
+// rounding) picks the same tile the road already occupies, so the roads stay put
+// and the nodes move onto them.
+export function snapToTile(v: number): number {
+  return Math.floor(v / TILE_SIZE) * TILE_SIZE + TILE_SIZE / 2
+}
+
+// The single source of truth for where a grid-mode node sits. Node markers, road
+// tiles and connector beziers all read from this, so they cannot drift apart.
+export function nodeCenter(
+  rowIndex: number, col: number, rowCols: number, maxRowCols: number,
 ): { x: number; y: number } {
+  const vrow = (maxRowCols - rowCols) / 2 + col
   return {
-    x: AVATAR_PADDING + rowIndex * (COL_WIDTH + CONN_W) + COL_WIDTH / 2,
-    y: ((maxRowCols - rowCols) / 2 + node.col + 0.5) * ROW_HEIGHT,
+    x: snapToTile(AVATAR_PADDING + rowIndex * (COL_WIDTH + CONN_W) + COL_WIDTH / 2),
+    y: snapToTile((vrow + 0.5) * ROW_HEIGHT),
   }
 }
 
-function startPos(mapHeight: number) { return { x: AVATAR_PADDING / 2, y: mapHeight / 2 } }
+function nodePosition(
+  rowIndex: number, node: QuestNode, rowCols: number, maxRowCols: number,
+): { x: number; y: number } {
+  return nodeCenter(rowIndex, node.col, rowCols, maxRowCols)
+}
+
+function startPos(mapHeight: number) {
+  return { x: AVATAR_PADDING / 2, y: snapToTile(mapHeight / 2) }
+}
 
 // ── Path tile renderer ────────────────────────────────────────────────────────
 // Lays PATH tiles from [A]Grass_pipo along each connector route.
@@ -227,9 +249,10 @@ async function buildPathTileGfx(
   if (rows.length > 0) {
     const firstRow = rows[0]
     const firstRowCols = firstRow[0]?.rowCols ?? firstRow.length
-    const startX = AVATAR_PADDING / 2
-    const startY = mapHeight / 2
-    const firstColCenterX = AVATAR_PADDING + COL_WIDTH / 2
+    const sp = startPos(mapHeight)
+    const startX = sp.x
+    const startY = sp.y
+    const firstColCenterX = nodeCenter(0, 0, firstRowCols, maxRowCols).x
     const midX = (startX + firstColCenterX) / 2
 
     const sTx = Math.floor(startX / T), sTy = Math.floor(startY / T)
@@ -237,8 +260,7 @@ async function buildPathTileGfx(
     const fTx = Math.floor(firstColCenterX / T)
 
     for (const node of firstRow) {
-      const vr = (maxRowCols - firstRowCols) / 2 + node.col
-      const ny = (vr + 0.5) / maxRowCols * mapHeight
+      const ny = nodeCenter(0, node.col, firstRowCols, maxRowCols).y
       const nTy = Math.floor(ny / T)
 
       for (let tx = Math.min(sTx, midTx); tx <= Math.max(sTx, midTx); tx++)
@@ -266,14 +288,13 @@ async function buildPathTileGfx(
         const childEntry = nodeRowIndex.get(childId)
         if (!childEntry || childEntry.ri <= parentEntry.ri) continue
 
-        const parentCenterX = AVATAR_PADDING + parentEntry.ri * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
-        const childCenterX  = AVATAR_PADDING + childEntry.ri  * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+        const p = nodeCenter(parentEntry.ri, parent.col, parentEntry.rowCols, maxRowCols)
+        const c = nodeCenter(childEntry.ri, childEntry.node.col, childEntry.rowCols, maxRowCols)
+        const parentCenterX = p.x, childCenterX = c.x
         const xMid = (parentCenterX + COL_WIDTH / 2 + childCenterX - COL_WIDTH / 2) / 2
 
-        const pr = (maxRowCols - parentEntry.rowCols) / 2 + parent.col
-        const cr = (maxRowCols - childEntry.rowCols) / 2 + childEntry.node.col
-        const y1 = (pr + 0.5) / maxRowCols * mapHeight
-        const y2 = (cr + 0.5) / maxRowCols * mapHeight
+        const y1 = p.y
+        const y2 = c.y
 
         const pTx = Math.floor(parentCenterX / T), pTy = Math.floor(y1 / T)
         const midTx = Math.floor(xMid / T)
@@ -336,7 +357,6 @@ function drawConnectorsGfx(
   worldLayer: PIXI.Container,
   rows: QuestNode[][],
   maxRowCols: number,
-  mapHeight: number,
   statusOf: (id: string) => NodeStatus,
   reachableIds: Set<string>,
   hiddenNodeIds: Set<string>,
@@ -355,31 +375,33 @@ function drawConnectorsGfx(
     const rowCols = rows[ri][0]?.rowCols ?? rows[ri].length
     for (const node of rows[ri]) nodeIndex.set(node.id, { ri, rowCols, node })
   }
-  const vrow = (node: QuestNode, rc: number) => (maxRowCols - rc) / 2 + node.col
-
-  const best = new Map<string, { variant: LineVariant; parentRi: number; childRi: number; pr: number; cr: number }>()
+  const best = new Map<string, { variant: LineVariant; parentRi: number; childRi: number; pCol: number; cCol: number; pRowCols: number; cRowCols: number }>()
   for (const { node: parent, ri: parentRi, rowCols: parentRowCols } of nodeIndex.values()) {
     if (hiddenNodeIds.has(parent.id)) continue
     for (const childId of parent.childIds) {
       if (hiddenNodeIds.has(childId)) continue
       const childEntry = nodeIndex.get(childId)
       if (!childEntry || childEntry.ri <= parentRi) continue
-      const pr = vrow(parent, parentRowCols), cr = vrow(childEntry.node, childEntry.rowCols)
-      const key = `${parentRi}:${pr}:${childEntry.ri}:${cr}`
+      const key = `${parentRi}:${parent.col}:${parentRowCols}:${childEntry.ri}:${childEntry.node.col}:${childEntry.rowCols}`
       const v = lineVariant(parent.id, childId, statusOf, reachableIds)
       const ex = best.get(key)
-      if (!ex || priority[v] > priority[ex.variant]) best.set(key, { variant: v, parentRi, childRi: childEntry.ri, pr, cr })
+      if (!ex || priority[v] > priority[ex.variant]) best.set(key, {
+        variant: v, parentRi, childRi: childEntry.ri,
+        pCol: parent.col, cCol: childEntry.node.col,
+        pRowCols: parentRowCols, cRowCols: childEntry.rowCols,
+      })
     }
   }
 
-  for (const { variant, parentRi, childRi, pr, cr } of best.values()) {
-    const parentCenterX = AVATAR_PADDING + parentRi * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
-    const childCenterX  = AVATAR_PADDING + childRi  * (COL_WIDTH + CONN_W) + COL_WIDTH / 2
+  for (const { variant, parentRi, childRi, pCol, cCol, pRowCols, cRowCols } of best.values()) {
+    const p = nodeCenter(parentRi, pCol, pRowCols, maxRowCols)
+    const c = nodeCenter(childRi, cCol, cRowCols, maxRowCols)
+    const parentCenterX = p.x, childCenterX = c.x
     const xStart = parentCenterX + COL_WIDTH / 2
     const xEnd   = childCenterX  - COL_WIDTH / 2
     const xMid   = (xStart + xEnd) / 2
-    const y1 = (pr + 0.5) / maxRowCols * mapHeight
-    const y2 = (cr + 0.5) / maxRowCols * mapHeight
+    const y1 = p.y
+    const y2 = c.y
     const gfx = new PIXI.Graphics()
     gfx.zIndex = (y1 + y2) / 2
 
@@ -436,14 +458,6 @@ function markerAlpha(status: NodeStatus, inReachable: boolean): number {
   return 0.8
 }
 
-function nodeRoadFill(status: NodeStatus, environment: string | undefined): { color: number; alpha: number } {
-  const { trail, frontier } = envColors(environment)
-  const t = parseRgba(trail), f = parseRgba(frontier)
-  if (status === 'completed' || status === 'pending') return { color: t.color, alpha: Math.min(t.alpha, 0.85) }
-  if (status === 'available')                         return { color: f.color, alpha: Math.min(f.alpha, 0.85) }
-  return { color: 0x2a2a2a, alpha: 0.5 }
-}
-
 async function loadNodeIcon(node: QuestNode): Promise<PIXI.Texture | null> {
   const base = (import.meta as { env: { BASE_URL: string } }).env.BASE_URL
   try {
@@ -457,7 +471,9 @@ async function loadNodeIcon(node: QuestNode): Promise<PIXI.Texture | null> {
   return null
 }
 
-const WANDER_RANGE = 10
+// Kept under half the 32px road width — with no marker pad beneath them,
+// wandering enemy sprites would otherwise stray visibly off the road.
+const WANDER_RANGE = 6
 
 async function buildNodeMarker(
   node: QuestNode, status: NodeStatus, inReachable: boolean,
@@ -465,16 +481,27 @@ async function buildNodeMarker(
 ): Promise<PIXI.Container> {
   const container = new PIXI.Container()
 
-  // bg: two-layer ellipse matching road cross-section (dark outer + coloured inner)
+  // bg: no marker pad — a filled ellipse here was wider than the 32px road it sat
+  // on and read as a hole punched through bright terrain (the sky acts' cloud
+  // floor especially). All that is left is a soft contact shadow to ground the
+  // icon on the road, plus a frontier-coloured ring on nodes you can actually
+  // travel to — the one piece of status the pad's fill used to carry.
   const bg = new PIXI.Graphics()
   const ry = NODE_RADIUS / 2
-  const fill = nodeRoadFill(status, environment)
-  bg.ellipse(0, 0, NODE_RADIUS + 2, ry + 2).fill({ color: 0x000000, alpha: 0.55 })
-  bg.ellipse(0, 0, NODE_RADIUS, ry).fill({ color: fill.color, alpha: fill.alpha })
+  bg.ellipse(0, ry - 2, 14, 5).fill({ color: 0x000000, alpha: 0.28 })
+  bg.ellipse(0, ry - 2, 9, 3).fill({ color: 0x000000, alpha: 0.22 })
+  if (status === 'available' || status === 'pending') {
+    const f = parseRgba(envColors(environment).frontier)
+    bg.ellipse(0, 0, NODE_RADIUS - 4, ry + 2)
+      .stroke({ color: 0x000000, width: 3, alpha: 0.35 })
+    bg.ellipse(0, 0, NODE_RADIUS - 4, ry + 2)
+      .stroke({ color: f.color, width: 1.5, alpha: Math.min(f.alpha, 0.85) })
+  }
   container.addChild(bg)
 
   // iconLayer: icons + labels, dimmed by status independently of the bg
   const iconLayer = new PIXI.Container()
+  iconLayer.label = 'icons'
   container.addChild(iconLayer)
 
   // Battle/elite nodes show the first enemy unit as icon.
@@ -571,30 +598,30 @@ async function buildNodeMarker(
       iconLayer.addChild(sprite)
     } else {
       const t = new PIXI.Text({ text: NODE_ICON[node.type] ?? '?',
-        style: { fontSize: 14, fill: '#ffffff', fontFamily: 'monospace' } })
+        style: mapLabelStyle(16), resolution: 2 })
       t.anchor.set(0.5)
       iconLayer.addChild(t)
     }
   }
 
   const badge = new PIXI.Text({ text: NODE_LABEL[node.type] ?? node.type.toUpperCase(),
-    style: { fontSize: 8, fill: '#999999', fontFamily: 'monospace', fontWeight: 'bold' } })
+    style: { ...mapLabelStyle(9), fontWeight: 'bold' }, resolution: 2 })
   badge.anchor.set(0.5, 1)
   badge.y = -ry - 3
   iconLayer.addChild(badge)
 
   const nameLabel = new PIXI.Text({ text: node.label ?? '',
-    style: { fontSize: 9, fill: '#dddddd', fontFamily: 'monospace' } })
+    style: mapLabelStyle(10), resolution: 2 })
   nameLabel.anchor.set(0.5, 0)
   nameLabel.y = ry + 4
   iconLayer.addChild(nameLabel)
 
   if (status === 'completed' && !isBattleType) {
-    const st = new PIXI.Text({ text: '✓', style: { fontSize: 11, fill: '#44cc44' } })
+    const st = new PIXI.Text({ text: '✓', style: mapLabelStyle(11, '#66ff66'), resolution: 2 })
     st.anchor.set(1, 1); st.position.set(NODE_RADIUS - 1, ry - 1)
     iconLayer.addChild(st)
   } else if (status === 'skipped') {
-    const st = new PIXI.Text({ text: '╳', style: { fontSize: 11, fill: '#884444' } })
+    const st = new PIXI.Text({ text: '╳', style: mapLabelStyle(11, '#ff8888'), resolution: 2 })
     st.anchor.set(1, 1); st.position.set(NODE_RADIUS - 1, ry - 1)
     iconLayer.addChild(st)
   }
@@ -622,8 +649,9 @@ async function buildNodeMarker(
 function updateMarkerStyle(
   marker: PIXI.Container, status: NodeStatus, inReachable: boolean,
 ): void {
-  // iconLayer is child index 1; bg (index 0) stays fully opaque
-  ;(marker.getChildAt(1) as PIXI.Container).alpha = markerAlpha(status, inReachable)
+  // bg (the contact shadow) stays fully opaque; only the icons + labels dim
+  const iconLayer = marker.getChildByLabel('icons')
+  if (iconLayer) iconLayer.alpha = markerAlpha(status, inReachable)
 }
 
 
@@ -760,8 +788,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
         }
 
         const label = new PIXI.Text({ text: node.label,
-          style: { fontSize: 11, fill: '#ffffff', fontFamily: 'monospace',
-            dropShadow: { alpha: 1, blur: 3, distance: 1, color: '#000000' } } })
+          style: mapLabelStyle(11), resolution: 2 })
         label.anchor.set(0.5, 0)
         label.position.set(0, 26)
         container.addChild(label)
@@ -946,7 +973,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
 
     // Connectors
     const { availableIds: aids, reachableIds: rids, hiddenNodeIds: hids } = stateRef.current
-    connGfxListRef.current = drawConnectorsGfx(worldLayer, rows, maxRowCols, mapHeight,
+    connGfxListRef.current = drawConnectorsGfx(worldLayer, rows, maxRowCols,
       id => getNodeStatus(id, aids, run), rids, hids, worldMap.environment)
 
     // Node markers
@@ -1020,7 +1047,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
     const wl = worldRef.current
     if (!wl) return
     for (const g of connGfxListRef.current) { wl.removeChild(g); g.destroy() }
-    connGfxListRef.current = drawConnectorsGfx(wl, rows, maxRowCols, mapHeight,
+    connGfxListRef.current = drawConnectorsGfx(wl, rows, maxRowCols,
       id => getNodeStatus(id, availableIds, run), reachableIds, hiddenNodeIds, worldMap.environment)
     for (const g of connGfxListRef.current) g.visible = showPaths
     for (const [nodeId, marker] of markersRef.current) {

--- a/web/src/components/ui/NodeMap/constants.ts
+++ b/web/src/components/ui/NodeMap/constants.ts
@@ -1,3 +1,17 @@
+import type * as PIXI from 'pixi.js'
+
+// Map text sits on terrain that ranges from near-black (ashen, vault) to the
+// near-white cloud floor of the sky acts, so no flat fill reads on all of them.
+// White with a black outline does: the outline carries the contrast on bright
+// terrain, the fill carries it on dark.
+export function mapLabelStyle(fontSize: number, fill = '#ffffff'): PIXI.TextStyleOptions {
+  return {
+    fontSize, fill, fontFamily: 'monospace',
+    stroke: { color: '#000000', width: 3, join: 'round' },
+    dropShadow: { alpha: 0.9, blur: 2, distance: 1, color: '#000000' },
+  }
+}
+
 export const NODE_ICON: Record<string, string> = {
   battle: '⚔', elite: '★', boss: '☠', rest: '⛺',
   event: '?', merchant: '⚖', memory: '◆',

--- a/web/src/components/ui/NodeMap/nodeLayout.test.ts
+++ b/web/src/components/ui/NodeMap/nodeLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { nodeCenter, snapToTile } from './NodeMapRederer'
+import { nodeCenter, snapToTile } from './nodeLayout'
 import { TILE_SIZE } from '../../../data/tiles/tileIndex'
 
 // Node markers, road tiles and connector beziers are all placed off nodeCenter.

--- a/web/src/components/ui/NodeMap/nodeLayout.test.ts
+++ b/web/src/components/ui/NodeMap/nodeLayout.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { nodeCenter, snapToTile } from './NodeMapRederer'
+import { TILE_SIZE } from '../../../data/tiles/tileIndex'
+
+// Node markers, road tiles and connector beziers are all placed off nodeCenter.
+// Road tiles are laid at floor(y / TILE_SIZE), so a node centre that is not on a
+// tile centre renders up to half a tile away from its own path — which is what
+// used to happen to every row whose rowCols parity differed from maxRowCols.
+const onTileCentre = (v: number) => ((v % TILE_SIZE) + TILE_SIZE) % TILE_SIZE === TILE_SIZE / 2
+
+describe('snapToTile', () => {
+  it('maps any point to the centre of the tile containing it', () => {
+    expect(snapToTile(0)).toBe(16)
+    expect(snapToTile(16)).toBe(16)
+    expect(snapToTile(31)).toBe(16)
+    expect(snapToTile(32)).toBe(48)
+    expect(snapToTile(96)).toBe(112)
+  })
+})
+
+describe('nodeCenter', () => {
+  it('lands on a tile centre for rows matching maxRowCols parity', () => {
+    for (const col of [0, 1, 2, 3]) {
+      const { x, y } = nodeCenter(2, col, 4, 4)
+      expect(onTileCentre(x)).toBe(true)
+      expect(onTileCentre(y)).toBe(true)
+    }
+  })
+
+  // The regression: rowCols 3 inside maxRowCols 4 offsets the row by half a
+  // cell, which used to put node centres on a tile boundary 16px off the road.
+  it('lands on a tile centre for parity-mismatched rows', () => {
+    for (const col of [0, 1, 2]) {
+      const { x, y } = nodeCenter(1, col, 3, 4)
+      expect(onTileCentre(x)).toBe(true)
+      expect(onTileCentre(y)).toBe(true)
+    }
+  })
+
+  it('covers every row shape the shipped acts use', () => {
+    for (let maxRowCols = 1; maxRowCols <= 6; maxRowCols++) {
+      for (let rowCols = 1; rowCols <= maxRowCols; rowCols++) {
+        for (let col = 0; col < rowCols; col++) {
+          for (const ri of [0, 1, 5]) {
+            const { x, y } = nodeCenter(ri, col, rowCols, maxRowCols)
+            expect(onTileCentre(x)).toBe(true)
+            expect(onTileCentre(y)).toBe(true)
+          }
+        }
+      }
+    }
+  })
+
+  it('keeps distinct columns on distinct tiles', () => {
+    const a = nodeCenter(0, 0, 4, 4).y
+    const b = nodeCenter(0, 1, 4, 4).y
+    expect(a).not.toBe(b)
+  })
+})

--- a/web/src/components/ui/NodeMap/nodeLayout.ts
+++ b/web/src/components/ui/NodeMap/nodeLayout.ts
@@ -1,0 +1,36 @@
+// Pure grid-layout geometry for the campaign node map. Deliberately free of
+// PixiJS (and of NodeMapRederer.tsx, which imports it) so it stays importable
+// from plain node-environment tests.
+import { TILE_SIZE } from '../../../data/tiles/tileIndex'
+
+export const COL_WIDTH      = 128
+export const ROW_HEIGHT     = 96
+export const AVATAR_PADDING = 80
+export const CONN_W         = 32
+
+// Everything the map draws on the ground — roads, node markers, the avatar — is
+// snapped to the centre of a 32px tile. Without this a row whose rowCols parity
+// differs from maxRowCols gets a half-row offset, landing the node centre on a
+// tile *boundary* while the road tiles under it are laid at floor(y / TILE_SIZE)
+// — a visible 16px gap between the node and its own path. Flooring (rather than
+// rounding) picks the same tile the road already occupies, so the roads stay put
+// and the nodes move onto them.
+export function snapToTile(v: number): number {
+  return Math.floor(v / TILE_SIZE) * TILE_SIZE + TILE_SIZE / 2
+}
+
+// The single source of truth for where a grid-mode node sits. Node markers, road
+// tiles and connector beziers all read from this, so they cannot drift apart.
+export function nodeCenter(
+  rowIndex: number, col: number, rowCols: number, maxRowCols: number,
+): { x: number; y: number } {
+  const vrow = (maxRowCols - rowCols) / 2 + col
+  return {
+    x: snapToTile(AVATAR_PADDING + rowIndex * (COL_WIDTH + CONN_W) + COL_WIDTH / 2),
+    y: snapToTile((vrow + 0.5) * ROW_HEIGHT),
+  }
+}
+
+export function startPos(mapHeight: number): { x: number; y: number } {
+  return { x: AVATAR_PADDING / 2, y: snapToTile(mapHeight / 2) }
+}


### PR DESCRIPTION
Act VI's sky environment renders a near-white cloud floor, which exposed three problems with the campaign node markers. None of them are Act 6 specific — the markers were styled for the dark environments the earlier acts used, and Act 6 is just where they stop being survivable.

## Labels had no outline

The type badge was `fontSize 8, fill '#999999'` and the node name `fontSize 9, fill '#dddddd'` — flat light-grey fills with no stroke and no shadow, invisible against light ground.

Both now use a shared `mapLabelStyle()` in `NodeMap/constants.ts`: white with a black outline plus drop shadow, which reads on a cloud floor and an ashen waste alike. The `✓`/`╳` status marks and the fallback glyph icon use it too, and the freeform world map's label switches to it so there is one definition rather than two. Text objects render at `resolution: 2` so a 3px outline on 9-10px type stays crisp.

## Node markers sat half a tile off their own road

`nodePosition()` placed a node at `((maxRowCols - rowCols) / 2 + col + 0.5) * ROW_HEIGHT`. When `maxRowCols - rowCols` is odd, that half-row offset lands the node centre exactly on a 32px tile *boundary*, while `buildPathTileGfx` lays its road tiles at `floor(y / TILE_SIZE)` — 16px lower. **Every act in the game has affected rows** (act6 rows 0/1/6; act10 has 12 of them; act8 has 7).

Three places computed a node's pixel centre independently and could disagree. They now all read from one `nodeCenter()` that snaps to the tile centre, so they cannot drift apart. Flooring rather than rounding picks the tile the road already occupies, so **the roads stay exactly where they are and the nodes move onto them** — no reshuffling of existing map art, and no changes to any act JSON.

## The marker pad fought the road

The two-layer ellipse was `rx 22 / ry 11` — 44px wide on a 32px road, bulging past both edges while leaving the road showing above and below. For locked/future nodes (most of the map) the fill was `0x2a2a2a @ 0.5`, which on bright terrain reads as a hole punched through the ground.

The pad is gone. In its place a soft contact shadow grounds the icon, and a frontier-coloured ring marks nodes you can actually travel to — the one piece of status the pad's fill used to carry. `WANDER_RANGE` drops from 10 to 6 so enemy sprites stay on the 32px road now that nothing sits under them.

## Verification

- New `nodeLayout.test.ts` asserts node centres land on tile centres across every row shape the shipped acts use, including the parity-mismatched case that regressed.
- `npm run build` (typecheck) clean; `npm run test` — 2050 tests pass.
- Storybook + Playwright screenshots of a new `SkyBrightTerrain` story (real act6 data, the worst case for contrast) plus the existing forest story and a spot-check against ashen: labels legible on all three, nodes centred on their roads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvMFZuUDw4srQ4WJaw4A2x)_