### PR TITLE
Wait, reroute, or scooch instead of aborting the walk when an NPC blocks the route

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -40,6 +40,8 @@ const T                 = 32
 const SPRITE_SIZE       = T * 1.5
 const WALK_PX_PER_S     = 160
 const NPC_WALK_PX_PER_S = 80
+const NPC_BLOCK_WAIT_POLL_MS = 150   // how often to re-check a blocked tile
+const NPC_BLOCK_WAIT_MAX_MS  = 900   // give up waiting and try to reroute after this long
 
 const NIGHT_LIGHT_INNER  = 4 * T   // fully lit within this radius of avatar
 const NIGHT_LIGHT_OUTER  = 7 * T   // fully dark beyond this radius
@@ -1720,6 +1722,7 @@ export function HubTownCanvas({
     // ── Exterior walk state ────────────────────────────────────────────────────
     let currentTile: [number, number] = [AVATAR_START.tx, AVATAR_START.ty]
     let walkQueue:   [number, number][] = []
+    let walkTarget:  [number, number] | null = null
     let isWalking    = false
     let pendingScreen: string | null = null
 
@@ -2546,14 +2549,41 @@ export function HubTownCanvas({
         }
         isWalking = true
         const [tx, ty] = walkQueue.shift()!
+        const queueRef = walkQueue
 
-        // An NPC may have wandered onto this tile since the path was planned —
-        // halt in place rather than tweening onto it.
+        // An NPC may have wandered onto this tile since the path was planned.
+        // Don't just give up on the journey — wait briefly for it to clear,
+        // then try to route around it, and only as a last resort step through.
         if (npcOccupiedTiles().has(`${tx},${ty}`)) {
-          isWalking     = false
-          walkQueue     = []
-          pendingScreen = null
-          return
+          let waited = 0
+          while (
+            npcOccupiedTiles().has(`${tx},${ty}`) &&
+            walkQueue === queueRef &&
+            waited < NPC_BLOCK_WAIT_MAX_MS
+          ) {
+            await new Promise<void>(resolve => setTimeout(resolve, NPC_BLOCK_WAIT_POLL_MS))
+            waited += NPC_BLOCK_WAIT_POLL_MS
+          }
+
+          if (walkQueue !== queueRef) {
+            // A new tap replaced the queue while we were waiting — let it take over.
+            processWalkQueue()
+            return
+          }
+
+          if (npcOccupiedTiles().has(`${tx},${ty}`)) {
+            if (walkTarget) {
+              const rerouteSet = exteriorWalkable()
+              for (const k of npcOccupiedTiles()) rerouteSet.delete(k)
+              const reroute = findPath(currentTile, walkTarget, rerouteSet)
+              if (reroute.length > 1) {
+                walkQueue = reroute.slice(1)
+                processWalkQueue()
+                return
+              }
+            }
+            // No route around either — scooch through rather than getting stuck.
+          }
         }
 
         const av = avatar
@@ -2649,6 +2679,7 @@ export function HubTownCanvas({
       for (const k of npcOccupiedTiles()) effectivePathSet.delete(k)
       const path = findPath(currentTile, target, effectivePathSet)
       walkQueue = path.slice(1)
+      walkTarget = target
       pendingScreen = nodeScreen ?? null
       if (!isWalking) processWalkQueue()
     }


### PR DESCRIPTION
## Summary
- Follow-up to #2078: after NPCs became solid to the player, `processWalkQueue()` would cancel the entire remaining journey the instant a wandering NPC stepped onto the player's next queued tile — the avatar just gave up mid-route.
- `processWalkQueue()` now handles a blocked next-tile in three tiers instead of hard-stopping:
  1. **Wait** up to `NPC_BLOCK_WAIT_MAX_MS` (900ms, polling every 150ms) for the NPC to clear the tile.
  2. If still blocked, **reroute** from the player's current tile to the original destination (tracked in a new `walkTarget`), routing around current NPC positions the same way `startWalk()`/`wanderNpc()` already do.
  3. If no route around exists either, **scooch through** — take the step anyway rather than leaving the avatar stuck.
- A fresh tap mid-wait is detected via array-reference comparison on `walkQueue` (the same mechanism `startWalk()` already relies on when re-tapping mid-walk) and immediately hands off to the new route instead of finishing the stale wait.

## Test plan
- [x] `npx tsc --noEmit -p .` in `web/` — no errors
- [x] `npx vitest run` in `web/` — 2097 tests passed (one unrelated Playwright browser-executable error, pre-existing in this environment)
- [ ] Manual: tap a destination whose route crosses a wandering NPC's path timed to collide mid-route — avatar pauses briefly instead of aborting, then continues once clear
- [ ] Manual: force a lingering block past the wait window — avatar reroutes around it instead of stopping
- [ ] Manual: force a fully boxed-in case with no alternate route — avatar still steps through rather than freezing
- [ ] Manual: re-tap a new destination while mid-wait for a blocked tile — immediately abandons the old route for the new one

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFBvy4982b4VouRHUCP51s)_