### PR TITLE
Fix city builder upgrade modal not refreshing + resident list scroll

### DIFF
--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1269,14 +1269,16 @@ export function CityBuilder({ onBack }: Props) {
     return () => clearInterval(id)
   }, [])
 
-  // ── Memoized catalog and collection (static/session-stable) ─────────────────
-  // These are NOT derived from React state — catalog never changes, collection
-  // doesn't change during a city builder session. Moved here (before any early
-  // return) so useMemo can be called unconditionally.
+  // ── Memoized catalog / live collection state ─────────────────────────────────
+  // catalog is static and never changes. collection DOES change during a
+  // session (mastery XP is granted on level-up), so it must be real state —
+  // handleLevelUp calls setCollection() right after saveCollection() so the
+  // upgrade modal (mLvl/upgradeCost/canAfford) reflects the new tier on the
+  // very next render. Both are declared here (before any early return) so
+  // useMemo/useState can be called unconditionally.
 
   const catalog = useMemo(() => getCardCatalog(), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const [collection] = useState(() => loadCollection())
+  const [collection, setCollection] = useState(() => loadCollection())
 
   // ── Derived data (memoized on city + currentTime) ─────────────────────────────
   // Previously computed inline on every render (every 100ms from animation loop),
@@ -1485,6 +1487,7 @@ export function CityBuilder({ onBack }: Props) {
       updatedCol.push({ cardName, count: 0, masteryXp: xpToGrant })
     }
     saveCollection(updatedCol)
+    setCollection(updatedCol)
     showToast(`${cardName} levelled up! Mastery ★${currentLvl + 1}`)
   }
 

--- a/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
+++ b/web/src/components/minigames/citybuilder/BuildingInspectModal.tsx
@@ -58,7 +58,7 @@ export function BuildingInspectModal({
 
   return (
     <div className="city-req-overlay" onClick={onClose}>
-      <div className="city-req-modal" onClick={e => e.stopPropagation()}>
+      <div className="city-req-modal city-req-modal--tabbed" onClick={e => e.stopPropagation()}>
         <div className="city-req-header u-flex u-items-c u-gap-4">
           <SpriteImg name={cell.cardName} className="city-req-sprite" />
           <div className="city-req-name">
@@ -77,6 +77,7 @@ export function BuildingInspectModal({
           >Upgrade</button>
         </div>
 
+        <div className="city-bld-body">
         {buildingTab === 'residents' && (
           cell.spawnedUnitName ? (
             <>
@@ -232,6 +233,7 @@ export function BuildingInspectModal({
         )}
 
         <button className="action-btn" onClick={onClose}>CLOSE</button>
+        </div>
       </div>
     </div>
   )

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11699,7 +11699,29 @@ html.light-mode .action-btn {
   flex-direction: column;
   align-items: center;
   gap: 8px;
-}.city-req-sprite  { width: 36px; height: 36px; image-rendering: pixelated; }
+  max-height: 80vh;
+  overflow-y: auto;
+}
+/* BuildingInspectModal has a tab row above scrollable content: keep the
+   header + tabs pinned, only the body below them scrolls. */
+.city-req-modal--tabbed {
+  overflow: hidden;
+}
+.city-req-modal--tabbed > .city-req-header,
+.city-req-modal--tabbed > .city-bld-tabs {
+  flex-shrink: 0;
+}
+.city-bld-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+.city-req-sprite  { width: 36px; height: 36px; image-rendering: pixelated; }
 .city-req-name    { font-size: 14px; color: #90e090; letter-spacing: 1px; }
 .city-req-mood              { font-size: 11px; letter-spacing: 1px; padding: 2px 6px; border-radius: 2px; }
 .city-req-mood--content     { color: #60d060; border: 1px solid #3a6a3a; }


### PR DESCRIPTION
## Summary

- Fix the city builder upgrade modal never reflecting the new mastery level/cost after a level-up. `collection` was loaded once at mount into `useState` and never updated, so `BuildingInspectModal` kept showing the *original* upgrade tier/cost even though gold was actually being deducted correctly at the real, increasing cost (`LEVEL_UP_COSTS`: 50k → 100k → 250k → 500k → 1M). Since the displayed cost/level/button state never advanced, players could keep clicking "LEVEL UP" believing each click cost 50,000 gold, while the real charge silently scaled up in the background.
- Make `collection` real React state and update it via `setCollection()` right alongside the gold update in `handleLevelUp`, so the modal (and `BuildingUpgradeList`/`CardPicker`, which share the same prop) reflect the new tier on the very next render.
- Fix the resident list inside the building modal not being scrollable: `.city-req-modal` had no `max-height`/`overflow`, so it just grew past the viewport. Added `max-height: 80vh; overflow-y: auto;` (matching `.quests-modal`/`.pet-modal`/`.town-directory`), plus a `--tabbed` modifier + `.city-bld-body` wrapper for `BuildingInspectModal` so its Residents/Upgrade tabs stay pinned while a long resident list scrolls beneath them.

## Test plan

- [x] `npm run build` — typecheck + Vite build passes clean
- [x] `npm run test` — 2106 tests passed (69 test files); the reported "Unhandled Error" about a missing Playwright browser executable during cleanup is documented pre-existing noise in `AGENTS.md`, unrelated to this change
- [ ] Manual verification in a running dev session recommended: open a building's upgrade tab, confirm the mastery star/cost/button update immediately after each LEVEL UP click and track the real increasing cost; open a building with many residents and confirm the header/tabs stay fixed while the list scrolls


---
_Generated by [Claude Code](https://claude.ai/code/session_01MaDyxMmxHVY6CRNu9d333k)_