### PR TITLE
Add unlit brazier flames + Ironhold Keep "Light the Watch-Fires" quest

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -330,6 +330,7 @@ export function HubTownCanvas({
     // art rather than at the very bottom edge of the tile cell.
     const FLAME_ANCHOR_Y = 0.72
     const FLAME_PARAMS: Record<FlameType, { scale: number; glowRadius: number; speed: number }> = {
+      unlit:   { scale: 0,    glowRadius: 0,   speed: 0    },
       flicker: { scale: 0.45, glowRadius: 1,   speed: 0.10 },
       low:     { scale: 0.65, glowRadius: 1.5, speed: 0.12 },
       medium:  { scale: 0.9,  glowRadius: 2.5, speed: 0.14 },
@@ -370,6 +371,10 @@ export function HubTownCanvas({
           anim.play()
           anim.anchor.set(0.5, 1)
           anim.width = anim.height = T * params.scale
+          // 'unlit' (e.g. a brazier waiting to be lit) still gets a sprite so a
+          // later stokeFlame live-refresh has something to reveal — it's just
+          // hidden until then, rather than never created at all.
+          anim.visible = src.type !== 'unlit'
           if (src.interactableId) {
             const list = interactableFlameSprites.get(src.interactableId) ?? []
             list.push({ sprite: anim, fallbackType: src.fallbackType ?? src.type, glow: src.glow })
@@ -968,6 +973,7 @@ export function HubTownCanvas({
         for (const { sprite, fallbackType, glow } of sprites) {
           const type = getFlameType(interactableStoreKey(locationKey, id), fallbackType)
           const params = FLAME_PARAMS[type]
+          sprite.visible = type !== 'unlit'
           sprite.animationSpeed = params.speed
           sprite.width = sprite.height = T * params.scale
           if (glow) glow.radius = params.glowRadius * T

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -56,6 +56,7 @@ import { getUnreadCount } from '../../game/news'
 import { interactableStoreKey, isInteractableGranted, markInteractableGranted, getInteractableMoves, setInteractableMove } from '../../game/hub/interactables'
 import { canDigToday, recordDig } from '../../game/hub/digs'
 import { getFlameType, setFlameType } from '../../game/hub/flames'
+import { recordGroupMember } from '../../game/hub/groupChallenges'
 import { shuffled } from '../../game/hub/shuffle'
 import { canForageToday, recordForage } from '../../game/hub/forages'
 import { getReputationTier } from '../../data/hub/buildingUpgrades'
@@ -2139,32 +2140,40 @@ function hasOfferableQuest(giverId: string): boolean {
       case 'stokeFlame': {
         // Consumes requiresItemId to move a flame decor entry owned by this same
         // interactable from fromFlameType to toFlameType (docs/hubworld.md §7) —
-        // e.g. feeding a log to a dying campfire to build it into a roaring blaze.
+        // e.g. feeding a log to a dying campfire to build it into a roaring
+        // blaze, or lighting a cold brazier (fromFlameType 'unlit') outright.
         const fromType = r.fromFlameType ?? 'flicker'
+        const isLighting = fromType === 'unlit'
         const current = getFlameType(storeKey, fromType)
         if (current !== fromType) {
-          setDialogueEvent({ speakerName: '', text: r.alreadyDoneText ?? "It's already burning as strong as it'll go.", onClose: next })
+          setDialogueEvent({ speakerName: '', text: r.alreadyDoneText ?? (isLighting ? "It's already lit." : "It's already burning as strong as it'll go."), onClose: next })
           return
         }
         const itemName = getHubItemCatalogEntry(r.requiresItemId)?.name ?? r.requiresItemId
         if (!hasHubItem(r.requiresItemId)) {
-          setDialogueEvent({ speakerName: '', text: `The fire needs feeding, but you don't have a ${itemName.toLowerCase()} to spare.` })
+          setDialogueEvent({ speakerName: '', text: `${isLighting ? 'This needs lighting, but' : 'The fire needs feeding, but'} you don't have a ${itemName.toLowerCase()} to spare.` })
           return
         }
         const confirm: DialogueChoice = {
-          label: `Feed the fire a ${itemName.toLowerCase()}`,
+          label: `${isLighting ? 'Light it with a' : 'Feed the fire a'} ${itemName.toLowerCase()}`,
           primary: true,
           onClick: () => {
             removeHubItem(r.requiresItemId, 1)
             setFlameType(storeKey, r.toFlameType)
             refreshInteractableFlameRef.current?.(def.id)
-            let text = 'The flames catch and swell, roaring higher than before. 🔥'
+            let text = isLighting ? 'The log catches — flame leaps up and settles into a steady burn. 🔥' : 'The flames catch and swell, roaring higher than before. 🔥'
             if (r.grantHubItem) {
               addHubItem(r.grantHubItem.itemId, r.grantHubItem.count ?? 1)
               const grantedName = getHubItemCatalogEntry(r.grantHubItem.itemId)?.name ?? r.grantHubItem.itemId
               text += ` The fire leaves behind ${r.grantHubItem.count ?? 1} ${grantedName.toLowerCase()}.`
             }
             if (r.setFlag) setDialogueFlag(r.setFlag)
+            if (r.groupId) {
+              const members = recordGroupMember(r.groupId, def.id)
+              if (r.groupTotal && members.length >= r.groupTotal && r.groupCompleteQuestStep) {
+                incrementQuestProgress(r.groupCompleteQuestStep.questId, r.groupCompleteQuestStep.stepKey, 1)
+              }
+            }
             emitSound('pickup')
             refreshState()
             setDialogueEvent({ speakerName: '', text, onClose: next })
@@ -2172,7 +2181,7 @@ function hasOfferableQuest(giverId: string): boolean {
         }
         setDialogueEvent({
           speakerName: '',
-          text: 'The fire is low, barely holding on.',
+          text: isLighting ? 'Cold and unlit — just waiting for a spark.' : 'The fire is low, barely holding on.',
           choices: [confirm, { label: 'Leave it', isExit: true, onClick: () => setDialogueEvent(null) }],
         })
         return

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -316,6 +316,7 @@ function GlowControls({ glow, glowRadius, pulse, onChange }: {
 }
 
 const FLAME_TYPE_OPTIONS: Array<{ value: FlameType; label: string }> = [
+  { value: 'unlit',   label: 'Unlit (no flame yet)' },
   { value: 'flicker', label: 'Flicker (dying embers)' },
   { value: 'low',     label: 'Low' },
   { value: 'medium',  label: 'Medium' },

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -220,6 +220,9 @@ export interface RawInteractableReaction {
   grantHubItem?: { itemId: string; count?: number }
   setFlag?: string
   alreadyDoneText?: string
+  groupId?: string
+  groupTotal?: number
+  groupCompleteQuestStep?: { questId: string; stepKey: string }
 }
 
 export interface RawInteractable {

--- a/web/src/data/bundles/bundles.json
+++ b/web/src/data/bundles/bundles.json
@@ -866,7 +866,10 @@
         "x": 0,
         "y": 1,
         "tileID": "brazierTop",
-        "zlayer": "above"
+        "zlayer": "above",
+        "flame": true,
+        "flameType": "low",
+        "flameColor": "normal"
       }
     ]
   },

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -35,8 +35,10 @@ export interface RawWindow {
   tileId: string
 }
 
-/** Strength tier of an animated flame effect, flicker (dying embers) to strong (roaring fire). */
-export type FlameType = 'flicker' | 'low' | 'medium' | 'strong'
+/** Strength tier of an animated flame effect: 'unlit' renders no flame/glow at
+ *  all (e.g. an unlit brazier waiting to be lit), then flicker (dying embers)
+ *  up to strong (roaring fire). */
+export type FlameType = 'unlit' | 'flicker' | 'low' | 'medium' | 'strong'
 /** Tint applied to the flame sprite. */
 export type FlameColor = 'normal' | 'supernatural' | 'blue' | 'green' | 'purple'
 
@@ -335,6 +337,10 @@ export interface RawInteractableReaction {
   grantHubItem?: { itemId: string; count?: number }
   setFlag?: string
   alreadyDoneText?: string
+  // stokeFlame — "light every member of this group today" tracking
+  groupId?: string
+  groupTotal?: number
+  groupCompleteQuestStep?: { questId: string; stepKey: string }
 }
 
 export interface RawInteractable {

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -932,27 +932,7 @@
       "comment": "dark pillars flanking the gate gap"
     },
     {
-      "comment": "braziers flanking the keep entrance"
-    },
-    {
-      "tx": 11,
-      "ty": 12,
-      "tileId": "brazierTop"
-    },
-    {
-      "tx": 11,
-      "ty": 13,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 15,
-      "ty": 12,
-      "tileId": "brazierTop"
-    },
-    {
-      "tx": 15,
-      "ty": 13,
-      "tileId": "brazierBottom"
+      "comment": "braziers flanking the keep entrance — see interactables[] (ironhold-brazier-keep-west/east) for the campfire-style flame"
     },
     {
       "comment": "central fountain in inner ward"
@@ -1615,72 +1595,7 @@
       "zlayer": "above"
     },
     {
-      "comment": "Outer Bailey — braziers flanking the central road, glowing at night"
-    },
-    {
-      "tx": 15,
-      "ty": 42,
-      "tileId": "brazierTop",
-      "glow": true,
-      "glowRadius": 3
-    },
-    {
-      "tx": 15,
-      "ty": 43,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 20,
-      "ty": 42,
-      "tileId": "brazierTop",
-      "glow": true,
-      "glowRadius": 3
-    },
-    {
-      "tx": 20,
-      "ty": 43,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 15,
-      "ty": 50,
-      "tileId": "brazierTop",
-      "glow": true,
-      "glowRadius": 3
-    },
-    {
-      "tx": 15,
-      "ty": 51,
-      "tileId": "brazierBottom"
-    },
-    {
-      "tx": 20,
-      "ty": 50,
-      "tileId": "brazierTop",
-      "glow": true,
-      "glowRadius": 3
-    },
-    {
-      "tx": 20,
-      "ty": 51,
-      "tileId": "brazierBottom"
-    },
-    {
-      "comment": "Outer Bailey — outer gate braziers"
-    },
-    {
-      "tx": 15,
-      "ty": 52,
-      "tileId": "brazierTop",
-      "glow": true,
-      "glowRadius": 2
-    },
-    {
-      "tx": 20,
-      "ty": 52,
-      "tileId": "brazierTop",
-      "glow": true,
-      "glowRadius": 2
+      "comment": "Outer Bailey — braziers flanking the central road and the outer gate are now interactables (ironhold-brazier-bailey-*/gate-*) — see interactables[] for the campfire-style flame"
     },
     {
       "comment": "drill yard — training gear and a campfire"
@@ -4728,6 +4643,156 @@
   },
   "interactables": [
     {
+      "id": "ironhold-brazier-keep-west",
+      "tx": 11,
+      "ty": 13,
+      "decor": [
+        { "dx": 0, "dy": -1, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" },
+        { "dx": 0, "dy": 0, "tileId": "brazierBottom" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-keep-east",
+      "tx": 15,
+      "ty": 13,
+      "decor": [
+        { "dx": 0, "dy": -1, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" },
+        { "dx": 0, "dy": 0, "tileId": "brazierBottom" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-bailey-nw",
+      "tx": 15,
+      "ty": 43,
+      "decor": [
+        { "dx": 0, "dy": -1, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" },
+        { "dx": 0, "dy": 0, "tileId": "brazierBottom" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-bailey-ne",
+      "tx": 20,
+      "ty": 43,
+      "decor": [
+        { "dx": 0, "dy": -1, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" },
+        { "dx": 0, "dy": 0, "tileId": "brazierBottom" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-bailey-sw",
+      "tx": 15,
+      "ty": 51,
+      "decor": [
+        { "dx": 0, "dy": -1, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" },
+        { "dx": 0, "dy": 0, "tileId": "brazierBottom" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-bailey-se",
+      "tx": 20,
+      "ty": 51,
+      "decor": [
+        { "dx": 0, "dy": -1, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" },
+        { "dx": 0, "dy": 0, "tileId": "brazierBottom" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-gate-west",
+      "tx": 15,
+      "ty": 52,
+      "decor": [
+        { "dx": 0, "dy": 0, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
+      "id": "ironhold-brazier-gate-east",
+      "tx": 20,
+      "ty": 52,
+      "decor": [
+        { "dx": 0, "dy": 0, "tileId": "brazierTop", "flame": true, "flameType": "unlit", "flameColor": "normal" }
+      ],
+      "reactions": [{
+        "type": "stokeFlame",
+        "requiresItemId": "log",
+        "fromFlameType": "unlit",
+        "toFlameType": "medium",
+        "groupId": "ironhold-braziers",
+        "groupTotal": 8,
+        "groupCompleteQuestStep": { "questId": "castle-light-the-watch-fires", "stepKey": "light-all" },
+        "alreadyDoneText": "This one's already burning — save your logs for the others."
+      }]
+    },
+    {
       "id": "ironholdkeep-forage-bush-1",
       "tx": 20,
       "ty": 45,
@@ -4807,6 +4872,27 @@
           "itemId": "chicken-feed",
           "price": 5,
           "speakerName": "Feed Stall"
+        }
+      ]
+    },
+    {
+      "id": "castle-log-stack",
+      "tx": 3,
+      "ty": 3,
+      "building": "quartermasters-store",
+      "decor": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "tileId": "logPile"
+        }
+      ],
+      "reactions": [
+        {
+          "type": "buyHubItem",
+          "itemId": "log",
+          "price": 4,
+          "speakerName": "Supply Stack"
         }
       ]
     },

--- a/web/src/data/hub/ironholdkeep/questDefs.json
+++ b/web/src/data/hub/ironholdkeep/questDefs.json
@@ -208,6 +208,31 @@
       }
     },
     {
+      "id": "castle-light-the-watch-fires",
+      "title": "Light the Watch-Fires",
+      "type": "fetch",
+      "giverNpcId": "castle-guard-master",
+      "receiverNpcId": "castle-guard-master",
+      "prerequisite": "quest:castle-night-watch",
+      "offerDialogue": "Eight watch-fires line the bailey and the gate. Light every one before the sun sets — a log apiece, from the quartermaster's stack — or they'll gutter out and you'll be starting from cold ash again.",
+      "activeDialogue": "Eight fires, one day. Mind you don't run short on logs partway through.",
+      "completeDialogue": "Every fire lit, and all in a single day. That's watch-discipline, traveller. The bailey's warmer for it.",
+      "steps": [
+        {
+          "key": "light-all",
+          "type": "report",
+          "targetNpcId": "castle-guard-master",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "relationship": {
+          "castle-guard-master": { "track": "ally", "points": 10 }
+        }
+      }
+    },
+    {
       "id": "castle-supply-tally",
       "title": "The Supply Tally",
       "type": "fetch",

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -336,12 +336,21 @@ export type HubInteractableReaction =
   | { type: 'forage'; lootTable?: 'wood' }
   /** Consumes `requiresItemId` to move a flame decor entry owned by this same
    *  interactable from fromFlameType (default 'flicker') to toFlameType — e.g.
-   *  feeding a log to a dying campfire to build it into a roaring blaze.
+   *  feeding a log to a dying campfire to build it into a roaring blaze, or a
+   *  log to an unlit brazier (fromFlameType 'unlit') to light it.
    *  Already at/past toFlameType shows alreadyDoneText instead. Optionally
    *  grants a hub-item and/or sets a dialogue flag (checkPrerequisite's
-   *  `flag:` syntax) on success, e.g. to gate a follow-up quest. */
+   *  `flag:` syntax) on success, e.g. to gate a follow-up quest.
+   *  groupId/groupTotal/groupCompleteQuestStep together support "light every
+   *  member of this group today" challenges: each successful stoke records
+   *  this interactable under groupId (web/src/game/hub/groupChallenges.ts,
+   *  same once-per-real-day shape as the flame state itself — the whole group
+   *  count lapses back to zero if not finished before the day ends); once
+   *  groupTotal distinct members have been recorded today, the given quest
+   *  step is incremented by 1, e.g. to make a quest turn-in-ready. */
   | { type: 'stokeFlame'; requiresItemId: string; fromFlameType?: FlameType; toFlameType: FlameType
-      grantHubItem?: { itemId: string; count?: number }; setFlag?: string; alreadyDoneText?: string }
+      grantHubItem?: { itemId: string; count?: number }; setFlag?: string; alreadyDoneText?: string
+      groupId?: string; groupTotal?: number; groupCompleteQuestStep?: { questId: string; stepKey: string } }
 
 export interface HubInteractable {
   id: string

--- a/web/src/game/hub/groupChallenges.ts
+++ b/web/src/game/hub/groupChallenges.ts
@@ -1,0 +1,50 @@
+// ─── Group daily challenges ───────────────────────────────────────────────────
+//
+// Tracks a shared "how many distinct members have you completed today" count
+// for a named group (e.g. `stokeFlame`'s optional groupId — light every
+// brazier in a courtyard before the day ends). Same lazy-date-expiry idiom as
+// flames.ts/digs.ts: a stale date is treated as "nothing done today" on read,
+// with no explicit reset needed — so if the group isn't finished before the
+// day rolls over, the count (and, independently, each member's own daily
+// state — see flames.ts) simply starts fresh next time.
+
+const KEY = 'jarv_hub_group_challenges'
+
+interface GroupEntry { date: string; memberIds: string[] }
+type GroupStore = Record<string, GroupEntry>
+
+function load(): GroupStore {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as GroupStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+function save(store: GroupStore): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(store))
+  } catch { /* ignore */ }
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/** Distinct member ids recorded for this group today (empty if none yet, or the last recorded day wasn't today). */
+export function getGroupProgressToday(groupId: string): string[] {
+  const entry = load()[groupId]
+  return entry && entry.date === todayKey() ? entry.memberIds : []
+}
+
+/** Records `memberId` as done for `groupId` today, returning the resulting (deduped) member list. */
+export function recordGroupMember(groupId: string, memberId: string): string[] {
+  const store = load()
+  const prev = store[groupId]
+  const memberIds = prev && prev.date === todayKey() ? [...prev.memberIds] : []
+  if (!memberIds.includes(memberId)) memberIds.push(memberId)
+  store[groupId] = { date: todayKey(), memberIds }
+  save(store)
+  return memberIds
+}


### PR DESCRIPTION
## Summary

- The shared `"brazier"` decor bundle's top tile now carries a steady low flame, the same treatment as the campfire — applies automatically everywhere the bundle is placed (Dreadspire Citadel, Gearford, Gravemoor, Hollowmere, Royal Palace, Saltmere Port).
- `FlameType` gains a 5th tier, `unlit` — no sprite, no glow at all — so a decor entry can start fully dark and be lit later via `stokeFlame`, instead of every tier always showing *some* flame. Authorable in the map editor too.
- `stokeFlame` gains optional `groupId`/`groupTotal`/`groupCompleteQuestStep` fields, backed by a new `web/src/game/hub/groupChallenges.ts` store (same lazy-date-expiry idiom as `flames.ts`/`digs.ts` — a stale date is just treated as "nothing done today," no explicit reset code needed). This lets a set of interactables share a single "finish them all today" quest step.
- Ironhold Keep's 8 exterior braziers (keep-entrance pair, 4 along the Outer Bailey road, 2 at the main gate) are now `stokeFlame` interactables, starting unlit. A new stall in the quartermaster's store sells logs to light them with.
- New quest **Light the Watch-Fires**, chained onto Guard-Master Doran's existing trust arc (`castle-watch-rotation` → `castle-drill-grounds` → `castle-night-watch`): light all 8 braziers in a single real day, or they all go dark again and you start over. Completion is driven entirely by the braziers' shared group progress (via `groupCompleteQuestStep`), not by simply talking to Doran — tapping him only turns the quest in once every brazier is genuinely lit that day.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2106/2106 tests pass
- [x] Validated `bundles.json`, `ironholdkeep/config.json`, `ironholdkeep/questDefs.json` parse as valid JSON
- [ ] Manual: visit a town using the brazier bundle (e.g. Gravemoor) and confirm braziers now show a steady low flame
- [ ] Manual: visit Ironhold Keep, confirm all 8 exterior braziers start dark, buy logs from the quartermaster's stall, light each one and confirm it visibly ignites immediately
- [ ] Manual: accept "Light the Watch-Fires" from Doran, light all 8 in one sitting, confirm the quest becomes turn-in-ready and completes; separately confirm lighting only some and letting the day roll over reverts everything to unlit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEtJuhwEuc8QMoaj5QdGTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEtJuhwEuc8QMoaj5QdGTC)_