### PR TITLE
Fix draft mode prize not resetting on play again

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ DO NOT USE AGENTS - Unless I explicitly state for you to do so.
 
 If browser verification is genuinely warranted: the app needs Firebase env vars to render past a blank white screen (`firebase.ts` calls `initializeApp` with `import.meta.env.VITE_FIREBASE_*`, which are unset by default and throw `auth/invalid-api-key` on load). `web/.env.test` has working fake-but-valid-format keys — copy it to `web/.env.local` (gitignored) before `npm run dev`. Don't commit `.env.local` or leave ad hoc driver scripts in the repo.
 
+`npm run test` (vitest) prints an `Unhandled Error` at the end about `browserType.launch: Executable doesn't exist at .../chrome-headless-shell` during browser-cleanup — this is Storybook's `@vitest/browser-playwright` addon looking for a Playwright browser variant that isn't preinstalled in this environment. It's noise, not a real failure: check the `Test Files`/`Tests` summary line (`N passed`) rather than treating this error as a regression to chase.
+
 ## Git Workflow — Avoiding Conflicts
 Before starting any new work, always rebase onto the latest `main`:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Jarv's Amazing Web Game
 
-All agent and Claude documentation is in **[AGENTS.md](AGENTS.md)**.
+**Read [AGENTS.md](AGENTS.md) in full before starting any task.** It covers session setup (`npm install` is required first — don't waste a typecheck/test run chasing "Cannot find module" errors that are really just a missing `node_modules`), git workflow, verification commands, and project conventions.
 
 Pending work is tracked in **[GitHub Issues](https://github.com/Jarvichi/jarvs-amazing-web-game/issues)**.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1076,6 +1076,7 @@ export default function App() {
     isWeeklyChallengeRef.current = false
     isDraftModeRef.current = true
     quickBattleModeRef.current = 'draft'
+    setQuickPlayRewardClaimed(false)
     battleFlawlessRef.current = true
     battleUsedStructure.current = false
     battleUsedMobileUnit.current = false


### PR DESCRIPTION
## Summary

Fixes a bug where winning a Card Draft battle a second time (via "Play Again") gave no prize. The only way to get a prize again was to fully leave and re-enter Draft Mode.

## Root cause

`quickPlayRewardClaimed` (`web/src/App.tsx`) gates the "CLAIM REWARD" button on the game-over screen. It's set to `true` when the player claims a prize, and is supposed to reset to `false` when a new battle starts.

`handlePlayAgain`'s Card Draft branch routes back to the draft screen and returns early — before reaching the line that resets `quickPlayRewardClaimed`. `handleDraftComplete`, which actually starts the new draft battle, never reset the flag either. So once claimed, the flag stayed `true` for the rest of the session, and the reward button never reappeared on later draft wins.

## Fix

Reset `quickPlayRewardClaimed` to `false` in `handleDraftComplete`, so it's cleared every time a new draft battle starts (both from the main menu and via "Play Again").

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — all 2106 tests pass
- [ ] Manual: play Card Draft, win, claim reward, click Play Again, draft again, win again, confirm "CLAIM REWARD" appears a second time

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkufQacyLsQRNSVdmhLHyC)_