### PR TITLE
Let the hub town and act maps bleed to the screen edge

### DIFF
--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -39,7 +39,16 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
   const statusOf = (id: string) => getNodeStatus(id, availableIds, run)
 
   return (
-    <OverlayScreen onBack={onBack} title={act.title} subtitle={act.subtitle}>
+    <OverlayScreen
+      onBack={onBack}
+      title={act.title}
+      subtitle={act.subtitle}
+      // Matches the hub: the act map reaches the screen edge rather than
+      // sitting inside .game-container's gutter. The toolbars above and below
+      // it stay inset — they are bordered boxes, so bleeding them would put a
+      // visible border under the phone's corner curve.
+      className="overlay-screen overlay-screen--bleed u-col u-grow"
+    >
       <div className="nodemap u-col u-grow">
 
         <Toolbar>

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -2183,7 +2183,14 @@ function hasOfferableQuest(giverId: string): boolean {
   }
 
   return (
-    <OverlayScreen title={`🏠 ${locationData.HUB_TOWN_NAME}`} right={activeFestival && `${activeFestival.icon} ${activeFestival.name}`}>
+    <OverlayScreen
+      title={`🏠 ${locationData.HUB_TOWN_NAME}`}
+      right={activeFestival && `${activeFestival.icon} ${activeFestival.name}`}
+      // --bleed lets the town canvas reach the screen edge instead of sitting
+      // inside .game-container's gutter, which read as a black outline that the
+      // phone's corner radius cropped unevenly.
+      className="overlay-screen overlay-screen--bleed u-col u-grow"
+    >
       {HubWorldToolbar(wrongSave, crystals, collectionCount, catalogTotal, isGameNight,  setTabbedModalOpen, onWorldMap, onLoginToggle, onSignOut, onPlayerTap, user, playerName, onFeedback, onBack)}
 
       <div

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8,6 +8,14 @@
 }
 
 :root {
+  /* The gutter .game-container holds around the whole app. Kept as variables,
+     not literals, because three breakpoints override it and anything wanting to
+     bleed past it (see .overlay-screen--bleed) has to cancel the exact current
+     value. A previous change edited two of the three rules and left the third
+     inconsistent — one source of truth prevents a repeat. */
+  --container-pad-x: 10px;
+  --container-pad-y: 6px;
+
   --game-text-color: #33ff33;
   --game-text-color-dim:   color-mix(in srgb, var(--game-text-color) 85%, transparent);
   --game-text-color-muted: color-mix(in srgb, var(--game-text-color) 70%, transparent);
@@ -188,7 +196,7 @@ body {
 .game-container {
   max-width: 740px;
   margin: 0 auto;
-  padding: 6px 10px;
+  padding: var(--container-pad-y) var(--container-pad-x);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -1291,7 +1299,7 @@ body {
 
 @media (max-width: 480px) {
   body { font-size: var(--font-md); }
-  .game-container { padding: 4px 6px; }
+  :root { --container-pad-x: 6px; --container-pad-y: 4px; }
   .game-title { font-size: var(--font-base); letter-spacing: 1px; }
 
   .hand-cards { gap: 4px; padding-bottom: 4px; }
@@ -1310,7 +1318,7 @@ body {
 
 /* Very small phones (≤380px — iPhone SE, older Android) */
 @media (max-width: 380px) {
-  .game-container { padding: 2px 4px; }
+  :root { --container-pad-x: 4px; --container-pad-y: 2px; }
   .game-title { font-size: var(--font-md); padding: 2px 0 3px; }
 
   .hand-cards { gap: 3px; }
@@ -4084,7 +4092,29 @@ body {
 .nm-map {
   overflow-x: auto;
   overflow-y: auto;
-  padding: 16px 8px 8px;
+  /* No side or bottom padding: this map is the screen. The 16px above it keeps
+     it off the toolbar. A phone's corner radius (~44-55px on iPhone) is far
+     deeper than any gutter we could afford, so the curve crops map content at
+     the corners whatever we do — an 8px band bought nothing there and only
+     showed as a black outline down the straight edges. */
+  padding: 16px 0 0;
+}
+
+/* Lets the map inside reach the physical screen edge by cancelling
+   .game-container's gutter. Opt-in per screen via OverlayScreen's className.
+   overflow:visible is what actually allows the escape — .overlay-screen's
+   default overflow-x:hidden would clip the negative margins away silently.
+   Safe on these screens specifically because both are full-height flex layouts
+   whose map does its own scrolling, so the outer box never needed to scroll;
+   .game-container's overflow:hidden still backstops the app as a whole. */
+.overlay-screen--bleed {
+  overflow: visible;
+}
+
+.overlay-screen--bleed .nm-map {
+  margin-left:   calc(-1 * var(--container-pad-x));
+  margin-right:  calc(-1 * var(--container-pad-x));
+  margin-bottom: calc(-1 * var(--container-pad-y));
 }
 
 /* Act-environment themed backgrounds */


### PR DESCRIPTION
The town canvas sat inside two nested gutters — `.game-container`'s 6px sides / 4px bottom plus `.nm-map`'s own `16px 8px 8px` — showing as a black outline around the map. On a phone with rounded screen corners that reads as broken: the curve cuts diagonally across the band, so the border seems to vanish at the corners while cropping map content there.

**Padding can't fix that.** An iPhone's corner radius is roughly 44–55px — far deeper than any gutter this layout can afford. The curve reaches canvas content at the corners no matter what, so the 8px band bought nothing where the problem actually is and only cost a visible black edge everywhere else. Edge-to-edge at least reads as deliberate.

## What changed

**`.game-container` padding becomes `--container-pad-x` / `--container-pad-y` variables.** Three breakpoints set that gutter (`10px/6px`, `6px/4px`, `4px/2px`) and anything bleeding past it has to cancel the exact current value — a literal in three places was a trap. The reverted safe-area change (#2097) broke by updating two of the three rules and missing the `≤380px` one. One source of truth now.

**`.nm-map` drops side and bottom padding**, keeping the 16px that holds it off the toolbar.

**New `.overlay-screen--bleed`**, opted into per screen via `OverlayScreen`'s existing `className` prop. The `overflow: visible` on it is the load-bearing part — `.overlay-screen` defaults to `overflow-x: hidden`, which would clip the negative margins away and leave the whole change doing nothing visible. That's safe on these two screens specifically because both are full-height flex layouts whose map scrolls itself, so the outer box never needed to scroll, and `.game-container`'s `overflow: hidden` still backstops the app.

**Toolbars deliberately do not bleed.** `.toolbar` carries a 1px border and 4px radius; pushing it to the edge would put a visible bordered box under the corner curve — recreating this exact artefact on different furniture.

## Two commits, independently revertible

The two screens have different DOM shapes — in the hub `.nm-map` is a direct child of `.overlay-screen`; in NodeMap it's nested inside `.nodemap` between two toolbars — though `.overlay-screen` is the clipping ancestor in both, so one modifier covers them.

- `39b1340` — mechanism + hub (the screen you reported)
- `9edb841` — act map opt-in

Split so the act map can be reverted alone if it reads worse edge-to-edge. No problem was reported there; it's included because you asked for both.

## Verification

- `npm run build` — clean
- `npm test` — 2,789 tests across 252 files, all passing

**This needs your eyes, and I want to be straight about why.** Storybook and desktop browsers can't show this — the artefact only exists on a device with a rounded screen, and the gutter being cancelled is 6px there. I'm changing `overflow` on a shared wrapper, which is the kind of thing that can have knock-on effects I can't see. Worth checking on the hub: that the map reaches the edge, the toolbar still sits inset, and nothing scrolls or clips oddly when you walk the avatar around. Then the act map, which is the half I'm less sure about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9XTp5N15A4N2Z5JHWAS75)_