### PR TITLE
PixiJS migration: CityBuilder road wear and walker sprites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,8 @@ usePixiApp(canvasRef, W, H, (app) => {
 | TowerDefence grid | `towerdefence/GameGrid.tsx` | ✅ PixiJS |
 | NodeMap terrain + connectors | `campaign/NodeMap.tsx` | Pending |
 | Battlefield lane canvas | `battle/BattlefieldCanvas.tsx` | ✅ PixiJS |
-| CityBuilder road + walkers | `citybuilder/CityGrid.tsx` | Pending |
+| CityBuilder road wear | `citybuilder/CityTerrainCanvas.tsx` | ✅ PixiJS |
+| CityBuilder walkers | `citybuilder/CityWalkerCanvas.tsx` | ✅ PixiJS |
 
 ---
 

--- a/web/src/components/minigames/citybuilder/CityGrid.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.stories.tsx
@@ -117,6 +117,46 @@ const verticalWearCity: any = {
   },
 }
 
+// ── Walkers ───────────────────────────────────────────────────────────────────
+// Walkers are drawn on a canvas layered over the DOM grid, so this story is the
+// check that the canvas sits above the cells and that bubbles land on top of it.
+
+const walker = (cellIndex: number, unitIndex: number, unitName: string, x: number, y: number, extra: any = {}): any => ({
+  cellIndex, unitIndex, unitName, x, y,
+  vx: 0, vy: 0, turnTimer: 0, taskTimer: 0, bubbleTimer: 0,
+  hidden: false, hiddenTimer: 0, trait: 'sociable', waypoints: [],
+  task: { type: 'idle', label: '' },
+  ...extra,
+})
+
+const walkerCity: any = {
+  ...emptyCity,
+  grid: makeGrid([0, 1, 7, 8, 13]),
+  happiness: { 0: 100, 1: 100, 7: 30, 8: 100, 13: 100 },
+}
+
+export const WithWalkers: Story = {
+  args: {} as any,
+  render: () => (
+    <WithRef
+      city={walkerCity}
+      walkers={[
+        walker(0, 0, 'Goblin',   60,  60),
+        walker(1, 0, 'Skeleton', 180, 60, { bubbleTimer: 5, task: { type: 'gathering', label: 'Gathering wood' } }),
+        walker(7, 0, 'Knight',   300, 140),
+        walker(8, 0, 'Goblin',   420, 140, { task: { type: 'chatting', label: '👋' } }),
+      ]}
+      builderWalkers={[{ queueIndex: 0, cardName: 'Wall', x: 120, y: 220, label: 'Building Wall' } as any]}
+      visualCarriers={[
+        { id: 'c1', carrying: { wood: 2 }, x: 300, y: 240, scale: 1, phase: 'returning' } as any,
+      ]}
+      bulldozerMode={false}
+      paintBrush={false} onCellTap={fn()} onPaint={fn()}
+      onWalkerClick={fn()}
+    />
+  ),
+}
+
 export const HorizontalRoadWear: Story = {
   args: {} as any,
   render: () => (

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -12,60 +12,6 @@ import { CityZoomControls } from './CityZoomControls'
 import { useZoomPan } from './useZoomPan'
 import { CityTerrainCanvas } from './CityTerrainCanvas'
 
-// ── Road path SVG ─────────────────────────────────────────────────────────────
-// Strips are centred on the cell boundary (bottom / right) so they straddle
-// the CSS grid gap, appearing IN the gap rather than deep inside the gap.
-// ROAD_EXT extends each strip beyond the cell boundary to bridge the gap.
-//   Horizontal (h wear) → full-width strip centred on the bottom boundary (y=100)
-//   Vertical   (v wear) → full-height strip centred on the right  boundary (x=100)
-// overflow="visible" on the SVG lets the ±ROAD_EXT portions render in the gap.
-
-const ROAD_W   = 20  // strip width as % of cell
-const ROAD_EXT = 12  // extra SVG units beyond boundary to cover the CSS grid gap
-
-function pathFill(wear: number, highlight = false): string {
-  const t = Math.min(1, wear / 100)
-  const r = Math.round(140 + (170 - 140) * t)
-  const g = Math.round(100 + (155 - 100) * t)
-  const b = Math.round(40  + (110 - 40)  * t)
-  const a = highlight
-    ? (0.55 + t * 0.35).toFixed(2)
-    : (0.25 + t * 0.45).toFixed(2)
-  return `rgba(${r},${g},${b},${a})`
-}
-
-interface RoadPathProps {
-  left: number; right: number; top: number; bottom: number
-}
-
-function RoadPath({ left, right, top, bottom }: RoadPathProps) {
-  const hasH = left > 0 || right > 0
-  const hasV = top > 0 || bottom > 0
-  if (!hasH && !hasV) return null
-
-  const wearH = Math.max(left, right)
-  const wearV = Math.max(top, bottom)
-  const wearX = Math.max(wearH, wearV)
-
-  const HALF = (ROAD_W / 2)/2
-  const hy = 100 - HALF
-  const vx = 100 - HALF
-
-  return (
-    <svg
-      viewBox="0 0 100 100"
-      preserveAspectRatio="none"
-      aria-hidden
-      overflow="visible"
-      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none', overflow: 'visible' }}
-    >
-      {hasH && <rect x={-ROAD_EXT} y={hy} width={100 + ROAD_EXT * 2} height={ROAD_W} fill={pathFill(wearH)} />}
-      {hasV && <rect x={vx} y={-ROAD_EXT} width={ROAD_W} height={100 + ROAD_EXT * 2} fill={pathFill(wearV)} />}
-      {hasH && hasV && <rect x={vx} y={hy} width={ROAD_W} height={ROAD_W} fill={pathFill(wearX, true)} />}
-    </svg>
-  )
-}
-
 // ── Props ─────────────────────────────────────────────────────────────────────
 
 export interface Props {
@@ -155,37 +101,13 @@ export function CityGrid({
       />
 
       <div className="city-zoom-wrapper" ref={wrapperRef}>
-        {/* ── Terrain background ──────────────────────────────────────────────
-            World-scale tile canvas, rendered behind everything. */}
-        <CityTerrainCanvas environment={environment} id={environment} />
-
-        {/* ── Road wear overlay ───────────────────────────────────────────────
-            Rendered BEHIND the main grid. */}
-        {useMemo(() => (
-          <div
-            className="city-road-layer"
-            style={{
-              gridTemplateColumns: `repeat(${cityCols}, 1fr)`,
-              gridTemplateRows:    `repeat(${cityRows}, 1fr)`,
-            }}
-          >
-            {Array.from({ length: cityCells }, (_, i) => {
-              const row = Math.floor(i / cityCols)
-              const col = i % cityCols
-              const h = city.roadWear?.h ?? []
-              const v = city.roadWear?.v ?? []
-              const wearLeft   = col === 0            ? 0 : (h[i - 1]       ?? 0)
-              const wearRight  = col === cityCols - 1 ? 0 : (h[i]            ?? 0)
-              const wearTop    = row === 0            ? 0 : (v[i - cityCols] ?? 0)
-              const wearBottom = row === cityRows - 1 ? 0 : (v[i]            ?? 0)
-              return (
-                <div key={i} className="city-road-cell">
-                  <RoadPath left={wearLeft} right={wearRight} top={wearTop} bottom={wearBottom} />
-                </div>
-              )
-            })}
-          </div>
-        ), [city.roadWear, cityCols, cityRows, cityCells])}
+        {/* ── Terrain background + road wear ──────────────────────────────────
+            World-scale tile canvas, rendered behind everything. Roads share
+            this app rather than opening a WebGL context of their own. */}
+        <CityTerrainCanvas
+          environment={environment} id={environment}
+          roadWear={city.roadWear} cols={cityCols} rows={cityRows}
+        />
 
         {useMemo(() => (
         <div

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -102,22 +102,13 @@ export function CityGrid({
         name: w.unitName,
         x: w.x, y: w.y, fps: 6,
         faded: rage >= 60,
-        badge: rage >= 40 ? '!' : undefined,
       })
     }
     for (const [idx, b] of builderWalkers.entries()) {
       out.push({ key: `b-${idx}`, name: 'Builder', x: b.x, y: b.y, fps: 8 })
     }
     for (const vc of visualCarriers) {
-      const res = Object.keys(vc.carrying)[0] as ResourceType
-      out.push({
-        key:  `c-${vc.id}`,
-        name: 'Goblin',
-        x: vc.x, y: vc.y, fps: 8,
-        scale: vc.scale,
-        badge: vc.phase === 'returning' ? RESOURCE_ICONS[res] : undefined,
-        badgeColor: '#ffffff',
-      })
+      out.push({ key: `c-${vc.id}`, name: 'Goblin', x: vc.x, y: vc.y, fps: 8, scale: vc.scale })
     }
     return out
   }, [walkers, builderWalkers, visualCarriers, city.happiness])
@@ -266,8 +257,8 @@ export function CityGrid({
         {/* Every moving sprite — residents, builders, carriers — on one canvas */}
         <CityWalkerCanvas sprites={canvasSprites} />
 
-        {/* Bubbles stay in the DOM: they carry text and nested sprite icons.
-            Positioned from the same walker coords the canvas draws from. */}
+        {/* Text stays in the DOM — bubbles, the "!" need marker and the carried
+            resource icon. Positioned from the same coords the canvas draws from. */}
         <div className="city-unit-overlay">
           {walkers.map(w => {
             if (w.hidden) return null
@@ -275,7 +266,8 @@ export function CityGrid({
             const wantsFriend    = wantsFriendSet.has(wKey)
             const showTaskBubble = visibleBubbleSet.has(wKey)
             const chatting       = w.task.type === 'chatting'
-            if (!chatting && !showTaskBubble && !wantsFriend) return null
+            const needs          = (100 - (city.happiness[w.cellIndex] ?? 100)) >= 40
+            if (!chatting && !showTaskBubble && !wantsFriend && !needs) return null
             return (
               <div
                 key={wKey}
@@ -293,6 +285,22 @@ export function CityGrid({
                     <SpriteImg name={w.affinityWith ?? w.unitName} className="city-speech-icon" />
                   </div>
                 )}
+                {needs && <span className="city-walker-need">!</span>}
+              </div>
+            )
+          })}
+
+          {/* Carriers show what they are hauling on the return leg */}
+          {visualCarriers.map(vc => {
+            if (vc.phase !== 'returning') return null
+            const res = Object.keys(vc.carrying)[0] as ResourceType
+            return (
+              <div
+                key={`carrier-${vc.id}`}
+                className="city-walker city-walker--bubble-only"
+                style={{ left: Math.round(vc.x), top: Math.round(vc.y) }}
+              >
+                <div className="city-carrier-load">{RESOURCE_ICONS[res]}</div>
               </div>
             )
           })}

--- a/web/src/components/minigames/citybuilder/CityGrid.tsx
+++ b/web/src/components/minigames/citybuilder/CityGrid.tsx
@@ -5,12 +5,16 @@ import {
   getRowDistrict, DISTRICT_INFO,
   RESOURCE_ICONS, ResourceType,
 } from '../../../game/cityBuilder'
-import { SpriteImg, AnimatedSpriteImg } from '../../ui/SpriteImg'
+import { SpriteImg } from '../../ui/SpriteImg'
 import { BuilderWalker, VisualCarrier } from '../CityBuilder'
 import { Walker } from './walkerTypes'
 import { CityZoomControls } from './CityZoomControls'
 import { useZoomPan } from './useZoomPan'
 import { CityTerrainCanvas } from './CityTerrainCanvas'
+import { CityWalkerCanvas, CitySprite } from './CityWalkerCanvas'
+
+/** Half-extent of a walker's tap target, matching the old 20×20 `.city-walker` box. */
+const WALKER_HIT_RADIUS = 12
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -39,7 +43,7 @@ export function CityGrid({
   const cityCells = cityCols * cityRows
 
   // ── Zoom / pan (shared hook) ─────────────────────────────────────────────────
-  const { wrapperRef, displayScale, stepZoom, zoomTo, getCellFromPoint: getCellFromPointRaw } =
+  const { wrapperRef, displayScale, stepZoom, zoomTo, getCellFromPoint: getCellFromPointRaw, getLocalPoint } =
     useZoomPan(worldRef, paintBrush, onPaint)
 
   const getCellFromPoint = useCallback(
@@ -85,12 +89,69 @@ export function CityGrid({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [city.grid, city.happiness, city.rows, city.cols])
 
+  // ── Canvas sprites ───────────────────────────────────────────────────────────
+  // Residents, builders and carriers flattened into the one list the canvas
+  // draws. Bubbles stay in the DOM below — they carry text and nested sprites.
+  const canvasSprites = useMemo<CitySprite[]>(() => {
+    const out: CitySprite[] = []
+    for (const w of walkers) {
+      if (w.hidden) continue
+      const rage = 100 - (city.happiness[w.cellIndex] ?? 100)
+      out.push({
+        key:  `w-${w.cellIndex}-${w.unitIndex}`,
+        name: w.unitName,
+        x: w.x, y: w.y, fps: 6,
+        faded: rage >= 60,
+        badge: rage >= 40 ? '!' : undefined,
+      })
+    }
+    for (const [idx, b] of builderWalkers.entries()) {
+      out.push({ key: `b-${idx}`, name: 'Builder', x: b.x, y: b.y, fps: 8 })
+    }
+    for (const vc of visualCarriers) {
+      const res = Object.keys(vc.carrying)[0] as ResourceType
+      out.push({
+        key:  `c-${vc.id}`,
+        name: 'Goblin',
+        x: vc.x, y: vc.y, fps: 8,
+        scale: vc.scale,
+        badge: vc.phase === 'returning' ? RESOURCE_ICONS[res] : undefined,
+        badgeColor: '#ffffff',
+      })
+    }
+    return out
+  }, [walkers, builderWalkers, visualCarriers, city.happiness])
+
+  // The canvas is pointer-events:none so it never swallows taps meant for the
+  // grid cells underneath. Walker taps are resolved here instead. It has to be
+  // the click capture phase: capture runs before the cell button's own onClick,
+  // so stopping propagation on a hit keeps the cell from also opening.
+  const walkerHitRef = useRef(walkers)
+  walkerHitRef.current = walkers
+  const onWalkerHitTest = useCallback((e: React.MouseEvent) => {
+    if (paintBrush) return
+    const p = getLocalPoint(e.clientX, e.clientY)
+    if (!p) return
+    // Last drawn wins, matching what the player sees on top.
+    for (let i = walkerHitRef.current.length - 1; i >= 0; i--) {
+      const w = walkerHitRef.current[i]
+      if (w.hidden) continue
+      if (Math.abs(p.x - w.x) <= WALKER_HIT_RADIUS && Math.abs(p.y - w.y) <= WALKER_HIT_RADIUS) {
+        e.stopPropagation()
+        e.preventDefault()
+        onWalkerClickRef.current(w.cellIndex, w.unitIndex)
+        return
+      }
+    }
+  }, [paintBrush, getLocalPoint])
+
   return (
     <>
       {toolbar}
       <div
         className={`city-world${paintBrush ? ' city-world--paint' : ''}`}
         ref={worldRef}
+        onClickCapture={onWalkerHitTest}
       >
       {/* Zoom controls — outside the zoom wrapper so they don't scale */}
       <CityZoomControls
@@ -202,29 +263,29 @@ export function CityGrid({
         // eslint-disable-next-line react-hooks/exhaustive-deps
         ), [city, cityCols, cityRows, cityCells, bulldozerMode, paintBrush, startPaint])}
 
-        {/* Walking units overlay */}
+        {/* Every moving sprite — residents, builders, carriers — on one canvas */}
+        <CityWalkerCanvas sprites={canvasSprites} />
+
+        {/* Bubbles stay in the DOM: they carry text and nested sprite icons.
+            Positioned from the same walker coords the canvas draws from. */}
         <div className="city-unit-overlay">
           {walkers.map(w => {
             if (w.hidden) return null
-            const happiness      = city.happiness[w.cellIndex] ?? 100
-            const rage           = 100 - happiness
             const wKey           = `${w.cellIndex}-${w.unitIndex}`
             const wantsFriend    = wantsFriendSet.has(wKey)
             const showTaskBubble = visibleBubbleSet.has(wKey)
+            const chatting       = w.task.type === 'chatting'
+            if (!chatting && !showTaskBubble && !wantsFriend) return null
             return (
               <div
-                key={`${w.cellIndex}-${w.unitIndex}`}
-                role="button"
-                tabIndex={0}
-                className={`city-walker${rage >= 60 ? ' city-walker--unhappy' : ''}`}
+                key={wKey}
+                className="city-walker city-walker--bubble-only"
                 style={{ left: Math.round(w.x), top: Math.round(w.y) }}
-                onClick={e => { e.stopPropagation(); onWalkerClickRef.current(w.cellIndex, w.unitIndex) }}
-                onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); onWalkerClickRef.current(w.cellIndex, w.unitIndex) } }}
               >
-                {w.task.type === 'chatting' && (
+                {chatting && (
                   <div className="city-chat-bubble">{w.task.label}</div>
                 )}
-                {showTaskBubble && w.task.type !== 'chatting' && (
+                {showTaskBubble && !chatting && (
                   <div className="city-task-bubble">{w.task.label}</div>
                 )}
                 {!showTaskBubble && wantsFriend && (
@@ -232,8 +293,6 @@ export function CityGrid({
                     <SpriteImg name={w.affinityWith ?? w.unitName} className="city-speech-icon" />
                   </div>
                 )}
-                <AnimatedSpriteImg name={w.unitName} frameCount={3} fps={6} className="city-walker-sprite" />
-                {rage >= 40 && <span className="city-walker-need">!</span>}
               </div>
             )
           })}
@@ -242,27 +301,13 @@ export function CityGrid({
           {builderWalkers.map((b, idx) => (
             <div
               key={`builder-${idx}`}
-              className="city-walker city-builder-walker"
+              className="city-walker city-walker--bubble-only city-builder-walker"
               style={{ left: Math.round(b.x), top: Math.round(b.y) }}
               title={b.label}
             >
               <div className="city-builder-bubble">{b.label}</div>
-              <AnimatedSpriteImg name="Builder" frameCount={3} fps={8} className="city-walker-sprite" />
             </div>
           ))}
-        </div>
-
-        {/* Carrier overlay */}
-        <div className="city-unit-overlay city-carrier-overlay">
-          {visualCarriers.map(vc => {
-            const res = Object.keys(vc.carrying)[0] as ResourceType
-            return (
-              <div key={vc.id} className="city-walker city-carrier-goblin" style={{ left: Math.round(vc.x), top: Math.round(vc.y), transform: `translate(-50%,-50%) scale(${vc.scale})` }}>
-                {vc.phase === 'returning' && <div className="city-carrier-load">{RESOURCE_ICONS[res]}</div>}
-                <AnimatedSpriteImg name="Goblin" frameCount={3} fps={8} className="city-walker-sprite" />
-              </div>
-            )
-          })}
         </div>
       </div>{/* end zoom wrapper */}
     </div>

--- a/web/src/components/minigames/citybuilder/CityTerrainCanvas.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityTerrainCanvas.stories.tsx
@@ -27,3 +27,41 @@ export const Volcano:  Story = { args: { environment: 'volcano',  id: 'city-volc
 export const Citadel:  Story = { args: { environment: 'citadel',  id: 'city-citadel'   } }
 export const Coast:    Story = { args: { environment: 'coast',    id: 'city-coast'     } }
 export const Frost:    Story = { args: { environment: 'frost',    id: 'city-frost'     } }
+
+// ── Road wear ─────────────────────────────────────────────────────────────────
+// A 6×4 grid, matching CITY_COLS × CITY_ROWS. h[i] is the edge between cell i
+// and i+1; v[i] the edge between cell i and i+6. Strips are drawn on each
+// cell's bottom/right boundary, so they land in the grid gap.
+
+const COLS = 6, ROWS = 4, CELLS = COLS * ROWS
+const noWear = () => new Array(CELLS).fill(0)
+
+const withWear = (h: number[], v: number[]) => ({
+  environment: 'farmland', id: 'city-roads', cols: COLS, rows: ROWS, roadWear: { h, v },
+})
+
+/** Top row fully worn left-to-right — a horizontal stripe under row 0. */
+export const RoadsHorizontal: Story = {
+  args: withWear(noWear().map((_, i) => (i < COLS - 1 ? 100 : 0)), noWear()),
+}
+
+/** Left column fully worn top-to-bottom — a vertical stripe right of col 0. */
+export const RoadsVertical: Story = {
+  args: withWear(noWear(), noWear().map((_, i) => (i % COLS === 0 && i < COLS * (ROWS - 1) ? 100 : 0))),
+}
+
+/** Crossing roads, so the brighter junction patches are visible. */
+export const RoadsJunction: Story = {
+  args: withWear(
+    noWear().map((_, i) => (Math.floor(i / COLS) === 1 && i % COLS < COLS - 1 ? 100 : 0)),
+    noWear().map((_, i) => (i % COLS === 2 && i < COLS * (ROWS - 1) ? 100 : 0)),
+  ),
+}
+
+/** The full wear ramp, faintest to heaviest, one level per column. */
+export const RoadsWearRamp: Story = {
+  args: withWear(
+    noWear().map((_, i) => (Math.floor(i / COLS) === 1 && i % COLS < COLS - 1 ? (i % COLS + 1) * 20 : 0)),
+    noWear(),
+  ),
+}

--- a/web/src/components/minigames/citybuilder/CityTerrainCanvas.tsx
+++ b/web/src/components/minigames/citybuilder/CityTerrainCanvas.tsx
@@ -4,16 +4,46 @@ import { usePixiApp } from '../../../hooks/usePixiApp'
 import { buildTerrainGfx, buildBgTileGfx, buildDecorGfx } from '../../../utils/terrainLayer'
 import { WORLD_ENV_TILES } from '../../../data/tiles/worldTileIndex'
 import { ENV_TILES } from '../../../data/tiles/tileIndex'
+import { roadCellRect, cellWear, roadStrips } from './cityRoadGeometry'
+import type { RoadWearMap } from '../../../game/cityBuilder'
 
 export interface Props {
   environment?: string
   /** Stable ID used as terrain scatter seed — use act/node ID for deterministic decoration */
   id?: string
+  /**
+   * Road-wear edge arrays. Drawn into this app rather than a canvas of their
+   * own: roads belong behind the DOM `.city-grid`, which is exactly where the
+   * terrain already sits, and a second WebGL context here would be a third one
+   * in the city view (see #1569 — iOS kills pages under context pressure).
+   */
+  roadWear?: RoadWearMap
+  cols?: number
+  rows?: number
 }
 
-function TerrainPixi({ environment, id, w, h }: Props & { w: number; h: number }) {
+function drawRoads(
+  g: PIXI.Graphics,
+  roadWear: RoadWearMap | undefined,
+  cols: number, rows: number,
+  w: number, h: number,
+): void {
+  if (g.destroyed) return
+  g.clear()
+  if (!roadWear) return
+  const { h: hWear = [], v: vWear = [] } = roadWear
+  for (let i = 0; i < cols * rows; i++) {
+    const strips = roadStrips(cellWear(i, cols, rows, hWear, vWear), roadCellRect(i, cols, rows, w, h))
+    for (const s of strips) {
+      g.rect(s.x, s.y, s.w, s.h).fill({ color: s.color, alpha: s.alpha })
+    }
+  }
+}
+
+function TerrainPixi({ environment, id, roadWear, cols, rows, w, h }: Props & { w: number; h: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const envDef = WORLD_ENV_TILES[environment ?? ''] ?? ENV_TILES[environment ?? '']
+  const roadGfxRef = useRef<PIXI.Graphics | null>(null)
 
   usePixiApp(containerRef, w, h, (app) => {
     const base  = new PIXI.Container()
@@ -21,23 +51,35 @@ function TerrainPixi({ environment, id, w, h }: Props & { w: number; h: number }
     const world = new PIXI.Container()
     const bg    = new PIXI.Container()
     const decor = new PIXI.Container()
-    app.stage.addChild(base, bg, decor, world)
+    const roads = new PIXI.Graphics()   // above the scenery, below the DOM grid
+    app.stage.addChild(base, bg, decor, world, roads)
     buildTerrainGfx(base, river, world,
       { environment, envDef, id, rivers: [] },
       w, h)
     buildBgTileGfx(bg, { environment, envDef }, w, h)
     buildDecorGfx(decor, { environment, envDef, id }, w, h)
+    roadGfxRef.current = roads
+    drawRoads(roads, roadWear, cols ?? 1, rows ?? 1, w, h)
   })
+
+  // Redraw when wear changes. The scene is built once in onReady, so this is
+  // the only path for later updates; a context loss can destroy the Graphics
+  // out from under us mid-rebuild, hence the destroyed guard in drawRoads.
+  useEffect(() => {
+    const g = roadGfxRef.current
+    if (g) drawRoads(g, roadWear, cols ?? 1, rows ?? 1, w, h)
+  }, [roadWear, cols, rows, w, h])
 
   return <div ref={containerRef} style={{ width: w, height: h }} />
 }
 
 /**
- * World-scale tile terrain background for the CityBuilder grid.
+ * World-scale tile terrain background for the CityBuilder grid, plus the
+ * road-wear overlay drawn on top of it.
  * Measures its container after mount, then renders a PixiJS tile scene.
  * Placed as the first child of city-zoom-wrapper so it scales with zoom/pan.
  */
-export function CityTerrainCanvas({ environment = 'farmland', id }: Props) {
+export function CityTerrainCanvas({ environment = 'farmland', id, roadWear, cols, rows }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const [dims, setDims] = useState<{ w: number; h: number } | null>(null)
 
@@ -58,7 +100,13 @@ export function CityTerrainCanvas({ environment = 'farmland', id }: Props) {
       ref={wrapRef}
       style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: 0, pointerEvents: 'none' }}
     >
-      {dims && <TerrainPixi environment={environment} id={id} w={dims.w} h={dims.h} />}
+      {dims && (
+        <TerrainPixi
+          environment={environment} id={id}
+          roadWear={roadWear} cols={cols} rows={rows}
+          w={dims.w} h={dims.h}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/components/minigames/citybuilder/CityWalkerCanvas.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityWalkerCanvas.stories.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CityWalkerCanvas, CitySprite } from './CityWalkerCanvas'
+
+const meta = {
+  component: CityWalkerCanvas,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story: React.ComponentType) => (
+      // Stands in for .city-zoom-wrapper — sprite coords are pixels in this box.
+      <div style={{ width: 480, height: 320, position: 'relative', background: '#2d5a27' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CityWalkerCanvas>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const resident = (key: string, name: string, x: number, y: number): CitySprite =>
+  ({ key, name, x, y, fps: 6 })
+
+export const Residents: Story = {
+  args: {
+    sprites: [
+      resident('w-0', 'Goblin',   80,  70),
+      resident('w-1', 'Skeleton', 200, 70),
+      resident('w-2', 'Orc',      320, 70),
+      resident('w-3', 'Dragon',   440, 70),
+    ],
+  },
+}
+
+/** Rising discontent: the "!" marker appears first, then the dimmed grey state. */
+export const UnhappyResidents: Story = {
+  args: {
+    sprites: [
+      { ...resident('w-0', 'Goblin', 80, 100) },
+      { ...resident('w-1', 'Goblin', 200, 100), badge: '!' },
+      { ...resident('w-2', 'Goblin', 320, 100), badge: '!', faded: true },
+    ],
+  },
+}
+
+export const Builders: Story = {
+  args: {
+    sprites: [
+      { key: 'b-0', name: 'Builder', x: 120, y: 160, fps: 8 },
+      { key: 'b-1', name: 'Builder', x: 240, y: 160, fps: 8 },
+    ],
+  },
+}
+
+/** Carriers scale with distance and show their load on the return leg. */
+export const Carriers: Story = {
+  args: {
+    sprites: [
+      { key: 'c-0', name: 'Goblin', x: 100, y: 160, fps: 8, scale: 0.7 },
+      { key: 'c-1', name: 'Goblin', x: 220, y: 160, fps: 8, scale: 1,   badge: '🌾', badgeColor: '#ffffff' },
+      { key: 'c-2', name: 'Goblin', x: 340, y: 160, fps: 8, scale: 1.3, badge: '🪵', badgeColor: '#ffffff' },
+    ],
+  },
+}
+
+/** Everything at once, as the live city renders it. */
+export const MixedCrowd: Story = {
+  args: {
+    sprites: [
+      resident('w-0', 'Goblin',   60,  60),
+      { ...resident('w-1', 'Skeleton', 160, 90), badge: '!' },
+      { ...resident('w-2', 'Orc',      260, 60), faded: true, badge: '!' },
+      resident('w-3', 'Dragon',   360, 90),
+      { key: 'b-0', name: 'Builder', x: 140, y: 220, fps: 8 },
+      { key: 'c-0', name: 'Goblin',  x: 300, y: 230, fps: 8, scale: 1.2, badge: '⛏', badgeColor: '#ffffff' },
+    ],
+  },
+}
+
+/** A name with no sprite art must not break the rest of the layer. */
+export const MissingSprite: Story = {
+  args: {
+    sprites: [
+      resident('w-0', 'Goblin', 160, 160),
+      resident('w-1', 'Not A Real Unit Name', 240, 160),
+      resident('w-2', 'Orc', 320, 160),
+    ],
+  },
+}

--- a/web/src/components/minigames/citybuilder/CityWalkerCanvas.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityWalkerCanvas.stories.tsx
@@ -32,13 +32,13 @@ export const Residents: Story = {
   },
 }
 
-/** Rising discontent: the "!" marker appears first, then the dimmed grey state. */
+/** Unhappy residents render dimmed and desaturated. */
 export const UnhappyResidents: Story = {
   args: {
     sprites: [
       { ...resident('w-0', 'Goblin', 80, 100) },
-      { ...resident('w-1', 'Goblin', 200, 100), badge: '!' },
-      { ...resident('w-2', 'Goblin', 320, 100), badge: '!', faded: true },
+      { ...resident('w-1', 'Goblin', 200, 100) },
+      { ...resident('w-2', 'Goblin', 320, 100), faded: true },
     ],
   },
 }
@@ -52,13 +52,13 @@ export const Builders: Story = {
   },
 }
 
-/** Carriers scale with distance and show their load on the return leg. */
+/** Carriers scale with distance; the load icon they carry is a DOM overlay. */
 export const Carriers: Story = {
   args: {
     sprites: [
       { key: 'c-0', name: 'Goblin', x: 100, y: 160, fps: 8, scale: 0.7 },
-      { key: 'c-1', name: 'Goblin', x: 220, y: 160, fps: 8, scale: 1,   badge: '🌾', badgeColor: '#ffffff' },
-      { key: 'c-2', name: 'Goblin', x: 340, y: 160, fps: 8, scale: 1.3, badge: '🪵', badgeColor: '#ffffff' },
+      { key: 'c-1', name: 'Goblin', x: 220, y: 160, fps: 8, scale: 1 },
+      { key: 'c-2', name: 'Goblin', x: 340, y: 160, fps: 8, scale: 1.3 },
     ],
   },
 }
@@ -68,11 +68,11 @@ export const MixedCrowd: Story = {
   args: {
     sprites: [
       resident('w-0', 'Goblin',   60,  60),
-      { ...resident('w-1', 'Skeleton', 160, 90), badge: '!' },
-      { ...resident('w-2', 'Knight',   260, 60), faded: true, badge: '!' },
+      { ...resident('w-1', 'Skeleton', 160, 90) },
+      { ...resident('w-2', 'Knight',   260, 60), faded: true },
       resident('w-3', 'Dragon',   360, 90),
       { key: 'b-0', name: 'Builder', x: 140, y: 220, fps: 8 },
-      { key: 'c-0', name: 'Goblin',  x: 300, y: 230, fps: 8, scale: 1.2, badge: '⛏', badgeColor: '#ffffff' },
+      { key: 'c-0', name: 'Goblin',  x: 300, y: 230, fps: 8, scale: 1.2 },
     ],
   },
 }

--- a/web/src/components/minigames/citybuilder/CityWalkerCanvas.stories.tsx
+++ b/web/src/components/minigames/citybuilder/CityWalkerCanvas.stories.tsx
@@ -26,7 +26,7 @@ export const Residents: Story = {
     sprites: [
       resident('w-0', 'Goblin',   80,  70),
       resident('w-1', 'Skeleton', 200, 70),
-      resident('w-2', 'Orc',      320, 70),
+      resident('w-2', 'Knight',   320, 70),
       resident('w-3', 'Dragon',   440, 70),
     ],
   },
@@ -69,7 +69,7 @@ export const MixedCrowd: Story = {
     sprites: [
       resident('w-0', 'Goblin',   60,  60),
       { ...resident('w-1', 'Skeleton', 160, 90), badge: '!' },
-      { ...resident('w-2', 'Orc',      260, 60), faded: true, badge: '!' },
+      { ...resident('w-2', 'Knight',   260, 60), faded: true, badge: '!' },
       resident('w-3', 'Dragon',   360, 90),
       { key: 'b-0', name: 'Builder', x: 140, y: 220, fps: 8 },
       { key: 'c-0', name: 'Goblin',  x: 300, y: 230, fps: 8, scale: 1.2, badge: '⛏', badgeColor: '#ffffff' },
@@ -83,7 +83,7 @@ export const MissingSprite: Story = {
     sprites: [
       resident('w-0', 'Goblin', 160, 160),
       resident('w-1', 'Not A Real Unit Name', 240, 160),
-      resident('w-2', 'Orc', 320, 160),
+      resident('w-2', 'Knight', 320, 160),
     ],
   },
 }

--- a/web/src/components/minigames/citybuilder/CityWalkerCanvas.tsx
+++ b/web/src/components/minigames/citybuilder/CityWalkerCanvas.tsx
@@ -1,0 +1,218 @@
+import React, { useRef, useEffect } from 'react'
+import * as PIXI from 'pixi.js'
+import { usePixiApp } from '../../../hooks/usePixiApp'
+import { loadAnimFramesOrStatic } from '../../../utils/pixiHelpers'
+
+/**
+ * One moving sprite on the city canvas — a resident, a builder, or a carrier.
+ * Deliberately flat and game-agnostic: the caller flattens its own state into
+ * these, so this component stays purely visual.
+ */
+export interface CitySprite {
+  /** Stable identity across ticks — sprites are pooled by this. */
+  key:    string
+  /** Sprite name, resolved through the usual slug rules. */
+  name:   string
+  /** Centre position, in untransformed wrapper pixels. */
+  x:      number
+  y:      number
+  /** Walk-cycle speed, frames per second. */
+  fps:    number
+  /** Drawn size in px before `scale`. */
+  size?:  number
+  scale?: number
+  /** Unhappy residents: dimmed and desaturated. */
+  faded?: boolean
+  /** Small glyph above the sprite — the "!" need marker, or a carried resource. */
+  badge?: string
+  badgeColor?: string
+}
+
+export interface Props {
+  sprites: CitySprite[]
+}
+
+const DEFAULT_SIZE = 20
+
+// Residents move on a 100 ms game tick, so raw positions would step 10 times a
+// second. Easing toward the target each rendered frame turns that into smooth
+// motion without the canvas needing to know anything about the simulation.
+const EASE_PER_FRAME = 0.28
+/** Beyond this, a move is a teleport (respawn, un-hide) and should not glide. */
+const SNAP_DISTANCE = 60
+
+// One shared filter — a per-sprite instance would mean a render target each.
+const desaturate = new PIXI.ColorMatrixFilter()
+desaturate.desaturate()
+
+interface PooledSprite {
+  view:   PIXI.Container
+  sprite: PIXI.AnimatedSprite
+  badge:  PIXI.Text | null
+  targetX: number
+  targetY: number
+  faded:  boolean
+}
+
+function makeBadge(text: string, color: string, size: number): PIXI.Text {
+  const t = new PIXI.Text({
+    text,
+    style: new PIXI.TextStyle({ fontSize: 10, fontWeight: 'bold', fill: color }),
+  })
+  t.anchor.set(0.5, 1)
+  t.y = -size / 2
+  return t
+}
+
+function WalkerPixi({ sprites, w, h }: Props & { w: number; h: number }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const layerRef     = useRef<PIXI.Container | null>(null)
+  const poolRef      = useRef<Map<string, PooledSprite>>(new Map())
+  // Bumped when the Pixi app becomes ready, to drive the first sync: init is
+  // async, so the sync effect below usually runs before there is a layer.
+  // Also re-fires after a context-loss rebuild, which starts a fresh scene.
+  const [ready, setReady] = React.useState(0)
+
+  usePixiApp(containerRef, w, h, (app) => {
+    // A rebuild after context loss lands here with the old scene destroyed;
+    // the pool still references those dead sprites, so start it over.
+    poolRef.current.clear()
+    const layer = new PIXI.Container()
+    app.stage.addChild(layer)
+    layerRef.current = layer
+    setReady(n => n + 1)
+
+    const tick = () => {
+      for (const p of poolRef.current.values()) {
+        if (p.view.destroyed) continue
+        const dx = p.targetX - p.view.x
+        const dy = p.targetY - p.view.y
+        if (Math.abs(dx) < 0.05 && Math.abs(dy) < 0.05) {
+          p.view.x = p.targetX
+          p.view.y = p.targetY
+        } else {
+          p.view.x += dx * EASE_PER_FRAME
+          p.view.y += dy * EASE_PER_FRAME
+        }
+      }
+    }
+    app.ticker.add(tick)
+  })
+
+  // Sync the sprite pool to the latest list. Runs on each 100 ms tick of the
+  // caller's simulation; the ticker above handles the frames in between.
+  useEffect(() => {
+    const layer = layerRef.current
+    if (!layer || layer.destroyed) return
+    const pool = poolRef.current
+
+    const live = new Set(sprites.map(s => s.key))
+    for (const [key, p] of pool) {
+      if (!live.has(key)) {
+        layer.removeChild(p.view)
+        p.view.destroy({ children: true })
+        pool.delete(key)
+      }
+    }
+
+    for (const s of sprites) {
+      const size = s.size ?? DEFAULT_SIZE
+      let p = pool.get(s.key)
+
+      if (!p) {
+        // Register synchronously with a placeholder frame so a second sync
+        // arriving before the textures load reuses this sprite rather than
+        // adding a duplicate that would then be orphaned.
+        const view   = new PIXI.Container()
+        const sprite = new PIXI.AnimatedSprite([PIXI.Texture.EMPTY])
+        sprite.anchor.set(0.5)
+        sprite.width  = size
+        sprite.height = size
+        view.addChild(sprite)
+        view.x = s.x
+        view.y = s.y
+        layer.addChild(view)
+        p = { view, sprite, badge: null, targetX: s.x, targetY: s.y, faded: false }
+        pool.set(s.key, p)
+
+        loadAnimFramesOrStatic(s.name, 3).then(frames => {
+          if (sprite.destroyed || !frames.length) return
+          sprite.textures = frames
+          // The EMPTY placeholder baked a scale against a 1×1 texture, so the
+          // size has to be re-applied once real frames are in.
+          sprite.width  = size
+          sprite.height = size
+          sprite.animationSpeed = s.fps / 60
+          if (frames.length > 1) sprite.play()
+        }).catch(() => { /* no sprite art for this name — keep the placeholder */ })
+      }
+
+      // A jump too large to be a walk step is a respawn — land it, don't glide.
+      if (Math.hypot(s.x - p.targetX, s.y - p.targetY) > SNAP_DISTANCE) {
+        p.view.x = s.x
+        p.view.y = s.y
+      }
+      p.targetX = s.x
+      p.targetY = s.y
+
+      p.view.scale.set(s.scale ?? 1)
+      const faded = !!s.faded
+      if (faded !== p.faded) {
+        p.sprite.alpha   = faded ? 0.45 : 1
+        p.sprite.filters = faded ? [desaturate] : []
+        p.faded = faded
+      }
+
+      const badgeText = s.badge ?? ''
+      if (badgeText && !p.badge) {
+        p.badge = makeBadge(badgeText, s.badgeColor ?? '#d04020', size)
+        p.view.addChild(p.badge)
+      } else if (!badgeText && p.badge) {
+        p.view.removeChild(p.badge)
+        p.badge.destroy()
+        p.badge = null
+      } else if (badgeText && p.badge) {
+        if (p.badge.text !== badgeText) p.badge.text = badgeText
+      }
+    }
+  }, [sprites, ready])
+
+  return <div ref={containerRef} style={{ width: w, height: h }} />
+}
+
+/**
+ * Canvas layer for the city's moving sprites, replacing one absolutely
+ * positioned `<div>` + swapping `<img>` per walker.
+ *
+ * Measures its container after mount, exactly as CityTerrainCanvas does, then
+ * renders the sprites at wrapper scale so zoom/pan carries it along.
+ *
+ * The canvas is `pointer-events: none` so it never swallows taps meant for the
+ * grid cells underneath — walker hit-testing is done by the parent against the
+ * same positions it passes in here.
+ */
+export function CityWalkerCanvas({ sprites }: Props) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [dims, setDims] = React.useState<{ w: number; h: number } | null>(null)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const measure = () => {
+      const { width, height } = el.getBoundingClientRect()
+      if (width > 0 && height > 0) setDims({ w: Math.ceil(width), h: Math.ceil(height) })
+    }
+    measure()
+    const raf = requestAnimationFrame(measure)
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  return (
+    <div
+      ref={wrapRef}
+      style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none' }}
+    >
+      {dims && <WalkerPixi sprites={sprites} w={dims.w} h={dims.h} />}
+    </div>
+  )
+}

--- a/web/src/components/minigames/citybuilder/CityWalkerCanvas.tsx
+++ b/web/src/components/minigames/citybuilder/CityWalkerCanvas.tsx
@@ -23,9 +23,6 @@ export interface CitySprite {
   scale?: number
   /** Unhappy residents: dimmed and desaturated. */
   faded?: boolean
-  /** Small glyph above the sprite — the "!" need marker, or a carried resource. */
-  badge?: string
-  badgeColor?: string
 }
 
 export interface Props {
@@ -48,20 +45,9 @@ desaturate.desaturate()
 interface PooledSprite {
   view:   PIXI.Container
   sprite: PIXI.AnimatedSprite
-  badge:  PIXI.Text | null
   targetX: number
   targetY: number
   faded:  boolean
-}
-
-function makeBadge(text: string, color: string, size: number): PIXI.Text {
-  const t = new PIXI.Text({
-    text,
-    style: new PIXI.TextStyle({ fontSize: 10, fontWeight: 'bold', fill: color }),
-  })
-  t.anchor.set(0.5, 1)
-  t.y = -size / 2
-  return t
 }
 
 function WalkerPixi({ sprites, w, h }: Props & { w: number; h: number }) {
@@ -132,7 +118,7 @@ function WalkerPixi({ sprites, w, h }: Props & { w: number; h: number }) {
         view.x = s.x
         view.y = s.y
         layer.addChild(view)
-        p = { view, sprite, badge: null, targetX: s.x, targetY: s.y, faded: false }
+        p = { view, sprite, targetX: s.x, targetY: s.y, faded: false }
         pool.set(s.key, p)
 
         loadAnimFramesOrStatic(s.name, 3).then(frames => {
@@ -163,17 +149,6 @@ function WalkerPixi({ sprites, w, h }: Props & { w: number; h: number }) {
         p.faded = faded
       }
 
-      const badgeText = s.badge ?? ''
-      if (badgeText && !p.badge) {
-        p.badge = makeBadge(badgeText, s.badgeColor ?? '#d04020', size)
-        p.view.addChild(p.badge)
-      } else if (!badgeText && p.badge) {
-        p.view.removeChild(p.badge)
-        p.badge.destroy()
-        p.badge = null
-      } else if (badgeText && p.badge) {
-        if (p.badge.text !== badgeText) p.badge.text = badgeText
-      }
     }
   }, [sprites, ready])
 
@@ -190,6 +165,11 @@ function WalkerPixi({ sprites, w, h }: Props & { w: number; h: number }) {
  * The canvas is `pointer-events: none` so it never swallows taps meant for the
  * grid cells underneath — walker hit-testing is done by the parent against the
  * same positions it passes in here.
+ *
+ * Sprites only: text badges and bubbles stay in the DOM. Beyond being easier to
+ * style, `PIXI.Text` releases a pooled canvas texture when it unloads, which
+ * throws if the renderer has already gone — and `usePixiApp`'s teardown
+ * destroys the stage's children on the way out.
  */
 export function CityWalkerCanvas({ sprites }: Props) {
   const wrapRef = useRef<HTMLDivElement>(null)

--- a/web/src/components/minigames/citybuilder/cityRoadGeometry.test.ts
+++ b/web/src/components/minigames/citybuilder/cityRoadGeometry.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  roadCellRect, cellWear, pathFillParts, roadStrips,
+  ROAD_LAYER_INSET, ROAD_LAYER_GAP,
+} from './cityRoadGeometry'
+
+// A 6×4 grid in a 608×408 wrapper makes the maths land on whole pixels:
+//   avail = 608-8 = 600, cellW = (600 - 6*5)/6 = 95
+//   avail = 408-8 = 400, cellH = (400 - 6*3)/4 = 95.5
+const W = 608, H = 408, COLS = 6, ROWS = 4
+
+describe('roadCellRect', () => {
+  it('insets the layer and splits the remainder by the grid gap', () => {
+    expect(roadCellRect(0, COLS, ROWS, W, H)).toEqual({
+      x: ROAD_LAYER_INSET, y: ROAD_LAYER_INSET, w: 95, h: 95.5,
+    })
+  })
+
+  it('steps by cell size plus gap across columns and down rows', () => {
+    expect(roadCellRect(1, COLS, ROWS, W, H).x).toBe(4 + 95 + ROAD_LAYER_GAP)
+    expect(roadCellRect(1, COLS, ROWS, W, H).y).toBe(4)
+    // index 6 = row 1, col 0
+    expect(roadCellRect(COLS, COLS, ROWS, W, H).x).toBe(4)
+    expect(roadCellRect(COLS, COLS, ROWS, W, H).y).toBe(4 + 95.5 + ROAD_LAYER_GAP)
+  })
+
+  it('leaves the same inset on the far edge as the near one', () => {
+    const last = roadCellRect(COLS * ROWS - 1, COLS, ROWS, W, H)
+    expect(last.x + last.w).toBeCloseTo(W - ROAD_LAYER_INSET, 6)
+    expect(last.y + last.h).toBeCloseTo(H - ROAD_LAYER_INSET, 6)
+  })
+})
+
+describe('cellWear', () => {
+  // h[i] = wear between cell i and i+1; v[i] = between cell i and i+cols.
+  const h = Array.from({ length: 24 }, (_, i) => i * 10)
+  const v = Array.from({ length: 24 }, (_, i) => i * 100)
+
+  it('reads the shared edges either side of an interior cell', () => {
+    expect(cellWear(7, COLS, ROWS, h, v)).toEqual({
+      left: 60, right: 70, top: 100, bottom: 700,
+    })
+  })
+
+  it('reports no wear across the outer boundary of the grid', () => {
+    // Cell 0 is the top-left corner: nothing to its left or above it.
+    expect(cellWear(0, COLS, ROWS, h, v)).toMatchObject({ left: 0, top: 0 })
+    // Cell 23 is bottom-right: nothing to its right or below it.
+    expect(cellWear(23, COLS, ROWS, h, v)).toMatchObject({ right: 0, bottom: 0 })
+  })
+
+  it('treats missing entries as unworn rather than NaN', () => {
+    expect(cellWear(7, COLS, ROWS, [], [])).toEqual({ left: 0, right: 0, top: 0, bottom: 0 })
+  })
+})
+
+describe('pathFillParts', () => {
+  it('maps an unworn path to the dark end of the ramp', () => {
+    expect(pathFillParts(0)).toEqual({ color: 0x8c6428, alpha: 0.25 })
+  })
+
+  it('maps a fully worn path to the pale end', () => {
+    expect(pathFillParts(100)).toEqual({ color: 0xaa9b6e, alpha: 0.7 })
+  })
+
+  it('clamps wear above 100 rather than overshooting the ramp', () => {
+    expect(pathFillParts(500)).toEqual(pathFillParts(100))
+  })
+
+  it('makes junction highlights more opaque than the strips they cross', () => {
+    expect(pathFillParts(50, true).alpha).toBeGreaterThan(pathFillParts(50).alpha)
+    // Same hue — only the alpha differs.
+    expect(pathFillParts(50, true).color).toBe(pathFillParts(50).color)
+  })
+})
+
+describe('roadStrips', () => {
+  const rect = { x: 100, y: 200, w: 100, h: 100 }  // 1 viewBox unit = 1px
+  const noWear = { left: 0, right: 0, top: 0, bottom: 0 }
+
+  it('draws nothing for a cell with no roads touching it', () => {
+    expect(roadStrips(noWear, rect)).toEqual([])
+  })
+
+  it('straddles the bottom boundary with a horizontal strip that spills into the gap', () => {
+    const [strip] = roadStrips({ ...noWear, right: 100 }, rect)
+    // Starts 5px before the cell's bottom edge (300) and runs 20px, so 15px
+    // land in the gap below — that overhang is what bridges the 6px CSS gap.
+    expect(strip).toMatchObject({ x: 100 - 12, y: 200 + 95, w: 124, h: 20 })
+  })
+
+  it('straddles the right boundary with a vertical strip', () => {
+    const [strip] = roadStrips({ ...noWear, bottom: 100 }, rect)
+    expect(strip).toMatchObject({ x: 100 + 95, y: 200 - 12, w: 20, h: 124 })
+  })
+
+  it('adds a highlighted square where the two strips cross', () => {
+    const strips = roadStrips({ left: 50, right: 0, top: 80, bottom: 0 }, rect)
+    expect(strips).toHaveLength(3)
+    const junction = strips[2]
+    expect(junction).toMatchObject({ x: 195, y: 295, w: 20, h: 20 })
+    // Junction takes the heavier of the two wear levels, and is drawn brighter.
+    expect(junction.alpha).toBe(pathFillParts(80, true).alpha)
+  })
+
+  it('takes the heavier wear of the two edges a strip represents', () => {
+    const [strip] = roadStrips({ ...noWear, left: 20, right: 90 }, rect)
+    expect(strip.color).toBe(pathFillParts(90).color)
+  })
+
+  it('scales each axis independently, as preserveAspectRatio="none" did', () => {
+    const wide = { x: 0, y: 0, w: 200, h: 50 }
+    const [strip] = roadStrips({ ...noWear, right: 100 }, wide)
+    expect(strip.h).toBe(20 * 0.5)   // 20 viewBox units × (50/100)
+    expect(strip.w).toBe(124 * 2)    // 124 viewBox units × (200/100)
+  })
+})

--- a/web/src/components/minigames/citybuilder/cityRoadGeometry.ts
+++ b/web/src/components/minigames/citybuilder/cityRoadGeometry.ts
@@ -20,9 +20,9 @@ const ROAD_EXT = 12
  */
 const HALF = (ROAD_W / 2) / 2
 
-/** Matches `.city-road-layer { inset: 4px }` — itself matching `.city-grid`'s border. */
+/** Matches `.city-grid`'s 4px border, which the roads must line up inside. */
 export const ROAD_LAYER_INSET = 4
-/** Matches the `gap: 6px` shared by `.city-road-layer` and `.city-grid`. */
+/** Matches `.city-grid { gap: 6px }` — the gap the strips are drawn into. */
 export const ROAD_LAYER_GAP = 6
 
 export interface Rect { x: number; y: number; w: number; h: number }

--- a/web/src/components/minigames/citybuilder/cityRoadGeometry.ts
+++ b/web/src/components/minigames/citybuilder/cityRoadGeometry.ts
@@ -1,0 +1,142 @@
+// ─── City road-wear geometry ─────────────────────────────────────────────────
+// Pure maths behind the road-wear layer, extracted so the PixiJS draw stays a
+// thin caller and the numbers are testable without a renderer.
+//
+// This reproduces what the old per-cell inline SVG did. Each cell carried an
+// `<svg viewBox="0 0 100 100" preserveAspectRatio="none" overflow="visible">`,
+// so a viewBox unit was 1% of the cell in each axis independently, and strips
+// were free to spill past the cell edge into the CSS grid gap. Both properties
+// are reproduced below: `roadStrips` scales x and y by separate factors, and
+// the returned rects may extend outside their cell.
+
+/** Strip width, in viewBox units (% of cell). */
+const ROAD_W = 20
+/** How far each strip runs past the cell boundary, to bridge the CSS grid gap. */
+const ROAD_EXT = 12
+/**
+ * Strips straddle the cell's bottom / right boundary rather than sitting inside
+ * it, so they land in the grid gap between cells: a quarter of the width sits
+ * before the boundary, the rest after.
+ */
+const HALF = (ROAD_W / 2) / 2
+
+/** Matches `.city-road-layer { inset: 4px }` — itself matching `.city-grid`'s border. */
+export const ROAD_LAYER_INSET = 4
+/** Matches the `gap: 6px` shared by `.city-road-layer` and `.city-grid`. */
+export const ROAD_LAYER_GAP = 6
+
+export interface Rect { x: number; y: number; w: number; h: number }
+
+/**
+ * Pixel rect of one cell of the road layer, in the coordinate space of
+ * `.city-zoom-wrapper` (the canvas covers it at `inset: 0`).
+ *
+ * `layerW`/`layerH` are the wrapper's full size; the inset is applied here.
+ */
+export function roadCellRect(
+  index: number,
+  cols: number, rows: number,
+  layerW: number, layerH: number,
+): Rect {
+  const availW = layerW - ROAD_LAYER_INSET * 2
+  const availH = layerH - ROAD_LAYER_INSET * 2
+  const cellW = (availW - ROAD_LAYER_GAP * (cols - 1)) / cols
+  const cellH = (availH - ROAD_LAYER_GAP * (rows - 1)) / rows
+  const col = index % cols
+  const row = Math.floor(index / cols)
+  return {
+    x: ROAD_LAYER_INSET + col * (cellW + ROAD_LAYER_GAP),
+    y: ROAD_LAYER_INSET + row * (cellH + ROAD_LAYER_GAP),
+    w: cellW,
+    h: cellH,
+  }
+}
+
+/**
+ * The four wear values that meet at a cell, read off the shared edge arrays.
+ * `h[i]` is wear between cell i and i+1; `v[i]` between cell i and i+cols.
+ * Edges of the grid have no neighbour, so they contribute no wear.
+ */
+export function cellWear(
+  index: number,
+  cols: number, rows: number,
+  h: number[], v: number[],
+): { left: number; right: number; top: number; bottom: number } {
+  const col = index % cols
+  const row = Math.floor(index / cols)
+  return {
+    left:   col === 0        ? 0 : (h[index - 1]    ?? 0),
+    right:  col === cols - 1 ? 0 : (h[index]        ?? 0),
+    top:    row === 0        ? 0 : (v[index - cols] ?? 0),
+    bottom: row === rows - 1 ? 0 : (v[index]        ?? 0),
+  }
+}
+
+/**
+ * Road colour for a wear level: dirt track darkens to a worn pale path as wear
+ * climbs, and grows more opaque with it. `highlight` is the brighter patch
+ * where a horizontal and a vertical strip cross.
+ *
+ * Split into a numeric colour + alpha for PixiJS. Alpha keeps the 2-decimal
+ * rounding the old `rgba()` string had, so output matches the SVG exactly.
+ */
+export function pathFillParts(wear: number, highlight = false): { color: number; alpha: number } {
+  const t = Math.min(1, wear / 100)
+  const r = Math.round(140 + (170 - 140) * t)
+  const g = Math.round(100 + (155 - 100) * t)
+  const b = Math.round(40  + (110 - 40)  * t)
+  const alpha = highlight
+    ? Number((0.55 + t * 0.35).toFixed(2))
+    : Number((0.25 + t * 0.45).toFixed(2))
+  return { color: (r << 16) | (g << 8) | b, alpha }
+}
+
+export interface RoadStrip extends Rect { color: number; alpha: number }
+
+/**
+ * The filled rects for one cell's roads, in wrapper pixel space.
+ *
+ * Strips are drawn on the cell's bottom and right boundaries whichever
+ * neighbour the wear came from — that asymmetry is deliberate and matches the
+ * original SVG, since each boundary is shared and would otherwise be painted
+ * twice.
+ */
+export function roadStrips(
+  wear: { left: number; right: number; top: number; bottom: number },
+  rect: Rect,
+): RoadStrip[] {
+  const hasH = wear.left > 0 || wear.right > 0
+  const hasV = wear.top  > 0 || wear.bottom > 0
+  if (!hasH && !hasV) return []
+
+  const wearH = Math.max(wear.left, wear.right)
+  const wearV = Math.max(wear.top,  wear.bottom)
+
+  // viewBox → pixels: each axis scales independently (preserveAspectRatio="none").
+  const sx = rect.w / 100
+  const sy = rect.h / 100
+  const at = (vx: number, vy: number, vw: number, vh: number): Rect => ({
+    x: rect.x + vx * sx,
+    y: rect.y + vy * sy,
+    w: vw * sx,
+    h: vh * sy,
+  })
+
+  const boundary = 100 - HALF  // 95 — strip starts just before the cell edge
+  const strips: RoadStrip[] = []
+
+  if (hasH) {
+    strips.push({ ...at(-ROAD_EXT, boundary, 100 + ROAD_EXT * 2, ROAD_W), ...pathFillParts(wearH) })
+  }
+  if (hasV) {
+    strips.push({ ...at(boundary, -ROAD_EXT, ROAD_W, 100 + ROAD_EXT * 2), ...pathFillParts(wearV) })
+  }
+  // Brighter square where the two strips overlap, so junctions read as junctions.
+  if (hasH && hasV) {
+    strips.push({
+      ...at(boundary, boundary, ROAD_W, ROAD_W),
+      ...pathFillParts(Math.max(wearH, wearV), true),
+    })
+  }
+  return strips
+}

--- a/web/src/components/minigames/citybuilder/useZoomPan.ts
+++ b/web/src/components/minigames/citybuilder/useZoomPan.ts
@@ -7,6 +7,8 @@ export interface ZoomPanControls {
   stepZoom:     (dir: 1 | -1) => void
   zoomTo:       (targetScale: number) => void
   getCellFromPoint: (clientX: number, clientY: number, cols: number, rows: number) => number
+  /** Client coords → untransformed wrapper-local pixels (the space walkers live in). */
+  getLocalPoint: (clientX: number, clientY: number) => { x: number; y: number } | null
 }
 
 /**
@@ -78,18 +80,24 @@ export function useZoomPan(
     zoomTo(next)
   }, [zoomTo])
 
-  const getCellFromPoint = useCallback((clientX: number, clientY: number, cols: number, rows: number): number => {
+  const getLocalPoint = useCallback((clientX: number, clientY: number) => {
     const el = containerRef.current
-    if (!el) return -1
+    if (!el) return null
     const rect = el.getBoundingClientRect()
     const { s, x, y } = tRef.current
-    const lx = (clientX - rect.left - x) / s
-    const ly = (clientY - rect.top  - y) / s
-    const col = Math.floor((lx / rect.width)  * cols)
-    const row = Math.floor((ly / rect.height) * rows)
+    return { x: (clientX - rect.left - x) / s, y: (clientY - rect.top - y) / s }
+  }, [containerRef])
+
+  const getCellFromPoint = useCallback((clientX: number, clientY: number, cols: number, rows: number): number => {
+    const el = containerRef.current
+    const p  = getLocalPoint(clientX, clientY)
+    if (!el || !p) return -1
+    const rect = el.getBoundingClientRect()
+    const col = Math.floor((p.x / rect.width)  * cols)
+    const row = Math.floor((p.y / rect.height) * rows)
     if (col < 0 || col >= cols || row < 0 || row >= rows) return -1
     return row * cols + col
-  }, [containerRef])
+  }, [containerRef, getLocalPoint])
 
   // Wheel zoom
   useEffect(() => {
@@ -224,5 +232,5 @@ export function useZoomPan(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef])
 
-  return { wrapperRef, displayScale, stepZoom, zoomTo, getCellFromPoint }
+  return { wrapperRef, displayScale, stepZoom, zoomTo, getCellFromPoint, getLocalPoint }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10485,43 +10485,13 @@ html.light-mode .action-btn {
   cursor: pointer;
 }
 
-.city-walker-sprite {
-  width: 20px;
-  height: 20px;
-  image-rendering: pixelated;
-}
-
-.city-walker--unhappy .city-walker-sprite {
-  opacity: 0.45;
-  filter: grayscale(1);
-}
-
-.city-walker-need {
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 9px;
-  color: #d04020;
-  font-weight: bold;
-  line-height: 1;
-}
-
-.city-carrier-overlay { position: absolute; inset: 0; pointer-events: none; }
-
-.city-carrier-goblin {
+/* Walkers themselves are drawn on the Pixi canvas; these anchors carry only
+   the bubbles, which stay in the DOM for their text and nested sprite icons.
+   Taps are hit-tested against walker positions in CityGrid, so the anchors
+   must not intercept pointer events of their own. */
+.city-walker--bubble-only {
   pointer-events: none;
-  z-index: 8;
-}
-
-.city-carrier-load {
-  position:   absolute;
-  top:        -10px;
-  left:       50%;
-  transform:  translateX(-50%);
-  font-size:  10px;
-  line-height: 1;
-  filter:     drop-shadow(0 1px 2px rgba(0,0,0,0.8));
+  cursor: default;
 }
 
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10397,18 +10397,6 @@ html.light-mode .action-btn {
   height: 100%;
 }
 
-/* Road wear overlay — sits behind the grid; SVG overflow is visible in the gap */
-.city-road-layer {
-  position: absolute;
-  inset: 4px;   /* matches .city-grid border-width */
-  display: grid;
-  gap: 6px;     /* matches .city-grid gap */
-  pointer-events: none;
-}
-.city-road-cell {
-  position: relative;
-}
-
 .city-cell {
   background: #2d5a27;
   border: 2px solid rgba(0, 40, 0, .15);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -10494,6 +10494,27 @@ html.light-mode .action-btn {
   cursor: default;
 }
 
+.city-walker-need {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 9px;
+  color: #d04020;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.city-carrier-load {
+  position:   absolute;
+  top:        -10px;
+  left:       50%;
+  transform:  translateX(-50%);
+  font-size:  10px;
+  line-height: 1;
+  filter:     drop-shadow(0 1px 2px rgba(0,0,0,0.8));
+}
+
 
 /* Builder walkers (construction) */
 .city-builder-walker {


### PR DESCRIPTION
Fixes #1347. Part of #1335.

## What changed

`CityGrid.tsx` was the last CityBuilder screen drawing moving content with DOM/SVG.

**Walkers were the real cost.** `CityBuilder.tsx` runs a `setInterval(…, 100)` that calls `setWalkers`, so every 100 ms React re-rendered one `<div>` per resident — each holding an `AnimatedSpriteImg` that swaps an `<img>` src per frame — plus builders and carriers in two more overlays. That interval was also the only thing moving them, so motion *stepped at 10 fps*. They now live on a pooled sprite layer, and a `PIXI.Ticker` eases between the simulation's positions, so the movement reads as smooth rather than stepping ten times a second. That's the visible payoff.

**Road wear was 24+ inline SVGs**, one `<svg>` per cell, rebuilt whenever `city.roadWear` changed. Now a single `Graphics` pass.

## Canvas topology

Roads draw into the **existing terrain app** rather than a canvas of their own. They belong behind the DOM `.city-grid`, which is exactly where the terrain already sits, and a separate context would have made three in the city view — this keeps it to two. Walkers need their own canvas because they layer *above* the same DOM grid.

## Two coordinate systems, deliberately kept apart

The road layer is a CSS grid at `inset: 4px` / `gap: 6px`; walkers use plain `overlayW / cols`, ignoring both. They are genuinely different spaces and unifying them would shift every walker. `cityRoadGeometry.ts` reproduces the road grid exactly — including that a viewBox unit was 1% of the cell *per axis* (`preserveAspectRatio="none"`) and that strips deliberately spill past the cell edge to bridge the gap.

## Notes

- **Sprites only on the canvas; all text stays in the DOM.** Bubbles, the "!" need marker and the carried-resource icon are DOM. I first put the two badges on the canvas as `PIXI.Text` and CI caught it: `Text` returns a pooled canvas texture when it unloads, which throws if the renderer has already gone — and `usePixiApp`'s teardown destroys the stage's children on the way out, so unmounting the city view crashed. No other migrated component uses `Text`, so nothing had hit this before.
- The canvas takes no pointer events, so it can't swallow taps meant for the grid cells beneath. Walker taps are hit-tested in the **click capture** phase — `pointerdown` would not have stopped the cell button's `onClick`, which is a separate event.
- The sprite pool resets if the app rebuilds after a WebGL context loss, since the old scene is destroyed with it.
- Dead CSS removed: `.city-road-layer`, `.city-road-cell`, `.city-walker-sprite`, `.city-walker--unhappy`, `.city-carrier-goblin`, `.city-carrier-overlay`.
- **Accepted trade-off:** canvas walkers can't carry `role="button"` / `tabIndex` / Enter, so keyboard access to "inspect resident" is lost. Consistent with `GameGrid` and `BattlefieldCanvas`, which are already canvas-only. Pointer and tap are unaffected.

## Verification

- New `cityRoadGeometry.test.ts` (16 cases) pins the geometry and the colour ramp against the old viewBox maths.
- `npm run test` — **2780 passed, 252 files**; `npm run build` clean.
  - Worth flagging for anyone verifying locally: the `storybook` browser project silently does not run in some sandboxes, where the suite reports a much lower count (`69 passed (252)` — the parenthesised number is the total, not the passes). It needs a `chrome-headless-shell` build matching the pinned Playwright version. The counts above match CI's exactly, so that project genuinely ran.
- Visual, so verified in Storybook: new `CityWalkerCanvas` stories (residents, unhappy, builders, carriers, mixed, missing-sprite), road stories on `CityTerrainCanvas`, and a `CityGrid → WithWalkers` story that confirms the sprite canvas layers above the grid cells and below the bubbles. Road strips land in the grid gap and junction highlights render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111UrsPdT7VGjEou1SusB3t