### PR TITLE
Add two new Ravenwatch quest lines, unblock the Dealer chain

### DIFF
--- a/web/src/data/hub/questPickupPlacement.test.ts
+++ b/web/src/data/hub/questPickupPlacement.test.ts
@@ -96,3 +96,78 @@ describe('Ravenwatch quest targets', () => {
     expect(stranded).toEqual([])
   })
 })
+
+// Reference integrity for hand-authored quests. A typo in any of these ids does
+// not crash anything — the quest just quietly never offers, never advances, or
+// never reveals its item — so it is exactly the kind of mistake that survives
+// into a build. `the-false-grave` is unfinished content (blank giver/receiver,
+// blank completion dialogue) and is excluded rather than fixed here.
+describe('Ravenwatch quest references', () => {
+  const npcIds = new Set(loc.HUB_NPCS.map(n => n.id))
+  const questIds = new Set(quests.HUB_QUEST_DEFS.map(q => q.id))
+  const pickupIds = new Set(pickups.map(p => p.id))
+  const authored = quests.HUB_QUEST_DEFS.filter(q => q.id !== 'the-false-grave')
+
+  it('names a real NPC or animal as giver and receiver', () => {
+    // Animals give and receive quests too (Rover, Pip, the stray cat), so both
+    // rosters count — same resolution the delivery-target check uses.
+    const givers = new Set([...npcIds, ...loc.HUB_ANIMALS.map(a => a.id)])
+    const bad = authored.flatMap(q => [
+      ...(givers.has(q.giverNpcId) ? [] : [`${q.id}: giver "${q.giverNpcId}"`]),
+      ...(givers.has(q.receiverNpcId) ? [] : [`${q.id}: receiver "${q.receiverNpcId}"`]),
+    ])
+    expect(bad).toEqual([])
+  })
+
+  it('lists only pickup ids that exist', () => {
+    const bad = authored.flatMap(q =>
+      (q.steps ?? []).flatMap(s => (s.pickupIds ?? [])
+        .filter(id => !pickupIds.has(id))
+        .map(id => `${q.id}/${s.key}: "${id}"`)))
+    expect(bad).toEqual([])
+  })
+
+  it('gates on quests that exist', () => {
+    // checkPrerequisite treats an unknown token as satisfied, so a typo'd
+    // quest id silently ungates the quest instead of failing loudly.
+    const bad = authored.flatMap(q => (q.prerequisite ?? '').split('|')
+      .map(t => t.trim())
+      .filter(t => t.startsWith('quest:') && !questIds.has(t.slice(6)))
+      .map(t => `${q.id}: "${t}"`))
+    expect(bad).toEqual([])
+  })
+
+  it('chains steps and pickups to pickup ids that exist', () => {
+    // A chain pointing at a missing id leaves the chained item permanently
+    // hidden, making the quest impossible to finish.
+    const badSteps = authored.flatMap(q => (q.steps ?? [])
+      .filter(s => s.chain && !pickupIds.has(s.chain))
+      .map(s => `${q.id}/${s.key} step chain: "${s.chain}"`))
+    const badPickups = pickups
+      .filter(p => p.chain && !pickupIds.has(p.chain))
+      .map(p => `${p.id} pickup chain: "${p.chain}"`)
+    expect([...badSteps, ...badPickups]).toEqual([])
+  })
+
+  it('gives every step of a multi-step quest its own progress key', () => {
+    // Progress is stored per step key, so a duplicate key makes two steps share
+    // a counter and complete together.
+    const bad = authored
+      .filter(q => new Set((q.steps ?? []).map(s => s.key)).size !== (q.steps ?? []).length)
+      .map(q => q.id)
+    expect(bad).toEqual([])
+  })
+
+  it('covers every step key when activeDialogue is keyed per step', () => {
+    // getActiveDialogue falls back to the first entry for an unlisted key, so a
+    // missing key shows the wrong hint rather than erroring.
+    const bad = authored.flatMap(q => {
+      if (typeof q.activeDialogue !== 'object' || q.activeDialogue === null) return []
+      const keyed = q.activeDialogue as Record<string, string | undefined>
+      return (q.steps ?? [])
+        .filter(s => !keyed[s.key])
+        .map(s => `${q.id}: no activeDialogue for step "${s.key}"`)
+    })
+    expect(bad).toEqual([])
+  })
+})

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -1366,7 +1366,7 @@
       "type": "lost-items",
       "giverNpcId": "dealer",
       "receiverNpcId": "dealer",
-      "prerequisite": "quest:dealer-lucky-charm",
+      "prerequisite": "quest:the-password-part-4",
       "offerDialogue": "Three decks of cards were swapped out on my tables last night — I only noticed because the backs feel different. Marked cards, the kind cheats use to read from a distance. I pulled them from circulation but someone took them back. Get them before anyone runs a game with them.",
       "activeDialogue": "Marked decks — slightly thicker than normal, with tiny notches on the corners. They were taken from where I left them behind the counter.",
       "completeDialogue": "These are the ones. Look at the notch pattern — it is consistent across all three decks, a code. This was not one cheat doing it for themselves. This was organised. Someone was running a scam operation out of my tables.",

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -3848,6 +3848,152 @@
           "count": 1
         }
       }
+    },
+    {
+      "id": "maeve-unwritten-chapter",
+      "title": "The Unwritten Chapter",
+      "type": "chain",
+      "giverNpcId": "chronicler",
+      "receiverNpcId": "chronicler",
+      "prerequisite": "quest:thorin-the-last-watch",
+      "offerDialogue": "The Chronicle has a hole in it, Commander — the whole Hearthstone affair, and not one line set down. I will not write it from rumour. Bring me the statements written on the day, the word of two who stood in the middle of it, and proper archive ink to set it down with.",
+      "activeDialogue": {
+        "accounts": "Three statements, written while it was still happening. One was left at the barracks gate, one along the market lane, and one down at the fisherman's dock. All three, please — two is an argument, three is a record.",
+        "garrison": "Now the garrison's account. Captain Thorin is in the north barracks. Ask him what he saw, in his own words, and do not let him summarise.",
+        "hearth": "And the town's account. Innkeeper Rosie kept the Wanderer's Rest open through the worst of it — she will have seen more than any guard.",
+        "inkwell": "One thing more. Archive ink, from the sealed inkwell Naia keeps in the Scholar's Hall. Chronicle ink outlasts the paper; ordinary ink is gone in a generation.",
+        "chapter": "That is everything. Bring it to me and I shall write the chapter tonight."
+      },
+      "completeDialogue": "Statements, testimony, and ink that will outlast us both. This is how a thing is remembered properly, Commander — not as a story that grows in the telling, but as a record. The chapter is as much yours as mine.",
+      "steps": [
+        {
+          "key": "accounts",
+          "type": "collect",
+          "pickupIds": [
+            "maeve-account-barracks",
+            "maeve-account-market",
+            "maeve-account-dock"
+          ],
+          "required": 3,
+          "itemName": "Witness Account",
+          "itemIcon": "📝"
+        },
+        {
+          "key": "garrison",
+          "type": "report",
+          "targetNpcId": "guard-captain-thorin",
+          "required": 1
+        },
+        {
+          "key": "hearth",
+          "type": "report",
+          "targetNpcId": "innkeeper-rosie",
+          "required": 1
+        },
+        {
+          "key": "inkwell",
+          "type": "collect",
+          "pickupIds": [
+            "maeve-chronicle-inkwell"
+          ],
+          "required": 1,
+          "chain": "maeve-account-dock",
+          "itemName": "Archive Inkwell",
+          "itemIcon": "🖋️"
+        },
+        {
+          "key": "chapter",
+          "type": "deliver",
+          "targetNpcId": "chronicler",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 120,
+        "collectible": {
+          "id": "unwritten-chapter",
+          "name": "The Unwritten Chapter",
+          "icon": "📖",
+          "desc": "The Fracture Chronicle's account of the Hearthstone, set down from primary sources."
+        },
+        "friendship": {
+          "chronicler": 20,
+          "guard-captain-thorin": 10,
+          "innkeeper-rosie": 10
+        }
+      }
+    },
+    {
+      "id": "trader-provenance",
+      "title": "The Provenance",
+      "type": "chain",
+      "giverNpcId": "trader",
+      "receiverNpcId": "trader",
+      "offerDialogue": "Right. Got something in the pile I can't put a price on, and I hate that more than losing money. Little marked thing, came out of a Fracture haul. The mark on the base isn't any maker I know — and I know all of them. Take it round the clever folk and find out what I'm sitting on.",
+      "activeDialogue": {
+        "curio": "It's in here somewhere, in amongst the rest of it. Small, dark, a mark stamped on the base. Have a rummage — you'll know it when you see it.",
+        "ink": "Gildwyn first. If that mark was stamped or printed, he'll know the hand that cut it. Card emporium, up in the market quarter.",
+        "chart": "Now Bram. Cartography room, north-east corner of the scholars' quarter. If that mark belongs to a place rather than a person, he'll put a finger on it.",
+        "fragments": "Bram says there were three pieces to a set like that. Two still out there — one past the church among the graves, one up in the courtyard. Fetch them both.",
+        "return": "That's the set. Bring it back to the den and we'll settle up proper."
+      },
+      "completeDialogue": "Well now. Three pieces, one mark, and a maker nobody's laid eyes on since before the Fracture. That isn't junk, friend, that's a find — and you did every step of the legwork, so here's your cut. Pleasure doing business.",
+      "steps": [
+        {
+          "key": "curio",
+          "type": "collect",
+          "pickupIds": [
+            "trader-marked-curio"
+          ],
+          "required": 1,
+          "itemName": "Marked Curio",
+          "itemIcon": "🔎"
+        },
+        {
+          "key": "ink",
+          "type": "report",
+          "targetNpcId": "gildwyn",
+          "required": 1
+        },
+        {
+          "key": "chart",
+          "type": "report",
+          "targetNpcId": "cartographer-bram",
+          "required": 1
+        },
+        {
+          "key": "fragments",
+          "type": "collect",
+          "pickupIds": [
+            "trader-curio-fragment-1",
+            "trader-curio-fragment-2"
+          ],
+          "required": 2,
+          "chain": "trader-marked-curio",
+          "itemName": "Curio Fragment",
+          "itemIcon": "🧩"
+        },
+        {
+          "key": "return",
+          "type": "deliver",
+          "targetNpcId": "trader",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 90,
+        "collectible": {
+          "id": "fracture-curio",
+          "name": "The Marked Curio",
+          "icon": "🔎",
+          "desc": "Three pieces of a pre-Fracture set, reunited. The maker's mark remains unidentified."
+        },
+        "friendship": {
+          "trader": 20,
+          "gildwyn": 10,
+          "cartographer-bram": 10
+        }
+      }
     }
   ],
   "pickupItems": [
@@ -5640,6 +5786,61 @@
           "tileId": "candlestickLitBottom"
         }
       ]
+    },
+    {
+      "id": "maeve-account-barracks",
+      "tx": 60,
+      "ty": 28,
+      "tileId": "note",
+      "questId": "maeve-unwritten-chapter"
+    },
+    {
+      "id": "maeve-account-market",
+      "tx": 12,
+      "ty": 23,
+      "tileId": "note",
+      "questId": "maeve-unwritten-chapter"
+    },
+    {
+      "id": "maeve-account-dock",
+      "tx": 46,
+      "ty": 47,
+      "tileId": "note",
+      "questId": "maeve-unwritten-chapter"
+    },
+    {
+      "id": "maeve-chronicle-inkwell",
+      "tx": 7,
+      "ty": 3,
+      "tileId": "potions",
+      "questId": "maeve-unwritten-chapter",
+      "building": "scholars-hall",
+      "chain": "maeve-account-dock",
+      "glow": true
+    },
+    {
+      "id": "trader-marked-curio",
+      "tx": 6,
+      "ty": 2,
+      "tileId": "pendant",
+      "questId": "trader-provenance",
+      "building": "trader-den"
+    },
+    {
+      "id": "trader-curio-fragment-1",
+      "tx": 21,
+      "ty": 48,
+      "tileId": "pendant",
+      "questId": "trader-provenance",
+      "chain": "trader-marked-curio"
+    },
+    {
+      "id": "trader-curio-fragment-2",
+      "tx": 35,
+      "ty": 22,
+      "tileId": "pendant",
+      "questId": "trader-provenance",
+      "chain": "trader-marked-curio"
     }
   ],
   "friendshipDialogue": {


### PR DESCRIPTION
Every existing Ravenwatch quest has been completed, leaving nothing to play and no way to exercise the quest flow by hand. This adds two new lines, and — as a side effect of the tests written alongside them — unblocks four already-written quests that were unreachable.

## Two new quest lines

Each runs five steps across several NPCs and several locations, rather than fetching one item from one place.

**"The Unwritten Chapter"** — Chronicler Maeve. Gather three witness statements from the barracks gate, the market lane and the fisherman's dock; take spoken accounts from Captain Thorin in the north barracks and Innkeeper Rosie at the inn; then collect archive ink from the Scholar's Hall, which only appears once the statements are in hand. *3 outdoor districts + 3 building interiors + 3 NPCs besides the giver.*

**"The Provenance"** — The Junk Trader. Find the marked curio in the den, have Gildwyn read the mark and Bram place it, then recover the two matching fragments Bram points you at, in the graveyard and the courtyard. *3 building interiors + 2 outdoor spots + 3 NPCs besides the giver.*

Both use per-step `activeDialogue` so the hint tracks progress, and `chain` on the later pickups so the sequence has to be walked in order rather than short-cut. Maeve and the Junk Trader were picked as givers because both are well-drawn characters who gave no quests at all — the existing load sits on about 20 of Ravenwatch's 60+ NPCs.

Every hint names a landmark that is actually where it says it is; each was cross-checked against `config.json`, since stale hints were exactly what the previous PR cleaned up. All seven new pickup tiles were verified free of water, building footprints, decor, interactables, NPCs and other pickups.

Pure data — no engine changes.

Deliberately avoided as givers: The Wanderer is gated behind `minLevel: 2` on the town hall and may not be present, and Minister Fallow is entangled with `the-false-grave`, which is unfinished content (blank giver, receiver and completion dialogue) sitting behind the church's key lock.

## Vince the Dealer's chain was unreachable

`dealer-marked-deck` gated on `quest:dealer-lucky-charm` — **a quest that does not exist in any of the 13 towns**, presumably a planned opener that was never written. `checkPrerequisite` resolves a `quest:` token by looking up its saved state, and an unknown id is never `completed`, so the gate could never open.

That made four written quests permanently unreachable: `dealer-marked-deck` heads the chain through `dealer-echo-bookie` → `dealer-fracture-intel` → `dealer-echo-final-bet`, each gated on the one before it. Re-pointed at `quest:the-password-part-4`, which is what every other Ravenwatch chain head uses (Zev, Orin, Gildwyn, Syla and Vex all open that way).

Isolated in its own commit so it can be reverted independently of the new content.

## Tests

A typo in a quest's giver, receiver, pickup id, prerequisite or chain doesn't crash anything — the quest quietly never offers, never advances, or never reveals its item. That is precisely how the Dealer's chain sat broken. New checks cover:

- givers and receivers resolve (NPCs **or** animals — Rover, Pip and the stray cat give quests too)
- step `pickupIds` exist
- `quest:` prerequisites name a real quest
- step and pickup `chain` ids exist
- step keys are unique within a quest
- a per-step `activeDialogue` covers every step

The existing placement sweep from #2108 already validates the seven new pickups for map bounds, water, building footprints, interior ids and the wall ring.

`npm run build` clean; `npm run test` 2135 passed, 0 failures.

## Not verified

These quests have **not** been played end to end in a browser — the reference integrity is unit-tested, but the live flow (offer → collect → report → chained reveal → turn-in) is not something unit tests can prove. Worth a run-through before relying on them. The same caveat still stands for #2108's arrow fixes, which also shipped without a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_