### PR TITLE
Finish The False Grave so it can actually be played

### DIFF
--- a/web/src/data/hub/questPickupPlacement.test.ts
+++ b/web/src/data/hub/questPickupPlacement.test.ts
@@ -3,6 +3,7 @@ import { createHubLocationData, createHubQuestData } from './loader'
 import type { RawConfig } from './config'
 import type { RawQuestConfig } from './questDefs'
 import { buildingWorldTile, pickupWorldTile } from '../../game/hub/npcLocator'
+import { getHubWorldData } from './hubWorldFactory'
 import ravenwatchConfig from './ravenwatch/config.json'
 import ravenwatchQuests from './ravenwatch/questDefs.json'
 
@@ -100,21 +101,23 @@ describe('Ravenwatch quest targets', () => {
 // Reference integrity for hand-authored quests. A typo in any of these ids does
 // not crash anything — the quest just quietly never offers, never advances, or
 // never reveals its item — so it is exactly the kind of mistake that survives
-// into a build. `the-false-grave` is unfinished content (blank giver/receiver,
-// blank completion dialogue) and is excluded rather than fixed here.
+// into a build.
 describe('Ravenwatch quest references', () => {
   const npcIds = new Set(loc.HUB_NPCS.map(n => n.id))
   const questIds = new Set(quests.HUB_QUEST_DEFS.map(q => q.id))
   const pickupIds = new Set(pickups.map(p => p.id))
-  const authored = quests.HUB_QUEST_DEFS.filter(q => q.id !== 'the-false-grave')
+  const interactableIds = new Set(loc.HUB_INTERACTABLES.map(i => i.id))
+  const authored = quests.HUB_QUEST_DEFS
 
-  it('names a real NPC or animal as giver and receiver', () => {
-    // Animals give and receive quests too (Rover, Pip, the stray cat), so both
-    // rosters count — same resolution the delivery-target check uses.
-    const givers = new Set([...npcIds, ...loc.HUB_ANIMALS.map(a => a.id)])
+  it('names a real NPC, animal or interactable as giver and receiver', () => {
+    // Animals give and receive quests too (Rover, Pip, the stray cat), and a
+    // world object can be the giver (the collapsed gravestone offers The False
+    // Grave) — so all three rosters count.
+    const receivers = new Set([...npcIds, ...loc.HUB_ANIMALS.map(a => a.id)])
+    const givers = new Set([...receivers, ...interactableIds])
     const bad = authored.flatMap(q => [
       ...(givers.has(q.giverNpcId) ? [] : [`${q.id}: giver "${q.giverNpcId}"`]),
-      ...(givers.has(q.receiverNpcId) ? [] : [`${q.id}: receiver "${q.receiverNpcId}"`]),
+      ...(receivers.has(q.receiverNpcId) ? [] : [`${q.id}: receiver "${q.receiverNpcId}"`]),
     ])
     expect(bad).toEqual([])
   })
@@ -170,4 +173,31 @@ describe('Ravenwatch quest references', () => {
     })
     expect(bad).toEqual([])
   })
+})
+
+// An interactable can offer a quest (a scarecrow, a collapsed gravestone). Its
+// `quest` reaction calls tryOfferQuest(def.id, ...), which matches on
+// `giverNpcId === def.id` — so the quest's giver must be the *interactable's own
+// id*, not an NPC and not blank. Get it wrong and there is no error anywhere: the
+// reaction chain calls next(), the world object does whatever else it was going
+// to do, and the quest is simply unofferable forever. Swept across every town.
+const { locationRegistry } = await getHubWorldData()
+
+describe('interactable-given quests', () => {
+  for (const [townKey, { locationData, locationQuests }] of Object.entries(locationRegistry)) {
+    const byId = new Map(locationQuests.HUB_QUEST_DEFS.map(q => [q.id, q]))
+    for (const interactable of locationData.HUB_INTERACTABLES) {
+      for (const reaction of interactable.reactions) {
+        if (reaction.type !== 'quest') continue
+        it(`${townKey}/${interactable.id}: quest "${reaction.questId}" names it as the giver`, () => {
+          const quest = byId.get(reaction.questId)
+          expect(quest, `no quest "${reaction.questId}" in ${townKey}`).toBeTruthy()
+          expect(
+            quest!.giverNpcId,
+            `${reaction.questId}.giverNpcId must be "${interactable.id}" for the offer to resolve`,
+          ).toBe(interactable.id)
+        })
+      }
+    }
+  }
 })

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -10295,7 +10295,8 @@
         "alric-heartstone-analysis",
         "orin-champions-stand",
         "aldous-the-hearthstone",
-        "thorin-the-last-watch"
+        "thorin-the-last-watch",
+        "the-false-grave"
       ],
       "schedule": [
         {
@@ -12184,6 +12185,7 @@
       "id": "npc_1781726431819",
       "name": "Minister Fallow",
       "sprite": "necromancer",
+      "questReceive": "the-false-grave",
       "tx": 6,
       "ty": 1,
       "dialogue": [
@@ -12756,17 +12758,10 @@
       ]
     },
     {
-      "id": "interactable-1782663378757",
+      "id": "ravenwatch-false-grave",
       "tx": 28,
       "ty": 53,
       "reactions": [
-        {
-          "type": "move",
-          "to": {
-            "tx": -1,
-            "ty": -1
-          }
-        },
         {
           "type": "dialogue",
           "text": "The gravestone falls into a hole below."
@@ -12774,6 +12769,13 @@
         {
           "type": "quest",
           "questId": "the-false-grave"
+        },
+        {
+          "type": "move",
+          "to": {
+            "tx": -1,
+            "ty": -1
+          }
         }
       ],
       "decor": [

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -3775,14 +3775,14 @@
       "id": "the-false-grave",
       "title": "The False Grave",
       "type": "chain",
-      "giverNpcId": "",
-      "receiverNpcId": "",
+      "giverNpcId": "ravenwatch-false-grave",
+      "receiverNpcId": "npc_1781726431819",
       "offerDialogue": "You look into the void exposed by the collapsed grave stone and see a cavern with multiple visible tunnels heading in opposite directions. Fetch the Elder, they might be able to help.",
       "activeDialogue": {
         "step-1": "The Elder should be told about the cavern under the grave.",
-        "step-2": ""
+        "step-2": "The Elder went quiet at the word tunnels, and named only one man — Minister Fallow, who keeps the church above the graveyard. Take it to him. The church door is locked; the key sits in the town hall office, if you have not already lifted it."
       },
-      "completeDialogue": "",
+      "completeDialogue": "Tunnels. Under my graves. I have kept this ground four hundred years, traveller, and I have never once been under it.\n\nThat is not a burial cavern. Someone dug up into the graveyard from below and set a stone over the hole to hide the work — a false grave, with no one in it. Whoever came up through it walked out into my town.\n\nSay nothing yet. I will sit with the stone tonight and see who comes back for it. Take this for your trouble — it was in the hole, and it is older than the church.",
       "steps": [
         {
           "key": "step-1",
@@ -3793,11 +3793,23 @@
         {
           "key": "step-2",
           "type": "deliver",
-          "required": 2,
+          "required": 1,
           "targetNpcId": "npc_1781726431819"
         }
       ],
-      "reward": {}
+      "reward": {
+        "crystals": 60,
+        "collectible": {
+          "id": "false-grave-marker",
+          "name": "Nameless Grave Marker",
+          "icon": "⚰️",
+          "desc": "The stone that capped the false grave. No name was ever cut into it — Minister Fallow says that was the point."
+        },
+        "friendship": {
+          "npc_1781726431819": 20,
+          "elder": 10
+        }
+      }
     },
     {
       "id": "elders-blessing",


### PR DESCRIPTION
`the-false-grave` was unfinished content excluded from the integrity tests in #2109. Looking properly at it changed the picture — and corrected something I got wrong there.

**It isn't giverless content that could never trigger.** It's offered by a world object: the gravestone at (28,53) in the graveyard, whose `quest` reaction fires when you tap it. The story, the steps and the world hook were all already placed. What was missing was small, so this finishes it rather than deleting it.

## Why it never worked

The interactable's `quest` reaction calls `tryOfferQuest(def.id, …)`, which resolves the giver by matching `giverNpcId` against **the interactable's own id**. The quest's `giverNpcId` was blank, so nothing matched, `tryOfferQuest` returned false, and the reaction chain simply called `next()` — the stone fell, the line printed, and no offer ever appeared. Thornwoodcamp's `shiny-stones` is the working precedent: its giver is literally `interactable-1781887233427`, the id of the scarecrow that offers it.

**Existing saves needed more than that fix.** The reactions ran `move` → `dialogue` → `quest`, and `move` persists to localStorage before the offer fails. The target is `(-1,-1)` — off-map. So on any save that had already tapped the stone, it was gone permanently and fixing the giver alone wouldn't bring it back. The interactable is renamed to `ravenwatch-false-grave` (moves are keyed by town + id, so a new id means no stored move applies and the stone reappears at its authored tile), and the reactions reordered to `dialogue` → `quest` → `move` so it only vanishes once the offer has been made. Re-offering isn't a risk — `tryOfferQuest` only offers a quest still marked `available`.

## What was filled in

| Field | Was | Now |
|---|---|---|
| `giverNpcId` | `""` | `ravenwatch-false-grave` |
| `receiverNpcId` | `""` | Minister Fallow, the final deliver target |
| `steps[1].required` | `2` | `1` — the only non-1 deliver step in Ravenwatch against 63 that use 1; it meant tapping Fallow twice with an empty hint in between |
| `activeDialogue["step-2"]` | `""` | written |
| `completeDialogue` | `""` | written |
| `reward` | `{}` | crystals + a keepsake collectible + friendship |

The payoff is Fallow's — he's the ghost minister who has kept that ground four hundred years and has never been under it. He had one line of dialogue ("Hello!"), so the quest text carries it.

Fallow gets a `questReceive` so the church shows a quest indicator (`HubTownCanvas` skips the marker entirely for NPCs without one), and the quest is appended to the elder's existing list since he's the step-1 target. The step-2 hint names the town hall office, because the church door is locked behind a key and `checkPrerequisite` has no item-based condition to gate on.

## Tests

New check, swept across all 13 towns: **every interactable `quest` reaction must name a quest whose `giverNpcId` equals that interactable's id.** This bug class is completely invisible at runtime — no error, no warning, the quest just doesn't exist — and it cost this quest its entire existence. Written before the fix; it failed on Ravenwatch and passed on Thornwoodcamp, which is exactly the signal wanted.

Also drops the `the-false-grave` exclusion from the reference-integrity checks now that its ids are real, and widens the giver check to accept an interactable id (it previously allowed only NPCs and animals).

`npm run build` clean; `npm run test` 2137 passed, 0 failures.

## Notes

- **Not played in a browser.** Same caveat as #2108 and #2109 — the references are unit-tested but the live flow isn't. It's four taps to check: gravestone at (28,53) → Elder → church key from the town hall office if needed → Fallow.
- **Deliver steps aren't order-enforced.** `pendingDelivery` matches any incomplete deliver step for the tapped NPC, so a player holding the church key could reach Fallow before the Elder and finish the steps backwards. That's pre-existing engine behaviour affecting many quests, not something this PR introduces — changing it would alter every town's quests, so I've left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_