### PR TITLE
Make units drift out of gas clouds instead of standing in them

### DIFF
--- a/web/src/components/battle/battlefieldCanvas/effects.ts
+++ b/web/src/components/battle/battlefieldCanvas/effects.ts
@@ -1,7 +1,7 @@
 import * as PIXI from 'pixi.js'
 import type { GameState, AnimEvent, ProjectileType } from '../../../game/types'
 import { BLOOD_POOL_FADE_MS } from '../../../game/engine/constants'
-import { gameToPixel } from '../../../utils/terrainLayer'
+import { gameToPixel, gameRadiusToPixels } from '../../../utils/terrainLayer'
 import { unitJitterPx } from './units'
 import type { Scene, EffectEntry } from './scene'
 
@@ -76,8 +76,12 @@ export function syncHazards(scene: Scene, state: GameState, w: number, h: number
     if (!entry) {
       entry = new PIXI.Container()
       const g = new PIXI.Graphics()
-      g.circle(0, 0, 32).fill({ color: 0x28c828, alpha: 0.55 })
-      g.circle(0, 0, 20).fill({ color: 0x50ff50, alpha: 0.3 })
+      // Drawn at the hazard's real radius so the green area is exactly the area that
+      // gasses units — see engine.ts's hazard damage check and the avoidance steering
+      // in engine/units.ts, both of which work off this same radius.
+      const { rx, ry } = gameRadiusToPixels(hz.radius, w, h)
+      g.ellipse(0, 0, rx, ry).fill({ color: 0x28c828, alpha: 0.55 })
+      g.ellipse(0, 0, rx * 0.62, ry * 0.62).fill({ color: 0x50ff50, alpha: 0.3 })
       entry.addChild(g)
       scene.hazardLayer.addChild(entry)
       scene.hazardPool.set(hz.id, entry)
@@ -94,12 +98,16 @@ export function syncHazards(scene: Scene, state: GameState, w: number, h: number
   }
 }
 
-function makeEffectVisual(kind: EffectEntry['kind'], ev: AnimEvent): PIXI.Container {
+function makeEffectVisual(kind: EffectEntry['kind'], ev: AnimEvent, w: number, h: number): PIXI.Container {
   const c = new PIXI.Container()
   const pType = ev.projectileType ?? 'magic'
   if (kind === 'gascloud') {
     const g = new PIXI.Graphics()
-    g.circle(0, 0, 28).fill({ color: 0x28c828, alpha: 0.6 })
+    // Sits on top of the Hazard's own circle (combat.ts pushes both for one cloud), so it
+    // has to use the same radius — a fixed-size blob inside a correctly-sized one reads as
+    // the cloud being smaller than it is.
+    const { rx, ry } = gameRadiusToPixels(ev.aoeRadius ?? 0, w, h)
+    g.ellipse(0, 0, rx, ry).fill({ color: 0x28c828, alpha: 0.6 })
     c.addChild(g)
   } else if (kind === 'aoe') {
     const g = new PIXI.Graphics()
@@ -126,7 +134,7 @@ export function syncAnimEvents(scene: Scene, state: GameState, w: number, h: num
     live.add(ev.id)
     let entry = scene.effectPool.get(ev.id)
     if (!entry) {
-      const container = makeEffectVisual(ev.kind, ev)
+      const container = makeEffectVisual(ev.kind, ev, w, h)
       scene.effectLayer.addChild(container)
       entry = { container, kind: ev.kind, createdAtMs: nowMs }
       scene.effectPool.set(ev.id, entry)

--- a/web/src/game/cards.ts
+++ b/web/src/game/cards.ts
@@ -61,14 +61,20 @@ interface RawUnitDef {
   bloodSummonAbility?: { cooldownMs: number; minionTemplate: RawUnitDef; range: number }
 }
 
+/** Radius (game units) of the lingering gas cloud dropped by `gascloud`-tagged units. */
+export const GAS_CLOUD_RADIUS = 45
+
 function deriveAttackEffect(tags: string[] | undefined, attack: number): AttackEffect | undefined {
   if (!tags || attack === 0) return undefined
   if (tags.includes('fire') || tags.includes('ember'))
     return { type: 'burn',     chance: 0.70, durationMs: 3000, dps: 8 }
   if (tags.includes('frost') || tags.includes('glacier'))
     return { type: 'freeze',   chance: 0.75, durationMs: 2500, slowFactor: 0.35 }
+  // GAS_CLOUD_RADIUS is the damage radius *and* the radius the green cloud is drawn at
+  // (battlefieldCanvas/effects.ts) — the two must agree or units get gassed while visibly
+  // clear of the cloud, and the hazard avoidance in engine/units.ts looks broken.
   if (tags.includes('gascloud'))
-    return { type: 'gascloud', chance: 1.00, durationMs: 8000, aoeRadius: 72, dps: 3 }
+    return { type: 'gascloud', chance: 1.00, durationMs: 8000, aoeRadius: GAS_CLOUD_RADIUS, dps: 3 }
   if (tags.includes('aoe'))
     return { type: 'aoe',      chance: 1.00, durationMs: 500,  aoeRadius: 72 }
   if (tags.includes('lightning'))

--- a/web/src/game/engine/units.test.ts
+++ b/web/src/game/engine/units.test.ts
@@ -8,8 +8,9 @@ import { newGame } from '../engine'
 import { moveUnits } from './units'
 import { spawnUnit } from './helpers'
 import { RoadDef, TerrainObstacle } from './terrain'
-import { LANE_WIDTH } from '../types'
-import { DEFEND_ZONE_MAX_X } from './constants'
+import { Hazard, LANE_WIDTH } from '../types'
+import { COMMANDER_HOME_X, COMMANDER_LEASH_PX, DEFEND_ZONE_MAX_X } from './constants'
+import { GAS_CLOUD_RADIUS, getCardCatalog } from '../cards'
 
 const MOBILE_TEMPLATE = {
   name: 'Test Runner', maxHp: 30, attack: 5, moveSpeed: 40,
@@ -430,5 +431,172 @@ describe('moveUnits — ruins are a one-tile obstacle on the soft-avoidance path
     s.field = [unit]
     for (let i = 0; i < 10; i++) moveUnits(s, 100)
     expect(unit.y).toBeLessThan(20)
+  })
+})
+
+describe('moveUnits — gas cloud avoidance', () => {
+  const RANGED_TEMPLATE = { ...MOBILE_TEMPLATE, attackRange: 100 }
+
+  /** A cloud matching what a `gascloud`-tagged unit drops (see deriveAttackEffect). */
+  function cloud(overrides: Partial<Hazard> = {}): Hazard {
+    return {
+      id: 'gas1', x: 250, y: 0, radius: GAS_CLOUD_RADIUS, dps: 3,
+      owner: 'opponent', expiresAt: 8000, ...overrides,
+    }
+  }
+
+  function inCloud(unit: { x: number; y: number }, hz: Hazard): boolean {
+    return Math.hypot(unit.x - hz.x, unit.y - hz.y) <= hz.radius
+  }
+
+  it('a unit fighting inside a cloud drifts out without losing its target', () => {
+    // The reported bug: a unit already in attack range early-continues before any steering
+    // runs, so it stood in the gas swinging until it died.
+    const s = newGame()
+    s.terrain = []
+    const hz = cloud()
+    s.hazards = [hz]
+
+    const unit = spawnUnit(RANGED_TEMPLATE, 'player')
+    unit.x = 250; unit.y = 10; unit.advanceY = 10
+    const foe = spawnUnit(MOBILE_TEMPLATE, 'opponent')
+    foe.x = 260; foe.y = 10
+    s.field = [unit, foe]
+
+    expect(inCloud(unit, hz)).toBe(true)
+    for (let i = 0; i < 40; i++) {
+      moveUnits(s, 100)
+      // Drift out, keep fighting — the target never leaves attack range.
+      expect(Math.hypot(unit.x - foe.x, unit.y - foe.y)).toBeLessThanOrEqual(unit.attackRange + 1e-6)
+    }
+    expect(inCloud(unit, hz)).toBe(false)
+  })
+
+  it('a cloud dropped exactly on a unit still resolves to a direction', () => {
+    const s = newGame()
+    s.terrain = []
+    const hz = cloud({ x: 250, y: 0 })
+    s.hazards = [hz]
+
+    const unit = spawnUnit(RANGED_TEMPLATE, 'player')
+    unit.x = 250; unit.y = 0; unit.advanceY = 0
+    const foe = spawnUnit(MOBILE_TEMPLATE, 'opponent')
+    foe.x = 250; foe.y = 0
+    s.field = [unit, foe]
+
+    for (let i = 0; i < 40; i++) moveUnits(s, 100)
+
+    expect(inCloud(unit, hz)).toBe(false)
+  })
+
+  it('a unit advancing up the lane steers around a cloud instead of through it', () => {
+    const s = newGame()
+    s.terrain = []
+    const hz = cloud({ x: 250, y: 0 })
+    s.hazards = [hz]
+
+    const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
+    unit.x = 150; unit.y = 0; unit.advanceY = 0
+    s.field = [unit]
+
+    let everInside = false
+    for (let i = 0; i < 120; i++) {
+      moveUnits(s, 100)
+      if (inCloud(unit, hz)) everInside = true
+    }
+
+    expect(everInside).toBe(false)
+    expect(unit.x).toBeGreaterThan(250) // still made it up the lane
+  })
+
+  it('ignores a cloud its own side dropped', () => {
+    const s = newGame()
+    s.terrain = []
+    s.hazards = [cloud({ owner: 'player' })]
+
+    const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
+    unit.x = 250; unit.y = 0; unit.advanceY = 0
+    s.field = [unit]
+
+    moveUnits(s, 100)
+
+    expect(unit.y).toBeCloseTo(0)
+  })
+
+  it('ignores a cloud that has already expired', () => {
+    const s = newGame()
+    s.terrain = []
+    s.gameTime = 9000
+    s.hazards = [cloud({ expiresAt: 8000 })]
+
+    const unit = spawnUnit(MOBILE_TEMPLATE, 'player')
+    unit.x = 250; unit.y = 0; unit.advanceY = 0
+    s.field = [unit]
+
+    moveUnits(s, 100)
+
+    expect(unit.y).toBeCloseTo(0)
+  })
+
+  it('a flying unit dodges too — gas damages flyers', () => {
+    const s = newGame()
+    s.terrain = []
+    const hz = cloud({ x: 250, y: 0 })
+    s.hazards = [hz]
+
+    const unit = spawnUnit({ ...MOBILE_TEMPLATE, flying: true }, 'player')
+    unit.x = 250; unit.y = 0; unit.advanceY = 0
+    s.field = [unit]
+
+    for (let i = 0; i < 40; i++) moveUnits(s, 100)
+
+    expect(inCloud(unit, hz)).toBe(false)
+  })
+
+  it('a commander drifts away from a cloud but stays on its leash', () => {
+    const s = newGame()
+    s.terrain = []
+    s.hazards = [cloud({ x: COMMANDER_HOME_X, y: 0 })]
+
+    const cmd = spawnUnit(MOBILE_TEMPLATE, 'player')
+    cmd.isCommander = true
+    cmd.commanderHomeX = COMMANDER_HOME_X
+    cmd.x = COMMANDER_HOME_X; cmd.y = 0; cmd.advanceY = 0
+    s.field = [cmd]
+
+    for (let i = 0; i < 60; i++) moveUnits(s, 100)
+
+    expect(Math.abs(cmd.y)).toBeGreaterThan(0)
+    expect(Math.abs(cmd.x - COMMANDER_HOME_X)).toBeLessThanOrEqual(COMMANDER_LEASH_PX + 1e-6)
+  })
+
+  it('every gascloud unit drops a cloud at the radius the avoidance and the art both use', () => {
+    // effects.ts draws the cloud straight off hazard.radius and engine.ts damages off the
+    // same value, so this is what keeps what you see, what hurts, and what units dodge
+    // from drifting apart.
+    const gasUnits = getCardCatalog().filter(c => c.unit?.tags?.includes('gascloud'))
+    expect(gasUnits.length).toBeGreaterThan(0)
+    for (const c of gasUnits) {
+      expect(c.unit!.attackEffect?.type).toBe('gascloud')
+      expect(c.unit!.attackEffect?.aoeRadius).toBe(GAS_CLOUD_RADIUS)
+    }
+  })
+
+  it('never pushes a unit into blocked terrain on a terrainValidated node', () => {
+    const s = newGame()
+    s.terrainValidated = true
+    s.terrain = [{ id: 'wall', type: 'rock', x: 250, y: 0, radius: 250 }]
+    s.hazards = [cloud({ x: 100, y: 0 })]
+
+    const unit = spawnUnit(RANGED_TEMPLATE, 'player')
+    unit.x = 100; unit.y = 0; unit.advanceY = 0
+    const foe = spawnUnit(MOBILE_TEMPLATE, 'opponent')
+    foe.x = 110; foe.y = 0
+    s.field = [unit, foe]
+
+    for (let i = 0; i < 60; i++) moveUnits(s, 100)
+
+    // The rock seals the lane from x≈0 to x≈500; the drift must not tunnel into it.
+    expect(unit.x).toBeLessThan(250)
   })
 })

--- a/web/src/game/engine/units.ts
+++ b/web/src/game/engine/units.ts
@@ -30,6 +30,67 @@ const BLOOD_CLUSTER_MIN    = 2     // minimum pools in a cluster to trigger avoi
 const MAX_BASE_GUARDS      = 2     // max units per side allowed to stay in guard-base mode
 const ROAD_WAYPOINT_ARRIVE_PX = 15 // distance within which a road waypoint counts as "reached"
 
+// ─── Ground-hazard (gas cloud) avoidance ──────────────────
+// Units used to stand inside an enemy gas cloud trading blows, or walk straight through
+// one, until the damage-per-second killed them — nothing in movement read s.hazards.
+// The push below is 2-D, unlike the lateral-only terrain/blood repulsion: a cloud centred
+// in the lane is wide enough that sidestepping alone can't clear it within ±LANE_MAX_Y.
+/** Deflection band outside the damaging radius, so units skirt a cloud rather than clip it. */
+const HAZARD_AVOID_MARGIN = 12
+/** Fraction of moveSpeed used when shuffling clear of a cloud while engaged — a shuffle, so
+ *  under 1 to keep it from overshooting the fight it's trying to stay in. */
+const HAZARD_DRIFT_SPEED_FACTOR = 0.9
+/** Deflection strength for a unit that's still steering, as a multiple of moveSpeed. Must
+ *  exceed 1 or advancing units grind forward into a cloud faster than it pushes them out —
+ *  the same reason the terrain and blood-pool deflections sit at 1.8. */
+const HAZARD_DEFLECT_FACTOR = 1.8
+/** Below this distance from a cloud's centre the away-vector is degenerate; pick a side. */
+const HAZARD_CENTRE_EPSILON = 5
+
+/**
+ * Direction to move to get clear of every enemy-owned hazard near this unit, plus how hard to
+ * commit to it: full strength anywhere inside the damaging radius (standing in gas is never
+ * something to leave half-heartedly), tapering to nothing across the margin band outside it so
+ * units passing by are deflected smoothly instead of snapping at the boundary. Strength 0 means
+ * the unit is clear and the vector is meaningless.
+ *
+ * Not gated on `flying` — engine.ts gasses flying units too, so they need to dodge as well.
+ */
+function hazardEscapeVector(
+  unit: Unit,
+  hazards: GameState['hazards'],
+): { hx: number; hy: number; strength: number } {
+  let hx = 0, hy = 0, strongest = 0
+  for (const hz of hazards) {
+    if (hz.owner === unit.owner) continue
+    const toUnitX = unit.x - hz.x
+    const toUnitY = unit.y - hz.y
+    const dist    = Math.hypot(toUnitX, toUnitY)
+    if (dist >= hz.radius + HAZARD_AVOID_MARGIN) continue
+    const strength = dist <= hz.radius ? 1 : 1 - (dist - hz.radius) / HAZARD_AVOID_MARGIN
+    strongest = Math.max(strongest, strength)
+    // Break ties deterministically by id parity — the same trick the terrain and blood-pool
+    // blocks use head-on, and it also splits a crowd around the cloud rather than sending
+    // every unit the same way.
+    const lateralDir = idNum(unit.id) % 2 === 0 ? -1 : 1
+    if (dist < HAZARD_CENTRE_EPSILON) {
+      // Clouds are dropped directly onto the unit they're aimed at, so "standing on the
+      // centre" is the common case here, not an edge case.
+      hy += lateralDir * strength
+    } else {
+      hx += (toUnitX / dist) * strength
+      hy += (toUnitY / dist) * strength
+      // Approaching along the cloud's own lane: the away-vector is purely backwards, so
+      // following it just stalls the unit nose-first against the gas. Add a sideways term
+      // so it rounds the cloud instead.
+      if (Math.abs(toUnitY) < HAZARD_CENTRE_EPSILON) hy += lateralDir * strength
+    }
+  }
+  const len = Math.hypot(hx, hy)
+  if (len === 0) return { hx: 0, hy: 0, strength: 0 }
+  return { hx: hx / len, hy: hy / len, strength: strongest }
+}
+
 export function moveUnits(s: GameState, deltaMs: number): void {
   const deltaSec = deltaMs / 1000
   const stance = s.playerStance ?? 'auto'
@@ -47,6 +108,70 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     )
     return nearby.length >= BLOOD_CLUSTER_MIN - 1
   })
+
+  // Hazards still burning this tick. tidyBattlefield purges expired ones at the *end* of the
+  // tick, well after movement, so the expiry has to be re-checked here.
+  const liveHazards = (s.hazards ?? []).filter(h => h.expiresAt > s.gameTime)
+
+  // Tile grid + road map, built once per battle (s.terrain/s.roads don't change mid-battle)
+  // and shared by the hard-blocking steering below and the hazard drift.
+  const ensureTerrainGrid = () => (s.terrainGridCache ??= {
+    obstacleTiles: buildObstacleTileMap(s.terrain),
+    roadTiles: buildRoadTileMap(s.roads ?? []),
+    flowFields: new Map(),
+  })
+
+  /** Whether `unit` may stand at (x, y). Always true where hard tile blocking is off. */
+  const canUnitEnter = (unit: Unit, x: number, y: number): boolean => {
+    if (!s.terrainValidated || unit.flying) return true
+    const { obstacleTiles, roadTiles } = ensureTerrainGrid()
+    const profile: MovementProfile = unit.tags?.includes('burrowing') ? 'burrowing' : 'ground'
+    const swims = unit.tags?.includes('swim') ?? false
+    const { tcx, tcy } = gameToContainingTile(x, y)
+    return isTilePassable(obstacleTiles, roadTiles, tcx, tcy, profile, swims)
+  }
+
+  /**
+   * Shuffle a unit clear of any gas cloud it's standing in, for the paths that skip steering
+   * entirely — a unit already in attack range, or one sitting on its movement target. Those
+   * early-`continue`s are why a unit would stand in a cloud swinging until it died.
+   *
+   * `engaged` is the unit it's currently in range of, if any: the drift is capped so that unit
+   * stays inside attackRange, making this "drift out, keep fighting" rather than a retreat.
+   * These paths bypass the end-of-loop clamps, so the leash and defend backstop are reapplied
+   * here.
+   */
+  const driftFromHazards = (unit: Unit, engaged: Unit | undefined, defending: boolean): void => {
+    if (liveHazards.length === 0) return
+    const { hx, hy, strength } = hazardEscapeVector(unit, liveHazards)
+    if (strength === 0) return
+
+    let step = unit.moveSpeed * HAZARD_DRIFT_SPEED_FACTOR * strength * deltaSec
+    if (engaged) {
+      // Furthest the unit can travel along (hx, hy) with its target still in range: solve
+      // |P + t·D − T| = attackRange for t. Guarded on the target already being in range, so
+      // the discriminant can't go negative.
+      const cx = unit.x - engaged.x
+      const cy = unit.y - engaged.y
+      const proj = cx * hx + cy * hy
+      const disc = proj * proj - (cx * cx + cy * cy) + unit.attackRange * unit.attackRange
+      if (disc <= 0) return
+      step = Math.min(step, Math.max(0, -proj + Math.sqrt(disc)))
+    }
+    if (step <= 0) return
+
+    const xStart = unit.x
+    const nx = Math.min(LANE_WIDTH - BASE_STOP_MARGIN, Math.max(BASE_STOP_MARGIN, unit.x + hx * step))
+    const ny = Math.min(LANE_MAX_Y, Math.max(LANE_MIN_Y, unit.y + hy * step))
+    if (canUnitEnter(unit, nx, ny))          { unit.x = nx; unit.y = ny }
+    else if (canUnitEnter(unit, unit.x, ny))   unit.y = ny
+    else if (canUnitEnter(unit, nx, unit.y))   unit.x = nx
+
+    if (defending) unit.x = Math.min(unit.x, Math.max(DEFEND_ZONE_MAX_X, xStart))
+    if (unit.isCommander && unit.commanderHomeX !== undefined) {
+      unit.x = Math.min(unit.commanderHomeX + COMMANDER_LEASH_PX, Math.max(unit.commanderHomeX - COMMANDER_LEASH_PX, unit.x))
+    }
+  }
 
   const livingOpponentUnits = s.field.some(u => u.owner === 'opponent' && u.hp > 0)
   const livingPlayerUnits   = s.field.some(u => u.owner === 'player'   && u.hp > 0)
@@ -159,7 +284,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       if (threat) {
         claimedThreats.add(threat.id)
         // Already engaging it — combat handles the attack, don't crowd closer.
-        if (threatDist <= unit.attackRange) continue
+        if (threatDist <= unit.attackRange) { driftFromHazards(unit, threat, true); continue }
         tx = threat.x
         ty = threat.isWall ? unit.y : threat.y
         hasTarget = true
@@ -169,7 +294,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
         hasTarget = false
       }
     } else if (nearestAhead) {
-      if (unitDist(unit, nearestAhead) <= unit.attackRange) continue
+      if (unitDist(unit, nearestAhead) <= unit.attackRange) { driftFromHazards(unit, nearestAhead, false); continue }
       // Attack: don't chase enemies — keep charging toward destination
       if (unit.owner !== 'player' || stance === 'auto') {
         tx = nearestAhead.x
@@ -180,7 +305,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       // Only turn back for enemies behind in auto mode
       const behind = findEnemyBehind(s.field, unit)
       if (behind) {
-        if (unitDist(unit, behind) <= unit.attackRange) continue
+        if (unitDist(unit, behind) <= unit.attackRange) { driftFromHazards(unit, behind, false); continue }
         tx = behind.x
         ty = behind.isWall ? unit.y : behind.y
         hasTarget = true
@@ -323,7 +448,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       ) {
         const attacker = s.field.find(u => u.id === ownCommander.lastAttackerId && u.hp > 0)
         if (attacker) {
-          if (unitDist(unit, attacker) <= unit.attackRange) continue
+          if (unitDist(unit, attacker) <= unit.attackRange) { driftFromHazards(unit, attacker, false); continue }
           tx = attacker.x
           ty = attacker.y
           hasTarget = true
@@ -358,7 +483,9 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     const dx = tx - unit.x
     const dy = ty - unit.y
     const d  = Math.sqrt(dx * dx + dy * dy)
-    if (d === 0) continue
+    // Already standing on its target (holding a slot, waiting on an affinity partner, …).
+    // Nothing to steer, but a cloud landing here still has to be walked out of.
+    if (d === 0) { driftFromHazards(unit, undefined, isDefending); continue }
 
     const inWallZone = unit.climber && s.field.some(w =>
       w.isWall && w.owner !== unit.owner && w.hp > 0 && Math.abs(unit.x - w.x) <= WALL_CLIMB_ZONE
@@ -400,13 +527,28 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     const speed = (inWallZone ? unit.moveSpeed * CLIMB_SPEED_FACTOR : unit.moveSpeed)
       * deltaSec * fogMult * affMoveMult * clampedMoatFactor * freezeFactor
 
-    // Terrain avoidance: lateral repulsion from nearby obstacles. Skipped when
-    // `terrainValidated` is on — that node uses hard tile blocking below
-    // instead (see game/engine/terrainGrid.ts). Untouched otherwise, so every
-    // existing act/node (terrainValidated absent/false) behaves exactly as
-    // before.
+    // Steering repulsion, folded into the step below.
+    let avoidX = 0
     let avoidY = 0
+
+    // Gas clouds. Unlike terrain and blood pools this pushes on both axes and applies to
+    // flying units too: a cloud is wide enough that sidestepping alone can't clear it inside
+    // LANE_MIN_Y..LANE_MAX_Y, and gas damages flyers.
+    if (liveHazards.length > 0) {
+      const { hx, hy, strength } = hazardEscapeVector(unit, liveHazards)
+      if (strength > 0) {
+        const push = unit.moveSpeed * HAZARD_DEFLECT_FACTOR * strength
+        avoidX += hx * push
+        avoidY += hy * push
+      }
+    }
+
     if (!unit.flying) {
+      // Terrain avoidance: lateral repulsion from nearby obstacles. Skipped when
+      // `terrainValidated` is on — that node uses hard tile blocking below
+      // instead (see game/engine/terrainGrid.ts). Untouched otherwise, so every
+      // existing act/node (terrainValidated absent/false) behaves exactly as
+      // before.
       if (!s.terrainValidated) {
         for (const obs of s.terrain) {
           const toObsX = obs.x - unit.x
@@ -449,7 +591,7 @@ export function moveUnits(s: GameState, deltaMs: number): void {
     }
 
     const step = Math.min(speed, d)
-    const candX = Math.min(LANE_WIDTH - BASE_STOP_MARGIN, Math.max(BASE_STOP_MARGIN, unit.x + (dx / d) * step))
+    const candX = Math.min(LANE_WIDTH - BASE_STOP_MARGIN, Math.max(BASE_STOP_MARGIN, unit.x + (dx / d) * step + avoidX * deltaSec))
     const candY = Math.min(LANE_MAX_Y, Math.max(LANE_MIN_Y, unit.y + (dy / d) * step + avoidY * deltaSec))
 
     if (!s.terrainValidated || unit.flying) {
@@ -461,12 +603,8 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       // a flow field (see buildFlowField in ./terrainGrid.ts). Grid and fields
       // are built once per battle and cached, since s.terrain/s.roads don't
       // change mid-battle.
-      s.terrainGridCache ??= {
-        obstacleTiles: buildObstacleTileMap(s.terrain),
-        roadTiles: buildRoadTileMap(s.roads ?? []),
-        flowFields: new Map(),
-      }
-      const { obstacleTiles, roadTiles } = s.terrainGridCache
+      const grid = ensureTerrainGrid()
+      const { obstacleTiles, roadTiles } = grid
       const profile: MovementProfile = unit.tags?.includes('burrowing') ? 'burrowing' : 'ground'
       const swims = unit.tags?.includes('swim') ?? false
       const canEnter = (x: number, y: number) => {
@@ -484,10 +622,10 @@ export function moveUnits(s: GameState, deltaMs: number): void {
       // defenders across the map the moment an obstacle got in the way.
       const goalX = isDefending ? 0 : (unit.owner === 'player' ? LANE_WIDTH : 0)
       const fieldKey = `${profile}|${swims}|${goalX}`
-      let field = s.terrainGridCache.flowFields.get(fieldKey)
+      let field = grid.flowFields.get(fieldKey)
       if (!field) {
         field = buildFlowField(obstacleTiles, roadTiles, profile, swims, goalX)
-        s.terrainGridCache.flowFields.set(fieldKey, field)
+        grid.flowFields.set(fieldKey, field)
       }
       const here = gameToContainingTile(unit.x, unit.y)
       const hereDist = field.get(`${here.tcx},${here.tcy}`)

--- a/web/src/utils/laneGrid.ts
+++ b/web/src/utils/laneGrid.ts
@@ -29,6 +29,21 @@ export function pixelToGame(px: number, py: number, w: number, h: number): { x: 
 }
 
 /**
+ * Pixel semi-axes of a circle of `radius` game units, for art that has to cover the same
+ * ground a game-space distance check does (gas clouds). The lane's two axes are scaled
+ * independently — x spans 500 units down the canvas height, y spans ±80 across 72% of its
+ * width — so a game-space circle is an ellipse on screen. Derived from gameToPixel rather
+ * than restating its factors, so the two cannot drift apart.
+ */
+export function gameRadiusToPixels(radius: number, w: number, h: number): { rx: number; ry: number } {
+  const origin = gameToPixel(0, 0, w, h)
+  return {
+    rx: Math.abs(gameToPixel(0, radius, w, h).px - origin.px),
+    ry: Math.abs(gameToPixel(radius, 0, w, h).py - origin.py),
+  }
+}
+
+/**
  * The tile index a game position anchors to, for art that snaps to the tile grid.
  *
  * Callers drawing the battlefield lane pass a tileScale (h / GRID_REF_HEIGHT),

--- a/web/src/utils/terrainLayer.ts
+++ b/web/src/utils/terrainLayer.ts
@@ -14,7 +14,7 @@ import type { TerrainObstacle, RoadDef, BattlefieldDecorItem } from '../game/eng
 // Lane coordinate/tile math lives in ./laneGrid (pixi-free so tests can import
 // it); re-exported here because most callers reach for it alongside the
 // build*Gfx helpers.
-export { gameToPixel, pixelToGame, TILE_RADIUS_SCALE } from './laneGrid'
+export { gameToPixel, pixelToGame, gameRadiusToPixels, TILE_RADIUS_SCALE } from './laneGrid'
 
 export interface TerrainLayerOptions {
   environment?: string


### PR DESCRIPTION
Units and commanders stood inside enemy gas clouds trading blows, or walked straight through one, taking damage every tick until they died. Two separate causes, both fixed here.

## Nothing in movement read `s.hazards`

`moveUnits` never looked at ground hazards — the only dynamic-object repulsion in the game was the blood-pool block. Worse, an engaged unit never reached the steering code at all: it early-`continue`s the moment its target is inside `attackRange`, which is exactly the "stands in the cloud and dies" case.

Avoidance is now a 2-D repulsion (`hazardEscapeVector`), unlike the lateral-only terrain and blood-pool deflections — a cloud centred in the lane is too wide to sidestep within `LANE_MIN_Y..LANE_MAX_Y`. It applies on both paths:

- **Engaged / stationary units** shuffle clear via `driftFromHazards`, with the step capped so the unit they're fighting stays inside `attackRange` — drift out, keep fighting, rather than disengaging. These paths bypass the end-of-loop clamps, so the commander leash and defend backstop are reapplied there, and the drift is checked against `isTilePassable` on `terrainValidated` nodes so it can't tunnel into terrain.
- **Steering units** fold the push into the existing `avoid` accumulator, now with an `avoidX` alongside `avoidY`.

Flying units dodge too, since `engine.ts` gasses them as well. Symmetric — both sides avoid clouds their opponent dropped, and clouds from their own side are ignored. Head-on approach along the cloud's own lane gets a sideways tiebreak by unit-id parity, the same trick the terrain block uses, so units round the cloud instead of stalling nose-first against it.

## The cloud you saw was not the cloud that hurt you

The damage radius was 72 game units, but the cloud was drawn as a fixed 32px circle that ignored `hazard.radius`. Because the lane maps x to the canvas height and y to 72% of its width, radius 72 spanned about two-thirds of the width — units were being gassed while visibly well clear of the green blob, and avoidance would have looked broken against art that disagreed with the damage zone.

Damage, art and avoidance now share one radius (`GAS_CLOUD_RADIUS`, 45 — between the ~22 the old art implied and the old 72, so the cloud becomes a genuinely dodgeable puddle without gutting the Plague Shaman). The renderer reads `hazard.radius` directly via a new `gameRadiusToPixels` helper that derives its two semi-axes from `gameToPixel`, so a game-space circle draws as the ellipse the lane's independently-scaled axes make of it, and the two can't drift apart again. Both draw sites are covered — the `Hazard` circle and the duplicate long-lived `gascloud` AnimEvent that overlays it.

## Files

- `web/src/game/engine/units.ts` — `hazardEscapeVector`, `driftFromHazards`, `canUnitEnter`, `avoidX`; the terrain-grid cache init is hoisted to a shared `ensureTerrainGrid` so the drift and the existing hard-blocking steering use one grid.
- `web/src/game/cards.ts` — `GAS_CLOUD_RADIUS`.
- `web/src/utils/laneGrid.ts` / `terrainLayer.ts` — `gameRadiusToPixels`.
- `web/src/components/battle/battlefieldCanvas/effects.ts` — radius-aware cloud rendering.

## Testing

`npm run build` passes. `npm test` — 2106 tests pass, including 9 new cases in `units.test.ts`: fighting inside a cloud drifts out while the target never leaves attack range (the regression test for the report), a cloud dropped dead-centre still resolves to a direction, an advancing unit routes around rather than through, own-side and expired clouds are ignored, flying units dodge, the commander drifts but stays on its leash, the drift can't push into blocked terrain, and every `gascloud` card in the catalog carries the shared radius.

The Storybook browser project can't run in this container (the pinned `chrome-headless-shell` binary isn't present) — unaffected by this change and it runs in CI. The cloud rendering change is visual and worth a look in Storybook.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169LBnALrYvnH7FEn97aG6W)_