### PR TITLE
Fix Ravenwatch quest item locations and minimap/arrow accuracy

### DIFF
--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import type { HubLocationBundle } from '../../data/hub/loader'
+import { edgeArrowPlacement, isOnScreen, minimapTransform, type ViewportRect } from './hubMinimapMath'
 
 const T = 32
 
@@ -41,19 +42,15 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
 
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [visible, setVisible] = useState(loadVisible)
-  // Off-screen edge arrow, in screen-fraction coords (0..1) + angle, or null when on-screen.
-  const [arrow, setArrow] = useState<{ fx: number; fy: number; angle: number } | null>(null)
+  // Off-screen edge arrow, positioned in px within this component's containing
+  // block (.nm-map) + angle, or null when the objective is on-screen. Pixels, not
+  // percentages: .nm-map carries 16px of top padding that the scroll viewport does
+  // not, so a percentage of the containing block lands ~16px above the true spot.
+  const [arrow, setArrow] = useState<{ left: number; top: number; angle: number } | null>(null)
 
   // World → minimap scale (letterboxed to preserve aspect ratio).
-  const innerW = MM_W - PAD * 2
-  const innerH = MM_H - PAD * 2
-  const scale  = Math.min(innerW / MAP_W, innerH / MAP_H)
-  const drawW  = MAP_W * scale
-  const drawH  = MAP_H * scale
-  const offX   = PAD + (innerW - drawW) / 2
-  const offY   = PAD + (innerH - drawH) / 2
-  const toMmX  = (wx: number) => offX + wx * scale
-  const toMmY  = (wy: number) => offY + wy * scale
+  const { scale, drawW, drawH, offX, offY, toMmX, toMmY } =
+    minimapTransform(MAP_W, MAP_H, MM_W, MM_H, PAD)
 
   // Redraw loop — runs only while the minimap is visible. Repaints when the
   // player tile, objectives, or viewport window change (keeps work minimal).
@@ -84,11 +81,14 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
       const vy = vp?.scrollTop  ?? 0
       const vw = vp?.clientWidth  ?? MAP_W
       const vh = vp?.clientHeight ?? MAP_H
+      // Where the game view sits inside this component's containing block.
+      const ox = vp?.offsetLeft ?? 0
+      const oy = vp?.offsetTop  ?? 0
 
-      const sig = `${Math.round(p.x)},${Math.round(p.y)}|${objSig}|${Math.round(vx)},${Math.round(vy)},${vw},${vh}`
+      const sig = `${Math.round(p.x)},${Math.round(p.y)}|${objSig}|${Math.round(vx)},${Math.round(vy)},${vw},${vh},${ox},${oy}`
       if (sig !== lastSig) {
         lastSig = sig
-        draw(ctx, p, { vx, vy, vw, vh })
+        draw(ctx, p, { vx, vy, vw, vh, ox, oy })
       }
       raf = requestAnimationFrame(frame)
     }
@@ -96,7 +96,7 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
     const draw = (
       c: CanvasRenderingContext2D,
       player: { x: number; y: number },
-      view: { vx: number; vy: number; vw: number; vh: number },
+      view: ViewportRect & { ox: number; oy: number },
     ) => {
       c.clearRect(0, 0, MM_W, MM_H)
 
@@ -162,25 +162,11 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
         const d = (o.x - player.x) ** 2 + (o.y - player.y) ** 2
         if (d < nearestD) { nearestD = d; nearest = o }
       }
-      if (nearest) {
-        const onScreen =
-          nearest.x >= view.vx && nearest.x <= view.vx + view.vw &&
-          nearest.y >= view.vy && nearest.y <= view.vy + view.vh
-        if (!onScreen) {
-          // Direction from the viewport centre to the objective.
-          const cx = view.vx + view.vw / 2
-          const cy = view.vy + view.vh / 2
-          const angle = Math.atan2(nearest.y - cy, nearest.x - cx)
-          // Project onto the edge of a centred unit box → screen fraction.
-          const dx = Math.cos(angle)
-          const dy = Math.sin(angle)
-          const m = Math.max(Math.abs(dx), Math.abs(dy)) || 1
-          const fx = 0.5 + (dx / m) * 0.45
-          const fy = 0.5 + (dy / m) * 0.45
-          setArrow({ fx, fy, angle })
-        } else {
-          setArrow(null)
-        }
+      if (nearest && !isOnScreen(nearest, view)) {
+        const { fx, fy, angle } = edgeArrowPlacement(nearest, view)
+        // Offset by the scroll viewport's own position so the arrow is placed
+        // against the game view, not against .nm-map's larger padding box.
+        setArrow({ left: view.ox + fx * view.vw, top: view.oy + fy * view.vh, angle })
       } else {
         setArrow(null)
       }
@@ -202,8 +188,8 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
         <div
           style={{
             position:      'absolute',
-            left:          `${arrow.fx * 100}%`,
-            top:           `${arrow.fy * 100}%`,
+            left:          arrow.left,
+            top:           arrow.top,
             transform:     `translate(-50%, -50%) rotate(${arrow.angle}rad)`,
             pointerEvents: 'none',
             zIndex:        8,

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -42,7 +42,7 @@ import { PLAYER_PET_ANIMAL_ID } from './hubAnimals'
 import type { UpgradeRow } from './HubTownUpgrades'
 import { nextUpgrade, purchaseUpgrade, getTownReputation, getUpgradeLevel, setUpgradeKindResolver, tributeAmount, tributeAvailable, collectTribute } from '../../game/hub/reputation'
 import { RelationshipView } from './RelationshipView'
-import { resolveNpcPlace } from '../../game/hub/npcLocator'
+import { buildingWorldTile, pickupWorldTile, resolveNpcPlace } from '../../game/hub/npcLocator'
 import { TreasureModal } from './TreasureModal'
 import { getCollectedTreasureIds, markTreasureCollected } from '../../game/hub/treasures'
 import { useHubClock } from '../../hooks/useHubClock'
@@ -521,12 +521,26 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   // the NPC who finishes the quest (see issue #1663).
   const minimapObjectives = useMemo<MinimapObjective[]>(() => {
     const out: MinimapObjective[] = []
+    const pushTile = (tile: { tx: number; ty: number } | null, kind: MinimapObjective['kind']) => {
+      if (tile) out.push({ x: tile.tx * T + T / 2, y: tile.ty * T + T / 2, kind })
+    }
+    // Tile to pin an NPC at. resolveNpcPlace falls back to interior-*local* coords
+    // when the building can't be placed on the map, which would drop the pin near
+    // the map origin — resolve indoors NPCs explicitly and skip when unplaceable.
+    const npcPinTile = (npc: HubNpc): { tx: number; ty: number } | null => {
+      const place = resolveNpcPlace(npc, gameHour, locationData)
+      return place.interiorId
+        ? buildingWorldTile(place.interiorId, locationData)
+        : { tx: place.tx, ty: place.ty }
+    }
     const pushNpc = (npcId: string | undefined) => {
+      if (!npcId) return
       const npc = locationData.HUB_NPCS.find(n => n.id === npcId)
-      if (npc) {
-        const place = resolveNpcPlace(npc, gameHour, locationData)
-        out.push({ x: place.tx * T + T / 2, y: place.ty * T + T / 2, kind: 'npc' })
-      }
+      if (npc) { pushTile(npcPinTile(npc), 'npc'); return }
+      // Some quests deliver to an animal (e.g. Ravenwatch's stray cat), which lives
+      // in HUB_ANIMALS rather than HUB_NPCS — without this the step gets no pin.
+      const animal = locationData.HUB_ANIMALS.find(a => a.id === npcId)
+      if (animal) pushTile({ tx: animal.tx, ty: animal.ty }, 'npc')
     }
     for (const quest of questDefs) {
       if (getQuestState(quest.id).status !== 'active') continue
@@ -541,7 +555,8 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
         for (const pid of incomplete.pickupIds ?? []) {
           if (pickedUpIds.has(pid)) continue
           const item = locationQuests.HUB_PICKUP_ITEMS.find(p => p.id === pid)
-          if (item) out.push({ x: item.tx * T + T / 2, y: item.ty * T + T / 2, kind: 'pickup' })
+          // Items inside a building carry interior-local coords — pin the building.
+          if (item) pushTile(pickupWorldTile(item, locationData), 'pickup')
         }
       } else {
         pushNpc(incomplete.targetNpcId)
@@ -550,10 +565,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     // Town Directory "show on map" pin — the chosen NPC's current location.
     if (pinnedNpcId) {
       const npc = locationData.HUB_NPCS.find(n => n.id === pinnedNpcId)
-      if (npc) {
-        const place = resolveNpcPlace(npc, gameHour, locationData)
-        out.push({ x: place.tx * T + T / 2, y: place.ty * T + T / 2, kind: 'directory' })
-      }
+      if (npc) pushTile(npcPinTile(npc), 'directory')
     }
     return out
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/components/hub/hubMinimapMath.test.ts
+++ b/web/src/components/hub/hubMinimapMath.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { edgeArrowPlacement, isOnScreen, minimapTransform, type ViewportRect } from './hubMinimapMath'
+
+describe('minimapTransform', () => {
+  it('maps the world corners onto the drawn rect corners', () => {
+    // Ravenwatch's map on the real 100x100 minimap canvas.
+    const t = minimapTransform(2400, 2240, 100, 100)
+    expect(t.toMmX(0)).toBeCloseTo(t.offX)
+    expect(t.toMmY(0)).toBeCloseTo(t.offY)
+    expect(t.toMmX(2400)).toBeCloseTo(t.offX + t.drawW)
+    expect(t.toMmY(2240)).toBeCloseTo(t.offY + t.drawH)
+  })
+
+  it('letterboxes with one uniform scale, centred in the slack axis', () => {
+    const t = minimapTransform(2400, 2240, 100, 100)
+    expect(t.drawW).toBeCloseTo(100)          // wider axis fills the canvas
+    expect(t.drawH).toBeLessThan(100)         // shorter axis is letterboxed
+    expect(t.offX).toBeCloseTo(0)
+    expect(t.offY).toBeCloseTo((100 - t.drawH) / 2)
+    // Same scale both ways — no aspect distortion.
+    expect(t.drawW / 2400).toBeCloseTo(t.drawH / 2240)
+  })
+
+  it('honours padding', () => {
+    const t = minimapTransform(100, 100, 100, 100, 10)
+    expect(t.drawW).toBeCloseTo(80)
+    expect(t.offX).toBeCloseTo(10)
+  })
+})
+
+describe('isOnScreen', () => {
+  const view: ViewportRect = { vx: 100, vy: 100, vw: 400, vh: 600 }
+
+  it('accepts points inside the window and rejects points outside', () => {
+    expect(isOnScreen({ x: 300, y: 400 }, view)).toBe(true)
+    expect(isOnScreen({ x: 99, y: 400 }, view)).toBe(false)
+    expect(isOnScreen({ x: 300, y: 701 }, view)).toBe(false)
+  })
+})
+
+describe('edgeArrowPlacement', () => {
+  // The arrow must sit on the straight line from the viewport centre to the
+  // objective. Expressed in screen pixels, the offset from centre is
+  // ((fx - 0.5) * vw, (fy - 0.5) * vh) — that vector has to stay parallel to
+  // (target - centre), which is exactly what the old square-box projection broke
+  // on non-square viewports.
+  const onTheRay = (target: { x: number; y: number }, view: ViewportRect) => {
+    const { fx, fy, angle } = edgeArrowPlacement(target, view)
+    const dx = target.x - (view.vx + view.vw / 2)
+    const dy = target.y - (view.vy + view.vh / 2)
+    const ex = (fx - 0.5) * view.vw
+    const ey = (fy - 0.5) * view.vh
+    // Cross product of the two vectors is zero when they are parallel.
+    expect(dx * ey - dy * ex).toBeCloseTo(0, 6)
+    // ...and pointing the same way, not backwards.
+    expect(dx * ex + dy * ey).toBeGreaterThan(0)
+    // The glyph's rotation must agree with where it was placed.
+    expect(Math.atan2(ey, ex)).toBeCloseTo(angle, 6)
+  }
+
+  const portrait: ViewportRect = { vx: 0, vy: 0, vw: 390, vh: 640 }
+  const landscape: ViewportRect = { vx: 0, vy: 0, vw: 1440, vh: 720 }
+
+  it('stays on the ray to the objective on a tall phone viewport', () => {
+    for (const target of [
+      { x: 2000, y: 500 },    // far east, slightly below centre
+      { x: 195, y: -800 },    // due north
+      { x: -600, y: 900 },    // south-west
+      { x: 1200, y: 1500 },   // south-east, shallow angle
+    ]) onTheRay(target, portrait)
+  })
+
+  it('stays on the ray to the objective on a wide desktop viewport', () => {
+    for (const target of [
+      { x: 3000, y: 400 },
+      { x: 720, y: -900 },
+      { x: -400, y: 1100 },
+    ]) onTheRay(target, landscape)
+  })
+
+  it('keeps the arrow inside the viewport, touching the inset edge', () => {
+    const { fx, fy } = edgeArrowPlacement({ x: 5000, y: 300 }, portrait)
+    expect(fx).toBeGreaterThan(0)
+    expect(fx).toBeLessThan(1)
+    expect(fy).toBeGreaterThan(0)
+    expect(fy).toBeLessThan(1)
+    // Far to the east ⇒ pinned against the right edge at the 0.9 inset.
+    expect(fx).toBeCloseTo(0.5 + 0.45)
+  })
+
+  it('respects the viewport offset when deriving the centre', () => {
+    const shifted: ViewportRect = { vx: 1000, vy: 2000, vw: 390, vh: 640 }
+    // Directly north of the shifted centre ⇒ straight up, no horizontal drift.
+    const { fx, fy, angle } = edgeArrowPlacement({ x: 1195, y: 0 }, shifted)
+    expect(fx).toBeCloseTo(0.5)
+    expect(fy).toBeCloseTo(0.5 - 0.45)
+    expect(angle).toBeCloseTo(-Math.PI / 2)
+  })
+
+  it('returns the centre when the objective is exactly at the centre', () => {
+    const { fx, fy } = edgeArrowPlacement({ x: 195, y: 320 }, portrait)
+    expect(fx).toBeCloseTo(0.5)
+    expect(fy).toBeCloseTo(0.5)
+  })
+})

--- a/web/src/components/hub/hubMinimapMath.ts
+++ b/web/src/components/hub/hubMinimapMath.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure coordinate maths for the hub minimap and its off-screen objective arrow.
+ * Kept out of the component so it can be tested without a canvas or a DOM.
+ */
+
+/** Visible world window, in world pixels. */
+export interface ViewportRect {
+  vx: number
+  vy: number
+  vw: number
+  vh: number
+}
+
+export interface MinimapTransform {
+  /** World pixels → minimap pixels. */
+  scale: number
+  /** Size of the drawn map rect inside the minimap canvas. */
+  drawW: number
+  drawH: number
+  /** Top-left of the drawn map rect inside the minimap canvas. */
+  offX: number
+  offY: number
+  toMmX: (wx: number) => number
+  toMmY: (wy: number) => number
+}
+
+/**
+ * Scale-to-fit (letterboxed) mapping from world pixels onto a mmW × mmH minimap
+ * canvas: one uniform scale for both axes, the map centred in whichever axis has
+ * slack. `pad` insets the drawable area on all four sides.
+ */
+export function minimapTransform(
+  mapW: number,
+  mapH: number,
+  mmW: number,
+  mmH: number,
+  pad = 0,
+): MinimapTransform {
+  const innerW = mmW - pad * 2
+  const innerH = mmH - pad * 2
+  const scale = Math.min(innerW / mapW, innerH / mapH)
+  const drawW = mapW * scale
+  const drawH = mapH * scale
+  const offX = pad + (innerW - drawW) / 2
+  const offY = pad + (innerH - drawH) / 2
+  return {
+    scale, drawW, drawH, offX, offY,
+    toMmX: (wx: number) => offX + wx * scale,
+    toMmY: (wy: number) => offY + wy * scale,
+  }
+}
+
+/** True when the world point is inside the visible window. */
+export function isOnScreen(target: { x: number; y: number }, view: ViewportRect): boolean {
+  return target.x >= view.vx && target.x <= view.vx + view.vw
+      && target.y >= view.vy && target.y <= view.vy + view.vh
+}
+
+export interface EdgeArrowPlacement {
+  /** Position as a fraction of the viewport (0..1 from its top-left corner). */
+  fx: number
+  fy: number
+  /** Bearing from the viewport centre to the target, in radians. */
+  angle: number
+}
+
+/**
+ * Where to park the off-screen objective arrow: on the ray from the viewport
+ * centre to the target, pushed out until it meets the edge of the viewport
+ * shrunk by `inset`.
+ *
+ * The projection has to happen against the viewport's real pixel dimensions.
+ * Projecting onto a *square* box and then applying the result as percentages of
+ * a non-square element (what this used to do) skews the arrow off the ray — the
+ * glyph points one way while sitting somewhere else, which is glaring on a tall
+ * phone viewport and only exact along the axes and the diagonals.
+ */
+export function edgeArrowPlacement(
+  target: { x: number; y: number },
+  view: ViewportRect,
+  inset = 0.9,
+): EdgeArrowPlacement {
+  const cx = view.vx + view.vw / 2
+  const cy = view.vy + view.vh / 2
+  const dx = target.x - cx
+  const dy = target.y - cy
+  const angle = Math.atan2(dy, dx)
+  if (dx === 0 && dy === 0) return { fx: 0.5, fy: 0.5, angle }
+  // Distance along the ray at which it crosses each inset edge; the nearer one wins.
+  const tx = dx === 0 ? Infinity : (view.vw / 2) * inset / Math.abs(dx)
+  const ty = dy === 0 ? Infinity : (view.vh / 2) * inset / Math.abs(dy)
+  const t = Math.min(tx, ty)
+  return {
+    fx: 0.5 + (dx * t) / view.vw,
+    fy: 0.5 + (dy * t) / view.vh,
+    angle,
+  }
+}

--- a/web/src/data/hub/questPickupPlacement.test.ts
+++ b/web/src/data/hub/questPickupPlacement.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { createHubLocationData, createHubQuestData } from './loader'
+import type { RawConfig } from './config'
+import type { RawQuestConfig } from './questDefs'
+import { buildingWorldTile, pickupWorldTile } from '../../game/hub/npcLocator'
+import ravenwatchConfig from './ravenwatch/config.json'
+import ravenwatchQuests from './ravenwatch/questDefs.json'
+
+// Placement invariants for Ravenwatch's quest items. Quest dialogue describes
+// where an item is ("by the pond", "in the games hall"), but nothing links the
+// prose to the coordinates, so items drift when the town layout is rebuilt.
+// These checks catch the mechanical half of that drift: items that cannot be
+// found at all, or that name a building they are not in.
+const loc = createHubLocationData(ravenwatchConfig as unknown as RawConfig)
+const quests = createHubQuestData(ravenwatchQuests as unknown as RawQuestConfig)
+
+const pickups = quests.HUB_PICKUP_ITEMS
+const exterior = pickups.filter(p => !p.building)
+const interior = pickups.filter(p => p.building)
+
+const tileKey = (tx: number, ty: number) => `${tx},${ty}`
+const pondTiles = new Set(loc.HUB_POND_TILES.map(([tx, ty]) => tileKey(tx, ty)))
+const buildingTiles = new Set(loc.HUB_BUILDING_TILES.map(([tx, ty]) => tileKey(tx, ty)))
+
+describe('Ravenwatch quest pickups', () => {
+  it('has items to check', () => {
+    expect(exterior.length).toBeGreaterThan(100)
+    expect(interior.length).toBeGreaterThan(50)
+  })
+
+  it('places every exterior item inside the map', () => {
+    const outside = exterior.filter(p =>
+      p.tx < 0 || p.ty < 0 || p.tx * 32 >= loc.MAP_W || p.ty * 32 >= loc.MAP_H)
+    expect(outside.map(p => p.id)).toEqual([])
+  })
+
+  it('never leaves an exterior item floating on open water', () => {
+    const drowned = exterior.filter(p => pondTiles.has(tileKey(p.tx, p.ty)))
+    expect(drowned.map(p => p.id)).toEqual([])
+  })
+
+  it('never hides an exterior item under a building footprint', () => {
+    const buried = exterior.filter(p => buildingTiles.has(tileKey(p.tx, p.ty)))
+    expect(buried.map(p => p.id)).toEqual([])
+  })
+
+  it('resolves every indoor item to a building placed on the map', () => {
+    // An unresolvable building means the minimap has no honest tile to pin, and
+    // the item's interior-local coords would otherwise be read as world coords.
+    const unplaceable = interior.filter(p => pickupWorldTile(p, loc) === null)
+    expect(unplaceable.map(p => p.id)).toEqual([])
+  })
+
+  it('names a real interior and sits within its grid', () => {
+    const bad = interior.filter(p => {
+      const room = loc.HUB_INTERIORS[p.building!]
+      return !room || p.tx < 0 || p.ty < 0 || p.tx >= room.width || p.ty >= room.height
+    })
+    expect(bad.map(p => `${p.id} @ ${p.building}`)).toEqual([])
+  })
+
+  it('keeps indoor items off the interior wall ring so they stay reachable', () => {
+    // Interiors are walkable on 1..width-2 / 1..height-2 (HubTownCanvas builds the
+    // walkable set that way); the outer ring is wall.
+    const inWall = interior.filter(p => {
+      const room = loc.HUB_INTERIORS[p.building!]
+      if (!room) return false
+      return p.tx < 1 || p.ty < 1 || p.tx > room.width - 2 || p.ty > room.height - 2
+    })
+    expect(inWall.map(p => `${p.id} @ ${p.building} (${p.tx},${p.ty})`)).toEqual([])
+  })
+})
+
+describe('Ravenwatch quest targets', () => {
+  it('delivers only to NPCs or animals that exist in the town', () => {
+    // Delivery steps pointing at an animal (the stray cat) resolve through
+    // HUB_ANIMALS, not HUB_NPCS — a lookup that only checks NPCs silently
+    // produces no map pin for those steps.
+    const npcIds = new Set(loc.HUB_NPCS.map(n => n.id))
+    const animalIds = new Set(loc.HUB_ANIMALS.map(a => a.id))
+    const unknown: string[] = []
+    for (const quest of quests.HUB_QUEST_DEFS) {
+      for (const step of quest.steps ?? []) {
+        const target = step.targetNpcId
+        if (!target) continue
+        if (!npcIds.has(target) && !animalIds.has(target)) unknown.push(`${quest.id} → ${target}`)
+      }
+    }
+    expect(unknown).toEqual([])
+  })
+
+  it('resolves every quest-giver in a building to a placeable location', () => {
+    const stranded = loc.HUB_NPCS
+      .filter(n => n.building && buildingWorldTile(n.building, loc) === null)
+      .map(n => `${n.id} @ ${n.building}`)
+    expect(stranded).toEqual([])
+  })
+})

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -358,7 +358,7 @@
       "receiverNpcId": "trader",
       "prerequisite": "quest:the-password-part-4",
       "offerDialogue": "Got a crate of supplies that needs to reach the trader den — can't leave the counter unattended. Take it over, would you?",
-      "activeDialogue": "The Junk Trader is in the den to the south-west. Don't let him talk you into a swap.",
+      "activeDialogue": "The Junk Trader is in the den just along to the east. Don't let him talk you into a swap.",
       "completeDialogue": "About time! These are exactly what I needed. Tell Bramble we're square.",
       "steps": [
         {
@@ -443,8 +443,8 @@
       "giverNpcId": "home-steward",
       "receiverNpcId": "home-steward",
       "prerequisite": "quest:the-password-part-4",
-      "offerDialogue": "I apologise for the bother, Commander, but I seem to have dropped a small locket while crossing the courtyard this morning. It belonged to the Commander's family.",
-      "activeDialogue": "I believe I dropped it somewhere near the well in the courtyard. It is a small silver locket.",
+      "offerDialogue": "I apologise for the bother, Commander, but I seem to have dropped a small locket while walking down past the old well this morning. It belonged to the Commander's family.",
+      "activeDialogue": "I believe I dropped it somewhere near the old stone well, on the lane just west of the courtyard. It is a small silver locket.",
       "completeDialogue": "Ah, there it is. My sincerest thanks — this is irreplaceable. I shall keep it safer from now on.",
       "steps": [
         {
@@ -560,7 +560,7 @@
       "receiverNpcId": "guild-master-ferryn",
       "prerequisite": "quest:the-password-part-4",
       "offerDialogue": "Someone borrowed the guild's primary ledger — without asking, naturally — and I believe it ended up in the trader den. I need that book back. Every transaction for the last year is in it.",
-      "activeDialogue": "Check the trader den to the south-west. The ledger is bound in dark leather with a guild stamp on the cover.",
+      "activeDialogue": "Check the trader den to the north-west. The ledger is bound in dark leather with a guild stamp on the cover.",
       "completeDialogue": "Intact. Every page. I will be having words with the trader. Here — your fee, as promised.",
       "steps": [
         {
@@ -782,7 +782,7 @@
       "receiverNpcId": "guild-master-ferryn",
       "prerequisite": "quest:merchants-herb",
       "offerDialogue": "Ferryn has been pestering me for the quarterly trade ledger. Fine — but I am not walking it over myself. It is on the counter. Take it to the guild hall.",
-      "activeDialogue": "Guild Master Ferryn is in the traders' building to the south-west. Try not to read it.",
+      "activeDialogue": "Guild Master Ferryn is in the traders' building to the south-east. Try not to read it.",
       "completeDialogue": "At last! Vex takes his time. Thank you for the legwork — much appreciated.",
       "steps": [
         {
@@ -3938,8 +3938,8 @@
     },
     {
       "id": "pendant-2",
-      "tx": 20,
-      "ty": 53,
+      "tx": 22,
+      "ty": 47,
       "tileId": "goldNecklace",
       "questId": "lost-pendant"
     },
@@ -3952,8 +3952,8 @@
     },
     {
       "id": "moonleaf-herb",
-      "tx": 3,
-      "ty": 55,
+      "tx": 55,
+      "ty": 21,
       "tileId": "bunchOfHerbs",
       "questId": "merchants-herb"
     },
@@ -3990,22 +3990,22 @@
     },
     {
       "id": "bait-jar-1",
-      "tx": 3,
-      "ty": 36,
+      "tx": 44,
+      "ty": 50,
       "tileId": "smallSack",
       "questId": "greyfishs-bait"
     },
     {
       "id": "bait-jar-2",
-      "tx": 6,
-      "ty": 40,
+      "tx": 50,
+      "ty": 50,
       "tileId": "smallSack",
       "questId": "greyfishs-bait"
     },
     {
       "id": "bait-jar-3",
-      "tx": 5,
-      "ty": 44,
+      "tx": 41,
+      "ty": 53,
       "tileId": "smallSack",
       "questId": "greyfishs-bait"
     },
@@ -4175,8 +4175,8 @@
     },
     {
       "id": "marsh-thyme",
-      "tx": 11,
-      "ty": 51,
+      "tx": 52,
+      "ty": 52,
       "tileId": "bunchOfHerbs",
       "questId": "rosie-recipe"
     },
@@ -4204,8 +4204,8 @@
     },
     {
       "id": "memory-shard-3",
-      "tx": 4,
-      "ty": 45,
+      "tx": 44,
+      "ty": 49,
       "tileId": "white_crystal3",
       "questId": "elder-fracture-memory"
     },
@@ -4503,19 +4503,19 @@
     },
     {
       "id": "rigging-device-2",
-      "tx": 5,
+      "tx": 7,
       "ty": 4,
       "tileId": "chest",
       "questId": "zev-rigged-games",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "rigging-device-3",
-      "tx": 4,
+      "tx": 9,
       "ty": 6,
       "tileId": "chest",
       "questId": "zev-rigged-games",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "fake-trophy",
@@ -4776,19 +4776,19 @@
     },
     {
       "id": "shadow-coin",
-      "tx": 4,
+      "tx": 2,
       "ty": 5,
       "tileId": "pileOfCoins",
       "questId": "zev-shadow-gambler",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "shadow-note",
-      "tx": 6,
+      "tx": 12,
       "ty": 4,
       "tileId": "note",
       "questId": "zev-shadow-gambler",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "shadow-token",
@@ -4800,27 +4800,27 @@
     },
     {
       "id": "tainted-trophy-1",
-      "tx": 4,
-      "ty": 4,
+      "tx": 8,
+      "ty": 2,
       "tileId": "goldChest",
       "questId": "orin-contaminated-trophies",
-      "building": "barracks-north"
+      "building": "arcade-building-e"
     },
     {
       "id": "tainted-trophy-2",
-      "tx": 6,
-      "ty": 4,
+      "tx": 10,
+      "ty": 3,
       "tileId": "goldChest",
       "questId": "orin-contaminated-trophies",
-      "building": "barracks-north"
+      "building": "arcade-building-e"
     },
     {
       "id": "tainted-trophy-3",
-      "tx": 5,
-      "ty": 6,
+      "tx": 2,
+      "ty": 4,
       "tileId": "goldChest",
       "questId": "orin-contaminated-trophies",
-      "building": "barracks-south"
+      "building": "arcade-building-e"
     },
     {
       "id": "echo-suspect-list",
@@ -4980,16 +4980,16 @@
     },
     {
       "id": "guild-doc-3",
-      "tx": 3,
-      "ty": 6,
+      "tx": 9,
+      "ty": 3,
       "tileId": "blackclosedBook",
       "questId": "ferryn-guild-lockdown",
-      "building": "trader-den"
+      "building": "traders-building"
     },
     {
       "id": "purification-crystal-1",
-      "tx": 5,
-      "ty": 40,
+      "tx": 42,
+      "ty": 51,
       "tileId": "blue_crystal3",
       "questId": "mira-purging-augments"
     },
@@ -5059,8 +5059,8 @@
     },
     {
       "id": "shelter-package-2",
-      "tx": 2,
-      "ty": 41,
+      "tx": 41,
+      "ty": 52,
       "tileId": "crate",
       "questId": "rosie-shelter-for-families"
     },
@@ -5080,8 +5080,8 @@
     },
     {
       "id": "fracture-residue-2",
-      "tx": 4,
-      "ty": 36,
+      "tx": 51,
+      "ty": 51,
       "tileId": "potions",
       "questId": "alric-fracture-study"
     },
@@ -5094,8 +5094,8 @@
     },
     {
       "id": "pond-hearthstone-disc",
-      "tx": 6,
-      "ty": 39,
+      "tx": 45,
+      "ty": 49,
       "tileId": "roundShieldFloor",
       "questId": "fisherman-fracture-depths"
     },
@@ -5122,19 +5122,19 @@
     },
     {
       "id": "surveillance-device-1",
-      "tx": 3,
+      "tx": 1,
       "ty": 3,
       "tileId": "chest",
       "questId": "zev-games-hall-clear",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "surveillance-device-2",
-      "tx": 6,
+      "tx": 13,
       "ty": 3,
       "tileId": "chest",
       "questId": "zev-games-hall-clear",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "surveillance-device-3",
@@ -5170,8 +5170,8 @@
     },
     {
       "id": "intel-note-3",
-      "tx": 61,
-      "ty": 23,
+      "tx": 51,
+      "ty": 27,
       "tileId": "note",
       "questId": "dealer-fracture-intel"
     },
@@ -5402,8 +5402,8 @@
     },
     {
       "id": "resource-bundle-1",
-      "tx": 5,
-      "ty": 42,
+      "tx": 52,
+      "ty": 54,
       "tileId": "crate",
       "questId": "ferryn-resource-cache"
     },
@@ -5517,11 +5517,11 @@
     },
     {
       "id": "zev-equipment-manifest",
-      "tx": 5,
-      "ty": 3,
+      "tx": 11,
+      "ty": 2,
       "tileId": "closedBook",
       "questId": "zev-games-hall-stands",
-      "building": "arcade-building-e"
+      "building": "arcade-building-w"
     },
     {
       "id": "champions-pledge",
@@ -5569,8 +5569,8 @@
     },
     {
       "id": "convergence-shard-2",
-      "tx": 2,
-      "ty": 37,
+      "tx": 52,
+      "ty": 51,
       "tileId": "yellow_crystal1",
       "questId": "elder-the-convergence"
     },

--- a/web/src/game/hub/npcLocator.test.ts
+++ b/web/src/game/hub/npcLocator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveNpcPlace, buildingWorldTile, areaNameForTile } from './npcLocator'
+import { resolveNpcPlace, buildingWorldTile, areaNameForTile, pickupWorldTile } from './npcLocator'
 import type { HubLocationBundle, HubNpc } from '../../data/hub/loader'
 
 // Minimal bundle with only the fields the locator reads.
@@ -34,6 +34,23 @@ describe('buildingWorldTile', () => {
   })
   it('walks up to the parent building for a virtual sub-room with no footprint of its own', () => {
     expect(buildingWorldTile('inn-upstairs', loc)).toEqual({ tx: 10, ty: 12 })
+  })
+})
+
+describe('pickupWorldTile', () => {
+  it('passes an exterior pickup through unchanged', () => {
+    expect(pickupWorldTile({ tx: 42, ty: 51 }, loc)).toEqual({ tx: 42, ty: 51 })
+  })
+  it('resolves a pickup inside a building to that building\'s door, not its local tile', () => {
+    // (4,3) is a tile in the inn's 6x6 interior grid — as a world tile it would
+    // land near the map origin, which is the bug this guards.
+    expect(pickupWorldTile({ tx: 4, ty: 3, building: 'inn' }, loc)).toEqual({ tx: 10, ty: 12 })
+  })
+  it('resolves a pickup in a virtual sub-room via its parent building', () => {
+    expect(pickupWorldTile({ tx: 1, ty: 1, building: 'inn-upstairs' }, loc)).toEqual({ tx: 10, ty: 12 })
+  })
+  it('returns null for a building that is not placed on the map', () => {
+    expect(pickupWorldTile({ tx: 4, ty: 3, building: 'nope' }, loc)).toBeNull()
   })
 })
 

--- a/web/src/game/hub/npcLocator.ts
+++ b/web/src/game/hub/npcLocator.ts
@@ -1,4 +1,4 @@
-import type { HubArea, HubLocationBundle, HubNpc } from '../../data/hub/loader'
+import type { HubArea, HubLocationBundle, HubNpc, HubPickupItem } from '../../data/hub/loader'
 import { getNpcLocation } from './hubNpcSchedule'
 
 const T = 32
@@ -48,6 +48,22 @@ export function buildingWorldTile(buildingId: string, loc: HubLocationBundle): {
     current = parent[0]
   }
   return null
+}
+
+/**
+ * World-map tile to point at for a quest pickup. A pickup with `building` set is
+ * inside that interior and its tx/ty are *interior-local* (typically 0-15), so they
+ * must never be used as world coordinates — that plants the marker near the map's
+ * top-left corner. Such pickups resolve to the building's exterior position instead,
+ * the same way NPCs indoors do. Returns null when the building cannot be placed on
+ * the map, so callers can drop the pin rather than show a wrong one.
+ */
+export function pickupWorldTile(
+  item: Pick<HubPickupItem, 'tx' | 'ty' | 'building'>,
+  loc: HubLocationBundle,
+): { tx: number; ty: number } | null {
+  if (!item.building) return { tx: item.tx, ty: item.ty }
+  return buildingWorldTile(item.building, loc)
 }
 
 /**

--- a/web/src/hooks/usePixiApp.ts
+++ b/web/src/hooks/usePixiApp.ts
@@ -94,9 +94,30 @@ export function usePixiApp(
     const resolution = computeCappedResolution(initW, initH, window.devicePixelRatio || 1)
     const contextInfo = { width: initW, height: initH, resolution }
 
+    // Pixi's ResizePlugin only re-measures resizeTo on the window's own `resize`
+    // event, so a container that changes size on its own (a toolbar wrapping to a
+    // second line, a flex sibling growing) leaves app.screen stale while the DOM
+    // reports the new size. Anything mixing the two — the hub minimap reads
+    // clientWidth/clientHeight while the canvas culls against app.screen — then
+    // disagrees about where the viewport is. Observe the element directly.
+    let resizeObserver: ResizeObserver | null = null
+    const observeResizeEl = (app: PIXI.Application) => {
+      if (!resizeEl || typeof ResizeObserver === 'undefined') return
+      resizeObserver = new ResizeObserver(() => {
+        // queueResize coalesces to the next frame, matching the plugin's own path.
+        if (appRef.current === app && app.renderer) app.queueResize()
+      })
+      resizeObserver.observe(resizeEl)
+    }
+    const disconnectResizeObserver = () => {
+      resizeObserver?.disconnect()
+      resizeObserver = null
+    }
+
     // Tears down a fully-initialised app and its canvas. Used both on unmount
     // and to discard a context-lost app immediately before rebuilding it.
     const teardown = (app: PIXI.Application) => {
+      disconnectResizeObserver()
       // If the WebGL context was already lost (e.g. the browser evicted it
       // under context pressure from other live apps), the renderer is gone and
       // app.canvas throws. Nothing remains to tear down — just note it.
@@ -239,6 +260,7 @@ export function usePixiApp(
         }
         canvas.addEventListener('webglcontextlost', contextLostHandler)
         container.appendChild(canvas)
+        observeResizeEl(app)
         onReady(app)
       }).catch(e => {
         console.error('[usePixiApp] app.init failed', e)
@@ -290,6 +312,7 @@ export function usePixiApp(
       destroyed = true
       controller.dispose()
       removeFallback()
+      disconnectResizeObserver()  // also covers an init that never reached teardown
       if (initialized && appRef.current) {
         teardown(appRef.current)
       }


### PR DESCRIPTION
Two complaints, both variations on "where the game says the thing is" not matching "where the thing is".

## 1. The minimap and guidance arrow (all towns)

**Quest items inside buildings were pinned at the map origin.** A pickup with `building` set carries *interior-local* tile coords (typically 0–15), not world coords. `HubWorld`'s objective memo used them verbatim, so with e.g. *The Strange Guest* active the three dots landed in the map's top-left corner instead of on The Wanderer's Rest, and the edge arrow pointed the player at the card shop. **198 pickups across the 13 towns are affected — 95 in Ravenwatch alone.** `HubTownCanvas` already filters on this field when rendering; the minimap never did.

Fixed by adding `pickupWorldTile()` next to the existing `buildingWorldTile()` in `npcLocator.ts` and using it for pins — dropping the pin rather than guessing when a building can't be placed. NPC pins get the same treatment, since `resolveNpcPlace` deliberately falls back to interior-local coords (fine for the Town Directory's text, not for a marker).

**The edge arrow pointed one way and sat somewhere else.** It projected onto a *square* unit box, then applied the result as percentages of a non-square element. The glyph's rotation was the true bearing but its position wasn't — exact only along the axes and diagonals, and badly off in between. On a 390×700 phone viewport a target at a true 30° bearing rendered at a visual 46°. It now projects against the viewport's real pixel dimensions.

**The arrow also sat ~16px too high.** `.nm-map` has `padding: 16px 0 0`, which the game viewport inside it does not share, so percentage positioning against the containing block missed by a constant 16px — a bigger share of a 600px phone viewport than a desktop one. Now positioned in px against the scroll viewport's own box.

**Pixi's renderer could go stale.** `ResizePlugin` only re-measures `resizeTo` on the window's `resize` event (confirmed in the installed source), so a container resizing on its own — a toolbar wrapping to a second line — leaves `app.screen` stale while the minimap reads live `clientWidth`/`clientHeight`. `usePixiApp` now observes the element.

## 2. Ravenwatch quest text vs item placement

The town has been rebuilt several times and items were left behind. The biggest cluster: **eleven items whose quests describe them as being at the pond** — "around the water's edge and the reeds", "hidden under the pond", "the pond bank" — **were sat in Gregor's Farm crop fields**, roughly 40 tiles from the nearest water. All eleven move to free tiles on the pond bank, matching the pond quests that were already correct.

Also moved:
- `moonleaf-herb`, "in the shade near the scholars' hall", from the extreme south-west corner into the Scholar's Quarter
- `intel-note-3`, "near the casino area", from the barracks fringe into Casino Row
- `pendant-2`, "near the church", from seven tiles south among the graves to directly below the church
- Seven of Zev's items from The Trophy Hall to The Games Hall — two different buildings, and every one of those quests says "in the games hall"
- `guild-doc-3`, one of three "compromised offices in the guild hall", from The Junk Trader's Den to the guild hall
- The three contaminated trophies, "removed from display", from the barracks to Orin's Trophy Hall

Dialogue corrected where there was nothing to move: `aldous-keepsake` placed the locket "near the well in the courtyard" — the locket is correctly beside the only stone well in town, but that well is on the lane west of the courtyard (the courtyard has a fountain). Three delivery quests also gave the wrong compass bearing to their target.

Every destination tile was checked free of water, building footprints, decor, interactables and other pickups.

### Deliberately left alone

- **Market-lane items.** Around eight sit past the Market Quarter area rect (which stops at tx 20), which looks wrong but isn't — the lane street runs continuously from tx 4 to tx 61, so "along the market lane" is accurate. The *area rect* is what's narrow; widening it would change the area badge across a large slice of the map.
- **All 95 interior placements** match their dialogue. They only *looked* wrong because of the pin bug above.
- **The courtyard fountain is real** (a `fountain` bundle at 36,25), so the quests referencing it are correct.

## Tests

No coverage existed for any of this. Added `hubMinimapMath.ts` with the extracted pure maths and tests asserting the arrow stays on the ray to its objective at both phone and desktop aspect ratios (this fails against the old projection), `pickupWorldTile` coverage in `npcLocator.test.ts`, and `questPickupPlacement.test.ts` guarding Ravenwatch items against being off-map, on water, buried under a building, or naming an interior they're not in — plus delivery targets resolving to neither an NPC nor an animal, which is how the stray cat's step lost its pin.

`npm run build` clean; `npm run test` 2129 passed, 0 failures (the trailing `browserType.launch` error is the usual Storybook/Playwright noise).

Scope note: the code fixes benefit every town, but the data audit was limited to Ravenwatch as agreed. The other 12 towns have 103 interior pickups whose text has not been reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_