### PR TITLE
fix(hub): move Caelen off the Northern Library Wing doorway

### DIFF
--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9007,7 +9007,7 @@
           "activity": "work",
           "location": {
             "type": "exterior",
-            "tx": 56,
+            "tx": 58,
             "ty": 9
           }
         },


### PR DESCRIPTION
## Summary
- In Ravenwatch, the Northern Library Wing's door sits at world tile `(56, 7)`, reachable only through a 2-tile-wide pocket (`x=55–56, y=7–8`) branching off the main street at `y=9`.
- Loremaster Caelen's daytime work post (`web/src/data/hub/ravenwatch/config.json`, 6am–8pm schedule) was pinned at `(56, 9)` — dead center of that pocket's only entrance. Since NPC-occupied tiles block pathfinding, one more NPC drifting into the pocket (or onto the door tile itself) could fully seal the entrance with no way around it, matching the reported "Caelen + another NPC block the Northern Library Wing" bug.
- Moved Caelen's work post from `(56, 9)` to `(58, 9)`, beside the approach path instead of blocking it, while keeping him stationed near the library.

## Test plan
- [x] `npm run build` (typecheck + Vite build) passes clean
- [x] Validated `config.json` still parses as valid JSON
- [ ] Visually confirm in-game that the Northern Library Wing is reliably reachable during Caelen's work hours

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn6B8njypWppxaaMWFE28d)_