### PR TITLE
feat(campaign): add Memory Charm to guarantee a fragment stays reachable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,6 +51,7 @@ import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/cam
 const MysteryScreen = lazy(() => import('./components/campaign/MysteryScreen').then(m => ({ default: m.MysteryScreen })))
 const MemoryFragmentScreen = lazy(() => import('./components/campaign/MemoryFragmentScreen').then(m => ({ default: m.MemoryFragmentScreen })))
 import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault, saveHubDefault } from './game/codex'
+import { getConsumables, addConsumable } from './game/itemStore'
 const CharacterEncounterScreen = lazy(() => import('./components/campaign/CharacterEncounterScreen').then(m => ({ default: m.CharacterEncounterScreen })))
 const NarratorJournalScreen = lazy(() => import('./components/hub/NarratorJournalScreen').then(m => ({ default: m.NarratorJournalScreen })))
 import { CharacterChoice, recordCharacterEncounter, getCharacterEncounterChance, resolveCharacterEncounterId } from './game/characters'
@@ -636,6 +637,7 @@ export default function App() {
     actId: string
     completionCount: number
     lastRunFailed: boolean
+    actHasUncollectedFragment: boolean
     proceed: (chosenCount: number) => void
   } | null>(null)
   const [foundItem, setFoundItem] = useState<Omit<import('./game/dailyLogin').UselessItem, 'acquiredDate'> | null>(null)
@@ -1414,13 +1416,17 @@ export default function App() {
       proceedAfterRelicSelect(null)
     }
 
-    // Show replay briefing if the player has completed this act before and it has modifiers
+    // Show replay briefing if the player has completed this act before and it either
+    // has modifiers, or still has an uncollected memory fragment (Memory Charm offer).
     const lastRunFailed = loadLastRunFailed()
-    if (completionCount > 0 && getModifierMax(act) > 0) {
+    const actHasUncollectedFragment = Object.values(act.nodes)
+      .some(n => n.type === 'memory' && n.fragmentId && !isFragmentDiscovered(n.fragmentId))
+    if (completionCount > 0 && (getModifierMax(act) > 0 || actHasUncollectedFragment)) {
       replayBriefingRef.current = {
         actId,
         completionCount,
         lastRunFailed,
+        actHasUncollectedFragment,
         proceed: proceedWithModifiers,
       }
       setScreen('replayBriefing')
@@ -1512,8 +1518,17 @@ export default function App() {
     if (!currentRun || !actData) return
     const act = actData
 
-    // Mark siblings as skipped (branch choice)
-    const afterSkip = skipSiblings(act.nodes, node.id, currentRun)
+    // Mark siblings as skipped (branch choice) — unless an active Memory Charm
+    // is guarding this act's uncollected fragment node(s) from being pruned.
+    const memoryCharmActive = (currentRun.consumables.find(c => c.id === 'memory_charm')?.count ?? 0) > 0
+    const protectedNodeIds = memoryCharmActive
+      ? new Set(
+          Object.values(act.nodes)
+            .filter(n => n.type === 'memory' && n.fragmentId && !isFragmentDiscovered(n.fragmentId))
+            .map(n => n.id)
+        )
+      : new Set<string>()
+    const afterSkip = skipSiblings(act.nodes, node.id, currentRun, protectedNodeIds)
     const activeMods = act ? getModifiersByCount(act, currentRun.activeModifierCount) : []
     const bonusCrystals = activeMods.filter(m => m.type === 'crystalBonus').reduce((s, m) => s + m.value, 0)
     const updatedRun: RunState = { ...afterSkip, pendingNodeId: node.id, crystalBonus: bonusCrystals }
@@ -1864,6 +1879,14 @@ export default function App() {
     if (!alreadyFound) {
       shardBonus = markFragmentDiscovered(fragment.id)
       if (areAllCampaignFragmentsDiscovered()) unlockHubWorld()
+      // A fresh fragment collected while carrying a Memory Charm spends it —
+      // it's only "used up" the moment it actually pays off.
+      const charmIdx = updatedConsumables.findIndex(c => c.id === 'memory_charm' && c.count > 0)
+      if (charmIdx !== -1) {
+        updatedConsumables = updatedConsumables
+          .map((c, i) => i === charmIdx ? { ...c, count: c.count - 1 } : c)
+          .filter(c => c.count > 0)
+      }
       if (shardBonus) {
         const existing = updatedConsumables.find(c => c.id === 'health_potion')
         updatedConsumables = existing
@@ -3439,16 +3462,27 @@ export default function App() {
       )}
 
       {screen === 'replayBriefing' && replayBriefingRef.current && (() => {
-        const { actId, completionCount, lastRunFailed, proceed } = replayBriefingRef.current!
+        const { actId, completionCount, lastRunFailed, actHasUncollectedFragment, proceed } = replayBriefingRef.current!
         // launchCampaign() already awaited loadAct(actId) before setting this ref,
         // so the act is guaranteed to be in cache by the time this renders.
         const act = getCachedAct(actId)
         if (!act) return null
+        const ownsCharm = getConsumables().find(c => c.id === 'memory_charm')?.count ?? 0
         return (
           <ReplayBriefingScreen
             act={act}
             completionCount={completionCount}
             lastRunFailed={lastRunFailed}
+            actHasUncollectedFragment={actHasUncollectedFragment}
+            crystals={crystals}
+            ownsCharm={ownsCharm > 0}
+            onBuyCharm={() => {
+              if (crystals < 1000) return
+              const next = crystals - 1000
+              saveCrystals(next)
+              setCrystals(next)
+              addConsumable('memory_charm', 1)
+            }}
             onBegin={chosenCount => { replayBriefingRef.current = null; clearLastRunFailed(); proceed(chosenCount) }}
             onBack={() => { replayBriefingRef.current = null; setScreen('title') }}
           />

--- a/web/src/components/campaign/NodeMap.tsx
+++ b/web/src/components/campaign/NodeMap.tsx
@@ -56,8 +56,11 @@ export function NodeMap({ act, run, onSelectNode, onUseConsumable, onBack, user 
             const def = ARCHETYPE_DEFS.find(d => d.id === run.archetype)
             return def ? <ToolbarLabel>{def.icon} {def.name}</ToolbarLabel> : null
           })()}
+          {(run.consumables?.find(c => c.id === 'memory_charm')?.count ?? 0) > 0 && (
+            <ToolbarLabel>🔮 Memory Charm active</ToolbarLabel>
+          )}
           <ToolbarLabel>Items</ToolbarLabel>
-          {ALL_CONSUMABLES.map(def => {
+          {ALL_CONSUMABLES.filter(def => !def.guaranteesFragment).map(def => {
             const rc    = run.consumables?.find(c => c.id === def.id)
             const count = rc?.count ?? 0
             return (

--- a/web/src/components/campaign/ReplayBriefingScreen.tsx
+++ b/web/src/components/campaign/ReplayBriefingScreen.tsx
@@ -13,6 +13,10 @@ interface Props {
   act: Act
   completionCount: number  // how many times the player has beaten this act (= min modifier count)
   lastRunFailed?: boolean  // if true, show mercy tiers (all options, min = 0)
+  actHasUncollectedFragment?: boolean  // this act still has a memory fragment the player hasn't found
+  crystals?: number
+  ownsCharm?: boolean      // player already holds a Memory Charm in their stash
+  onBuyCharm?: () => void
   onBegin: (chosenCount: number) => void
   onBack: () => void
 }
@@ -91,7 +95,7 @@ function buildMercyTiers(act: Act): TierOption[] {
   return tiers
 }
 
-export function ReplayBriefingScreen({ act, completionCount, lastRunFailed, onBegin, onBack }: Props) {
+export function ReplayBriefingScreen({ act, completionCount, lastRunFailed, actHasUncollectedFragment, crystals, ownsCharm, onBuyCharm, onBegin, onBack }: Props) {
   const mercy = lastRunFailed === true
   const tiers = mercy ? buildMercyTiers(act) : buildTiers(act, completionCount)
   const [selected, setSelected] = useState(mercy ? 0 : completionCount)
@@ -165,6 +169,29 @@ export function ReplayBriefingScreen({ act, completionCount, lastRunFailed, onBe
           )
         })}
       </div>
+
+      {actHasUncollectedFragment && (
+        <div className="rb-charm u-col u-gap-3 u-text-c">
+          {ownsCharm ? (
+            <div className="rb-subtitle">
+              🔮 <strong>Memory Charm</strong> equipped — a missing fragment will stay reachable on the map this run.
+            </div>
+          ) : (
+            <>
+              <div className="rb-subtitle">
+                A memory fragment from this chapter is still missing.
+              </div>
+              <button
+                className="action-btn rb-charm-buy-btn"
+                disabled={(crystals ?? 0) < 1000}
+                onClick={onBuyCharm}
+              >
+                🔮 BUY MEMORY CHARM — 1000◆
+              </button>
+            </>
+          )}
+        </div>
+      )}
 
       <div className="rb-actions u-col u-gap-5 u-items-c">
         <button className="action-btn action-btn--large rb-begin-btn" onClick={() => onBegin(selected)}>

--- a/web/src/data/consumables.json
+++ b/web/src/data/consumables.json
@@ -16,5 +16,14 @@
     "lore": "The Dominion believes in second chances. Third chances cost extra.",
     "livesAmount": 1,
     "price": 30
+  },
+  {
+    "id": "memory_charm",
+    "name": "Memory Charm",
+    "icon": "🔮",
+    "desc": "Keeps a missing memory fragment reachable on the map this run. Not consumed unless you actually collect one.",
+    "lore": "A sliver of the Dominion's own recall, bound in glass. It hums toward what you've forgotten.",
+    "price": 1000,
+    "guaranteesFragment": true
   }
 ]

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -16,6 +16,8 @@ export interface ConsumableDef {
   lore: string
   healAmount?: number
   livesAmount?: number
+  /** Not used/consumed manually — see App.tsx handleSelectNode/handleMemoryCollect. */
+  guaranteesFragment?: boolean
   price: number
 }
 
@@ -838,10 +840,32 @@ export function getAvailableNodeIds(nodes: Record<string, QuestNode>, run: RunSt
 }
 
 /**
- * When the player picks one node from a set of sibling options, the others
- * in the same parent→children group get marked as skipped.
+ * True if `startId` (or anything reachable from it via childIds) is in
+ * `protectedIds`. Used to keep a branch leading to a guaranteed memory
+ * fragment from being pruned by skipSiblings, even indirectly.
  */
-export function skipSiblings(nodes: Record<string, QuestNode>, chosenId: string, run: RunState): RunState {
+function leadsToProtectedNode(nodes: Record<string, QuestNode>, startId: string, protectedIds: Set<string>): boolean {
+  const seen = new Set<string>()
+  const stack = [startId]
+  while (stack.length > 0) {
+    const id = stack.pop()!
+    if (seen.has(id)) continue
+    seen.add(id)
+    if (protectedIds.has(id)) return true
+    const node = nodes[id]
+    if (node) stack.push(...node.childIds)
+  }
+  return false
+}
+
+/**
+ * When the player picks one node from a set of sibling options, the others
+ * in the same parent→children group get marked as skipped — unless a
+ * sibling leads to a `protectedNodeIds` node (e.g. an uncollected memory
+ * fragment guarded by an active Memory Charm), in which case it's left
+ * available so the player can still detour into it later this run.
+ */
+export function skipSiblings(nodes: Record<string, QuestNode>, chosenId: string, run: RunState, protectedNodeIds: Set<string> = new Set()): RunState {
   const parentMap = buildParentMap(nodes)
   const parents = parentMap[chosenId] ?? []
   // Never skip a node that is also a child of the chosen node — it's still reachable.
@@ -851,6 +875,7 @@ export function skipSiblings(nodes: Record<string, QuestNode>, chosenId: string,
     const parent = nodes[pid]
     for (const cid of parent.childIds) {
       if (cid !== chosenId && !run.completedNodeIds.includes(cid) && !run.skippedNodeIds.includes(cid) && !chosenChildren.has(cid)) {
+        if (protectedNodeIds.size > 0 && leadsToProtectedNode(nodes, cid, protectedNodeIds)) continue
         siblings.push(cid)
       }
     }


### PR DESCRIPTION
## Summary

Adds a purchasable **Memory Charm** (1000 crystal) so players close to unlocking the secret hub world can guarantee an uncollected memory fragment stays reachable on the node map, instead of risking it getting branch-skipped.

- Acts are branching DAGs (`skipSiblings()`), and completing an act only requires reaching the boss — a memory fragment node can be permanently missed if the player's path choices route around it, with no prior catch-up mechanism.
- `memory_charm` is a new `consumables.json` entry (like Health Potion / Second Wind), purchasable through the existing merchant. It's carried in the run via the existing consumable-stash drain/return machinery — no new persistence needed.
- While a run carries an active charm, `skipSiblings()` leaves any branch leading to this act's uncollected memory node(s) available instead of pruning it, so it stays visible/clickable on the map no matter which fork is taken.
- The charm is only spent the instant a fragment is actually freshly collected. If it's never visited, nothing happens to the charm — it's returned to the stash at run end (existing `clearRun()` behavior) and can be used on a future run.
- It's excluded from the manual "use" toolbar (it's passive, not a click-to-consume item) and shows a small "Memory Charm active" indicator on the map instead.
- Beyond the merchant, players can also buy/equip the charm right when starting a replay of an act that still has a missing fragment (`ReplayBriefingScreen`), directly addressing the "add an option when starting a campaign" ask.

## Test plan

- [x] `npm run build` — TypeScript + Vite build passes clean
- [x] `npm run test` — 2106/2106 tests pass (the Playwright browser-cleanup error is documented pre-existing noise, not a regression)
- [ ] Manual: buy a Memory Charm, start/replay an act with a known uncollected fragment, choose the branch that would normally skip that memory node, confirm it stays clickable, collect it, confirm the charm's count drops by one
- [ ] Manual: carry a charm through a run without visiting the fragment node, confirm it's still in the stash afterward rather than silently spent

---
_Generated by [Claude Code](https://claude.ai/code/session_011JX2CMmhJybAboAHzN7Yuw)_