### PR TITLE
Retry town-access fetch and report it by player impact

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -693,7 +693,12 @@ export default function App() {
   // Admin-controlled hub-world town access — locked until fetched/enabled.
   const [enabledTownIds, setEnabledTownIds] = useState<Set<string>>(new Set())
   useEffect(() => {
-    fetchEnabledTownIds().then(ids => setEnabledTownIds(new Set(ids)))
+    // Re-fetch when connectivity returns: a player whose first attempt failed
+    // would otherwise stay locked out of every toggleable town until reload.
+    const load = () => { fetchEnabledTownIds().then(ids => setEnabledTownIds(new Set(ids))) }
+    load()
+    window.addEventListener('online', load)
+    return () => window.removeEventListener('online', load)
   }, [])
   // "Preview as player" lets the admin see the fogged map as a regular
   // player would, by suppressing their own town-access bypass.

--- a/web/src/game/townAccess.test.ts
+++ b/web/src/game/townAccess.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// townAccess.ts imports the firebase singleton at module load; stub it so node
+// tests don't initialise a real app.
+vi.mock('../firebase', () => ({ auth: {}, db: {} }))
+
+const getDoc = vi.fn()
+vi.mock('firebase/firestore', () => ({
+  doc:    () => ({}),
+  getDoc: (...args: unknown[]) => getDoc(...args),
+  setDoc: vi.fn(),
+}))
+
+const logError = vi.fn()
+const logWarn  = vi.fn()
+vi.mock('../logger', () => ({
+  logError: (...args: unknown[]) => logError(...args),
+  logWarn:  (...args: unknown[]) => logWarn(...args),
+}))
+
+// Minimal localStorage for the node test environment. Re-applied in beforeEach
+// because afterEach clears the navigator stub with it.
+const storage = new Map<string, string>()
+const stubLocalStorage = () => vi.stubGlobal('localStorage', {
+  getItem:    (k: string) => storage.get(k) ?? null,
+  setItem:    (k: string, v: string) => { storage.set(k, String(v)) },
+  removeItem: (k: string) => { storage.delete(k) },
+  clear:      () => { storage.clear() },
+})
+
+import {
+  fetchEnabledTownIds, isTownAccessible, ALWAYS_OPEN_LOCATION_IDS,
+} from './townAccess'
+
+const CACHE_KEY = 'jarv_town_access_cache'
+
+const snapshot = (enabled?: string[]) => ({
+  exists: () => enabled !== undefined,
+  data:   () => ({ enabled }),
+})
+
+const setOnline = (online: boolean) => vi.stubGlobal('navigator', { onLine: online })
+
+/**
+ * Runs the fetch with the retry backoff collapsed. Timers must advance while
+ * the promise is mid-flight, so drain the microtask queue between ticks.
+ */
+async function fetchWithFakeTimers(): Promise<string[]> {
+  vi.useFakeTimers()
+  try {
+    const pending = fetchEnabledTownIds()
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(2000)
+    }
+    return await pending
+  } finally {
+    vi.useRealTimers()
+  }
+}
+
+beforeEach(() => {
+  storage.clear()
+  getDoc.mockReset()
+  logError.mockReset()
+  logWarn.mockReset()
+  stubLocalStorage()
+  setOnline(true)
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+// ── fetchEnabledTownIds ───────────────────────────────────────────────────────
+
+describe('fetchEnabledTownIds', () => {
+  it('returns the enabled list and caches it', async () => {
+    getDoc.mockResolvedValue(snapshot(['gravemoor', 'appleford']))
+
+    expect(await fetchEnabledTownIds()).toEqual(['gravemoor', 'appleford'])
+    expect(storage.get(CACHE_KEY)).toBe(JSON.stringify(['gravemoor', 'appleford']))
+    expect(logWarn).not.toHaveBeenCalled()
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('skips the network entirely when offline', async () => {
+    setOnline(false)
+    storage.set(CACHE_KEY, JSON.stringify(['hollowmere']))
+
+    // Being offline is expected, not a failure — nothing should be reported.
+    expect(await fetchEnabledTownIds()).toEqual(['hollowmere'])
+    expect(getDoc).not.toHaveBeenCalled()
+    expect(logWarn).not.toHaveBeenCalled()
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('retries after a transient failure and reports nothing on success', async () => {
+    getDoc
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce(snapshot(['gearford']))
+
+    expect(await fetchWithFakeTimers()).toEqual(['gearford'])
+    expect(getDoc).toHaveBeenCalledTimes(2)
+    expect(logWarn).not.toHaveBeenCalled()
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('warns and serves the cache when every attempt fails', async () => {
+    storage.set(CACHE_KEY, JSON.stringify(['gravemoor']))
+    getDoc.mockRejectedValue(Object.assign(new Error('boom'), { code: 'unavailable' }))
+
+    expect(await fetchWithFakeTimers()).toEqual(['gravemoor'])
+    expect(getDoc).toHaveBeenCalledTimes(3)
+    // The player carries on with last-known-good access, so this is not an error.
+    expect(logError).not.toHaveBeenCalled()
+    expect(logWarn).toHaveBeenCalledTimes(1)
+    expect(logWarn.mock.calls[0][1]).toMatchObject({ code: 'unavailable', attempts: 3, hadCache: true })
+  })
+
+  it('errors when every attempt fails and there is no cache', async () => {
+    getDoc.mockRejectedValue(new Error('boom'))
+
+    // Nothing to fall back on — the player is locked out of every toggleable town.
+    expect(await fetchWithFakeTimers()).toEqual([])
+    expect(logWarn).not.toHaveBeenCalled()
+    expect(logError).toHaveBeenCalledTimes(1)
+    expect(logError.mock.calls[0][1]).toMatchObject({ attempts: 3, hadCache: false })
+  })
+
+  it('falls back to the cache without reporting when the doc does not exist', async () => {
+    storage.set(CACHE_KEY, JSON.stringify(['appleford']))
+    getDoc.mockResolvedValue(snapshot(undefined))
+
+    expect(await fetchEnabledTownIds()).toEqual(['appleford'])
+    expect(getDoc).toHaveBeenCalledTimes(1)
+    expect(logWarn).not.toHaveBeenCalled()
+    expect(logError).not.toHaveBeenCalled()
+  })
+})
+
+// ── isTownAccessible ──────────────────────────────────────────────────────────
+
+describe('isTownAccessible', () => {
+  it('lets the admin reach everything', () => {
+    expect(isTownAccessible('royal-palace', new Set(), true)).toBe(true)
+  })
+
+  it('keeps the always-open towns open even with nothing enabled', () => {
+    for (const id of ALWAYS_OPEN_LOCATION_IDS) {
+      expect(isTownAccessible(id, new Set(), false)).toBe(true)
+    }
+  })
+
+  it('gates every other town on the enabled set', () => {
+    const enabled = new Set(['gravemoor'])
+    expect(isTownAccessible('gravemoor', enabled, false)).toBe(true)
+    expect(isTownAccessible('royal-palace', enabled, false)).toBe(false)
+  })
+})

--- a/web/src/game/townAccess.ts
+++ b/web/src/game/townAccess.ts
@@ -12,7 +12,7 @@
 
 import { doc, getDoc, setDoc } from 'firebase/firestore'
 import { db } from '../firebase'
-import { logError } from '../logger'
+import { logError, logWarn } from '../logger'
 
 const TOWN_ACCESS_DOC = doc(db, 'globalState', 'townAccess')
 const LOCAL_KEY = 'jarv_town_access_cache'
@@ -48,24 +48,61 @@ function saveLocalCache(ids: string[]): void {
   try { localStorage.setItem(LOCAL_KEY, JSON.stringify(ids)) } catch { /* ignore */ }
 }
 
+/** Backoff before each retry attempt. Length = number of retries after the first try. */
+const RETRY_DELAYS_MS = [400, 1200]
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
 /**
  * Fetch the admin-enabled town id list. Falls back to the last-known local
  * cache on error, and to an empty list (locked) if nothing has ever loaded —
  * towns stay locked until the admin turns them on.
+ *
+ * Retries a couple of times before giving up: a single transient Firestore
+ * blip on a device with no cache would otherwise fog 11 of the 13 towns for
+ * the rest of the session (App re-fetches on `online`, not on a timer).
  */
 export async function fetchEnabledTownIds(): Promise<string[]> {
-  try {
-    const snap = await getDoc(TOWN_ACCESS_DOC)
-    if (snap.exists()) {
-      const ids = (snap.data().enabled as string[] | undefined) ?? []
-      saveLocalCache(ids)
-      return ids
-    }
-    return loadLocalCache()
-  } catch (e) {
-    logError('fetchEnabledTownIds failed, using local cache', { error: String(e) })
+  // Offline is an expected state, not a failure — don't attempt or report it.
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     return loadLocalCache()
   }
+
+  let lastError: unknown
+  for (let attempt = 1; attempt <= RETRY_DELAYS_MS.length + 1; attempt++) {
+    try {
+      const snap = await getDoc(TOWN_ACCESS_DOC)
+      if (snap.exists()) {
+        const ids = (snap.data().enabled as string[] | undefined) ?? []
+        saveLocalCache(ids)
+        return ids
+      }
+      return loadLocalCache()
+    } catch (e) {
+      lastError = e
+      const delay = RETRY_DELAYS_MS[attempt - 1]
+      if (delay !== undefined) await sleep(delay)
+    }
+  }
+
+  // Every attempt failed. Severity follows the impact on the player: with a
+  // cache they carry on with last-known-good access, without one they are
+  // locked out of every toggleable town.
+  const cached = loadLocalCache()
+  const ctx = {
+    error: String(lastError),
+    code: (lastError as { code?: string } | undefined)?.code,
+    attempts: RETRY_DELAYS_MS.length + 1,
+    hadCache: cached.length > 0,
+    // Sampled after the retries: connectivity may have dropped part-way through.
+    online: typeof navigator !== 'undefined' ? navigator.onLine : undefined,
+  }
+  if (cached.length > 0) {
+    logWarn('fetchEnabledTownIds failed, using cached town access', ctx)
+  } else {
+    logError('fetchEnabledTownIds failed with no cache — towns locked', ctx)
+  }
+  return cached
 }
 
 /** Admin-only: persist the enabled-town list. Firestore rules reject non-admin writes. */

--- a/web/src/logger.ts
+++ b/web/src/logger.ts
@@ -7,6 +7,7 @@
 type ErrorLogger = (msg: string, ctx?: Record<string, unknown>) => void
 
 let _logError: ErrorLogger = () => {}
+let _logWarn: ErrorLogger = () => {}
 
 export function setErrorLogger(fn: ErrorLogger): void {
   _logError = fn
@@ -14,4 +15,16 @@ export function setErrorLogger(fn: ErrorLogger): void {
 
 export function logError(msg: string, ctx?: Record<string, unknown>): void {
   _logError(msg, ctx)
+}
+
+export function setWarnLogger(fn: ErrorLogger): void {
+  _logWarn = fn
+}
+
+/**
+ * Degraded-but-handled conditions: the player is unaffected or recovered on a
+ * fallback. Use `logError` only when something is actually broken for them.
+ */
+export function logWarn(msg: string, ctx?: Record<string, unknown>): void {
+  _logWarn(msg, ctx)
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import rollbar from './rollbar'
-import { setErrorLogger } from './logger'
+import { setErrorLogger, setWarnLogger } from './logger'
 import { initCrashSentinel } from './utils/crashSentinel'
 import { initResumeJournal } from './utils/resumeJournal'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import App from './App'
 
 setErrorLogger((msg, ctx) => rollbar.error(msg, ctx as object))
+setWarnLogger((msg, ctx) => rollbar.warn(msg, ctx as object))
 
 // Report if the previous session died without a clean exit (e.g. iOS Safari
 // killing the page under memory pressure) — before React renders, so crash


### PR DESCRIPTION
Fixes #2013. Also resolves #2008 (same defect, reported ~11h earlier).

## The bug

`fetchEnabledTownIds` reads the admin-controlled enabled-town list from Firestore, logs at *error* severity on any failure, and falls back to the local cache. `App.tsx` calls it **once on mount and never again**.

So a single transient Firestore blip on a device with no cache — first visit, cleared storage, private window — left `enabledTownIds` empty for the rest of the session. All 11 toggleable towns render fogged; only Ravenwatch and Millhaven stay reachable. There was no retry and no recovery short of a page reload.

Separately, the reporting was wrong in both directions: being offline is an expected state, not an error, and it filed a fresh Rollbar item each time — while carrying no diagnostic context beyond the message string, so there was nothing to triage from.

## Changes

- **`game/townAccess.ts`** — short-circuit to the cache when `navigator.onLine === false` (the guard pattern already used in `useCloudSync`, `DailyChallengeScreen`, `EndlessLeaderboardScreen`, `GameOver`); retry twice on a 400ms/1200ms backoff; log only once every attempt has failed, with `{ error, code, attempts, hadCache, online }`. Severity now follows impact — `logWarn` when the cache carries the player through, `logError` only when there is no cache and they are genuinely locked out.
- **`App.tsx`** — re-fetch on the window `online` event so a failed first attempt self-heals instead of needing a reload.
- **`logger.ts` / `main.tsx`** — add `setWarnLogger`/`logWarn` alongside the existing error pair, wired to `rollbar.warn`. Game-logic files previously had no way to report a degraded-but-handled condition.

`saveEnabledTownIds`, `isTownAccessible`, the preview-as-player helpers, and the `!snap.exists()` branch are unchanged.

## Verification

- New `game/townAccess.test.ts` (9 cases): offline skips the network and logs nothing; a transient failure retries and succeeds silently; all-attempts-fail warns with a cache and errors without one; doc-not-exist falls back quietly; `isTownAccessible` admin/always-open/gated cases.
- `npm run test` — 2059 passed, 67 files, no regressions.
- `npm run build` — clean typecheck and build.

No browser verification: logic/data change, nothing visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111UrsPdT7VGjEou1SusB3t

---
_Generated by [Claude Code](https://claude.ai/code/session_0111UrsPdT7VGjEou1SusB3t)_