### PR TITLE
Revert the safe-area change — it shrank the play area on iPhone

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,11 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <!-- viewport-fit=cover lets the page paint into the notch/home-indicator
-       areas; styles.css then pads content back out via env(safe-area-inset-*).
-       Required because the status bar style below is black-translucent, so an
-       iOS home-screen install already renders under the status bar. -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jarv's Amazing Web Game</title>
 
   <!-- Favicon -->

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8,17 +8,6 @@
 }
 
 :root {
-  /* Device safe areas — the notch/status bar and the home indicator.
-     Only ever non-zero when the page is served with viewport-fit=cover on a
-     device that has cutouts, which for us means an iOS home-screen install
-     (the manifest is display:standalone and the status bar is black-translucent,
-     so the web view really does extend under both). In every normal browser
-     env() falls back to 0px and these are inert. */
-  --safe-top:    env(safe-area-inset-top, 0px);
-  --safe-right:  env(safe-area-inset-right, 0px);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left:   env(safe-area-inset-left, 0px);
-
   --game-text-color: #33ff33;
   --game-text-color-dim:   color-mix(in srgb, var(--game-text-color) 85%, transparent);
   --game-text-color-muted: color-mix(in srgb, var(--game-text-color) 70%, transparent);
@@ -199,14 +188,7 @@ body {
 .game-container {
   max-width: 740px;
   margin: 0 auto;
-  /* Base 6px/10px inset, plus whatever the device reserves for its cutouts.
-     box-sizing is border-box globally, so this eats into the 100vh height
-     rather than overflowing it. */
-  padding:
-    calc(6px  + var(--safe-top))
-    calc(10px + var(--safe-right))
-    calc(6px  + var(--safe-bottom))
-    calc(10px + var(--safe-left));
+  padding: 6px 10px;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -1309,13 +1291,7 @@ body {
 
 @media (max-width: 480px) {
   body { font-size: var(--font-md); }
-  .game-container {
-    padding:
-      calc(4px + var(--safe-top))
-      calc(6px + var(--safe-right))
-      calc(4px + var(--safe-bottom))
-      calc(6px + var(--safe-left));
-  }
+  .game-container { padding: 4px 6px; }
   .game-title { font-size: var(--font-base); letter-spacing: 1px; }
 
   .hand-cards { gap: 4px; padding-bottom: 4px; }
@@ -3737,8 +3713,8 @@ body {
 
 .wn-notification {
   position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
+  top: 0;
+  right: 0;
   width: min(340px, 95vw);
   background: #1c1c1e;
   border: 1px solid var(--game-border);
@@ -7432,9 +7408,9 @@ body {
 
 .integrity-warning {
   position: fixed;
-  top: var(--safe-top);
-  left: var(--safe-left);
-  right: var(--safe-right);
+  top: 0;
+  left: 0;
+  right: 0;
   z-index: 9999;
   display: flex;
   align-items: center;
@@ -9586,7 +9562,7 @@ html.light-mode .action-btn {
 /* ── Secret #1 — Konami Code toast ──────────────────────────────────────── */
 .konami-toast {
   position: fixed;
-  top: calc(1rem + var(--safe-top));
+  top: 1rem;
   left: 50%;
   transform: translateX(-50%);
   background: #1a2a1a;
@@ -11279,7 +11255,7 @@ html.light-mode .action-btn {
 
 .city-toast {
   position: fixed;
-  top: calc(16px + var(--safe-top));
+  top: 16px;
   left: 50%;
   transform: translateX(-50%);
   background: #0a1a0a;
@@ -12057,7 +12033,7 @@ html.light-mode .action-btn {
 
 .minigame-toast {
   position: fixed;
-  top: calc(16px + var(--safe-top));
+  top: 16px;
   left: 50%;
   transform: translateX(-50%);
   background: #1a1a3a;


### PR DESCRIPTION
Reverts `8b7514a` from #2096. Reopens #2086.

## Why

The safe-area work made the game visibly worse on an iPhone home-screen install — everything compressed. That is a real regression, not a cosmetic quibble, and it should not have shipped.

**Mechanism.** `viewport-fit=cover` is the switch that makes `env(safe-area-inset-*)` return real values; without it they are always `0px`. Adding it to `index.html` woke those insets up, and they were then fed into `.game-container`'s padding. `box-sizing: border-box` is global and the container is `height: 100vh`/`100dvh`, so that padding comes **out of** the content box — and `styles.css:8514` confirms `.game-container` is the fixed-height box every screen scrolls inside.

In standalone mode the insets are roughly 47–59px top and 34px bottom. So about 10% of the vertical space disappeared and the flex column squeezed to fit. Exactly the reported symptom.

**A second defect in the same commit.** There is a third padding override at `styles.css:1337` — `@media (max-width: 380px) { .game-container { padding: 2px 4px; } }` — which was never updated. Phones ≤380px got the expanded viewport with no inset back, i.e. the inverse bug. The change was not even internally consistent.

**What went wrong in review.** The original commit message and PR both claimed "no visual change in a normal browser". That was true of desktop and beside the point: the change targeted phones, which is precisely where it altered layout, and it was asserted without ever being checked on a device. Any future attempt here must be verified on a real handset before it ships.

Stepping back, the change spent something the player feels every session — screen space — to fix a cosmetic overlap that had evidently been fine in practice. Even implemented correctly it was a poor trade.

## Scope

`8b7514a` touched only `web/index.html` and `web/src/styles.css`. The audio-resume (`65d7e31`) and cloud-save (`f9c1ee9`) commits from #2096 touch different files, are unaffected by this revert, and **stay shipped** — #2089 remains closed.

Verified no residue: no `safe-area`, `--safe-`, or `viewport-fit` references remain in either file, and all three `.game-container` padding rules are back to their originals (`6px 10px`, `4px 6px`, `2px 4px`).

## If this is retried later

Not proposed here, and no work implied — but recorded so the next attempt does not repeat the mistake. A retry must be **height-neutral**. The most promising option is to stop opting into the cutout at all: change `apple-mobile-web-app-status-bar-style` from `black-translucent` to `black`, so iOS reserves the status bar itself rather than the page padding for it. One line, no `env()` arithmetic, and it cannot silently shrink the play area — though it still changes how much screen the game gets, so it too needs looking at on a real iPhone first.

## Verification

- `npm run build` (tsc + vite) — clean
- `npm test` — 2,789 tests across 252 files, all passing
- Still needs your eyes on the device: once this deploys, reload the home-screen install and confirm the layout is back to its previous size.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9XTp5N15A4N2Z5JHWAS75)_