### PR TITLE
Card synergy tags — surface combos in the UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,14 @@ Rules:
 
 **Apply this pattern to all future components, and refactor existing large screens when touching them for other reasons.**
 
+## Card Synergies
+
+Synergy groups and card-to-card combo links are documented in
+**[`docs/synergies.md`](docs/synergies.md)**. Read it before:
+- Adding or resizing a synergy group (`web/src/data/synergies.json`)
+- Adding tags to cards in `web/src/data/cards.json`
+- Changing where synergy badges or the deck-builder highlighting appear
+
 ## Constants vs JSON Config
 Complex constants that are likely to be extended (multiplicity) should be JSON config files, or added to an existing JSON file if colocating makes sense.
 

--- a/docs/synergies.md
+++ b/docs/synergies.md
@@ -91,7 +91,20 @@ theme — nothing useful to say about them, so they say nothing.
 | `components/cards/SynergyBadges.tsx` | Up to 2 group icons plus a `⚡N` deck-pairing count. Icon-only — labels are in the tooltip. |
 | `components/cards/CardTile.tsx` | Renders the badges in the corner of the card art. `deckMatches` prop is deck-builder only. |
 | `components/cards/CardDetailModal.tsx` | Collapsible SYNERGY row: every pairing and every group, in plain English. |
-| `components/cards/DeckBuilder.tsx` | Live scoring against the deck — gold border, `⚡N` count, and a "Synergy" sort. |
+| `components/cards/DeckBuilder.tsx` | Live scoring against the deck — see below. |
+
+In the deck builder the two tiers get two different visuals, because at 92%
+group coverage a single "shares a group" glow would light up most of the
+browser:
+
+| Signal | Visual |
+|---|---|
+| Shares a group with the deck | `collection-cell--synergy` — dim gold border |
+| Directly pairs with a deck card | `collection-cell--combo` — bright border and glow, plus `⚡N` on the tile |
+| Either | Counts toward the "⚡ Synergy" sort, which floats the best fits to the top |
+
+`⚡N` is a count of direct pairings only, never of shared groups — it has to
+mean one thing to the player.
 
 Scoring a whole browser is done through `buildDeckProfile` once per deck change,
 then `getDeckSynergy` per card. Don't call `getDeckSynergy` with a freshly built

--- a/docs/synergies.md
+++ b/docs/synergies.md
@@ -1,0 +1,98 @@
+# Card Synergies
+
+How the game answers "what does this card work with". Read this before editing
+`web/src/data/synergies.json`, adding a synergy group, or changing where synergy
+information is surfaced.
+
+Implementation: `web/src/game/synergies.ts`. Tests: `web/src/game/synergies.test.ts`.
+
+## Two tiers
+
+Nothing here is a new mechanic. Both tiers are read out of card data that already
+drives the battle engine.
+
+### Tier 1 — Synergy groups
+
+Curated themes in `web/src/data/synergies.json`. A card is in a group when any of
+its tags matches one of the group's `tags`, or when it is named in the group's
+`cards` array. "Its tags" means `getAllCardTags` in `web/src/game/cards.ts` —
+theme tags from `cards.json` plus the unit template's combat tags.
+
+Broad signal: *these belong in the same deck*.
+
+### Tier 2 — Combo links
+
+Derived per card, no authoring:
+
+| Kind | Source | Reads as |
+|---|---|---|
+| `affinity` | `unit.affinity` — the proximity buff `processAffinities` resolves each tick in `web/src/game/engine/units.ts` | "Near an Archer: +25% attack speed" |
+| `spawns` | `unit.structureEffect` of type `spawn`, when the spawned template is itself a playable card | "Spawns a Goblin every 9s" |
+| `spawned-by` | the reverse of `spawns` | "Ancient Barracks keeps producing these" |
+
+Narrow signal, and mechanically real, so a combo link is weighted at **3×** a
+shared group when scoring a card against a deck (`COMBO_WEIGHT` in
+`synergies.ts`).
+
+An affinity or spawn whose partner has no card of its own produces no link — the
+player can't act on it.
+
+## Groups
+
+| Group | Tags | Members |
+|---|---|---|
+| ⚜ Dominion Core | `core` | 27 |
+| ❄ Frostbind | `frost`, `glacier`, `waitedwinter` | 65 |
+| 🔥 Emberkin | `ember`, `fire` | 45 |
+| 🍄 Blight | `spore`, `fungal` | 40 |
+| 💀 Deathless | `undead`, `ashen` | 50 |
+| 🐾 Beastpack | `beast` | 47 |
+| 🌩 Skyborne | `sky`, `storm` | 45 |
+| 🌊 Tidewalkers | `reef`, `sunken`, `tidal` | 51 |
+| ✨ Arcanum | `arcane`, `archive`, `spire` | 62 |
+| 🛡 Iron Host | `iron`, `citadel` | 58 |
+| ⚙ Clockwork | `clockwork` | 19 |
+| 🏚 Siegeworks | `siege`, `vault`, `wreck` | 40 |
+| 🏜 Dunerunners | `sand` | 34 |
+| 🌲 Verdant | `forest` | 49 |
+| 🌿 Canopy | `canopy` | 27 |
+| 🗿 Ancients | `ancient`, `mercenary` | 48 |
+| 🌫 Pale March | `marches`, `causeway` | 50 |
+| 🌾 Harvest | `fields`, `orchard` | 50 |
+| 🕯 Candlelight | `candlecity`, `vigilroads` | 50 |
+| 🪞 Mirror Marsh | `marsh` | 25 |
+| 🎭 Hollow Court | `court`, `throne` | 50 |
+| 👑 Vigil Crown | `vigilcity`, `reaches` | 50 |
+
+Around 92% of the catalogue falls in at least one group. The cards that don't
+carry only generic combat tags (`melee`, `ranged`, `armored`, …) and have no
+theme — nothing useful to say about them, so they say nothing.
+
+## Rules for adding a group
+
+- **Keep it between 2 and 70 cards.** `synergies.test.ts` enforces this. A group
+  matching a sixth of the catalogue is a category, not a combo hint, and it makes
+  the deck builder glow on everything.
+- **Never group on a generic combat tag.** `melee`, `ranged`, `armored`, `large`,
+  `fast`, `slow`, `magic`, `flying` are all far too broad, and `CardDetailModal`
+  already renders them as trait chips. `forgotten` is a 350-card catch-all — not
+  a theme.
+- **Prefer a tag that already exists** over adding one to `cards.json`. Card tags
+  are also read by `weeklyChallenge.ts`, `quests.ts` and `chronicle.ts`, so a new
+  tag widens those pools too.
+- **Write `desc` as advice, not flavour.** It is shown to the player in the card
+  detail modal and should say *why* the cards want to be together.
+- Update the table above when you add or resize a group.
+
+## Where it surfaces
+
+| Surface | Shows |
+|---|---|
+| `components/cards/SynergyBadges.tsx` | Up to 2 group icons plus a `⚡N` deck-pairing count. Icon-only — labels are in the tooltip. |
+| `components/cards/CardTile.tsx` | Renders the badges in the corner of the card art. `deckMatches` prop is deck-builder only. |
+| `components/cards/CardDetailModal.tsx` | Collapsible SYNERGY row: every pairing and every group, in plain English. |
+| `components/cards/DeckBuilder.tsx` | Live scoring against the deck — gold border, `⚡N` count, and a "Synergy" sort. |
+
+Scoring a whole browser is done through `buildDeckProfile` once per deck change,
+then `getDeckSynergy` per card. Don't call `getDeckSynergy` with a freshly built
+profile inside a loop.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "jarvs-amazing-web-game",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "jarvs-amazing-web-game",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/web/src/components/cards/CardDetailModal.stories.tsx
+++ b/web/src/components/cards/CardDetailModal.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CardDetailModal } from './CardDetailModal';
 
 import { exampleCard } from '../../game/types.sample';
+import { getCardCatalog } from '../../game/cards';
 
 const meta = {
   component: CardDetailModal,
@@ -16,6 +17,19 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     "card": exampleCard,
+    "collection": [],
+    "onClose": fn()
+  },
+};
+
+/**
+ * A real catalogue card, so the SYNERGY row has something to show — a spawner
+ * link to the unit it produces plus its synergy groups. `exampleCard` is not in
+ * the catalogue and has neither.
+ */
+export const WithSynergy: Story = {
+  args: {
+    "card": getCardCatalog().find(c => c.name === 'Ancient Barracks')!,
     "collection": [],
     "onClose": fn()
   },

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -15,6 +15,7 @@ import {
   mergeAugmentEffects,
 } from '../../game/collection'
 import { ALL_AUGMENT_SLOTS, AugmentSetDef, augmentSlotLabel, getAugmentCard, getAugmentSetDef, scaledAugmentEffect } from '../../game/augments'
+import { getComboLinks, getSynergyGroups } from '../../game/synergies'
 import { CardTile } from './CardTile'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { MasteryBar } from '../ui/MasteryBar'
@@ -112,6 +113,9 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
 
   const [expandedRow, setExpandedRow] = useState<string | null>(null)
   const toggleRow = (key: string) => setExpandedRow(prev => prev === key ? null : key)
+
+  const synergyGroups = getSynergyGroups(card)
+  const comboLinks    = getComboLinks(card)
 
   // Stats — card name for "played", unit name for "died"
   const statsPlayed  = getCardStats(card.name)
@@ -353,6 +357,38 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
                 )}
               </div>
             ) : null}
+
+            {/* Synergy — groups this card shares, and the cards it directly pairs with */}
+            {(synergyGroups.length > 0 || comboLinks.length > 0) && (
+              <div className="cdm-sw-block u-col u-gap-1">
+                <button className="cdm-sw-row u-flex u-gap-3 cdm-sw-row--btn" onClick={() => toggleRow('synergy')}>
+                  <span className="cdm-sw-label cdm-sw-label--synergy">⚡ Synergy</span>
+                  <span className="cdm-sw-tags">
+                    {[
+                      ...synergyGroups.map(g => g.label),
+                      ...(comboLinks.length > 0
+                        ? [`${comboLinks.length} card pairing${comboLinks.length === 1 ? '' : 's'}`]
+                        : []),
+                    ].join(', ')}
+                  </span>
+                  <span className="cdm-sw-chevron">{expandedRow === 'synergy' ? '▲' : '▼'}</span>
+                </button>
+                {expandedRow === 'synergy' && (
+                  <div className="cdm-sw-detail">
+                    {comboLinks.map(link => (
+                      <div key={`${link.kind}-${link.partner}`} className="cdm-synergy-item">
+                        <strong>{link.partner}</strong> — {link.detail}
+                      </div>
+                    ))}
+                    {synergyGroups.map(g => (
+                      <div key={g.id} className="cdm-synergy-item">
+                        <strong>{g.icon} {g.label}</strong> — {g.desc}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Mastery (not shown for augments) */}
             {card.cardType !== 'augment' && <div className="cdm-mastery-block">

--- a/web/src/components/cards/CardTile.stories.tsx
+++ b/web/src/components/cards/CardTile.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { CardTile } from './CardTile';
 import { exampleCard } from '../../game/types.sample';
+import { getCardCatalog } from '../../game/cards';
+
+const catalogCard = (name: string) => getCardCatalog().find(c => c.name === name)!;
 
 
 
@@ -58,6 +61,25 @@ export const ShowDetails: Story = {
   args: {
     card: exampleCard,
     showDetails: true,  
+  },
+};
+
+/**
+ * A real catalogue card, so the synergy badges resolve. `exampleCard` is not in
+ * the catalogue and therefore has no groups — deliberate, it keeps the other
+ * stories showing the plain tile.
+ */
+export const WithSynergy: Story = {
+  args: {
+    card: catalogCard('Ancient Barracks'),
+  },
+};
+
+/** Deck builder context — the ⚡ count is how many deck cards this one pairs with. */
+export const WithDeckMatches: Story = {
+  args: {
+    card: catalogCard('Ancient Barracks'),
+    deckMatches: 4,
   },
 };
 

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -4,6 +4,8 @@ import { rarityStars } from '../../game/cards'
 import { AUGMENT_SPRITE } from '../../game/augments'
 import { SpriteImg } from '../ui/SpriteImg'
 import { useCardDetail } from './useCardDetail'
+import { getSynergyGroups } from '../../game/synergies'
+import { SynergyBadges } from './SynergyBadges'
 
 const UPGRADE_SPRITE: Record<string, string> = {
   buffAttack: 'upgrade-attack',
@@ -130,12 +132,14 @@ interface Props {
   upgradeable?: boolean // collection: show UPGRADE badge
   displayCost?: number  // override displayed cost (e.g. after archetype discounts)
   showDetails?: boolean  // collection: show details button
+  deckMatches?: number   // deck builder: how many deck cards this one pairs with
 }
 
-export function CardTile({ card, canAfford = true, disabled = false, onClick, lockedSecs = 0, upgradeable = false , showDetails = false, displayCost }: Props) {
+export function CardTile({ card, canAfford = true, disabled = false, onClick, lockedSecs = 0, upgradeable = false , showDetails = false, displayCost, deckMatches = 0 }: Props) {
   const heroLocked = card.isHero && lockedSecs > 0
   const clickable = canAfford && !disabled && !heroLocked
   const { openDetail, cardDetailNode } = useCardDetail()
+  const synergyGroups = getSynergyGroups(card)
 
   let stats: string
 
@@ -194,6 +198,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
       {upgradeable && <div className="card-upgrade-badge">UPGRADE</div>}
       <div className={`card-title${isSecret ? ' card-title--badge' : ''}`}>{card.name}</div>
       <div className="card-art u-flex u-items-c u-just-c">
+        <SynergyBadges groups={synergyGroups} deckMatches={deckMatches} />
         {card.unit
           ? <SpriteImg name={card.unit.name} className="card-sprite" />
           : card.upgradeEffect

--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -312,14 +312,18 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
 
   // Synergy against the current deck, recomputed on every add/remove. The deck
   // profile is built once and reused across all ~960 browser cards.
-  const synergyScores = useMemo(() => {
+  const synergyByName = useMemo(() => {
     const profile = buildDeckProfile(deck.map(e => e.cardName))
-    const scores  = new Map<string, number>()
-    for (const card of catalog) scores.set(card.name, getDeckSynergy(card, profile).score)
-    return scores
+    const result  = new Map<string, { combos: number; groups: number; score: number }>()
+    for (const card of catalog) {
+      const s = getDeckSynergy(card, profile)
+      result.set(card.name, { combos: s.combos.length, groups: s.groups.length, score: s.score })
+    }
+    return result
   }, [catalog, deck])
 
-  const synergyOf = (card: Card) => synergyScores.get(card.name) ?? 0
+  const NO_SYNERGY = { combos: 0, groups: 0, score: 0 }
+  const synergyOf = (card: Card) => synergyByName.get(card.name) ?? NO_SYNERGY
 
   const sorted = useMemo(() => [...filtered].sort((a, b) => {
     if (groupKey !== 'none') {
@@ -332,11 +336,11 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
       case 'mana-asc':  return a.cost - b.cost
       case 'mana-desc': return b.cost - a.cost
       case 'rarity':    return RARITY_ORDER[a.rarity] - RARITY_ORDER[b.rarity]
-      case 'synergy':   return (synergyOf(b) - synergyOf(a)) || a.name.localeCompare(b.name)
+      case 'synergy':   return (synergyOf(b).score - synergyOf(a).score) || a.name.localeCompare(b.name)
       default:          return groupKey === 'none' ? defaultSortKey(a) - defaultSortKey(b) : 0
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [filtered, sortKey, groupKey, synergyScores])
+  }), [filtered, sortKey, groupKey, synergyByName])
 
   const activeFilterCount =
     (typeFilter    !== 'all' ? 1 : 0) +
@@ -576,7 +580,7 @@ setCollectionCollapsed(false)
                           <CardTile
                             card={card}
                             onClick={() => removeCard(entry.cardName)}
-                            deckMatches={synergyOf(card)}
+                            deckMatches={synergyOf(card).combos}
                             showDetails={true}
                           />
                           <div className="cell-footer">
@@ -840,11 +844,11 @@ setCollectionCollapsed(true)
                           {showHeader && (
                             <div className="collection-group-header">{label}</div>
                           )}
-                          <div className={`collection-cell u-col${resting ? ' collection-cell--resting' : ''}${synergy > 0 ? ' collection-cell--synergy' : ''}`}>
+                          <div className={`collection-cell u-col${resting ? ' collection-cell--resting' : ''}${synergy.combos > 0 ? ' collection-cell--combo' : synergy.groups > 0 ? ' collection-cell--synergy' : ''}`}>
                             <CardTile
                               card={card}
                               canAfford={canAdd}
-                              deckMatches={synergy}
+                              deckMatches={synergy.combos}
                               onClick={canAdd ? () => addCard(card.name) : undefined}
                             />
                             <div className="cell-footer">

--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react'
 import { Card, CardType, CardRarity, UnitTag } from '../../game/types'
 import { getCardCatalog, getCardThemeTags } from '../../game/cards'
+import { buildDeckProfile, getDeckSynergy } from '../../game/synergies'
 import {
   loadCollection,
   loadDeck,
@@ -59,7 +60,7 @@ interface Props {
 type AutoStrategy = 'aggro' | 'control' | 'balanced' | 'ranged'
 type RarityFilter = 'all' | CardRarity
 type TypeFilter   = 'all' | CardType
-type SortKey  = 'default' | 'az' | 'za' | 'mana-asc' | 'mana-desc' | 'rarity'
+type SortKey  = 'default' | 'az' | 'za' | 'mana-asc' | 'mana-desc' | 'rarity' | 'synergy'
 type GroupKey = 'none' | 'type' | 'rarity' | 'mana' | 'act'
 
 const ALL_TAGS: UnitTag[] = [
@@ -309,6 +310,17 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
     return true
   }), [catalog, collection, typeFilter, rarityFilter, tagFilter, affinityFilter, q, affinityGroupNames])
 
+  // Synergy against the current deck, recomputed on every add/remove. The deck
+  // profile is built once and reused across all ~960 browser cards.
+  const synergyScores = useMemo(() => {
+    const profile = buildDeckProfile(deck.map(e => e.cardName))
+    const scores  = new Map<string, number>()
+    for (const card of catalog) scores.set(card.name, getDeckSynergy(card, profile).score)
+    return scores
+  }, [catalog, deck])
+
+  const synergyOf = (card: Card) => synergyScores.get(card.name) ?? 0
+
   const sorted = useMemo(() => [...filtered].sort((a, b) => {
     if (groupKey !== 'none') {
       const cmp = groupSortValue(a).localeCompare(groupSortValue(b))
@@ -320,9 +332,11 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
       case 'mana-asc':  return a.cost - b.cost
       case 'mana-desc': return b.cost - a.cost
       case 'rarity':    return RARITY_ORDER[a.rarity] - RARITY_ORDER[b.rarity]
+      case 'synergy':   return (synergyOf(b) - synergyOf(a)) || a.name.localeCompare(b.name)
       default:          return groupKey === 'none' ? defaultSortKey(a) - defaultSortKey(b) : 0
     }
-  }), [filtered, sortKey, groupKey])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [filtered, sortKey, groupKey, synergyScores])
 
   const activeFilterCount =
     (typeFilter    !== 'all' ? 1 : 0) +
@@ -562,6 +576,7 @@ setCollectionCollapsed(false)
                           <CardTile
                             card={card}
                             onClick={() => removeCard(entry.cardName)}
+                            deckMatches={synergyOf(card)}
                             showDetails={true}
                           />
                           <div className="cell-footer">
@@ -736,6 +751,7 @@ setCollectionCollapsed(true)
                             ['mana-asc',  'Mana ↑'],
                             ['mana-desc', 'Mana ↓'],
                             ['rarity',    'Rarity'],
+                            ['synergy',   '⚡ Synergy'],
                           ] as [SortKey, string][]).map(([val, label]) => (
                             <button
                               key={val}
@@ -816,6 +832,7 @@ setCollectionCollapsed(true)
                       const xp      = getMasteryXp(collection, card.name)
                       const { level: lvl } = masteryProgress(xp)
                       const label   = groupLabel(card)
+                      const synergy = synergyOf(card)
                       const showHeader = label !== null && label !== lastGroup
                       if (showHeader) lastGroup = label
                       return (
@@ -823,10 +840,11 @@ setCollectionCollapsed(true)
                           {showHeader && (
                             <div className="collection-group-header">{label}</div>
                           )}
-                          <div className={`collection-cell u-col${resting ? ' collection-cell--resting' : ''}`}>
+                          <div className={`collection-cell u-col${resting ? ' collection-cell--resting' : ''}${synergy > 0 ? ' collection-cell--synergy' : ''}`}>
                             <CardTile
                               card={card}
                               canAfford={canAdd}
+                              deckMatches={synergy}
                               onClick={canAdd ? () => addCard(card.name) : undefined}
                             />
                             <div className="cell-footer">

--- a/web/src/components/cards/SynergyBadges.stories.tsx
+++ b/web/src/components/cards/SynergyBadges.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { SynergyBadges } from './SynergyBadges';
+import { SYNERGY_GROUPS } from '../../game/synergies';
+
+const meta = {
+  component: SynergyBadges,
+  tags: ['ci'],
+} satisfies Meta<typeof SynergyBadges>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SingleGroup: Story = {
+  args: {
+    groups: SYNERGY_GROUPS.slice(0, 1),
+  },
+};
+
+export const TwoGroups: Story = {
+  args: {
+    groups: SYNERGY_GROUPS.slice(0, 2),
+  },
+};
+
+/** More groups than fit — only the first two render, the rest stay in the tooltip. */
+export const OverflowingGroups: Story = {
+  args: {
+    groups: SYNERGY_GROUPS.slice(0, 4),
+  },
+};
+
+/** Deck builder context: the ⚡ count is how many deck cards this one pairs with. */
+export const WithDeckMatches: Story = {
+  args: {
+    groups: SYNERGY_GROUPS.slice(0, 2),
+    deckMatches: 3,
+  },
+};
+
+/** No groups and no deck matches — renders nothing rather than an empty box. */
+export const Empty: Story = {
+  args: {
+    groups: [],
+  },
+};

--- a/web/src/components/cards/SynergyBadges.tsx
+++ b/web/src/components/cards/SynergyBadges.tsx
@@ -1,0 +1,39 @@
+import { SynergyGroup } from '../../game/synergies'
+
+interface Props {
+  /** Groups this card belongs to, most specific first. Only the first `maxGroups` render. */
+  groups: SynergyGroup[]
+  /**
+   * How many cards in the current deck this card pairs with. Omit outside the
+   * deck builder — the ⚡ count only means something next to a deck.
+   */
+  deckMatches?: number
+  /** Cap on group icons shown. The card tile is dense; two is all that fits. */
+  maxGroups?: number
+}
+
+/**
+ * Synergy markers for a card. Icon-only by design — a card tile has no room for
+ * group names, so the labels live in the `title` tooltip and the full breakdown
+ * lives in CardDetailModal.
+ */
+export function SynergyBadges({ groups, deckMatches = 0, maxGroups = 2 }: Props) {
+  const shown = groups.slice(0, maxGroups)
+  if (shown.length === 0 && deckMatches === 0) return null
+
+  const tooltip = [
+    ...groups.map(g => `${g.icon} ${g.label}`),
+    deckMatches > 0 ? `Pairs with ${deckMatches} card${deckMatches === 1 ? '' : 's'} in your deck` : '',
+  ].filter(Boolean).join('\n')
+
+  return (
+    <div className="card-synergy-badge" title={tooltip}>
+      {shown.map(g => (
+        <span key={g.id} className="card-synergy-icon">{g.icon}</span>
+      ))}
+      {deckMatches > 0 && (
+        <span className="card-synergy-count">⚡{deckMatches}</span>
+      )}
+    </div>
+  )
+}

--- a/web/src/data/cards.json
+++ b/web/src/data/cards.json
@@ -16209,6 +16209,7 @@
     },
     {
       "name": "Wizard",
+      "tags": ["core", "arcane"],
       "rarity": "rare",
       "cost": 3,
       "cardType": "unit",
@@ -16232,6 +16233,7 @@
     },
     {
       "name": "Stone Wall",
+      "tags": ["core"],
       "rarity": "common",
       "cost": 1,
       "cardType": "structure",
@@ -16242,6 +16244,7 @@
     },
     {
       "name": "Lumber Camp",
+      "tags": ["core"],
       "rarity": "common",
       "cost": 2,
       "cardType": "structure",
@@ -16252,6 +16255,7 @@
     },
     {
       "name": "Windmill",
+      "tags": ["core"],
       "rarity": "uncommon",
       "cost": 3,
       "cardType": "structure",
@@ -16262,6 +16266,7 @@
     },
     {
       "name": "Farm",
+      "tags": ["core"],
       "rarity": "uncommon",
       "cost": 3,
       "cardType": "structure",
@@ -16272,6 +16277,7 @@
     },
     {
       "name": "Mana Spring",
+      "tags": ["core"],
       "rarity": "uncommon",
       "cost": 3,
       "cardType": "structure",
@@ -16282,6 +16288,7 @@
     },
     {
       "name": "Healer's Hut",
+      "tags": ["core"],
       "rarity": "uncommon",
       "cost": 3,
       "cardType": "structure",
@@ -16292,6 +16299,7 @@
     },
     {
       "name": "Stone Mason",
+      "tags": ["core"],
       "rarity": "rare",
       "cost": 4,
       "cardType": "structure",
@@ -16302,6 +16310,7 @@
     },
     {
       "name": "Blacksmith",
+      "tags": ["core", "iron"],
       "rarity": "rare",
       "cost": 4,
       "cardType": "structure",
@@ -16474,6 +16483,7 @@
     },
     {
       "name": "Golem",
+      "tags": ["core", "ancient"],
       "rarity": "legendary",
       "cost": 5,
       "cardType": "unit",
@@ -16497,6 +16507,7 @@
     },
     {
       "name": "Ogre",
+      "tags": ["core", "beast"],
       "rarity": "uncommon",
       "cost": 3,
       "cardType": "unit",
@@ -16624,6 +16635,7 @@
     },
     {
       "name": "Ogre Den",
+      "tags": ["core", "beast"],
       "rarity": "rare",
       "cost": 4,
       "cardType": "structure",
@@ -16912,6 +16924,7 @@
     },
     {
       "name": "Fire Mage",
+      "tags": ["core", "ember", "arcane"],
       "rarity": "rare",
       "cost": 3,
       "cardType": "unit",
@@ -16935,6 +16948,7 @@
     },
     {
       "name": "Mammoth",
+      "tags": ["core", "beast", "frost"],
       "rarity": "rare",
       "cost": 4,
       "cardType": "unit",
@@ -16971,6 +16985,7 @@
     },
     {
       "name": "Giant",
+      "tags": ["core", "ancient"],
       "rarity": "legendary",
       "cost": 5,
       "cardType": "unit",
@@ -16981,6 +16996,7 @@
     },
     {
       "name": "Wyvern",
+      "tags": ["core", "beast", "sky"],
       "rarity": "legendary",
       "cost": 4,
       "cardType": "unit",
@@ -16991,6 +17007,7 @@
     },
     {
       "name": "Behemoth",
+      "tags": ["core", "beast", "ancient"],
       "rarity": "legendary",
       "cost": 6,
       "cardType": "unit",
@@ -17157,6 +17174,7 @@
     },
     {
       "name": "Mage Tower",
+      "tags": ["core", "arcane"],
       "rarity": "rare",
       "cost": 4,
       "cardType": "structure",
@@ -17180,6 +17198,7 @@
     },
     {
       "name": "Mammoth Pen",
+      "tags": ["core", "beast", "frost"],
       "rarity": "legendary",
       "cost": 5,
       "cardType": "structure",
@@ -17216,6 +17235,7 @@
     },
     {
       "name": "Giant's Hall",
+      "tags": ["core", "ancient"],
       "rarity": "legendary",
       "cost": 5,
       "cardType": "structure",
@@ -17226,6 +17246,7 @@
     },
     {
       "name": "Wyvern Roost",
+      "tags": ["core", "beast", "sky"],
       "rarity": "legendary",
       "cost": 5,
       "cardType": "structure",
@@ -17236,6 +17257,7 @@
     },
     {
       "name": "Ancient Altar",
+      "tags": ["core", "ancient", "arcane"],
       "rarity": "legendary",
       "cost": 7,
       "cardType": "structure",
@@ -24437,6 +24459,7 @@
     },
     {
       "name": "Void Titan",
+      "tags": ["core", "ancient"],
       "rarity": "mythic",
       "cost": 5,
       "cardType": "unit",
@@ -24447,6 +24470,7 @@
     },
     {
       "name": "Prism Wyrm",
+      "tags": ["core", "arcane", "sky"],
       "rarity": "mythic",
       "cost": 5,
       "cardType": "unit",
@@ -24457,6 +24481,7 @@
     },
     {
       "name": "World's End",
+      "tags": ["core", "ancient"],
       "rarity": "mythic",
       "cost": 5,
       "cardType": "upgrade",
@@ -24470,6 +24495,7 @@
     },
     {
       "name": "Eternal Forge",
+      "tags": ["core", "iron", "ember"],
       "rarity": "mythic",
       "cost": 5,
       "cardType": "structure",
@@ -24480,6 +24506,7 @@
     },
     {
       "name": "Dreadnought",
+      "tags": ["core", "iron", "siege"],
       "rarity": "mythic",
       "cost": 5,
       "cardType": "unit",

--- a/web/src/data/synergies.json
+++ b/web/src/data/synergies.json
@@ -1,0 +1,108 @@
+{
+  "groups": [
+    {
+      "id": "core",
+      "label": "Dominion Core",
+      "icon": "⚜",
+      "desc": "The founding Dominion cards — cheap walls, economy structures and the old giants. They ask for nothing and fit into any deck.",
+      "tags": ["core"],
+      "cards": []
+    },
+    {
+      "id": "frostbind",
+      "label": "Frostbind",
+      "icon": "❄",
+      "desc": "Frost attacks chill what they hit. Stack enough of them and the enemy front line never reaches your base.",
+      "tags": ["frost", "glacier"],
+      "cards": []
+    },
+    {
+      "id": "emberkin",
+      "label": "Emberkin",
+      "icon": "🔥",
+      "desc": "Ember attacks burn over time. Burn damage stacks from every source, so a wide ember board out-damages a tall one.",
+      "tags": ["ember", "fire"],
+      "cards": []
+    },
+    {
+      "id": "blight",
+      "label": "Blight",
+      "icon": "🍄",
+      "desc": "Spore and fungal cards trade raw power for volume. Their dens keep spawning long after the first wave is dead.",
+      "tags": ["spore", "fungal"],
+      "cards": []
+    },
+    {
+      "id": "deathless",
+      "label": "Deathless",
+      "icon": "💀",
+      "desc": "Undead and ashen cards are built to be replaced. Cheap bodies plus a shrine that keeps making more of them.",
+      "tags": ["undead", "ashen"],
+      "cards": []
+    },
+    {
+      "id": "beastpack",
+      "label": "Beastpack",
+      "icon": "🐾",
+      "desc": "Beasts hit hard and move fast but die alone. Pair them with their pens so the pack is never down to one.",
+      "tags": ["beast"],
+      "cards": []
+    },
+    {
+      "id": "skyborne",
+      "label": "Skyborne",
+      "icon": "🌩",
+      "desc": "Sky and storm cards ignore walls entirely. Bring them when the enemy plan is to out-fortify you.",
+      "tags": ["sky", "storm"],
+      "cards": []
+    },
+    {
+      "id": "tidewalkers",
+      "label": "Tidewalkers",
+      "icon": "🌊",
+      "desc": "Reef and sunken cards swim past terrain that stops everything else, then arrive together.",
+      "tags": ["reef", "sunken", "tidal"],
+      "cards": []
+    },
+    {
+      "id": "arcanum",
+      "label": "Arcanum",
+      "icon": "✨",
+      "desc": "Arcane cards are fragile and ranged. They want a wall in front and an upgrade behind — both of which the group brings.",
+      "tags": ["arcane", "archive", "spire"],
+      "cards": []
+    },
+    {
+      "id": "ironhost",
+      "label": "Iron Host",
+      "icon": "🛡",
+      "desc": "Citadel discipline: armoured bodies, wall lines and the barracks that refill them. Slow to start, hard to break.",
+      "tags": ["iron", "citadel"],
+      "cards": []
+    },
+    {
+      "id": "clockwork",
+      "label": "Clockwork",
+      "icon": "⚙",
+      "desc": "Clockwork cards run on tempo — the mana and speed effects in this group are what make the expensive frames land on time.",
+      "tags": ["clockwork"],
+      "cards": []
+    },
+    {
+      "id": "siegeworks",
+      "label": "Siegeworks",
+      "icon": "🏚",
+      "desc": "Siege and salvage cards out-range towers and chew through structures. Weak to anything that closes the distance.",
+      "tags": ["siege", "vault", "wreck"],
+      "cards": []
+    },
+    {
+      "id": "dunerunners",
+      "label": "Dunerunners",
+      "icon": "🏜",
+      "desc": "Sand and marches cards are cheap, fast and expendable — a swarm that wins by arriving before the answer does.",
+      "tags": ["sand", "marches"],
+      "cards": []
+    }
+  ]
+}

--- a/web/src/data/synergies.json
+++ b/web/src/data/synergies.json
@@ -13,7 +13,7 @@
       "label": "Frostbind",
       "icon": "❄",
       "desc": "Frost attacks chill what they hit. Stack enough of them and the enemy front line never reaches your base.",
-      "tags": ["frost", "glacier"],
+      "tags": ["frost", "glacier", "waitedwinter"],
       "cards": []
     },
     {
@@ -100,8 +100,80 @@
       "id": "dunerunners",
       "label": "Dunerunners",
       "icon": "🏜",
-      "desc": "Sand and marches cards are cheap, fast and expendable — a swarm that wins by arriving before the answer does.",
-      "tags": ["sand", "marches"],
+      "desc": "Sand cards are cheap, fast and expendable — a swarm that wins by arriving before the answer does.",
+      "tags": ["sand"],
+      "cards": []
+    },
+    {
+      "id": "verdant",
+      "label": "Verdant",
+      "icon": "🌲",
+      "desc": "The forest shard: cheap bodies, cheap walls and the groves that keep replacing both. The deck every player starts with.",
+      "tags": ["forest"],
+      "cards": []
+    },
+    {
+      "id": "canopy",
+      "label": "Canopy",
+      "icon": "🌿",
+      "desc": "Canopy cards fight above the treeline — climbers and vine-runners that go over the wall your opponent built.",
+      "tags": ["canopy"],
+      "cards": []
+    },
+    {
+      "id": "ancients",
+      "label": "Ancients",
+      "icon": "🗿",
+      "desc": "Old, expensive and slow. One ancient wins a board on its own — as long as something cheaper buys it the time to land.",
+      "tags": ["ancient", "mercenary"],
+      "cards": []
+    },
+    {
+      "id": "palemarch",
+      "label": "Pale March",
+      "icon": "🌫",
+      "desc": "Amarath's border war — the vanguard from the misted marches and the toll-road behind it.",
+      "tags": ["marches", "causeway"],
+      "cards": []
+    },
+    {
+      "id": "harvest",
+      "label": "Harvest",
+      "icon": "🌾",
+      "desc": "The Unremembered Fields and the Bone Orchards: cards grown to be cut down and grown again.",
+      "tags": ["fields", "orchard"],
+      "cards": []
+    },
+    {
+      "id": "candlelight",
+      "label": "Candlelight",
+      "icon": "🕯",
+      "desc": "The vigil rite — the Candle City and the roads walked to keep it lit. Slow, relentless, hard to put out.",
+      "tags": ["candlecity", "vigilroads"],
+      "cards": []
+    },
+    {
+      "id": "mirrormarsh",
+      "label": "Mirror Marsh",
+      "icon": "🪞",
+      "desc": "Still-water cards that copy, split and come back. What you kill is rarely all of it.",
+      "tags": ["marsh"],
+      "cards": []
+    },
+    {
+      "id": "hollowcourt",
+      "label": "Hollow Court",
+      "icon": "🎭",
+      "desc": "Amarath's masked nobility and the throne behind them — expensive, precise, and built to punish an over-committed board.",
+      "tags": ["court", "throne"],
+      "cards": []
+    },
+    {
+      "id": "vigilcrown",
+      "label": "Vigil Crown",
+      "icon": "👑",
+      "desc": "The Crown Reaches and the capital — the Court's last field army. The most disciplined cards in the game.",
+      "tags": ["vigilcity", "reaches"],
       "cards": []
     }
   ]

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -175,6 +175,11 @@ export function getCardThemeTags(name: string): string[] {
   return THEME_TAGS_BY_NAME.get(name) ?? []
 }
 
+/** A card's tags: theme tags from cards.json plus the unit's combat tags. */
+export function getAllCardTags(card: Card): string[] {
+  return [...getCardThemeTags(card.name), ...(card.unit?.tags ?? [])]
+}
+
 // Exported shared templates (for backward compatibility)
 export const GOBLIN_UNIT  = TEMPLATES['goblin']  as UnitTemplate
 export const ARCHER_UNIT  = TEMPLATES['archer']  as UnitTemplate

--- a/web/src/game/synergies.test.ts
+++ b/web/src/game/synergies.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { getCardCatalog, getAllCardTags } from './cards'
+import {
+  SYNERGY_GROUPS,
+  getSynergyGroups,
+  getComboLinks,
+  getGroupMembers,
+  buildDeckProfile,
+  getDeckSynergy,
+} from './synergies'
+
+const catalog = getCardCatalog()
+const byName  = new Map(catalog.map(c => [c.name, c]))
+
+/**
+ * A group matching a sixth of the catalogue is a category, not a combo hint.
+ * Keep every group small enough that "shares a group with your deck" still
+ * means something.
+ */
+const MAX_GROUP_MEMBERS = 70
+
+describe('synergy group definitions', () => {
+  it('has unique ids and at least five groups', () => {
+    const ids = SYNERGY_GROUPS.map(g => g.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(SYNERGY_GROUPS.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('gives every group a label, icon and description', () => {
+    for (const g of SYNERGY_GROUPS) {
+      expect(g.label, g.id).toBeTruthy()
+      expect(g.icon,  g.id).toBeTruthy()
+      expect(g.desc,  g.id).toBeTruthy()
+    }
+  })
+
+  it('keeps every group between 2 and MAX_GROUP_MEMBERS cards', () => {
+    for (const g of SYNERGY_GROUPS) {
+      const members = getGroupMembers(g.id)
+      expect(members.length, `${g.id} has ${members.length} members`).toBeGreaterThanOrEqual(2)
+      expect(members.length, `${g.id} has ${members.length} members`).toBeLessThanOrEqual(MAX_GROUP_MEMBERS)
+    }
+  })
+
+  it('only names tags that exist on at least one card', () => {
+    const known = new Set(catalog.flatMap(getAllCardTags))
+    for (const g of SYNERGY_GROUPS) {
+      for (const tag of g.tags) {
+        expect(known.has(tag), `group '${g.id}' references unknown tag '${tag}'`).toBe(true)
+      }
+    }
+  })
+
+  it('only names explicit member cards that exist', () => {
+    for (const g of SYNERGY_GROUPS) {
+      for (const name of g.cards) {
+        expect(byName.has(name), `group '${g.id}' references unknown card '${name}'`).toBe(true)
+      }
+    }
+  })
+
+  it('orders a card\'s groups most-specific first', () => {
+    for (const card of catalog) {
+      const groups = getSynergyGroups(card)
+      const sizes  = groups.map(g => getGroupMembers(g.id).length)
+      expect([...sizes].sort((a, b) => a - b)).toEqual(sizes)
+    }
+  })
+})
+
+describe('combo links', () => {
+  it('only links to cards that exist in the catalogue', () => {
+    for (const card of catalog) {
+      for (const link of getComboLinks(card)) {
+        expect(byName.has(link.partner), `${card.name} -> ${link.partner}`).toBe(true)
+      }
+    }
+  })
+
+  it('has no duplicate (kind, partner) pairs on a card', () => {
+    for (const card of catalog) {
+      const keys = getComboLinks(card).map(l => `${l.kind}:${l.partner}`)
+      expect(new Set(keys).size, card.name).toBe(keys.length)
+    }
+  })
+
+  it('pairs every spawns link with a spawned-by link on the other card', () => {
+    for (const card of catalog) {
+      for (const link of getComboLinks(card).filter(l => l.kind === 'spawns')) {
+        const back = getComboLinks(byName.get(link.partner)!)
+        expect(
+          back.some(l => l.kind === 'spawned-by' && l.partner === card.name),
+          `${link.partner} is missing the spawned-by link back to ${card.name}`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('finds the Goblin/Archer affinity in both the data and the links', () => {
+    const goblin = byName.get('Goblin')!
+    expect(goblin.unit?.affinity?.withName).toBe('Archer')
+    const link = getComboLinks(goblin).find(l => l.kind === 'affinity')
+    expect(link?.partner).toBe('Archer')
+    expect(link?.detail).toContain('Battle Cry')
+  })
+
+  it('resolves spawner structures to the card they spawn', () => {
+    const spawners = catalog.filter(c => c.unit?.structureEffect?.type === 'spawn')
+    expect(spawners.length).toBeGreaterThan(100)
+    const linked = spawners.filter(c => getComboLinks(c).some(l => l.kind === 'spawns'))
+    // Not every spawned template is a playable card — those simply get no link.
+    expect(linked.length).toBeGreaterThan(spawners.length * 0.9)
+  })
+})
+
+describe('getDeckSynergy', () => {
+  it('scores zero against an empty deck', () => {
+    const deck = buildDeckProfile([])
+    for (const name of ['Goblin', 'Archer', 'Farm']) {
+      expect(getDeckSynergy(byName.get(name)!, deck).score).toBe(0)
+    }
+  })
+
+  it('ranks a combo partner above a card that only shares a group', () => {
+    const goblin = byName.get('Goblin')!
+    const deck   = buildDeckProfile(['Archer'])
+
+    const comboScore = getDeckSynergy(goblin, deck).score
+    expect(getDeckSynergy(goblin, deck).combos.map(l => l.partner)).toContain('Archer')
+
+    // A card sharing a group with Archer but with no direct link to it.
+    const archerGroups = new Set(getSynergyGroups(byName.get('Archer')!).map(g => g.id))
+    const groupOnly = catalog.find(c =>
+      c.name !== 'Archer' &&
+      getSynergyGroups(c).some(g => archerGroups.has(g.id)) &&
+      !getComboLinks(c).some(l => l.partner === 'Archer'),
+    )
+    expect(groupOnly, 'expected a group-only card to compare against').toBeDefined()
+
+    const groupScore = getDeckSynergy(groupOnly!, deck).score
+    expect(groupScore).toBeGreaterThan(0)
+    expect(comboScore).toBeGreaterThan(groupScore)
+  })
+
+  it('does not let a card in the deck score against itself', () => {
+    const goblin = byName.get('Goblin')!
+    const alone  = getDeckSynergy(goblin, buildDeckProfile(['Goblin']))
+    expect(alone.score).toBe(0)
+
+    // A second member of one of Goblin's groups makes that group count.
+    const group = getSynergyGroups(goblin)[0]
+    const other = getGroupMembers(group.id).find(n => n !== 'Goblin')!
+    const paired = getDeckSynergy(goblin, buildDeckProfile(['Goblin', other]))
+    expect(paired.groups.some(g => g.id === group.id)).toBe(true)
+  })
+
+  it('updates as cards are added to the deck', () => {
+    const goblin = byName.get('Goblin')!
+    const before = getDeckSynergy(goblin, buildDeckProfile(['Farm'])).score
+    const after  = getDeckSynergy(goblin, buildDeckProfile(['Farm', 'Archer'])).score
+    expect(after).toBeGreaterThan(before)
+  })
+})

--- a/web/src/game/synergies.ts
+++ b/web/src/game/synergies.ts
@@ -131,6 +131,13 @@ function buildIndex(): SynergyIndex {
     }
   }
 
+  // Most specific (smallest) group first, sorted once here rather than on every
+  // card tile render.
+  const sizeOf = (g: SynergyGroup) => membersByGroup.get(g.id)!.length
+  for (const groups of groupsByCard.values()) {
+    groups.sort((a, b) => sizeOf(a) - sizeOf(b))
+  }
+
   return { groupsByCard, combosByCard, membersByGroup }
 }
 
@@ -155,12 +162,10 @@ function affinityEffectText(effectType: string, effectAmount: number): string {
 
 /** Synergy groups this card belongs to, most specific (smallest group) first. */
 export function getSynergyGroups(card: Card): SynergyGroup[] {
-  const { groupsByCard, membersByGroup } = index()
-  const groups = groupsByCard.get(card.name) ?? []
-  return [...groups].sort(
-    (a, b) => (membersByGroup.get(a.id)?.length ?? 0) - (membersByGroup.get(b.id)?.length ?? 0)
-  )
+  return index().groupsByCard.get(card.name) ?? EMPTY_GROUPS
 }
+
+const EMPTY_GROUPS: SynergyGroup[] = []
 
 /** Named cards this card has a direct mechanical pairing with. */
 export function getComboLinks(card: Card): ComboLink[] {

--- a/web/src/game/synergies.ts
+++ b/web/src/game/synergies.ts
@@ -1,0 +1,213 @@
+// ─── Card Synergies ───────────────────────────────────────────────────────────
+//
+// Two tiers of "these cards work together", both resolved from data that
+// already exists:
+//
+//  1. Synergy groups — curated themes from data/synergies.json, matched against
+//     a card's tags (theme tags in cards.json plus the unit's combat tags).
+//     Broad signal: "these belong in the same deck".
+//
+//  2. Combo links — precise, per-card pairings derived from the card data:
+//       • affinity   — unit.affinity names an ally that grants a proximity buff
+//                      (resolved every tick by processAffinities in engine/units.ts)
+//       • spawns     — a structure whose spawned unit is itself a playable card
+//       • spawned-by — the reverse of the above
+//     Narrow signal, and mechanically real, so it outranks group matches.
+
+import { Card } from './types'
+import { getCardCatalog, getAllCardTags } from './cards'
+import synergyData from '../data/synergies.json'
+
+export interface SynergyGroup {
+  id: string
+  label: string
+  /** Emoji shown on card tiles — icon only at tile size, label in the tooltip. */
+  icon: string
+  /** One sentence on why these cards want to be in a deck together. */
+  desc: string
+  /** Card tags that put a card in this group. */
+  tags: string[]
+  /** Explicit member names, for cards whose tags don't place them. */
+  cards: string[]
+}
+
+export type ComboKind = 'affinity' | 'spawns' | 'spawned-by'
+
+export interface ComboLink {
+  kind: ComboKind
+  /** Name of the other card in the pairing. */
+  partner: string
+  /** Plain-English explanation, e.g. "Spawns a Goblin every 9s". */
+  detail: string
+}
+
+export interface DeckSynergy {
+  /** Groups this card shares with at least one card already in the deck. */
+  groups: SynergyGroup[]
+  /** Combo partners that are actually in the deck. */
+  combos: ComboLink[]
+  /** Ranking weight — combos count for more than a shared theme. */
+  score: number
+}
+
+/** A combo partner in the deck is worth this many shared-group matches. */
+const COMBO_WEIGHT = 3
+
+export const SYNERGY_GROUPS: SynergyGroup[] = (synergyData.groups as SynergyGroup[])
+
+// ─── Indexes ──────────────────────────────────────────────────────────────────
+//
+// Built once, lazily, on first use — 960 cards is enough work that we don't want
+// it running at module-import time in every test file that touches this module.
+
+interface SynergyIndex {
+  groupsByCard: Map<string, SynergyGroup[]>
+  combosByCard: Map<string, ComboLink[]>
+  /** Card names per group id — used by the group-size test and the detail modal. */
+  membersByGroup: Map<string, string[]>
+}
+
+let _index: SynergyIndex | null = null
+
+function pushLink(map: Map<string, ComboLink[]>, cardName: string, link: ComboLink): void {
+  const existing = map.get(cardName)
+  if (!existing) {
+    map.set(cardName, [link])
+    return
+  }
+  // A structure can spawn a unit it also has an affinity with — keep one link per
+  // (kind, partner) pair so the badge count doesn't double up.
+  if (existing.some(l => l.kind === link.kind && l.partner === link.partner)) return
+  existing.push(link)
+}
+
+function buildIndex(): SynergyIndex {
+  const catalog      = getCardCatalog()
+  const cardNames    = new Set(catalog.map(c => c.name))
+  const groupsByCard = new Map<string, SynergyGroup[]>()
+  const combosByCard = new Map<string, ComboLink[]>()
+  const membersByGroup = new Map<string, string[]>(SYNERGY_GROUPS.map(g => [g.id, []]))
+
+  for (const card of catalog) {
+    // ── Tier 1: groups ──
+    const tags = new Set(getAllCardTags(card))
+    const groups = SYNERGY_GROUPS.filter(g =>
+      g.tags.some(t => tags.has(t)) || g.cards.includes(card.name)
+    )
+    if (groups.length > 0) {
+      groupsByCard.set(card.name, groups)
+      for (const g of groups) membersByGroup.get(g.id)!.push(card.name)
+    }
+
+    // ── Tier 2: combo links ──
+    const unit = card.unit
+    if (!unit) continue
+
+    const affinity = unit.affinity
+    // Only surface an affinity whose partner is a card the player can actually run.
+    if (affinity && cardNames.has(affinity.withName)) {
+      pushLink(combosByCard, card.name, {
+        kind: 'affinity',
+        partner: affinity.withName,
+        detail: `Near a ${affinity.withName}: ${affinityEffectText(affinity.effectType, affinity.effectAmount)} — "${affinity.label}"`,
+      })
+    }
+
+    const fx = unit.structureEffect
+    // A spawner whose unit has no card of its own (4 of them) simply has no link.
+    if (fx?.type === 'spawn' && fx.unitTemplate && cardNames.has(fx.unitTemplate.name)) {
+      const spawned  = fx.unitTemplate.name
+      const everySec = fx.intervalMs > 0 ? ` every ${Math.round(fx.intervalMs / 1000)}s` : ''
+      pushLink(combosByCard, card.name, {
+        kind: 'spawns',
+        partner: spawned,
+        detail: `Spawns a ${spawned}${everySec} — free bodies without spending a card.`,
+      })
+      pushLink(combosByCard, spawned, {
+        kind: 'spawned-by',
+        partner: card.name,
+        detail: `${card.name} keeps producing these${everySec}, so buffs aimed at them keep paying out.`,
+      })
+    }
+  }
+
+  return { groupsByCard, combosByCard, membersByGroup }
+}
+
+function index(): SynergyIndex {
+  if (!_index) _index = buildIndex()
+  return _index
+}
+
+/** Human-readable form of an affinity's buff — mirrors the wording in CardDetailModal. */
+function affinityEffectText(effectType: string, effectAmount: number): string {
+  const pct = Math.round(Math.abs(effectAmount - 1) * 100)
+  const dir = effectAmount >= 1 ? '+' : '−'
+  switch (effectType) {
+    case 'attackSpeed': return `${dir}${pct}% attack speed`
+    case 'damage':      return `${dir}${pct}% damage`
+    case 'moveSpeed':   return `${dir}${pct}% move speed`
+    default:            return `${dir}${pct}%`
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Synergy groups this card belongs to, most specific (smallest group) first. */
+export function getSynergyGroups(card: Card): SynergyGroup[] {
+  const { groupsByCard, membersByGroup } = index()
+  const groups = groupsByCard.get(card.name) ?? []
+  return [...groups].sort(
+    (a, b) => (membersByGroup.get(a.id)?.length ?? 0) - (membersByGroup.get(b.id)?.length ?? 0)
+  )
+}
+
+/** Named cards this card has a direct mechanical pairing with. */
+export function getComboLinks(card: Card): ComboLink[] {
+  return index().combosByCard.get(card.name) ?? []
+}
+
+/** Card names in a synergy group. */
+export function getGroupMembers(groupId: string): string[] {
+  return index().membersByGroup.get(groupId) ?? []
+}
+
+/**
+ * A deck reduced to what synergy scoring needs. Build this once per deck change
+ * and reuse it across every card being scored — the deck builder scores the
+ * whole 960-card browser on each add/remove.
+ */
+export interface DeckProfile {
+  names: Set<string>
+  /** How many deck cards belong to each group id. */
+  groupCounts: Map<string, number>
+}
+
+export function buildDeckProfile(deckNames: Iterable<string>): DeckProfile {
+  const { groupsByCard } = index()
+  const names       = new Set(deckNames)
+  const groupCounts = new Map<string, number>()
+  for (const name of names) {
+    for (const g of groupsByCard.get(name) ?? []) {
+      groupCounts.set(g.id, (groupCounts.get(g.id) ?? 0) + 1)
+    }
+  }
+  return { names, groupCounts }
+}
+
+/**
+ * How well this card pairs with a deck. A card already in the deck never scores
+ * against itself: it needs a second deck member of the group to count.
+ */
+export function getDeckSynergy(card: Card, deck: DeckProfile): DeckSynergy {
+  const inDeck = deck.names.has(card.name)
+
+  const combos = getComboLinks(card).filter(l => deck.names.has(l.partner))
+
+  const groups = (index().groupsByCard.get(card.name) ?? []).filter(g => {
+    const count = deck.groupCounts.get(g.id) ?? 0
+    return count >= (inDeck ? 2 : 1)
+  })
+
+  return { groups, combos, score: combos.length * COMBO_WEIGHT + groups.length }
+}

--- a/web/src/game/weeklyChallenge.ts
+++ b/web/src/game/weeklyChallenge.ts
@@ -13,7 +13,7 @@
 //   }
 
 import { logError } from '../logger'
-import { getCardCatalog, getCardThemeTags } from './cards'
+import { getCardCatalog, getAllCardTags } from './cards'
 import { hashStr, makeSeededRng, seededShuffle } from './seededRandom'
 import {
   getChronicleFragments, addChronicleFragments, removeChronicleFragments,
@@ -82,10 +82,8 @@ export function getWeeklyChallenge(now: Date = new Date()): WeeklyChallengeDef {
 
 // ── Deck building ─────────────────────────────────────────────────────────────
 
-/** A card's tags: theme tags from cards.json plus the unit's combat tags. */
-export function getAllCardTags(card: Card): string[] {
-  return [...getCardThemeTags(card.name), ...(card.unit?.tags ?? [])]
-}
+/** Re-exported for existing callers — the helper itself now lives in cards.ts. */
+export { getAllCardTags }
 
 function hasAnyTag(card: Card, tags: string[]): boolean {
   return getAllCardTags(card).some(t => tags.includes(t))

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1042,6 +1042,32 @@ body {
   opacity: 0.5;
 }
 
+/* Synergy markers — corner of the art, so the dense bottom row is untouched. */
+.card-synergy-badge {
+  position: absolute;
+  top: -2px;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  line-height: 1;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.card-synergy-icon {
+  font-size: 0.55rem;
+  opacity: 0.8;
+}
+
+.card-synergy-count {
+  font-size: 0.5rem;
+  font-weight: bold;
+  letter-spacing: -0.02em;
+  color: var(--color-gold-alt);
+  text-shadow: 0 0 5px rgba(255, 204, 0, 0.7);
+}
+
 .card-sprite {
   max-width: 64px;
   max-height: 40px;
@@ -3471,6 +3497,7 @@ body {
 .cdm-sw-label--strong   { color: #55cc55; }
 .cdm-sw-label--weak     { color: #ff6655; }
 .cdm-sw-label--affinity { color: var(--color-gold-alt); }
+.cdm-sw-label--synergy  { color: #6cf; }
 .cdm-sw-tags {
   color: var(--game-text-color-dim);
   text-transform: capitalize;
@@ -3491,6 +3518,8 @@ body {
   line-height: 1.5;
 }
 .cdm-sw-detail strong { color: var(--game-text-color); }
+/* One pairing or group per line — the synergy row lists several at once. */
+.cdm-synergy-item + .cdm-synergy-item { margin-top: 5px; }
 .cdm-sw-detail em { font-style: normal; color: #aad4ff; }
 
 .cdm-mastery-block {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5444,10 +5444,15 @@ body {
   opacity: 0.5;
 }
 
-/* Pairs with something already in the deck. */
+/* Shares a synergy group with the deck — common, so kept subtle. */
 .collection-cell--synergy .card-tile {
+  border-color: rgba(255, 204, 0, 0.5);
+}
+
+/* Directly pairs with a deck card (affinity or spawner) — the strong signal. */
+.collection-cell--combo .card-tile {
   border-color: var(--color-gold-alt);
-  box-shadow: 0 0 8px rgba(255, 204, 0, 0.35);
+  box-shadow: 0 0 10px rgba(255, 204, 0, 0.45);
 }
 
 .cell-resting-label {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5444,6 +5444,12 @@ body {
   opacity: 0.5;
 }
 
+/* Pairs with something already in the deck. */
+.collection-cell--synergy .card-tile {
+  border-color: var(--color-gold-alt);
+  box-shadow: 0 0 8px rgba(255, 204, 0, 0.35);
+}
+
 .cell-resting-label {
   color: var(--color-orange-alt);
   font-size: var(--font-xxs);


### PR DESCRIPTION
Closes #882
Closes #1918
Closes #1919
Closes #1920

## Why

The game already has a real synergy system that players can't see. 202 unit templates carry an `affinity` block — a proximity buff `processAffinities` resolves every tick in `web/src/game/engine/units.ts` — and 272 structures spawn a unit, 268 of which are playable cards in their own right. Today the only way to learn any of that is to open one specific card's detail modal and expand a collapsed row that's gated behind Mastery 1.

So: badges on the tile, a plain-English breakdown in the detail modal, and live feedback while deck building.

## What changed

**Data — `web/src/data/synergies.json`** (#1918)
22 synergy groups defined over the tags cards already have. Every group is between 2 and 70 cards, enforced by a test: a group matching a sixth of the catalogue is a category, not a combo hint. Generic combat tags (`melee`, `ranged`, `armored`, `flying`) are deliberately excluded — too broad, and `CardDetailModal` already renders them as trait chips.

`cards.json` also gains theme tags on the 27 cards that had none (`Wizard`, `Stone Wall`, `Farm`, `Golem`, `Fire Mage`, `Wyvern`, `Dreadnought`, …). They were invisible to synergy and to the existing weekly-challenge and quest tag pools. 92% of the 960-card catalogue now falls in at least one group; the rest carry only generic combat tags and have nothing useful to say.

**Logic — `web/src/game/synergies.ts`**
Two tiers, both read out of existing data:
- *Synergy groups* — broad, "these belong in the same deck"
- *Combo links* — precise, derived per card: affinity partners, and spawner links in both directions. Weighted 3× a shared group, since they're specific and mechanically real.

`buildDeckProfile` / `getDeckSynergy` score a card against a deck; the profile is built once per deck change so the whole browser can be rescored on every add.

`getAllCardTags` moves from `weeklyChallenge.ts` to `cards.ts`, where the tag data lives, and is re-exported so existing callers are untouched.

**UI** (#1919, #1920)
- `SynergyBadges` — icon-only group markers plus a `⚡N` pairing count, in the corner of the card art so the already-dense bottom row of the tile is untouched
- `CardDetailModal` — a collapsible SYNERGY row matching the existing strengths/weaknesses/affinity rows, listing each pairing ("Spawns a Vine Runner every 9s") and each group
- `DeckBuilder` — live scoring, plus a "⚡ Synergy" sort

One thing changed after seeing it render: a single glow for "shares a group" lit up nearly the whole browser at 92% coverage. Split into two signals — a dim border for a shared group, a bright glow plus `⚡N` for a direct pairing — so each visual means exactly one thing.

**Docs** — `docs/synergies.md` (the model, the group table, and the rules for adding a group), pointed at from `AGENTS.md`.

## Verification

- `npm run build` — clean
- `npm run test` — 2065 passed, including 15 new tests in `synergies.test.ts` (group integrity and sizing, link symmetry, catalogue resolution, deck scoring) and `weeklyChallenge.test.ts` unchanged after the `getAllCardTags` move
- Storybook checked in a browser for the tile, detail modal and deck builder — this is where the two-signal split came from

The storybook vitest project can't run in this environment (its Playwright wants chromium build 1217; 1194 is installed), so those story tests are unverified here and will run in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRvTy8TwziahZVS5hHwh4X)_