### PR TITLE
Walk the avatar along the roads instead of straight to the node

### DIFF
--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -15,7 +15,7 @@ import { NodeMapHpBar } from '../../campaign/NodeMapHpBar'
 import { ToolbarSpacer } from '../../ui/Toolbar/ToolbarSpacer'
 import { ToolbarLabel } from '../../ui/Toolbar/ToolbarLabel'
 import { usePixiApp } from '../../../hooks/usePixiApp'
-import { loadSpriteTexture, loadAnimFrames, loadTextureUrl, loadTileTexture, makeClickable, tweenTo } from '../../../utils/pixiHelpers'
+import { loadSpriteTexture, loadAnimFrames, loadTextureUrl, loadTileTexture, makeClickable, tweenAlongPath } from '../../../utils/pixiHelpers'
 import { ENV_TILES, TILE_SIZE, type EnvTileDef } from '../../../data/tiles/tileIndex'
 import { WORLD_ENV_TILES, WORLD_DECOR_FILE } from '../../../data/tiles/worldTileIndex'
 import { GIFT_OWNER_UID } from '../../../game/gifts'
@@ -23,7 +23,9 @@ import { hashStr, envColors, parseRgba, sampleBezier, bezierBand } from '../../.
 import { renderPathTiles } from '../../../utils/tileLookup'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx, buildBorderGfx } from '../../../utils/terrainLayer'
 import { NODE_ICON, NODE_LABEL, mapLabelStyle } from '../../ui/NodeMap/constants'
-import { COL_WIDTH, ROW_HEIGHT, AVATAR_PADDING, CONN_W, nodeCenter, startPos } from '../../ui/NodeMap/nodeLayout'
+import { COL_WIDTH, ROW_HEIGHT, AVATAR_PADDING, CONN_W, nodeCenter, startPos,
+  elbowCorners, edgeCorners, cornerPolyline, fillCornerPath, worldWalkRoute,
+  type PixelPoint } from '../../ui/NodeMap/nodeLayout'
 import { getCurrentWorldLocation } from '../../../game/world/worldState'
 import { NodePeekModal } from '../../ui/NodeMap/NodePeekModal'
 
@@ -44,6 +46,11 @@ interface Props {
 
 const AVATAR_SIZE    = 36
 const WALK_DURATION  = 700
+// Pace calibrated so a straight hop between adjacent grid columns still takes
+// WALK_DURATION; longer routes take proportionally longer rather than sprinting.
+const WALK_SPEED     = (COL_WIDTH + CONN_W) / WALK_DURATION
+const WALK_MIN_MS    = 400
+const WALK_MAX_MS    = 2400
 const NODE_RADIUS    = 22
 
 // ── Game logic helpers ────────────────────────────────────────────────────────
@@ -69,42 +76,11 @@ export function getWorldNodeStatus(node: QuestNode, clearedNodeIds: Set<string>,
   return cleared ? 'available' : 'locked'
 }
 
-interface PixelPoint { x: number; y: number }
-interface TileCorner { tx: number; ty: number }
-
-// The single-bend elbow between two points: horizontal at a's row, vertical
-// at the midpoint column, horizontal at b's row — as 4 corner tile coords.
-function elbowCorners(a: PixelPoint, b: PixelPoint, T: number): TileCorner[] {
-  const aTx = Math.floor(a.x / T), aTy = Math.floor(a.y / T)
-  const bTx = Math.floor(b.x / T), bTy = Math.floor(b.y / T)
-  const midTx = Math.floor((a.x + b.x) / 2 / T)
-  return [{ tx: aTx, ty: aTy }, { tx: midTx, ty: aTy }, { tx: midTx, ty: bTy }, { tx: bTx, ty: bTy }]
-}
-
-// Full corner-tile list for an edge, optionally steered through hand-authored
-// waypoints (see QuestNode.connectionWaypoints). With no waypoints this is
-// exactly elbowCorners(node, target, T) — a single bend, unchanged from before.
-function edgeCorners(node: PixelPoint, target: PixelPoint, waypoints: PixelPoint[] | undefined, T: number): TileCorner[] {
-  const pts = [node, ...(waypoints ?? []), target]
-  const corners: TileCorner[] = []
-  for (let i = 0; i < pts.length - 1; i++) {
-    const seg = elbowCorners(pts[i], pts[i + 1], T)
-    corners.push(...(i === 0 ? seg : seg.slice(1))) // dedupe the shared join corner
-  }
-  return corners
-}
-
-// Fills every tile along a corner-to-corner path, where each consecutive
-// pair shares either a row (ty) or a column (tx) — guaranteed by elbowCorners.
-function fillCornerPath(pathSet: Set<string>, key: (tx: number, ty: number) => string, corners: TileCorner[]): void {
-  for (let i = 0; i < corners.length - 1; i++) {
-    const a = corners[i], b = corners[i + 1]
-    if (a.ty === b.ty) {
-      for (let tx = Math.min(a.tx, b.tx); tx <= Math.max(a.tx, b.tx); tx++) pathSet.add(key(tx, a.ty))
-    } else {
-      for (let ty = Math.min(a.ty, b.ty); ty <= Math.max(a.ty, b.ty); ty++) pathSet.add(key(a.tx, ty))
-    }
-  }
+function routeDuration(route: PixelPoint[]): number {
+  let len = 0
+  for (let i = 1; i < route.length; i++)
+    len += Math.hypot(route[i].x - route[i - 1].x, route[i].y - route[i - 1].y)
+  return Math.min(Math.max(len / WALK_SPEED, WALK_MIN_MS), WALK_MAX_MS)
 }
 
 async function buildWorldPathTiles(
@@ -663,6 +639,10 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
   const avatarRef    = useRef<PIXI.AnimatedSprite | null>(null)
   const isWalkingRef = useRef(false)
   const peekNodeRef  = useRef<QuestNode | null>(null)
+  // Where the avatar actually stands on the world map. Tracked separately from
+  // getCurrentWorldLocation(), which only advances once travel is confirmed —
+  // peeking a town and backing out still leaves the avatar standing there.
+  const avatarNodeIdRef = useRef<string>(getCurrentWorldLocation())
   const deadRef      = useRef(false)
 
   // Always-current state for use inside async PixiJS callbacks
@@ -818,22 +798,13 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
             // road tiles along (including any hand-authored connectionWaypoints),
             // so the reveal swath fully covers the actual bent road art instead
             // of a straight line — and can never drift out of sync with it,
-            // since both come from the same edgeCorners() call. Interior bends
-            // snap to their tile center (matching the drawn tile); the two
-            // endpoints stay at the real node/target pixel position so halos
-            // still center correctly.
-            const corners = edgeCorners(
-              { x: nodeX, y: nodeY }, { x: targetX, y: targetY },
-              node.connectionWaypoints?.[connId], TILE_SIZE,
+            // since both come from the same edgeCorners() call.
+            const from = { x: nodeX, y: nodeY }, to = { x: targetX, y: targetY }
+            const pts = cornerPolyline(
+              edgeCorners(from, to, node.connectionWaypoints?.[connId], TILE_SIZE), from, to,
             )
             const path = new Path2D()
-            corners.forEach((c, i) => {
-              const last = corners.length - 1
-              const px = i === 0 ? nodeX : i === last ? targetX : c.tx * TILE_SIZE + TILE_SIZE / 2
-              const py = i === 0 ? nodeY : i === last ? targetY : c.ty * TILE_SIZE + TILE_SIZE / 2
-              if (i === 0) path.moveTo(px, py)
-              else path.lineTo(px, py)
-            })
+            pts.forEach((p, i) => (i === 0 ? path.moveTo(p.x, p.y) : path.lineTo(p.x, p.y)))
             fogCtx.strokeStyle = 'rgba(0,0,0,1)'
             fogCtx.globalAlpha = 0.45
             fogCtx.lineWidth = 130
@@ -1055,32 +1026,40 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
     mapEl.scrollTop  = node.y - mapEl.clientHeight / 2
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  function handleWalk(node: QuestNode, pos: { x: number; y: number }) {
+  // Walks the avatar along `route` at a steady pace instead of teleporting it in
+  // a straight line, then opens the node's peek modal.
+  function walkRoute(node: QuestNode, route: PixelPoint[]) {
     const app    = appRef.current
     const avatar = avatarRef.current
-    if (!app || !avatar || isWalkingRef.current) return
+    if (!app || !avatar || isWalkingRef.current || route.length < 2) return
     isWalkingRef.current = true
     avatar.play()
     emitSound('mapFootstep')
-    tweenTo(avatar, pos.x, pos.y, WALK_DURATION, app).then(() => {
+    tweenAlongPath(avatar, route, routeDuration(route), app).then(() => {
       avatar.stop()
       isWalkingRef.current = false
       setPeekNode(node)
     })
   }
 
-  function handleWalkFreeform(node: QuestNode) {
-    const app    = appRef.current
+  function handleWalk(node: QuestNode, pos: { x: number; y: number }) {
     const avatar = avatarRef.current
-    if (!app || !avatar || isWalkingRef.current || node.x === undefined) return
-    isWalkingRef.current = true
-    avatar.play()
-    emitSound('mapFootstep')
-    tweenTo(avatar, node.x, node.y!, WALK_DURATION, app).then(() => {
-      avatar.stop()
-      isWalkingRef.current = false
-      setPeekNode(node)
-    })
+    if (!avatar) return
+    // The road tiles between two grid nodes are laid along elbowCorners() of the
+    // same two points, so walking that elbow puts the avatar on the drawn road.
+    const from = { x: avatar.x, y: avatar.y }
+    walkRoute(node, cornerPolyline(elbowCorners(from, pos, TILE_SIZE), from, pos))
+  }
+
+  function handleWalkFreeform(node: QuestNode) {
+    const avatar = avatarRef.current
+    if (!avatar || node.x === undefined || node.y === undefined) return
+    // Travel is not restricted to adjacent towns, so the route is stitched from
+    // the roads through every town in between — otherwise a hop to a distant
+    // town would still cut straight across the map.
+    const from = { x: avatar.x, y: avatar.y }
+    walkRoute(node, worldWalkRoute(worldMap.nodes, avatarNodeIdRef.current, node.id, from))
+    avatarNodeIdRef.current = node.id
   }
 
   return (

--- a/web/src/components/ui/NodeMap/nodeLayout.test.ts
+++ b/web/src/components/ui/NodeMap/nodeLayout.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { nodeCenter, snapToTile } from './nodeLayout'
+import { nodeCenter, snapToTile, elbowCorners, edgeCorners, cornerPolyline,
+  fillCornerPath, worldWalkRoute, type PixelPoint } from './nodeLayout'
+import type { QuestNode } from '../../../game/questline'
 import { TILE_SIZE } from '../../../data/tiles/tileIndex'
 
 // Node markers, road tiles and connector beziers are all placed off nodeCenter.
@@ -55,5 +57,114 @@ describe('nodeCenter', () => {
     const a = nodeCenter(0, 0, 4, 4).y
     const b = nodeCenter(0, 1, 4, 4).y
     expect(a).not.toBe(b)
+  })
+})
+
+// ── Walk routing ──────────────────────────────────────────────────────────────
+// The avatar used to tween straight to the target node, cutting across terrain.
+// It now follows the road, which only holds if its route stays on tiles the
+// road renderer actually laid — that is what these assert.
+
+const tileKey = (x: number, y: number) =>
+  `${Math.floor(x / TILE_SIZE)},${Math.floor(y / TILE_SIZE)}`
+
+// Every tile the road renderer would lay for a single edge.
+function roadTilesFor(a: PixelPoint, b: PixelPoint, waypoints?: PixelPoint[]): Set<string> {
+  const tiles = new Set<string>()
+  fillCornerPath(tiles, (tx, ty) => `${tx},${ty}`, edgeCorners(a, b, waypoints, TILE_SIZE))
+  return tiles
+}
+
+// Walking a polyline only stays on the road if the tiles it passes through are
+// road tiles — sampling densely catches a leg that cuts a corner between them.
+function sampledTiles(route: PixelPoint[]): string[] {
+  const out: string[] = []
+  for (let i = 1; i < route.length; i++) {
+    const a = route[i - 1], b = route[i]
+    const steps = Math.max(1, Math.ceil(Math.hypot(b.x - a.x, b.y - a.y)))
+    for (let s = 0; s <= steps; s++)
+      out.push(tileKey(a.x + (b.x - a.x) * (s / steps), a.y + (b.y - a.y) * (s / steps)))
+  }
+  return out
+}
+
+describe('grid walk route', () => {
+  it('bends through the elbow rather than going straight to the node', () => {
+    const from = nodeCenter(0, 0, 4, 4)
+    const to   = nodeCenter(1, 3, 4, 4)
+    const route = cornerPolyline(elbowCorners(from, to, TILE_SIZE), from, to)
+
+    expect(route.length).toBeGreaterThan(2)          // not a single straight leg
+    expect(route[0]).toEqual(from)
+    expect(route[route.length - 1]).toEqual(to)
+    // The turn happens at the midpoint column, holding each node's row first.
+    expect(route[1].y).toBe(from.y)
+    expect(route[route.length - 2].y).toBe(to.y)
+  })
+
+  it('stays on road tiles the whole way', () => {
+    const road = roadTilesFor(nodeCenter(0, 0, 4, 4), nodeCenter(1, 3, 4, 4))
+    const from = nodeCenter(0, 0, 4, 4), to = nodeCenter(1, 3, 4, 4)
+    const route = cornerPolyline(elbowCorners(from, to, TILE_SIZE), from, to)
+    for (const tile of sampledTiles(route)) expect(road.has(tile)).toBe(true)
+  })
+
+  it('stays on road tiles for every row-to-row pairing', () => {
+    for (let fromCol = 0; fromCol < 4; fromCol++) {
+      for (let toCol = 0; toCol < 3; toCol++) {
+        const from = nodeCenter(0, fromCol, 4, 4)
+        const to   = nodeCenter(1, toCol, 3, 4)   // parity-mismatched target row
+        const road = roadTilesFor(from, to)
+        const route = cornerPolyline(elbowCorners(from, to, TILE_SIZE), from, to)
+        for (const tile of sampledTiles(route)) expect(road.has(tile)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('world walk route', () => {
+  const nodes: Record<string, QuestNode> = {
+    a: { id: 'a', x: 100, y: 100, connections: ['b'] } as QuestNode,
+    b: { id: 'b', x: 400, y: 300, connections: ['c'] } as QuestNode,
+    c: { id: 'c', x: 700, y: 100 } as QuestNode,
+  }
+
+  it('routes through intermediate towns instead of cutting across country', () => {
+    const from = { x: 100, y: 100 }
+    const route = worldWalkRoute(nodes, 'a', 'c', from)
+    // It must actually pass through b rather than heading straight for c.
+    expect(route.some(p => p.x === 400 && p.y === 300)).toBe(true)
+    expect(route[route.length - 1]).toEqual({ x: 700, y: 100 })
+  })
+
+  it('stays on the roads drawn for each leg it crosses', () => {
+    const road = new Set([
+      ...roadTilesFor({ x: 100, y: 100 }, { x: 400, y: 300 }),
+      ...roadTilesFor({ x: 400, y: 300 }, { x: 700, y: 100 }),
+    ])
+    for (const tile of sampledTiles(worldWalkRoute(nodes, 'a', 'c', { x: 100, y: 100 })))
+      expect(road.has(tile)).toBe(true)
+  })
+
+  it('follows an edge in reverse using the waypoints authored on the far end', () => {
+    const wp = [{ x: 250, y: 100 }]
+    const withWp: Record<string, QuestNode> = {
+      ...nodes,
+      b: { ...nodes.b, connectionWaypoints: { a: wp } } as QuestNode,
+    }
+    // Authored a→b as b's waypoints; walking a→b must reverse them, and the
+    // route must sit on the road drawn for that same bend.
+    const road = roadTilesFor({ x: 100, y: 100 }, { x: 400, y: 300 }, [...wp].reverse())
+    for (const tile of sampledTiles(worldWalkRoute(withWp, 'a', 'b', { x: 100, y: 100 })))
+      expect(road.has(tile)).toBe(true)
+  })
+
+  it('falls back to a direct elbow when two towns are not connected', () => {
+    const isolated: Record<string, QuestNode> = {
+      a: { id: 'a', x: 100, y: 100 } as QuestNode,
+      z: { id: 'z', x: 600, y: 400 } as QuestNode,
+    }
+    const route = worldWalkRoute(isolated, 'a', 'z', { x: 100, y: 100 })
+    expect(route[route.length - 1]).toEqual({ x: 600, y: 400 })
   })
 })

--- a/web/src/components/ui/NodeMap/nodeLayout.ts
+++ b/web/src/components/ui/NodeMap/nodeLayout.ts
@@ -2,6 +2,10 @@
 // PixiJS (and of NodeMapRederer.tsx, which imports it) so it stays importable
 // from plain node-environment tests.
 import { TILE_SIZE } from '../../../data/tiles/tileIndex'
+import type { QuestNode } from '../../../game/questline'
+
+export interface PixelPoint { x: number; y: number }
+export interface TileCorner { tx: number; ty: number }
 
 export const COL_WIDTH      = 128
 export const ROW_HEIGHT     = 96
@@ -33,4 +37,136 @@ export function nodeCenter(
 
 export function startPos(mapHeight: number): { x: number; y: number } {
   return { x: AVATAR_PADDING / 2, y: snapToTile(mapHeight / 2) }
+}
+
+// ── Road geometry ─────────────────────────────────────────────────────────────
+// Roads are laid as axis-aligned runs of tiles between "corners". Everything
+// that needs to know where a road physically goes — the tile renderer, the fog
+// reveal, and the avatar's walk route — derives it from these, so none of them
+// can drift out of sync with the art.
+
+// The single-bend elbow between two points: horizontal at a's row, vertical
+// at the midpoint column, horizontal at b's row — as 4 corner tile coords.
+export function elbowCorners(a: PixelPoint, b: PixelPoint, T: number): TileCorner[] {
+  const aTx = Math.floor(a.x / T), aTy = Math.floor(a.y / T)
+  const bTx = Math.floor(b.x / T), bTy = Math.floor(b.y / T)
+  const midTx = Math.floor((a.x + b.x) / 2 / T)
+  return [{ tx: aTx, ty: aTy }, { tx: midTx, ty: aTy }, { tx: midTx, ty: bTy }, { tx: bTx, ty: bTy }]
+}
+
+// Full corner-tile list for an edge, optionally steered through hand-authored
+// waypoints (see QuestNode.connectionWaypoints). With no waypoints this is
+// exactly elbowCorners(node, target, T) — a single bend.
+export function edgeCorners(
+  node: PixelPoint, target: PixelPoint, waypoints: PixelPoint[] | undefined, T: number,
+): TileCorner[] {
+  const pts = [node, ...(waypoints ?? []), target]
+  const corners: TileCorner[] = []
+  for (let i = 0; i < pts.length - 1; i++) {
+    const seg = elbowCorners(pts[i], pts[i + 1], T)
+    corners.push(...(i === 0 ? seg : seg.slice(1))) // dedupe the shared join corner
+  }
+  return corners
+}
+
+// Corner tiles → a pixel polyline tracing the road they describe. Interior
+// bends snap to their tile center (matching the drawn tile); the two endpoints
+// stay at their real pixel position so the line starts and ends dead on the
+// node. Sharing this with the walk routes means the avatar physically follows
+// the road art rather than an independently-derived approximation of it.
+export function cornerPolyline(corners: TileCorner[], from: PixelPoint, to: PixelPoint): PixelPoint[] {
+  const last = corners.length - 1
+  return corners.map((c, i) => ({
+    x: i === 0 ? from.x : i === last ? to.x : c.tx * TILE_SIZE + TILE_SIZE / 2,
+    y: i === 0 ? from.y : i === last ? to.y : c.ty * TILE_SIZE + TILE_SIZE / 2,
+  }))
+}
+
+// Fills every tile along a corner-to-corner path, where each consecutive
+// pair shares either a row (ty) or a column (tx) — guaranteed by elbowCorners.
+export function fillCornerPath(
+  pathSet: Set<string>, key: (tx: number, ty: number) => string, corners: TileCorner[],
+): void {
+  for (let i = 0; i < corners.length - 1; i++) {
+    const a = corners[i], b = corners[i + 1]
+    if (a.ty === b.ty) {
+      for (let tx = Math.min(a.tx, b.tx); tx <= Math.max(a.tx, b.tx); tx++) pathSet.add(key(tx, a.ty))
+    } else {
+      for (let ty = Math.min(a.ty, b.ty); ty <= Math.max(a.ty, b.ty); ty++) pathSet.add(key(a.tx, ty))
+    }
+  }
+}
+
+// ── Travel routing ────────────────────────────────────────────────────────────
+
+// Undirected adjacency over node connections — the data lists an edge on one
+// endpoint only, but roads are drawn (and walked) in both directions.
+function buildAdjacency(nodes: Record<string, QuestNode>): Map<string, Set<string>> {
+  const adj = new Map<string, Set<string>>()
+  const link = (a: string, b: string) => {
+    if (!adj.has(a)) adj.set(a, new Set())
+    adj.get(a)!.add(b)
+  }
+  for (const node of Object.values(nodes)) {
+    for (const connId of (node.connections ?? node.childIds ?? [])) {
+      if (!nodes[connId]) continue
+      link(node.id, connId)
+      link(connId, node.id)
+    }
+  }
+  return adj
+}
+
+// Shortest chain of connected nodes between two ids, so world-map travel walks
+// the roads through the towns in between instead of cutting across country.
+// Returns null when the two are not connected at all.
+export function connectionRoute(
+  nodes: Record<string, QuestNode>, fromId: string, toId: string,
+): QuestNode[] | null {
+  if (fromId === toId || !nodes[fromId] || !nodes[toId]) return null
+  const adj = buildAdjacency(nodes)
+  const prev = new Map<string, string>()
+  const seen = new Set([fromId])
+  const queue = [fromId]
+  while (queue.length) {
+    const id = queue.shift()!
+    if (id === toId) break
+    for (const next of adj.get(id) ?? []) {
+      if (seen.has(next)) continue
+      seen.add(next)
+      prev.set(next, id)
+      queue.push(next)
+    }
+  }
+  if (!seen.has(toId)) return null
+  const chain: QuestNode[] = []
+  for (let id: string | undefined = toId; id !== undefined; id = prev.get(id)) chain.unshift(nodes[id])
+  return chain
+}
+
+// Waypoints are authored on one endpoint of an edge; walking the other way
+// needs them in reverse.
+export function edgeWaypoints(a: QuestNode, b: QuestNode): PixelPoint[] | undefined {
+  return a.connectionWaypoints?.[b.id] ?? b.connectionWaypoints?.[a.id]?.slice().reverse()
+}
+
+// The full pixel route the avatar walks from `from` to node `toId`, following
+// the drawn roads through every town in between.
+export function worldWalkRoute(
+  nodes: Record<string, QuestNode>, fromId: string, toId: string, from: PixelPoint,
+): PixelPoint[] {
+  const target = nodes[toId]
+  const to = { x: target.x!, y: target.y! }
+  const chain = connectionRoute(nodes, fromId, toId)
+  if (!chain) return cornerPolyline(edgeCorners(from, to, undefined, TILE_SIZE), from, to)
+
+  const route: PixelPoint[] = []
+  for (let i = 0; i < chain.length - 1; i++) {
+    const a = chain[i], b = chain[i + 1]
+    const ap = i === 0 ? from : { x: a.x!, y: a.y! }
+    const bp = { x: b.x!, y: b.y! }
+    const leg = cornerPolyline(edgeCorners(ap, bp, edgeWaypoints(a, b), TILE_SIZE), ap, bp)
+    route.push(...(i === 0 ? leg : leg.slice(1))) // dedupe the shared join point
+  }
+  return route
 }

--- a/web/src/utils/pixiHelpers.ts
+++ b/web/src/utils/pixiHelpers.ts
@@ -195,3 +195,47 @@ export function tweenTo(
     app.ticker.add(tick)
   })
 }
+
+/**
+ * Tween a Container along a polyline, easing the journey as a whole rather than
+ * each leg — chaining tweenTo() calls instead would decelerate into every bend
+ * and accelerate out of it. Distance is distributed by segment length, so the
+ * object holds a steady pace around corners. Resolves when the walk completes.
+ */
+export function tweenAlongPath(
+  obj: PIXI.Container,
+  points: Array<{ x: number; y: number }>,
+  durationMs: number,
+  app: PIXI.Application,
+): Promise<void> {
+  if (points.length < 2) return Promise.resolve()
+
+  const segLen: number[] = []
+  let total = 0
+  for (let i = 1; i < points.length; i++) {
+    const d = Math.hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y)
+    segLen.push(d)
+    total += d
+  }
+  if (total === 0) return Promise.resolve()
+
+  return new Promise(resolve => {
+    let elapsed = 0
+    const tick = (ticker: PIXI.Ticker) => {
+      elapsed += ticker.deltaMS
+      const t = Math.min(elapsed / durationMs, 1)
+      const e = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t
+
+      let d = e * total
+      let i = 0
+      while (i < segLen.length - 1 && d > segLen[i]) { d -= segLen[i]; i++ }
+      const a = points[i], b = points[i + 1]
+      const f = segLen[i] === 0 ? 0 : d / segLen[i]
+      obj.x = a.x + (b.x - a.x) * f
+      obj.y = a.y + (b.y - a.y) * f
+
+      if (t >= 1) { app.ticker.remove(tick); resolve() }
+    }
+    app.ticker.add(tick)
+  })
+}


### PR DESCRIPTION
Tapping a node tweened the avatar directly from where it stood to the target, so it cut across terrain instead of following the path drawn between the two. It's most obvious on the campaign maps, where the road bends through an elbow the player could watch it ignore.

## Routes come from the road's own geometry

Rather than deriving a route independently (which could drift from the art), the walk reuses the corner lists the road tiles are laid along:

- **Grid maps:** `elbowCorners()` of the two node centres — exactly what `buildPathTileGfx()` fills — so the avatar is provably on the drawn road.
- **World map:** travel isn't restricted to adjacent towns, so it BFSes the connection graph and stitches each leg's road together. A hop to a distant town now walks *through* the towns in between instead of flying over the map. Hand-authored `connectionWaypoints` are honoured in both directions (they're stored on one endpoint, so walking the other way reverses them).

The fog-of-war reveal already built a pixel polyline from those same corners; that logic is now the shared `cornerPolyline()` rather than a second copy.

## Motion

Adds `tweenAlongPath()`, which eases the journey as a whole and distributes distance by segment length. Chaining `tweenTo()` calls instead would have decelerated into every bend and accelerated out of it. Walk time scales with route length so pace stays constant, clamped so long world routes stay watchable.

## Testing

The pure road geometry moves into `nodeLayout.ts` next to the grid layout helpers. That keeps it out of the PixiJS import graph — the constraint that broke CI on the last PR — and lets the tests assert what actually matters: a **densely sampled** walk route only ever touches tiles the road renderer laid. Sampling per-pixel rather than per-vertex is the point; it catches a leg that cuts a corner between two on-road waypoints.

Coverage: the grid elbow holds each node's row before turning; routes stay on road tiles across every row-to-row pairing including parity-mismatched rows; world routes pass through intermediate towns; reversed waypoints stay on the drawn bend; disconnected towns fall back to a direct elbow.

Writing these caught a real bug — `buildAdjacency()` assumed every node carries `connections` or `childIds`, and threw on one that had neither.

## Verification

- `npm run build` (typecheck) clean; `npm run test` — 2057 tests pass.
- Frame-by-frame Playwright capture of an actual walk in Storybook: the avatar moves horizontally along its starting row first, then down the mid column, then across to the target — a straight-line tween would have descended diagonally from the first frame.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvMFZuUDw4srQ4WJaw4A2x)_