### PR TITLE
fix(campaign): make Memory Charm bypass the random node-hide roll

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,7 +27,7 @@ import { getCardCatalog } from './game/cards'
 import { applyStatUpgrade } from './game/playerStats'
 import {
   loadRun, loadRunRaw, saveRun, clearRun, newRun, LIVES_START, LIVES_MAX,
-  getAvailableNodeIds, skipSiblings, isActComplete,
+  getAvailableNodeIds, skipSiblings, isActComplete, getProtectedFragmentNodeIds,
   generateRewardChoices, generateEndlessRewardChoices, generateMerchantCards, MERCHANT_PRICES,
   loadAct, getCachedAct, getCampaignForAct,
   loadFatigued, saveFatigued, clearFatigued, getTopPlayedCards,
@@ -50,7 +50,7 @@ const EventScreen = lazy(() => import('./components/campaign/EventScreen').then(
 import { MerchantScreen, MerchantItem, cardMerchantItem } from './components/campaign/MerchantScreen'
 const MysteryScreen = lazy(() => import('./components/campaign/MysteryScreen').then(m => ({ default: m.MysteryScreen })))
 const MemoryFragmentScreen = lazy(() => import('./components/campaign/MemoryFragmentScreen').then(m => ({ default: m.MemoryFragmentScreen })))
-import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault, saveHubDefault } from './game/codex'
+import { MemoryFragment, isFragmentDiscovered, markFragmentDiscovered, isHubWorldUnlocked, unlockHubWorld, areAllCampaignFragmentsDiscovered, loadHubDefault, saveHubDefault, getDiscoveredFragmentIds } from './game/codex'
 import { getConsumables, addConsumable } from './game/itemStore'
 const CharacterEncounterScreen = lazy(() => import('./components/campaign/CharacterEncounterScreen').then(m => ({ default: m.CharacterEncounterScreen })))
 const NarratorJournalScreen = lazy(() => import('./components/hub/NarratorJournalScreen').then(m => ({ default: m.NarratorJournalScreen })))
@@ -1520,14 +1520,7 @@ export default function App() {
 
     // Mark siblings as skipped (branch choice) — unless an active Memory Charm
     // is guarding this act's uncollected fragment node(s) from being pruned.
-    const memoryCharmActive = (currentRun.consumables.find(c => c.id === 'memory_charm')?.count ?? 0) > 0
-    const protectedNodeIds = memoryCharmActive
-      ? new Set(
-          Object.values(act.nodes)
-            .filter(n => n.type === 'memory' && n.fragmentId && !isFragmentDiscovered(n.fragmentId))
-            .map(n => n.id)
-        )
-      : new Set<string>()
+    const protectedNodeIds = getProtectedFragmentNodeIds(act.nodes, currentRun, getDiscoveredFragmentIds())
     const afterSkip = skipSiblings(act.nodes, node.id, currentRun, protectedNodeIds)
     const activeMods = act ? getModifiersByCount(act, currentRun.activeModifierCount) : []
     const bonusCrystals = activeMods.filter(m => m.type === 'crystalBonus').reduce((s, m) => s + m.value, 0)

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -3,7 +3,7 @@ import * as PIXI from 'pixi.js'
 import { User } from 'firebase/auth'
 import { emitSound } from '../../../game/sound'
 import { getDiscoveredFragmentIds } from '../../../game/codex'
-import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar, ARCHETYPE_DEFS, WorldMap } from '../../../game/questline'
+import { Act, QuestNode, RunState, ReplayModifier, getAvailableNodeIds, getProtectedFragmentNodeIds, loadNodeHistory, getModifiersByCount, ALL_CONSUMABLES, loadPlayerAvatar, ARCHETYPE_DEFS, WorldMap } from '../../../game/questline'
 import { spriteSlug } from '../../../game/sprites'
 import { StatRow } from '../../ui/StatRow'
 import { getCardUnit } from '../../../game/cards'
@@ -141,10 +141,11 @@ function buildRows(nodes: Record<string, QuestNode>): QuestNode[][] {
     .map(r => byRow[r].sort((a, b) => a.col - b.col))
 }
 
-function computeHiddenNodeIds(nodes: Record<string, QuestNode>, run: RunState, discoveredFragIds: Set<string>): Set<string> {
+function computeHiddenNodeIds(nodes: Record<string, QuestNode>, run: RunState, discoveredFragIds: Set<string>, protectedNodeIds: Set<string>): Set<string> {
   const ids = new Set<string>()
   for (const node of Object.values(nodes)) {
     if (node.type !== 'memory' || !node.fragmentId) continue
+    if (protectedNodeIds.has(node.id)) continue // Memory Charm guarantees visibility
     const alreadyFound   = discoveredFragIds.has(node.fragmentId)
     const visitedThisRun = run.completedNodeIds.includes(node.id)
     if (alreadyFound && !visitedThisRun) {
@@ -618,9 +619,13 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
   )
   const reachableIds      = useMemo(() => run ? computeReachableIds(worldMap.nodes, run) : new Set<string>(), [worldMap.nodes, run])
   const discoveredFragIds = useMemo(() => getDiscoveredFragmentIds(), [])
-  const hiddenNodeIds     = useMemo(
-    () => run ? computeHiddenNodeIds(worldMap.nodes, run, discoveredFragIds) : new Set<string>(),
+  const protectedNodeIds  = useMemo(
+    () => run ? getProtectedFragmentNodeIds(worldMap.nodes, run, discoveredFragIds) : new Set<string>(),
     [worldMap.nodes, run, discoveredFragIds],
+  )
+  const hiddenNodeIds     = useMemo(
+    () => run ? computeHiddenNodeIds(worldMap.nodes, run, discoveredFragIds, protectedNodeIds) : new Set<string>(),
+    [worldMap.nodes, run, discoveredFragIds, protectedNodeIds],
   )
 
   const mapHeight = mapHeightProp ?? (isFreeform ? 520 : maxRowCols * ROW_HEIGHT)

--- a/web/src/game/questline.ts
+++ b/web/src/game/questline.ts
@@ -840,6 +840,22 @@ export function getAvailableNodeIds(nodes: Record<string, QuestNode>, run: RunSt
 }
 
 /**
+ * Memory nodes in `nodes` that an active Memory Charm guarantees this run:
+ * this act's uncollected fragment nodes, or none if no charm is carried.
+ * Takes `discoveredFragIds` as a parameter (rather than importing codex.ts)
+ * to avoid a circular import — codex.ts already imports from questline.ts.
+ */
+export function getProtectedFragmentNodeIds(nodes: Record<string, QuestNode>, run: RunState, discoveredFragIds: Set<string>): Set<string> {
+  const memoryCharmActive = (run.consumables.find(c => c.id === 'memory_charm')?.count ?? 0) > 0
+  if (!memoryCharmActive) return new Set()
+  return new Set(
+    Object.values(nodes)
+      .filter(n => n.type === 'memory' && n.fragmentId && !discoveredFragIds.has(n.fragmentId))
+      .map(n => n.id)
+  )
+}
+
+/**
  * True if `startId` (or anything reachable from it via childIds) is in
  * `protectedIds`. Used to keep a branch leading to a guaranteed memory
  * fragment from being pruned by skipSiblings, even indirectly.


### PR DESCRIPTION
## Summary

Follow-up fix to the Memory Charm (#2103). Testing surfaced a real case where a player owned the charm before starting a run, the correct branch wasn't skipped, and the target memory node still never appeared on the map across two attempts.

Root cause: `computeHiddenNodeIds()` in `NodeMapRederer.tsx` is a **second, independent** gate on memory-node visibility that the original charm work didn't account for. For any undiscovered fragment, there's an ~80% chance per run that its node is hidden from rendering entirely (`hashStr(node.id + String(run.runSeed)) % 100 >= 20`) — completely separate from `skipSiblings`/branch pruning. A node can be fully reachable in the graph and still never get drawn, purely from an unlucky `run.runSeed` roll.

- `questline.ts`: extracted `getProtectedFragmentNodeIds()` — which memory nodes an active charm guarantees — out of `App.tsx`'s `handleSelectNode` into a shared helper, since it now has two consumers (branch-skip protection and node-hide protection) that need to agree.
- `App.tsx`: `handleSelectNode` now calls the shared helper instead of its own inline computation (behavior unchanged, just de-duplicated).
- `NodeMapRederer.tsx`: `computeHiddenNodeIds()` takes the same protected-node set and skips hiding those nodes, so a charm-guaranteed fragment is always drawn on the map — not just theoretically reachable.

## Test plan

- [x] `npm run build` — TypeScript + Vite build passes clean
- [x] `npm run test` — 2106/2106 tests pass (Playwright browser-cleanup error is documented pre-existing noise)
- [ ] Manual: with a Memory Charm active and a known-uncollected fragment, restart the run several times and confirm the fragment's node renders every time instead of ~1-in-5

---
_Generated by [Claude Code](https://claude.ai/code/session_011JX2CMmhJybAboAHzN7Yuw)_