### PR TITLE
Fix Ravenwatch's outdated "your quarters" NPC dialogue

### DIFF
--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -7999,7 +7999,7 @@
           "entryTx": 9,
           "entryTy": 4,
           "requiredQuest": "aldous-hidden-passage",
-          "label": "Back to quarters"
+          "label": "Back to the residence"
         },
         {
           "tx": 10,
@@ -9872,9 +9872,9 @@
       "ty": 9,
       "screen": "home-shelf",
       "dialogue": [
-        "Your quarters are just inside, Commander. I keep your things in order.",
+        "The residence is just inside, Commander. I help Steward Aldous keep it in order.",
         "The shelf holds everything you've gathered on your journey.",
-        "Rest is just as important as battle. Your quarters await."
+        "Rest is just as important as battle. Come sit a while before you head back out."
       ],
       "conversationTopics": [
         "ravenwatch-home-shelf-topic-auto-1",
@@ -10167,7 +10167,7 @@
       "ty": 5,
       "questGive": "aldous-keepsake",
       "dialogue": [
-        "Welcome home, Commander. Your quarters are ready.",
+        "Welcome, Commander. Come in out of the cold — you're always welcome here.",
         "I have kept everything in order during your absence.",
         "Rest here. Tomorrow's battles can wait."
       ],

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -14018,7 +14018,7 @@
       "start": "start",
       "nodes": {
         "start": {
-          "text": "Your quarters are just inside, Commander. I keep your things in order.",
+          "text": "The residence is just inside, Commander. I help Steward Aldous keep it in order.",
           "choices": [
             {
               "label": "That sounds like it weighs on you.",
@@ -14234,7 +14234,7 @@
       "start": "start",
       "nodes": {
         "start": {
-          "text": "Rest is just as important as battle. Your quarters await.",
+          "text": "Rest is just as important as battle. Come sit a while before you head back out.",
           "choices": [
             {
               "label": "That sounds like it weighs on you.",
@@ -17042,7 +17042,7 @@
       "start": "start",
       "nodes": {
         "start": {
-          "text": "Welcome home, Commander. Your quarters are ready.",
+          "text": "Welcome, Commander. Come in out of the cold — you're always welcome here.",
           "choices": [
             {
               "label": "That sounds like it weighs on you.",
@@ -23120,7 +23120,7 @@
     {
       "id": "ravenwatch-home-shelf-topic-auto-1",
       "npcId": "home-shelf",
-      "label": "💬 \"Your quarters are just inside, Commander.\"",
+      "label": "💬 \"The residence is just inside, Commander.\"",
       "treeId": "ravenwatch-home-shelf-topic-auto-1"
     },
     {
@@ -23302,7 +23302,7 @@
     {
       "id": "ravenwatch-home-steward-topic-auto-1",
       "npcId": "home-steward",
-      "label": "💬 \"Welcome home, Commander.\"",
+      "label": "💬 \"Welcome, Commander.\"",
       "treeId": "ravenwatch-home-steward-topic-auto-1"
     },
     {


### PR DESCRIPTION
## Summary
- In Ravenwatch, Steward Maren (`home-shelf`) and Steward Aldous (`home-steward`), who stand near the "Stewards Residence" building, had dialogue calling it "your quarters" / greeting the player with "Welcome home, Commander" — a holdover from when that building used to be the player's house.
- The player's actual house in Ravenwatch is now the separate, purchasable "Lakeside Cottage" (`building-1`, `requiresOwnership: true`, `upgradeKind: "playerHouse"`) — the Stewards Residence is not flagged as player-owned in the data model at all, so the old lines no longer make sense.
- Reworded the affected lines to frame the Stewards Residence as Steward Aldous's own home/office (where he manages the Commander's affairs), not the player's living quarters. Left the lines that don't assert ownership (e.g. "I have kept everything in order during your absence.") unchanged.
- Updated all three places each line lives in this codebase's content model (they're hand-maintained copies, not generated at build time): the NPC `dialogue` array in `config.json`, the matching conversation-topic tree `start.text` in `questDefs.json`, and the corresponding topic-list button `label` previews. Also fixed the "Back to quarters" hidden-passage exit label for the same reason.

## Test plan
- [x] JSON syntax validated for both edited files (`python3 -m json.tool`)
- [x] `npx vitest run` in `web/` — 2097 tests passed (one unrelated pre-existing Playwright browser-executable error)
- [ ] Manual: talk to Steward Maren and Steward Aldous in Ravenwatch's Stewards Residence and confirm the new lines read naturally and no longer claim the player lives there

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFBvy4982b4VouRHUCP51s)_