### PR TITLE
Mobile robustness: safe areas, audio resume, and cloud saves that actually upload

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- viewport-fit=cover lets the page paint into the notch/home-indicator
+       areas; styles.css then pads content back out via env(safe-area-inset-*).
+       Required because the status bar style below is black-translucent, so an
+       iOS home-screen install already renders under the status bar. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Jarv's Amazing Web Game</title>
 
   <!-- Favicon -->

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -52,6 +52,36 @@ export function setMusicVolume(val: number): void {
   }
 }
 
+/**
+ * Nudge a suspended context back to life.
+ *
+ * Mobile browsers suspend the AudioContext whenever the page is backgrounded,
+ * and nothing brings it back on its own — so without this the first time a
+ * player switches apps or locks their phone, sound is gone for the rest of the
+ * session (music worst of all, since a running track has no later event to
+ * re-trigger it). Safe to call unconditionally: resuming a running context is
+ * a no-op, and resume() rejects only when there is no user gesture behind it,
+ * which we treat as "try again on the next one".
+ */
+function resumeCtx(): void {
+  if (!ctx || ctx.state !== 'suspended') return
+  ctx.resume().catch(() => {
+    // Expected when the browser wants a fresh user gesture first — the next
+    // tap routes through getCtx() and retries. Not player-visible on its own.
+  })
+}
+
+/**
+ * Resume on return to foreground so music restarts without waiting for the
+ * player to trigger another sound. Registered once at module load; harmless in
+ * Node/test environments, which have no `document`.
+ */
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') resumeCtx()
+  })
+}
+
 function getCtx(): AudioContext | null {
   if (!isSoundEnabled()) return null
   try {
@@ -61,6 +91,10 @@ function getCtx(): AudioContext | null {
       masterGain.gain.value = SOUND_BASE_GAIN * getSoundVolume()
       masterGain.connect(ctx.destination)
     }
+    // Most calls arrive from a tap, which is exactly the gesture the browser
+    // wants before it will un-suspend. This is the path that recovers audio if
+    // the visibilitychange resume above was rejected for lacking one.
+    resumeCtx()
     return ctx
   } catch {
     return null

--- a/web/src/hooks/useCloudSync.ts
+++ b/web/src/hooks/useCloudSync.ts
@@ -1,6 +1,7 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import type { User } from 'firebase/auth'
 import { uploadSave, getRemoteSaveIfNewer } from '../game/cloudSave'
+import { logWarn } from '../logger'
 
 interface SyncPrompt {
   remoteDate: Date
@@ -18,14 +19,71 @@ interface UseCloudSyncResult {
   clearSyncPrompt: () => void
 }
 
+/** Don't re-upload more often than this, however many triggers fire. */
+const UPLOAD_THROTTLE_MS = 30 * 1000
+
 /**
- * Checks for a newer remote save whenever the player lands on the title screen
- * and surfaces a prompt if one is found. Also runs a periodic auto-upload every
- * 5 minutes while the player is on the title screen.
+ * Throttle for leaving-the-page uploads. Not zero: closing a tab fires
+ * visibilitychange→hidden *and* pagehide back to back, and there is no value in
+ * writing the same payload twice. Short enough that a genuine background,
+ * return, background still saves each time.
+ */
+const LEAVE_THROTTLE_MS = 2000
+
+/** Periodic auto-upload cadence while the game is open. */
+const AUTO_UPLOAD_INTERVAL_MS = 5 * 60 * 1000
+
+/**
+ * Keeps the cloud save current and offers to restore a newer one.
+ *
+ * The restore prompt is deliberately title-screen only — that is the one place
+ * it is safe to swap local state out from under the player.
+ *
+ * Uploads are not. They run wherever the player is, for two reasons that both
+ * cost real progress on mobile:
+ *
+ *  - Uploading only on the title screen meant a player who opened the app,
+ *    played a long campaign session and closed the tab from inside a run never
+ *    uploaded at all. iOS Safari evicts localStorage after ~7 days without
+ *    interaction, so that player has no cloud copy to fall back on.
+ *  - Backgrounding is where sessions actually end on a phone, and it is the
+ *    last moment we are reliably given before the tab can be killed.
+ *
+ * So: upload on the way out (hidden/pagehide), and on a timer regardless of
+ * screen to cover a hard crash that never fires either event.
  */
 export function useCloudSync({ user, screen, flushPlaytimeToStorage }: UseCloudSyncOptions): UseCloudSyncResult {
   const [syncPrompt, setSyncPrompt] = useState<SyncPrompt | null>(null)
   const syncPromptedRef = useRef(false)
+  const lastUploadRef = useRef(0)
+
+  // Latest values, read from listeners that are registered once. Without these
+  // the effect below would have to re-subscribe on every screen change.
+  const uidRef = useRef<string | null>(null)
+  uidRef.current = user && !user.isAnonymous ? user.uid : null
+  const flushRef = useRef(flushPlaytimeToStorage)
+  flushRef.current = flushPlaytimeToStorage
+
+  /**
+   * Upload unless we just did. `leaving` shortens the throttle right down for
+   * the page-exit case, where this is the last chance we get — it still dedupes
+   * the hidden/pagehide pair that a tab close fires.
+   */
+  const syncNow = useCallback((reason: string, leaving = false): void => {
+    const uid = uidRef.current
+    if (!uid) return
+    if (!navigator.onLine) return
+    const now = Date.now()
+    if (now - lastUploadRef.current < (leaving ? LEAVE_THROTTLE_MS : UPLOAD_THROTTLE_MS)) return
+    lastUploadRef.current = now
+    flushRef.current()
+    uploadSave(uid).catch(err => {
+      // Not logError: the local save is intact and the next trigger retries, so
+      // the player is not broken — but a player who only ever fails to upload
+      // is one device wipe from losing everything, so it must not be silent.
+      logWarn('[cloudSync] upload failed', { reason, err: String(err) })
+    })
+  }, [])
 
   // On arriving at the title screen, check if the remote save is newer and prompt the user.
   // Reset the prompted flag whenever we leave the title so re-visiting prompts again if needed.
@@ -41,18 +99,34 @@ export function useCloudSync({ user, screen, flushPlaytimeToStorage }: UseCloudS
     }).catch(() => { /* offline or error — silently skip */ })
   }, [screen, user])
 
-  // Periodic auto-sync: upload local save every 5 minutes while on the title screen and online.
+  // Upload as the player leaves — backgrounding the app, switching tabs, or
+  // closing it. These are the only events iOS reliably delivers before it can
+  // kill the page, so they are forced past the throttle. The write is still
+  // best-effort: if the tab dies mid-request the next trigger covers it.
+  //
+  // Both events are needed. pagehide is the one that fires on a real
+  // navigation away or tab close; visibilitychange is the one that fires when
+  // the player switches apps, which on a phone is how sessions usually end.
   useEffect(() => {
-    if (screen !== 'title') return
-    const uid = user?.uid
-    if (!uid || user?.isAnonymous) return
-    const id = setInterval(() => {
-      if (!navigator.onLine) return
-      flushPlaytimeToStorage()
-      uploadSave(uid).catch(() => { /* silent */ })
-    }, 5 * 60 * 1000)
+    const onHide = () => {
+      if (document.visibilityState === 'hidden') syncNow('visibility-hidden', true)
+    }
+    const onPageHide = () => syncNow('pagehide', true)
+    // `true` here is the `leaving` flag, not `force` — see syncNow.
+    document.addEventListener('visibilitychange', onHide)
+    window.addEventListener('pagehide', onPageHide)
+    return () => {
+      document.removeEventListener('visibilitychange', onHide)
+      window.removeEventListener('pagehide', onPageHide)
+    }
+  }, [syncNow])
+
+  // Periodic auto-upload, on every screen rather than only the title. Catches
+  // the session that ends in a crash or an OS kill with no hidden/pagehide.
+  useEffect(() => {
+    const id = setInterval(() => syncNow('interval'), AUTO_UPLOAD_INTERVAL_MS)
     return () => clearInterval(id)
-  }, [screen, user, flushPlaytimeToStorage])
+  }, [syncNow])
 
   return { syncPrompt, clearSyncPrompt: () => setSyncPrompt(null) }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8,6 +8,17 @@
 }
 
 :root {
+  /* Device safe areas — the notch/status bar and the home indicator.
+     Only ever non-zero when the page is served with viewport-fit=cover on a
+     device that has cutouts, which for us means an iOS home-screen install
+     (the manifest is display:standalone and the status bar is black-translucent,
+     so the web view really does extend under both). In every normal browser
+     env() falls back to 0px and these are inert. */
+  --safe-top:    env(safe-area-inset-top, 0px);
+  --safe-right:  env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left:   env(safe-area-inset-left, 0px);
+
   --game-text-color: #33ff33;
   --game-text-color-dim:   color-mix(in srgb, var(--game-text-color) 85%, transparent);
   --game-text-color-muted: color-mix(in srgb, var(--game-text-color) 70%, transparent);
@@ -188,7 +199,14 @@ body {
 .game-container {
   max-width: 740px;
   margin: 0 auto;
-  padding: 6px 10px;
+  /* Base 6px/10px inset, plus whatever the device reserves for its cutouts.
+     box-sizing is border-box globally, so this eats into the 100vh height
+     rather than overflowing it. */
+  padding:
+    calc(6px  + var(--safe-top))
+    calc(10px + var(--safe-right))
+    calc(6px  + var(--safe-bottom))
+    calc(10px + var(--safe-left));
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -1291,7 +1309,13 @@ body {
 
 @media (max-width: 480px) {
   body { font-size: var(--font-md); }
-  .game-container { padding: 4px 6px; }
+  .game-container {
+    padding:
+      calc(4px + var(--safe-top))
+      calc(6px + var(--safe-right))
+      calc(4px + var(--safe-bottom))
+      calc(6px + var(--safe-left));
+  }
   .game-title { font-size: var(--font-base); letter-spacing: 1px; }
 
   .hand-cards { gap: 4px; padding-bottom: 4px; }
@@ -3713,8 +3737,8 @@ body {
 
 .wn-notification {
   position: fixed;
-  top: 0;
-  right: 0;
+  top: var(--safe-top);
+  right: var(--safe-right);
   width: min(340px, 95vw);
   background: #1c1c1e;
   border: 1px solid var(--game-border);
@@ -7408,9 +7432,9 @@ body {
 
 .integrity-warning {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: var(--safe-top);
+  left: var(--safe-left);
+  right: var(--safe-right);
   z-index: 9999;
   display: flex;
   align-items: center;
@@ -9562,7 +9586,7 @@ html.light-mode .action-btn {
 /* ── Secret #1 — Konami Code toast ──────────────────────────────────────── */
 .konami-toast {
   position: fixed;
-  top: 1rem;
+  top: calc(1rem + var(--safe-top));
   left: 50%;
   transform: translateX(-50%);
   background: #1a2a1a;
@@ -11255,7 +11279,7 @@ html.light-mode .action-btn {
 
 .city-toast {
   position: fixed;
-  top: 16px;
+  top: calc(16px + var(--safe-top));
   left: 50%;
   transform: translateX(-50%);
   background: #0a1a0a;
@@ -12033,7 +12057,7 @@ html.light-mode .action-btn {
 
 .minigame-toast {
   position: fixed;
-  top: 16px;
+  top: calc(16px + var(--safe-top));
   left: 50%;
   transform: translateX(-50%);
   background: #1a1a3a;


### PR DESCRIPTION
Three fixes for bugs mobile players are hitting on `jawg.uk` today. All pure web work with no Capacitor dependency — the subset of #2082 worth doing while the store project is parked.

Closes #2086, closes #2089.

## 1. Safe-area insets (#2086)

The manifest is `display: standalone` and `index.html` sets the iOS status bar style to `black-translucent`, so a home-screen install **already** renders the web view under the status bar and home indicator. `styles.css` had no `env(safe-area-inset-*)` rules across 15,698 lines, leaving the top of the UI behind the clock and battery.

Added `--safe-*` custom properties on `:root` and folded them into `.game-container`'s padding (base rule and the ≤480px override). `box-sizing: border-box` is global, so this eats into the `100vh`/`100dvh` height rather than overflowing it.

Also inset the five fixed-position elements that escape the container's padding and sit inside a ~47–59px notch: `.wn-notification` and `.integrity-warning` at `top: 0`, and `.konami-toast` / `.city-toast` / `.minigame-toast` at `1rem`/`16px`. The bottom-anchored toasts already sit at 60–80px, clearing the ~34px home indicator.

No visual change in a normal browser — `viewport-fit=cover` only opts into the cutout areas and `env()` falls back to `0px`.

## 2. AudioContext resume (#2089)

`getCtx()` created the context but nothing called `resume()` anywhere. Mobile browsers suspend the AudioContext on background, so the first time a player switched apps or locked their phone, sound was dead for the rest of the session — music worst of all, since a running track has no later event to re-trigger it.

Resumes from two places because either alone leaves a gap: a `visibilitychange` listener so music returns unprompted, and `getCtx()` itself, which nearly always runs off a tap and so carries the user gesture the browser may insist on. Resuming a running context is a no-op. The listener is guarded on `typeof document` so Node/Vitest imports stay side-effect free.

## 3. Cloud saves upload outside the title screen (new — no existing issue)

The one I'd most want merged, and not covered by any ticket in #2082.

Both upload paths in `useCloudSync.ts` bailed on `if (screen !== 'title') return`, so saves only reached Firestore while the player sat idle on the title screen. Someone who opened the app, played a long campaign session and closed the tab from inside a run **never uploaded at all**.

That's a real data-loss path, not a theoretical one: iOS Safari evicts localStorage after ~7 days without interaction, and the game keeps everything there across 441 call sites. Such a player has no cloud copy to restore from.

Now uploads on `visibilitychange` → hidden and `pagehide` — the events that mark a session actually ending on a phone, and the last moments iOS reliably gives before it can kill the page — plus the existing 5-minute timer, now running on every screen so a crash or OS kill that fires neither event loses at most five minutes.

Shared path extracted into `syncNow()`, throttled to 30s normally and 2s on the way out. The short window still dedupes the `hidden`/`pagehide` pair a tab close fires, while letting a genuine background → return → background sequence save each time. Listeners read uid and the playtime flush through refs so they register once rather than re-subscribing on every screen change.

Upload failures now go to `logWarn` instead of being swallowed. Not `logError` — the local save is intact and the next trigger retries, so nothing is broken right now, but a player whose uploads always fail is one device wipe from losing everything and that should be visible in Rollbar.

The restore prompt is unchanged and stays title-screen only: that's the one place it's safe to swap local state out from under the player.

## Not done, deliberately

While investigating I found the mobile hardening is further along than #2082 implied — `pixiContextLossController.ts` plus the visibility probe in `usePixiApp.ts` already handle iOS silently reclaiming a backgrounded tab's WebGL context, which was the main jetsam symptom.

One correction to #2082: it lists the unbounded texture cache in `pixiHelpers.ts` as a memory risk. That framing is wrong — `_cache` only holds `Promise<Texture>` handles; the texture memory itself lives in PixiJS's own `PIXI.Assets` cache, so evicting `_cache` would free nothing without a matching `Assets.unload()`. I'll correct the note on the parent issue rather than ticket it.

## Verification

- `npm run build` (tsc + vite) — clean
- `npm test` — 2,789 tests across 252 files, all passing

Device checks still worth doing before release: home-screen install on a notched iPhone to confirm nothing clips; background 30s and confirm audio returns; play into a campaign run, background the app, and confirm the save lands in Firestore.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9XTp5N15A4N2Z5JHWAS75)_