### PR TITLE
Make campfire stoking daily-repeatable and actually visible

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -24,6 +24,7 @@ import { FlameColor, FlameType, HubInteractable, HubInterior, HubInteriorExit, H
 import { createAnimalSystem, AnimalSystem, GlowSource, PLAYER_OWNER_ID } from './hubAnimals'
 import { getActivePet } from '../../game/hub/pet'
 import { isInteractableGranted, interactableStoreKey } from '../../game/hub/interactables'
+import { getFlameType } from '../../game/hub/flames'
 import type { AnimalType } from '../../game/hub/animals'
 import { createWeatherSystem } from './hubWeather'
 import { resolveWeather } from '../../game/hub/weather'
@@ -142,6 +143,9 @@ interface Props {
   moveInteractableRef?:       React.MutableRefObject<((id: string, tx: number, ty: number) => void) | null>
   /** Receives a callback to add a live "Sold" badge to a shop interactable */
   markInteractableSoldRef?:   React.MutableRefObject<((id: string) => void) | null>
+  /** Receives a callback to refresh an interactable's flame sprite(s) live
+   *  (size/speed) after a stokeFlame reaction changes its persisted FlameType */
+  refreshInteractableFlameRef?: React.MutableRefObject<((id: string) => void) | null>
   /** Receives a callback to float a ❤️/💔 above a named exterior NPC's head
    *  when their friendship changes. No-ops if that NPC isn't currently a
    *  visible exterior sprite (indoors, gated, or not on screen). */
@@ -163,6 +167,7 @@ export function HubTownCanvas({
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
   onInteractableTap, interactableIndicatorsRef, interactableMovesRef, moveInteractableRef, markInteractableSoldRef,
+  refreshInteractableFlameRef,
   showFriendshipReactionRef,
   buildingUpgradeLevelsRef,
   locationData,
@@ -298,7 +303,28 @@ export function HubTownCanvas({
     // Animated flame overlays flagged on decor (§ flame effect). Collected inline
     // alongside decorGlows in the same two decor-building loops below, then spawned
     // once texture loading settles (see spawnFlame).
-    interface FlameSource { parent: PIXI.Container; x: number; y: number; type: FlameType; color: FlameColor; sortY?: number }
+    interface FlameSource {
+      parent: PIXI.Container; x: number; y: number; type: FlameType; color: FlameColor; sortY?: number
+      /** Set only for interactable-owned flame decor — lets a later stokeFlame
+       *  live-update find and refresh this sprite without a full rebuild. */
+      interactableId?: string
+      /** The decor's authored default FlameType, re-used as getFlameType's
+       *  fallback when refreshing this sprite live. */
+      fallbackType?: FlameType
+      /** The implicit night-glow entry derived from this flame (undefined when
+       *  the decor set its own explicit glow) — mutated in place on refresh so
+       *  the light grows/shrinks in step with the flame instead of staying
+       *  frozen at whatever size it had when first built. */
+      glow?: GlowSource
+    }
+    // interactableId -> its live flame sprites (+ the fallback type and derived
+    // glow entry each needs to re-resolve/resize against). Populated by
+    // spawnFlames, read by refreshInteractableFlame (registered into
+    // refreshInteractableFlameRef further down, mirroring
+    // markInteractableSoldRef/moveInteractableRef) so a stokeFlame reaction can
+    // update the sprite immediately instead of waiting for the player to leave
+    // and re-enter (buildInteractable only reruns on re-entry).
+    const interactableFlameSprites = new Map<string, { sprite: PIXI.AnimatedSprite; fallbackType: FlameType; glow?: GlowSource }[]>()
     // Vertical anchor point within a tile a flame sits on, as a fraction of tile
     // height (0 = top, 1 = bottom) — tuned to sit over a tile's fire-pit/hearth
     // art rather than at the very bottom edge of the tile cell.
@@ -323,10 +349,15 @@ export function HubTownCanvas({
     // flame sprite itself lives in), so "flame: true" lights the surrounding dark by default.
     function collectFlame(target: FlameSource[], glows: GlowSource[], hasExplicitGlow: boolean,
       parent: PIXI.Container, parentX: number, parentY: number, worldX: number, worldY: number,
-      type: FlameType | undefined, color: FlameColor | undefined, sortY?: number): void {
+      type: FlameType | undefined, color: FlameColor | undefined, sortY?: number,
+      interactableId?: string, fallbackType?: FlameType): void {
       const t = type ?? 'medium'
-      target.push({ parent, x: parentX, y: parentY, type: t, color: color ?? 'normal', sortY })
-      if (!hasExplicitGlow) glows.push({ x: worldX, y: worldY - T / 2, radius: FLAME_PARAMS[t].glowRadius * T, pulse: true })
+      let glow: GlowSource | undefined
+      if (!hasExplicitGlow) {
+        glow = { x: worldX, y: worldY - T / 2, radius: FLAME_PARAMS[t].glowRadius * T, pulse: true }
+        glows.push(glow)
+      }
+      target.push({ parent, x: parentX, y: parentY, type: t, color: color ?? 'normal', sortY, interactableId, fallbackType, glow })
     }
     function spawnFlames(sources: FlameSource[]): void {
       if (sources.length === 0) return
@@ -339,6 +370,11 @@ export function HubTownCanvas({
           anim.play()
           anim.anchor.set(0.5, 1)
           anim.width = anim.height = T * params.scale
+          if (src.interactableId) {
+            const list = interactableFlameSprites.get(src.interactableId) ?? []
+            list.push({ sprite: anim, fallbackType: src.fallbackType ?? src.type, glow: src.glow })
+            interactableFlameSprites.set(src.interactableId, list)
+          }
           anim.tint = FLAME_TINTS[src.color]
           anim.position.set(src.x, src.y)
           if (src.sortY != null) anim.zIndex = src.sortY * T + T + 1.5
@@ -759,10 +795,14 @@ export function HubTownCanvas({
           const parent = d.zlayer === 'above' ? above! : root
           if (d.glow) decorGlows.push({ x: (pos.tx + d.dx) * T + T / 2, y: (pos.ty + d.dy) * T + T / 2, radius: (d.glowRadius ?? 2) * T, pulse: !!d.pulse })
           if (d.flame) {
+            // Resolve today's actual flame type (a stokeFlame reaction may have
+            // upgraded it) rather than always showing the decor's authored default.
+            const fallbackType = d.flameType ?? 'medium'
+            const effectiveType = getFlameType(interactableStoreKey(locationKey, def.id), fallbackType)
             collectFlame(flames, decorGlows, !!d.glow, parent,
               d.dx * T + T / 2, d.dy * T + T * FLAME_ANCHOR_Y,
               (pos.tx + d.dx) * T + T / 2, (pos.ty + d.dy) * T + T * FLAME_ANCHOR_Y,
-              d.flameType, d.flameColor, pos.ty + d.dy)
+              effectiveType, d.flameColor, pos.ty + d.dy, def.id, fallbackType)
           }
           if (d.spriteId) {
             loadTextureUrl(`${base}sprites/${d.spriteId}.svg`).then(tex => {
@@ -917,6 +957,26 @@ export function HubTownCanvas({
       }
     }
     if (markInteractableSoldRef) markInteractableSoldRef.current = doMarkInteractableSold
+
+    // Live flame refresh — updates already-spawned flame sprite(s) after a
+    // stokeFlame reaction changes an interactable's persisted FlameType, so the
+    // campfire visibly builds up immediately instead of only on next re-entry.
+    const doRefreshInteractableFlame = (id: string): void => {
+      try {
+        const sprites = interactableFlameSprites.get(id)
+        if (!sprites) return
+        for (const { sprite, fallbackType, glow } of sprites) {
+          const type = getFlameType(interactableStoreKey(locationKey, id), fallbackType)
+          const params = FLAME_PARAMS[type]
+          sprite.animationSpeed = params.speed
+          sprite.width = sprite.height = T * params.scale
+          if (glow) glow.radius = params.glowRadius * T
+        }
+      } catch (e) {
+        rollbar.error('[HubTownCanvas] refreshInteractableFlame failed', { id, error: String(e) })
+      }
+    }
+    if (refreshInteractableFlameRef) refreshInteractableFlameRef.current = doRefreshInteractableFlame
 
     // ── Blocked paths (quest-gated obstructions) ──────────────────────────────
     interface BlockedNpcEntry {

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -447,6 +447,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   const moveInteractableRef = useRef<((id: string, tx: number, ty: number) => void) | null>(null)
   // Receives the canvas's live "Sold" badge callback
   const markInteractableSoldRef = useRef<((id: string) => void) | null>(null)
+  // Receives the canvas's callback to refresh an interactable's flame sprite live
+  const refreshInteractableFlameRef = useRef<((id: string) => void) | null>(null)
   // Receives the canvas's callback to float a ❤️/💔 above an NPC's head
   const showFriendshipReactionRef = useRef<((npcId: string, kind: 'up' | 'down') => void) | null>(null)
   // Per-interactable tap counts so dialogue arrays cycle
@@ -2155,6 +2157,7 @@ function hasOfferableQuest(giverId: string): boolean {
           onClick: () => {
             removeHubItem(r.requiresItemId, 1)
             setFlameType(storeKey, r.toFlameType)
+            refreshInteractableFlameRef.current?.(def.id)
             let text = 'The flames catch and swell, roaring higher than before. 🔥'
             if (r.grantHubItem) {
               addHubItem(r.grantHubItem.itemId, r.grantHubItem.count ?? 1)
@@ -2239,6 +2242,7 @@ function hasOfferableQuest(giverId: string): boolean {
             interactableMovesRef={interactableMovesRef}
             moveInteractableRef={moveInteractableRef}
             markInteractableSoldRef={markInteractableSoldRef}
+            refreshInteractableFlameRef={refreshInteractableFlameRef}
             showFriendshipReactionRef={showFriendshipReactionRef}
             buildingUpgradeLevelsRef={buildingUpgradeLevelsRef}
             locationData={locationData}

--- a/web/src/game/hub/flames.ts
+++ b/web/src/game/hub/flames.ts
@@ -1,16 +1,20 @@
 // ─── Flame state ──────────────────────────────────────────────────────────────
 //
 // Persistence for the `stokeFlame` interactable reaction (docs/hubworld.md §7):
-// once a flame decor entry has been fed (e.g. a log tossed on a campfire), its
-// upgraded FlameType persists across reloads. Entries are keyed with
-// interactableStoreKey(town, id) — the same convention as interactable
-// grants/digs/forages — mapping to the current FlameType.
+// feeding a flame decor entry (e.g. tossing a log on a campfire) upgrades its
+// FlameType for the rest of the day, the same once-per-real-day shape as
+// digs.ts/forages.ts — the upgrade automatically lapses back to the authored
+// default once the stored date is no longer today, with no explicit reset
+// needed (the gate is just recomputed fresh on each read, same trick
+// canDigToday uses). Entries are keyed with interactableStoreKey(town, id) —
+// the same convention as interactable grants/digs/forages.
 
 import type { FlameType } from '../../data/hub/loader'
 
 const KEY = 'jarv_hub_flame_state'
 
-type FlameStore = Record<string, FlameType>
+interface FlameEntry { type: FlameType; date: string }
+type FlameStore = Record<string, FlameEntry>
 
 function load(): FlameStore {
   try {
@@ -27,14 +31,25 @@ function save(store: FlameStore): void {
   } catch { /* ignore */ }
 }
 
-/** This interactable's current flame type, falling back to `fallback` (its authored default) if never stoked. */
-export function getFlameType(storeKey: string, fallback: FlameType): FlameType {
-  return load()[storeKey] ?? fallback
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
 }
 
-/** Record this interactable's flame as upgraded/changed to `type`. */
+/**
+ * This interactable's current flame type, falling back to `fallback` (its
+ * authored default) if never stoked today — a stoke from a previous day (or
+ * an old pre-daily-reset save, which stored a plain FlameType string with no
+ * `date`) reads back as `undefined` here and falls back the same way.
+ */
+export function getFlameType(storeKey: string, fallback: FlameType): FlameType {
+  const entry = load()[storeKey]
+  if (!entry || entry.date !== todayKey()) return fallback
+  return entry.type
+}
+
+/** Record this interactable's flame as upgraded/changed to `type` for today. */
 export function setFlameType(storeKey: string, type: FlameType): void {
   const store = load()
-  store[storeKey] = type
+  store[storeKey] = { type, date: todayKey() }
   save(store)
 }


### PR DESCRIPTION
## Summary

Follow-up to #2060/#2061. User report: fed the Thornwood campfire a log a few days ago, expected it to reset daily like a dig spot — it didn't.

Root cause (two separate bugs, fixed together):

1. `stokeFlame` was built as a **one-time permanent upgrade** — `web/src/game/hub/flames.ts` had no date/expiry logic at all, unlike `digs.ts`/`forages.ts`'s `todayKey()` cooldown pattern.
2. Independently, **`HubTownCanvas.tsx` never actually read the persisted flame state back** — the flame sprite was always built straight from the decor's authored default (`flicker`), so the upgrade never rendered, in any session, ever.

Changes:
- `web/src/game/hub/flames.ts`: store shape is now `{ type, date }`; `getFlameType` only honors the stored type when its date is today, otherwise falling back to the authored default — mirroring `digs.ts`'s exact `todayKey()`/`canDigToday` pattern. An old plain-string entry (pre-fix save) reads back as `undefined` on `.date` and falls back cleanly too, so anyone already stuck invisibly-permanently-strong self-heals on next load.
- `web/src/components/hub/HubTownCanvas.tsx`: interactable-owned flame decor now resolves its effective type through `getFlameType` instead of always using the authored default. Also adds a `refreshInteractableFlameRef` live-update callback (mirroring the existing `markInteractableSoldRef` pattern) so the campfire visibly builds up immediately after stoking, instead of only on next re-entry — including its derived night-glow radius, which now grows/shrinks with it.
- `web/src/components/hub/HubWorld.tsx`: wires the new ref through and calls it right after `setFlameType` in the `stokeFlame` handler.

No schema, quest, or content changes — the one-time `flag:thornwood-flame-stoked` quest gate and the two-quest chain are unaffected; only the flame-feeding/charcoal loop itself becomes an ongoing daily activity.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2106/2106 tests pass
- [ ] Manual: feed the campfire a log, confirm it visibly builds up to a strong flame immediately; reload same-day and confirm it's still strong; simulate a day passing and confirm it reverts to flicker and can be fed again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEtJuhwEuc8QMoaj5QdGTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEtJuhwEuc8QMoaj5QdGTC)_