### PR TITLE
Make the Firestore rules deploy actually work

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,8 +72,32 @@ jobs:
   deploy-firebase:
     needs: build
     runs-on: ubuntu-latest
+    # Authenticates with a service-account JSON key rather than the deprecated
+    # --token flag. Workload Identity Federation would be preferable, but
+    # firebase-tools currently discards ADC/WIF credentials and fails with a
+    # misleading "have you run firebase login?" — firebase-tools#10726.
+    # The secret is lifted into env because `secrets` is not available to
+    # job-level `if:` conditions.
+    env:
+      FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Write service account key
+        if: env.FIREBASE_SERVICE_ACCOUNT != ''
+        run: echo "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-sa.json"
+
+      # Pinned rather than @latest: an unpinned CLI silently changes between runs.
       - name: Deploy Firestore rules
-        run: npx firebase-tools@latest deploy --only firestore:rules --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }}
+        if: env.FIREBASE_SERVICE_ACCOUNT != ''
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
+        run: >
+          npx --yes firebase-tools@15.25.1 deploy --only firestore:rules
+          --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }} --non-interactive
+
+      # Warns rather than fails: a red X meaning "a secret is unset" trains
+      # everyone to ignore red X's, which is how this went unnoticed for days.
+      - name: Warn when the secret is missing
+        if: env.FIREBASE_SERVICE_ACCOUNT == ''
+        run: echo "::warning::FIREBASE_SERVICE_ACCOUNT is not set — Firestore rules were not deployed"

--- a/Firebase.md
+++ b/Firebase.md
@@ -55,15 +55,37 @@ the **Firebase Admin** or **Editor** role on project `jawg-a3271`.
 
 ## Firestore Security Rules
 
-Current rules are in `web/src/game/cloudSave.ts` (commented at the top).
-Deploy them via the Firebase Console or CLI:
+The rules live in **`firestore.rules`** at the repo root — the single source of
+truth. `firebase.json` points the CLI at it. They cover player saves
+(`saves/{uid}`, readable/writable only by that authenticated user; anonymous
+users have no access) plus the daily/weekly leaderboards and other collections.
+
+### Automatic deploy
+
+The `deploy-firebase` job in `.github/workflows/deploy.yml` pushes the rules on
+every merge to `main`. It needs one repo secret:
+
+| Secret | What it is |
+|---|---|
+| `FIREBASE_SERVICE_ACCOUNT` | The **full JSON key** of a service account with the *Firebase Rules Admin* role (`roles/firebaserules.admin`; `roles/firebase.admin` also works) |
+
+Create it in the Google Cloud console under IAM → Service Accounts → Keys →
+Add key → JSON, then paste the whole file into the secret.
+
+If the secret is unset the job **warns and skips** rather than failing, so a
+green workflow does not by itself prove the rules deployed — check the job log.
+
+> **Why a JSON key and not Workload Identity Federation?** WIF is the better
+> practice, but `firebase-tools` currently discards ADC/WIF credentials and dies
+> with a misleading "Failed to authenticate, have you run firebase login?"
+> ([firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726)).
+> A JSON key is long-lived — rotate it periodically.
+
+### Manual deploy
 
 ```bash
-firebase deploy --only firestore:rules
+firebase deploy --only firestore:rules --project jawg-a3271
 ```
-
-The rules grant each authenticated user read/write access only to their own
-document at `saves/{uid}`. Anonymous users have no access.
 
 ---
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/web/src/game/cloudSave.ts
+++ b/web/src/game/cloudSave.ts
@@ -1,15 +1,9 @@
 import { doc, setDoc, getDoc, Timestamp } from 'firebase/firestore'
 import { db } from '../firebase'
 
-// Required Firestore Security Rules:
-//   rules_version = '2';
-//   service cloud.firestore {
-//     match /databases/{database}/documents {
-//       match /saves/{userId} {
-//         allow read, write: if request.auth != null && request.auth.uid == userId;
-//       }
-//     }
-//   }
+// Firestore security rules live in `firestore.rules` at the repo root — the
+// single source of truth, deployed by the deploy-firebase CI job. This file
+// previously carried a partial copy that had drifted out of date.
 
 // Keys that are device-specific and should not be synced to the cloud.
 const SKIP_KEYS = new Set(['jarv_battle_state', 'jarv_player_id'])


### PR DESCRIPTION
> ⚠️ **Action required:** this needs a `FIREBASE_SERVICE_ACCOUNT` repo secret before the rules will deploy. Details below.

The deploy workflow has been red on every merge since at least 31 July. It isn't the site — `build` and `deploy` both pass and jawg.uk is current. Only `deploy-firebase` fails:

```
npx firebase-tools@latest deploy --only firestore:rules --project *** --token
error: option '--token <token>' argument missing
```

`secrets.FIREBASE_TOKEN` expands to nothing, so `--token` is passed with no value.

## A second blocker was hidden behind the first

There was no `firebase.json` (or `.firebaserc`) anywhere in the repo, and `firebase deploy --only firestore:rules` resolves the rules file through it. I reproduced both failures in order:

```
# no firebase.json — never even reaches auth
Error: Not in a Firebase app directory (could not locate firebase.json)

# with firebase.json — config resolves, now stops at credentials
... at async autoAuth (firebase-tools/lib/requireAuth.js:38)
```

So this job has **never succeeded**, and `firestore.rules` has never deployed from CI. Those 93 lines govern player saves and the daily/weekly leaderboards, so the committed rules and the rules actually enforced in Firebase have been drifting apart. That's the part that matters here — the red X was cosmetic, the rules drift isn't.

## Changes

- **`firebase.json`** (new) points the CLI at `firestore.rules`.
- **`deploy-firebase`** authenticates with a service-account JSON key via `GOOGLE_APPLICATION_CREDENTIALS` instead of the deprecated `--token`.
- **Pinned `firebase-tools@15.25.1`** instead of `@latest`, which silently changes between runs.
- **A missing secret now warns and skips** rather than failing. A red X meaning "a secret is unset" is precisely how this went unnoticed for days.
- **Docs de-duplicated:** `Firebase.md` pointed at a stale partial copy of the rules commented in `cloudSave.ts` that covered only `saves/{userId}` and omitted the leaderboards entirely. Docs now point at `firestore.rules`; the comment is replaced by a pointer.

### Why a JSON key and not Workload Identity Federation

WIF is the better practice, but `firebase-tools` currently discards ADC/WIF credentials and dies with a misleading "Failed to authenticate, have you run firebase login?" ([firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726), open as of June 2026). It's a timeout in its `autoAuth()` path — the same function the local run above now reaches. A JSON key works today; it's long-lived, so worth rotating periodically.

## What you need to do

1. Create a service account with **Firebase Rules Admin** (`roles/firebaserules.admin`; `roles/firebase.admin` also works) and download its JSON key.
2. Add the full JSON as a repo secret named `FIREBASE_SERVICE_ACCOUNT`.
3. `FIREBASE_TOKEN` can then be deleted.

**Before the first deploy**, worth diffing the live rules in the Firebase console against `firestore.rules` — since CI has never pushed them, anything added by hand in the console would be overwritten.

## Verification

- Reproduced the "no firebase.json" failure and confirmed the error changes to an auth failure once it exists — that shift is the evidence the config resolves, since credentials aren't available locally.
- `deploy.yml` re-parsed as YAML to confirm the `env`/`if` blocks are well-formed (`secrets` isn't available to job-level `if:`, hence lifting it into `env`).
- Typecheck clean, 2081 tests pass — `cloudSave.ts` only lost a comment.
- `deploy.yml` runs on `main` only, so this PR can't exercise any of it. After merge: confirm `deploy-firebase` is green **and** check the job log actually deployed rather than warning-and-skipping, then confirm the console rules match `firestore.rules` including the leaderboard sections.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvMFZuUDw4srQ4WJaw4A2x)_