### PR TITLE
NPC routing respects building open/closed hours (#2111, phase 1)

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1351,10 +1351,31 @@ export function HubTownCanvas({
     const interiorQuestIndicators     = new Map<string, PIXI.Text>()
     const interiorIndicatorBaseY      = new Map<string, number>()
 
+    // Building-hours-aware resolution of a schedule's location (#2111): if it
+    // targets a closed interior, resolve to standing just outside that
+    // building's door instead — an NPC should never be placed or walked into a
+    // building the player themselves would be bounced from as closed. Used both
+    // for a named NPC's initial on-load placement and every later schedule
+    // change, so neither path can spawn or route one into a closed building.
+    // `function` (not a const arrow) so it's hoisted — the initial-placement
+    // loop below calls it before this line runs.
+    function effectiveScheduleLocation(
+      loc: NpcScheduleEntry['location'] | null,
+    ): NpcScheduleEntry['location'] | null {
+      if (loc?.type !== 'interior') return loc
+      const interior = HUB_INTERIORS[loc.buildingId]
+      if (!interior || isBuildingOpen(interior, gameHourRef.current)) return loc
+      const door = HUB_DOORS.find(d => d.buildingId === loc.buildingId)
+      return door ? { type: 'exterior', tx: door.tx, ty: door.ty } : null
+    }
+
     const npcBubbleTargets: { npc: HubNpc; cx: number; cy: number }[] = []
     for (const npc of EXTERIOR_NPCS) {
-      // Start NPC at their scheduled position so they appear in the right place on load
-      const initLoc = npc.schedule ? getNpcLocation(npc, gameHourRef.current) : null
+      // Start NPC at their scheduled position so they appear in the right place on
+      // load — routed through effectiveScheduleLocation so a schedule that would
+      // otherwise start them inside a currently-closed building instead starts
+      // them just outside its door.
+      const initLoc = npc.schedule ? effectiveScheduleLocation(getNpcLocation(npc, gameHourRef.current)) : null
       const startTx = initLoc?.type === 'exterior' ? initLoc.tx : npc.tx
       const startTy = initLoc?.type === 'exterior' ? initLoc.ty : npc.ty
       const cx = startTx * T + T / 2
@@ -1537,6 +1558,11 @@ export function HubTownCanvas({
       scaredBubble:       PIXI.Container | null
       scaredBubbleTimer:  number
       scaredBubbleCooldown: number
+      // Brief reaction shown when a wander target's building closes mid-walk
+      // (#2111) — kept separate from scaredBubble so the two can never clobber
+      // each other if both conditions land on the same NPC at once.
+      doorReactionBubble: PIXI.Container | null
+      doorReactionTimer:  number
     }
 
     const unitNpcs: UnitNpcState[] = []
@@ -1582,6 +1608,8 @@ export function HubTownCanvas({
           scaredBubble:         null,
           scaredBubbleTimer:    0,
           scaredBubbleCooldown: 0,
+          doorReactionBubble:   null,
+          doorReactionTimer:    0,
         }
         unitNpcs.push(state)
 
@@ -1595,6 +1623,19 @@ export function HubTownCanvas({
     const doorTileSet = new Set(HUB_DOORS.map(d => `${d.tx},${d.ty}`))
     // Spawn tiles that aren't doors — used for respawning so NPCs don't immediately despawn
     const nonDoorSpawnTiles = NPC_SPAWN_TILES.filter(([tx, ty]) => !doorTileSet.has(`${tx},${ty}`))
+    // Door tile → the building it belongs to, for the open/closed check below.
+    const doorBuildingByTile = new Map(HUB_DOORS.map(d => [`${d.tx},${d.ty}`, d.buildingId]))
+    // Whether the door at (tx, ty) currently leads somewhere an ambient NPC can
+    // enter (#2111). Tiles that aren't doors, or whose building has no interior
+    // data, are treated as open — this only ever *restricts* routing for
+    // buildings we can actually check.
+    function isDoorOpen(tx: number, ty: number): boolean {
+      const buildingId = doorBuildingByTile.get(`${tx},${ty}`)
+      if (!buildingId) return true
+      const interior = HUB_INTERIORS[buildingId]
+      if (!interior) return true
+      return isBuildingOpen(interior, gameHourRef.current)
+    }
     const TARGET_NPC_COUNT = 12
     let respawnTimer = 2000
 
@@ -1611,12 +1652,32 @@ export function HubTownCanvas({
         else if (targetX > npc.sprite.x + 1) npc.sprite.scale.x = Math.abs(npc.sprite.scale.x)
         await tweenLinear(npc.sprite, targetX, targetY, duration)
         npc.currentTile = [tx, ty]
-        // Despawn NPCs that reach a building door — they "go inside"
+        // Despawn NPCs that reach a building door — they "go inside" — but only
+        // if it's actually open. wanderNpc never *chooses* a closed door as a
+        // target (below), so arriving at a closed one here means the building
+        // shut while this NPC was already walking to it (#2111 point 2): react
+        // instead of vanishing into it, then pick a new destination.
         if (doorTileSet.has(`${tx},${ty}`)) {
+          if (!isDoorOpen(tx, ty)) {
+            reactToClosedDoor(npc)
+            npc.walkQueue = []
+            // wanderNpc only kicks off processNpcWalkQueue when !isWalking — this
+            // function never clears the flag on its own success path (only the
+            // empty-queue and catch branches do), so it must be reset here or
+            // wanderNpc's chosen path would sit in walkQueue forever unprocessed.
+            npc.isWalking = false
+            wanderNpc(npc)
+            return
+          }
           if (npc.scaredBubble) {
             bubbleLayer.removeChild(npc.scaredBubble)
             npc.scaredBubble = null
             npc.scaredBubbleTimer = 0
+          }
+          if (npc.doorReactionBubble) {
+            bubbleLayer.removeChild(npc.doorReactionBubble)
+            npc.doorReactionBubble = null
+            npc.doorReactionTimer = 0
           }
           npc.sprite.parent?.removeChild(npc.sprite)
           const idx = unitNpcs.indexOf(npc)
@@ -1727,14 +1788,31 @@ export function HubTownCanvas({
       }
     }
 
+    // Brief "no entry" reaction shown when a wander target's building closes
+    // while the NPC is already walking to it (#2111). Self-contained rather than
+    // reusing the ghost-encounter scaredBubble machinery, which has its own
+    // proximity-driven cooldown semantics this shouldn't interact with.
+    function reactToClosedDoor(npc: UnitNpcState): void {
+      if (npc.doorReactionBubble) return  // already reacting
+      const bubble = createSpeechBubble('🚫', npc.sprite.x, npc.sprite.y - SPRITE_SIZE)
+      bubble.zIndex = npc.sprite.zIndex + 1
+      bubbleLayer.addChild(bubble)
+      npc.doorReactionBubble = bubble
+      npc.doorReactionTimer  = 1200
+    }
+
     function wanderNpc(npc: UnitNpcState) {
       const effectivePathSet = exteriorWalkable()
       // Route around other NPCs.
       const occupied = npcOccupiedTiles(npc)
       for (const k of occupied) effectivePathSet.delete(k)
       const ghosts = npc.isGhost ? [] : unitNpcs.filter(n => n.isGhost)
+      // Never pick a closed building's door as a destination (#2111 point 1) —
+      // combined with the isDoorOpen re-check in processNpcWalkQueue, this means
+      // a wander only ever ends in "went inside" when that building was open both
+      // when chosen and on arrival.
       const allOptions = NPC_SPAWN_TILES.filter(
-        ([tx, ty]) => tx !== npc.currentTile[0] || ty !== npc.currentTile[1],
+        ([tx, ty]) => (tx !== npc.currentTile[0] || ty !== npc.currentTile[1]) && isDoorOpen(tx, ty),
       ) as [number, number][]
       if (allOptions.length === 0) return
       // Non-ghost NPCs avoid tiles within 5 tiles of any ghost
@@ -1790,6 +1868,8 @@ export function HubTownCanvas({
           scaredBubble:         null,
           scaredBubbleTimer:    0,
           scaredBubbleCooldown: 0,
+          doorReactionBubble:   null,
+          doorReactionTimer:    0,
         }
         unitNpcs.push(state)
         loadAnimFrames(slug, 3).then(frames => { state.animFrames = frames }).catch(() => {})
@@ -2028,6 +2108,11 @@ export function HubTownCanvas({
           bubbleLayer.removeChild(npc.scaredBubble)
           npc.scaredBubble = null
           npc.scaredBubbleTimer = 0
+        }
+        if (npc.doorReactionBubble) {
+          bubbleLayer.removeChild(npc.doorReactionBubble)
+          npc.doorReactionBubble = null
+          npc.doorReactionTimer = 0
         }
       }
 
@@ -3244,8 +3329,13 @@ export function HubTownCanvas({
           if (!npc?.schedule) continue
           const ws = namedNpcWalkStates.get(npcId)
           if (!ws) continue
-          namedNpcActivity.set(npcId, getNpcActivity(npc, gameHourRef.current))
-          const newLoc = getNpcLocation(npc, gameHourRef.current)
+          const scheduledLoc = getNpcLocation(npc, gameHourRef.current)
+          const newLoc = effectiveScheduleLocation(scheduledLoc)
+          // effectiveScheduleLocation only returns a new object when it redirects
+          // away from a closed building — reference equality is enough to tell
+          // whether that happened. Redirected NPCs are waiting outside a locked
+          // door, not performing their scheduled activity, so drop the pose.
+          namedNpcActivity.set(npcId, newLoc === scheduledLoc ? getNpcActivity(npc, gameHourRef.current) : null)
           walkNamedNpc(npc, ws, container, newLoc)
         }
       }
@@ -3428,6 +3518,17 @@ export function HubTownCanvas({
               npc.scaredBubbleTimer    = 0
               npc.scaredBubbleCooldown = 10_000  // don't re-spawn while ghost is still nearby
             }
+          }
+        }
+
+        // Closed-door reaction (#2111) — independent of the ghost-scared bubble
+        // above, decays on its own short timer regardless of ghost proximity.
+        if (npc.doorReactionBubble) {
+          npc.doorReactionTimer -= ticker.deltaMS
+          npc.doorReactionBubble.position.set(npc.sprite.x, npc.sprite.y - SPRITE_SIZE)
+          if (npc.doorReactionTimer <= 0) {
+            bubbleLayer.removeChild(npc.doorReactionBubble)
+            npc.doorReactionBubble = null
           }
         }
       }

--- a/web/src/data/hub/npcScheduleIntegrity.test.ts
+++ b/web/src/data/hub/npcScheduleIntegrity.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { getHubWorldData } from './hubWorldFactory'
+import { isBuildingOpen } from '../../game/hub/hubNpcSchedule'
+import { hourInRange } from '../../game/hub/hubClock'
+
+// Guard for #2111: an NPC's schedule can place them inside a building during
+// hours that building's own `hours` window says it's closed. Nothing enforced
+// this before — HubTownCanvas's schedule-walk just followed the schedule with no
+// regard for the interior's own hours — so a mismatch shipped silently: the
+// Elder's schedule sent them into Ravenwatch's town-hall from 06:00, two hours
+// before its own 08:00 opening. Swept across every town.
+const { locationRegistry } = await getHubWorldData()
+
+describe('NPC schedules respect building hours', () => {
+  for (const [townKey, { locationData }] of Object.entries(locationRegistry)) {
+    for (const npc of locationData.HUB_NPCS) {
+      for (const entry of npc.schedule ?? []) {
+        if (entry.location.type !== 'interior') continue
+        const { buildingId } = entry.location
+        const interior = locationData.HUB_INTERIORS[buildingId]
+        if (!interior) continue  // a missing interior is a different kind of bug, not this one
+
+        it(`${townKey}/${npc.id}: scheduled in "${buildingId}" only while it's open`, () => {
+          const closedHours: number[] = []
+          for (let h = 0; h < 24; h++) {
+            if (hourInRange(h, entry.startHour, entry.endHour) && !isBuildingOpen(interior, h))
+              closedHours.push(h)
+          }
+          expect(
+            closedHours,
+            `${npc.id}'s ${entry.startHour}–${entry.endHour} schedule entry places them in ` +
+            `"${buildingId}", but it's closed at hour(s) ${closedHours.join(', ')}`,
+          ).toEqual([])
+        })
+      }
+    }
+  }
+})

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -8331,8 +8331,8 @@
         }
       ],
       "hours": {
-        "open": 8,
-        "close": 18
+        "open": 6,
+        "close": 20
       },
       "wallTileId": "interiorWallWhite",
       "exits": [


### PR DESCRIPTION
Closes the first two asks in #2111 — NPCs shouldn't enter or spawn from closed buildings, and should react rather than vanish if a building closes mid-route. This is phase 1 of a larger plan; the two bigger asks (leaving town via exit tiles, following an NPC inside to watch them live) are separate, larger follow-ups I'd rather ship independently — happy to go straight into either next.

## The bug, already reproducible

Two NPC subsystems route through building doors — schedule-driven named NPCs (`walkNamedNpc`) and ambient wandering NPCs (`wanderNpc`/`processNpcWalkQueue`) — and **neither ever checked `isBuildingOpen`**. This wasn't hypothetical: Ravenwatch's Elder is scheduled into `town-hall` from 06:00, but `town-hall`'s own hours were `08:00–18:00`. The door a player themselves gets bounced from as "closed" is one the Elder was scripted to walk straight through, two hours early.

## The fix

**Named NPCs** — added `effectiveScheduleLocation()`, consulted both at a schedule-driven NPC's initial on-load placement and every later schedule change. When a schedule targets a closed interior, it resolves to standing just outside that building's door instead of walking in — so an NPC can no longer spawn or route into a building the player would themselves be turned away from. Their activity pose (work/eat/etc.) is dropped while redirected, since they're waiting outside, not actually doing it.

**Ambient NPCs** — `wanderNpc` no longer offers a closed building's door as a wander target. `processNpcWalkQueue` no longer despawns one into a building that closed while it was already en route — instead it shows a brief "🚫" reaction bubble and re-wanders somewhere else. That's its own state (`doorReactionBubble`/`Timer`) on `UnitNpcState`, kept separate from the existing ghost-scared-bubble mechanic so the two can't clobber each other, with the same cleanup-on-despawn and cleanup-on-entering-an-interior handling already applied to `scaredBubble`.

**Data**: widened `town-hall`'s hours to `06:00–20:00` to actually cover the Elder's schedule, rather than leaving the new test red against a known conflict.

Building `hours` are only authored in Ravenwatch today (14 interiors); every other town's buildings are unrestricted, so this is a no-op everywhere else — `isBuildingOpen` treats a building with no `hours` field as always open.

## A bug in my own first draft

While reviewing my own diff before committing, I caught a real freeze: in the ambient-NPC reroute branch I called `wanderNpc(npc)` without resetting `npc.isWalking`. `wanderNpc` only kicks off movement when `!isWalking`, and `processNpcWalkQueue` never clears that flag on its own success path — so the NPC would have set a new destination and then never moved, stuck at the closed door forever. Fixed before it ever left this branch; flagging it here since it's exactly the kind of bug that's invisible in a diff and only shows up by tracing the state machine by hand.

## Tests

New `npcScheduleIntegrity.test.ts`, swept across all 13 towns: for every NPC schedule entry that places them in a building, every hour in that window must find the building open (or the building has no `hours` restriction). Written before the data fix and confirmed to fail on exactly — and only — the Elder/town-hall conflict, passing everywhere else.

`npm run build` clean; `npm run test` 2329 passed, 0 failures.

## Verified in a browser

Ran the dev server against Ravenwatch and watched ~16 seconds of live play: no console errors traced to any of the new code (only the expected Firebase/Firestore connectivity noise from this sandbox), and NPCs were clearly alive — new ambient speech bubbles kept appearing on different NPCs, positions shifted, nothing frozen.

I could **not** catch a live building-open/closed transition — the game hour derives from the real device clock with no debug override, so hitting one of Ravenwatch's exact hour boundaries deterministically wasn't practical in this session. That half rests on the new test sweep (which exercises the same `isBuildingOpen`/`hourInRange` functions the canvas code calls) plus the manual trace that caught the freeze above, not on a live observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_