### PR TITLE
Only show the NPC actually scheduled inside a building (#2111, phase 3)

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -9,7 +9,7 @@ import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, isShopItemSold } from '../../game/shopSchedule'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
-import { isBuildingOpen, getNpcLocation, getNpcActivity, getNpcDialoguePool } from '../../game/hub/hubNpcSchedule'
+import { isBuildingOpen, getNpcLocation, getNpcActivity, getNpcDialoguePool, resolveNpcInteriorPresence } from '../../game/hub/hubNpcSchedule'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } from '../../game/sound'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
@@ -182,7 +182,7 @@ export function HubTownCanvas({
     HUB_STREET_TILES, HUB_STREET_NONWALKABLE_TILES,
     EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES, HUB_POND_GROUPS, HUB_BRIDGE_TILES,
     HUB_FESTIVAL_DECOR,
-    HUB_DOORS, HUB_INTERIORS, EXTERIOR_NPCS, INTERIOR_NPCS,
+    HUB_DOORS, HUB_INTERIORS, HUB_NPCS, EXTERIOR_NPCS,
     NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES,
    HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES, HUB_ANIMALS, HUB_CHICKEN_ZONES,
     EXIT_TILES: exitTilesData,
@@ -2383,67 +2383,43 @@ export function HubTownCanvas({
         )
       }
 
-      // Interior NPCs — rendered inside the room, tappable
-      const interiorNpcList: HubNpc[] = (INTERIOR_NPCS[buildingId] ?? []).filter(n => isVisibleAtLevel(n, currentLevel))
-      for (const npc of interiorNpcList) {
-        interiorWalkable.delete(`${npc.tx},${npc.ty}`)
+      // NPCs actually present inside this room right now (#2111) — a resident
+      // with no schedule is always shown at their static spot (unchanged
+      // behaviour); a resident *with* a schedule, or any other NPC in town
+      // whose schedule currently brings them here, is shown only while that's
+      // actually true, at that schedule entry's own tx/ty — which is often not
+      // a resident's static position (a shopkeeper's work post vs. where
+      // they're standing off-shift, or a sleep entry pointing at a different
+      // sub-room like the inn's upstairs). Two previously-separate blocks
+      // (residents-by-static-building, schedule-driven visitors) collapse into
+      // one since both are now the exact same query: who resolves here right now.
+      const presentNpcs: { npc: HubNpc; tx: number; ty: number }[] = HUB_NPCS
+        .filter(n => isVisibleAtLevel(n, currentLevel))
+        .flatMap(n => {
+          const pos = resolveNpcInteriorPresence(n, buildingId, gameHourRef.current)
+          return pos ? [{ npc: n, tx: pos.tx, ty: pos.ty }] : []
+        })
+      for (const { npc, tx, ty } of presentNpcs) {
+        interiorWalkable.delete(`${tx},${ty}`)
         // Activity pose swap, mirroring the exterior ticker logic — resolved once
         // here since this block only reruns when the player re-enters the room.
-        const interiorSpriteSlug = resolveNpcSprite(npc.sprite)
-        const interiorBaseTexUrl = `${base}sprites/${interiorSpriteSlug}.svg`
-        const interiorActivity = npc.schedule ? getNpcActivity(npc, gameHourRef.current) : null
-        const interiorTexLoader = interiorActivity
-          ? loadTextureUrl(`${base}sprites/${interiorSpriteSlug}-${interiorActivity}.svg`).catch(() => loadTextureUrl(interiorBaseTexUrl))
-          : loadTextureUrl(interiorBaseTexUrl)
-        interiorTexLoader.then(tex => {
+        const npcSpriteSlug = resolveNpcSprite(npc.sprite)
+        const npcBaseTexUrl = `${base}sprites/${npcSpriteSlug}.svg`
+        const npcActivity = getNpcActivity(npc, gameHourRef.current)
+        const npcTexLoader = npcActivity
+          ? loadTextureUrl(`${base}sprites/${npcSpriteSlug}-${npcActivity}.svg`).catch(() => loadTextureUrl(npcBaseTexUrl))
+          : loadTextureUrl(npcBaseTexUrl)
+        npcTexLoader.then(tex => {
           if (!interiorActive || currentInteriorId !== buildingId) return
           const s = new PIXI.Sprite(tex)
           s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
           s.anchor.set(0.5, 1)
-          s.position.set(npc.tx * T + T / 2, npc.ty * T + T)
+          s.position.set(tx * T + T / 2, ty * T + T)
           s.eventMode = 'static'
           s.cursor    = 'pointer'
           s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
             e.stopPropagation()
             if (npc.dialogue.length > 0 || npc.screen || npc.questGive || npc.questReceive || npc.dialogueTree) {
-              const idx = npcDialogueIndex.get(npc.id) ?? 0
-              const pool = getNpcDialoguePool(npc, gameHourRef.current)
-              onNpcTapRef.current?.(pool[idx % pool.length] ?? '', npc.id)
-              npcDialogueIndex.set(npc.id, idx + 1)
-            }
-          })
-          interiorLayer.addChild(s)
-        }).catch(() => {})
-      }
-
-      // Scheduled exterior NPCs — render inside this building when their schedule says so
-      const scheduledVisitors = EXTERIOR_NPCS.filter(npc => {
-        if (!npc.schedule) return false
-        const loc = getNpcLocation(npc, gameHourRef.current)
-        return loc?.type === 'interior' && loc.buildingId === buildingId
-      })
-      for (const npc of scheduledVisitors) {
-        const loc = getNpcLocation(npc, gameHourRef.current) as { type: 'interior'; buildingId: string; tx: number; ty: number }
-        interiorWalkable.delete(`${loc.tx},${loc.ty}`)
-        // Activity pose swap, mirroring the exterior ticker logic — resolved once
-        // here since this block only reruns when the player re-enters the room.
-        const visitorSpriteSlug = resolveNpcSprite(npc.sprite)
-        const visitorBaseTexUrl = `${base}sprites/${visitorSpriteSlug}.svg`
-        const visitorActivity = getNpcActivity(npc, gameHourRef.current)
-        const visitorTexLoader = visitorActivity
-          ? loadTextureUrl(`${base}sprites/${visitorSpriteSlug}-${visitorActivity}.svg`).catch(() => loadTextureUrl(visitorBaseTexUrl))
-          : loadTextureUrl(visitorBaseTexUrl)
-        visitorTexLoader.then(tex => {
-          if (!interiorActive || currentInteriorId !== buildingId) return
-          const s = new PIXI.Sprite(tex)
-          s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
-          s.anchor.set(0.5, 1)
-          s.position.set(loc.tx * T + T / 2, loc.ty * T + T)
-          s.eventMode = 'static'
-          s.cursor    = 'pointer'
-          s.on('pointerdown', (e: PIXI.FederatedPointerEvent) => {
-            e.stopPropagation()
-            if (npc.dialogue.length > 0 || npc.questGive || npc.questReceive || npc.dialogueTree) {
               const idx = npcDialogueIndex.get(npc.id) ?? 0
               const pool = getNpcDialoguePool(npc, gameHourRef.current)
               onNpcTapRef.current?.(pool[idx % pool.length] ?? '', npc.id)
@@ -2496,15 +2472,18 @@ export function HubTownCanvas({
         })
       }
 
-      // Quest indicators for interior NPCs
+      // Quest indicators for interior NPCs — positioned at each NPC's resolved
+      // tx/ty (presentNpcs above), not their static npc.tx/npc.ty: a resident
+      // with a schedule can render somewhere other than their static spot, and
+      // this has to track the sprite it's floating over.
       interiorQuestIndicators.clear()
       interiorIndicatorBaseY.clear()
-      for (const npc of interiorNpcList) {
+      for (const { npc, tx, ty } of presentNpcs) {
         if (!npc.questGive && !npc.questReceive) continue
-        const indBaseY = npc.ty * T + T - SPRITE_SIZE - 8
+        const indBaseY = ty * T + T - SPRITE_SIZE - 8
         const ind = new PIXI.Text({ text: '!', style: { fontSize: 16, fill: '#ffdd44', fontWeight: 'bold', fontFamily: 'monospace', stroke: { color: '#1a1a1a', width: 3 } } })
         ind.anchor.set(0.5, 1)
-        ind.position.set(npc.tx * T + T / 2, indBaseY)
+        ind.position.set(tx * T + T / 2, indBaseY)
         ind.visible = false
         interiorLayer.addChild(ind)
         interiorQuestIndicators.set(npc.id, ind)

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -1938,8 +1938,13 @@
         "fish": [
           "Line's been quiet all morning. That's never a good sign out here.",
           "Watch the reef line. It's been swallowing more than fish lately."
+        ],
+        "sleep": [
+          "...mmh... the reef... something's out there... zzz...",
+          "Zzz... don't go dark... don't go dark... zzz..."
         ]
       },
+      "sleepDialogue": "...mmh... the reef... something's out there... zzz...",
       "questGive": "millhaven-lost-at-sea",
       "questReceive": "millhaven-missing-catch",
       "schedule": [
@@ -1951,6 +1956,17 @@
             "type": "exterior",
             "tx": 32,
             "ty": 6
+          }
+        },
+        {
+          "startHour": 20,
+          "endHour": 6,
+          "activity": "sleep",
+          "location": {
+            "type": "interior",
+            "buildingId": "inn-millhaven-upstairs",
+            "tx": 5,
+            "ty": 2
           }
         }
       ],

--- a/web/src/data/hub/npcScheduleIntegrity.test.ts
+++ b/web/src/data/hub/npcScheduleIntegrity.test.ts
@@ -36,3 +36,27 @@ describe('NPC schedules respect building hours', () => {
     }
   }
 })
+
+// Guard for #2111: resolveNpcInteriorPresence (hubNpcSchedule.ts) deliberately
+// has no fallback for an hour a scheduled NPC's own schedule doesn't cover — a
+// gap just means "not present anywhere," which for a building resident means
+// vanishing from every room for that stretch. Ravenwatch's Minister Fallow
+// shipped exactly this: a single 00:00–06:00 sleep entry with the remaining 18
+// hours uncovered. Swept across every town, every NPC with a schedule.
+describe('NPC schedules cover all 24 hours', () => {
+  for (const [townKey, { locationData }] of Object.entries(locationRegistry)) {
+    for (const npc of locationData.HUB_NPCS) {
+      if (!npc.schedule?.length) continue
+
+      it(`${townKey}/${npc.id}: schedule has no gap`, () => {
+        const uncoveredHours = Array.from({ length: 24 }, (_, h) => h)
+          .filter(h => !npc.schedule!.some(e => hourInRange(h, e.startHour, e.endHour)))
+        expect(
+          uncoveredHours,
+          `${npc.id}'s schedule has no entry covering hour(s) ${uncoveredHours.join(', ')} — ` +
+          `they won't be placed anywhere during ${uncoveredHours.length === 1 ? 'that hour' : 'those hours'}`,
+        ).toEqual([])
+      })
+    }
+  }
+})

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -12218,6 +12218,16 @@
             "ty": 2
           },
           "activity": "sleep"
+        },
+        {
+          "startHour": 6,
+          "endHour": 0,
+          "location": {
+            "type": "interior",
+            "buildingId": "church",
+            "tx": 6,
+            "ty": 1
+          }
         }
       ],
       "favoriteGiftItemId": "bones",

--- a/web/src/game/hub/hubNpcSchedule.test.ts
+++ b/web/src/game/hub/hubNpcSchedule.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getNpcActivity, getNpcDialoguePool, isNpcAsleep, NPC_ACTIVITIES } from './hubNpcSchedule'
+import { getNpcActivity, getNpcDialoguePool, isNpcAsleep, NPC_ACTIVITIES, resolveNpcInteriorPresence } from './hubNpcSchedule'
 import type { HubNpc } from '../../data/hub/loader'
 
 const npc: HubNpc = {
@@ -106,5 +106,74 @@ describe('isNpcAsleep', () => {
     expect(isNpcAsleep(wrapsMidnight, 3)).toBe(true)
     expect(isNpcAsleep(wrapsMidnight, 6)).toBe(false)
     expect(isNpcAsleep(wrapsMidnight, 21)).toBe(false)
+  })
+})
+
+describe('resolveNpcInteriorPresence', () => {
+  // A shopkeeper on a day shift, sleeping upstairs at night — modelled on
+  // Ravenwatch's Gildwyn/Vorn pair (#2111): their static `building` is the
+  // shop, but their schedule's own tx/ty differs from their static position,
+  // and their sleep entry points at a different building entirely.
+  const shopkeeper: HubNpc = {
+    id: 'gildwyn', name: 'Gildwyn', sprite: 'hub-npc-merchant', tx: 4, ty: 5, dialogue: [],
+    building: 'card-shop',
+    schedule: [
+      { startHour: 6, endHour: 20, activity: 'work', location: { type: 'interior', buildingId: 'card-shop', tx: 6, ty: 3 } },
+      { startHour: 20, endHour: 6, activity: 'sleep', location: { type: 'interior', buildingId: 'inn-upstairs', tx: 2, ty: 1 } },
+    ],
+  }
+
+  it('resolves a scheduled resident to their shift position, not their static tx/ty', () => {
+    expect(resolveNpcInteriorPresence(shopkeeper, 'card-shop', 12)).toEqual({ tx: 6, ty: 3 })
+  })
+
+  it('resolves a scheduled resident into a different building than their static one', () => {
+    // "Follow them to bed" (#2111 point 4): a resident isn't confined to their
+    // static `building` once they have a schedule.
+    expect(resolveNpcInteriorPresence(shopkeeper, 'inn-upstairs', 23)).toEqual({ tx: 2, ty: 1 })
+  })
+
+  it('is absent from their static building while scheduled elsewhere', () => {
+    // The bug this whole thing fixes: two shift NPCs must not both resolve
+    // present in the same building at once.
+    expect(resolveNpcInteriorPresence(shopkeeper, 'card-shop', 23)).toBeNull()
+  })
+
+  it('is absent from an unrelated building entirely', () => {
+    expect(resolveNpcInteriorPresence(shopkeeper, 'trader-den', 12)).toBeNull()
+  })
+
+  it('is absent during an hour their schedule does not cover (a gap)', () => {
+    const gappy: HubNpc = {
+      ...shopkeeper,
+      schedule: [{ startHour: 6, endHour: 20, location: { type: 'interior', buildingId: 'card-shop', tx: 6, ty: 3 } }],
+    }
+    // No entry covers 20–06 — deliberately no fallback to the static position.
+    expect(resolveNpcInteriorPresence(gappy, 'card-shop', 23)).toBeNull()
+  })
+
+  it('falls back to the static tx/ty for a resident with no schedule at all', () => {
+    const noSchedule: HubNpc = { ...shopkeeper, schedule: undefined }
+    expect(resolveNpcInteriorPresence(noSchedule, 'card-shop', 3)).toEqual({ tx: 4, ty: 5 })
+  })
+
+  it('a schedule-less resident is absent from any building but their static one', () => {
+    const noSchedule: HubNpc = { ...shopkeeper, schedule: undefined }
+    expect(resolveNpcInteriorPresence(noSchedule, 'inn-upstairs', 3)).toBeNull()
+  })
+
+  it('resolves a schedule-driven visitor with no static building at all', () => {
+    // Ravenwatch's Elder: no `building` field, only ever placed by schedule.
+    const visitor: HubNpc = {
+      id: 'elder', name: 'The Elder', sprite: 'hub-npc-elder', tx: 19, ty: 10, dialogue: [],
+      schedule: [{ startHour: 6, endHour: 20, location: { type: 'interior', buildingId: 'town-hall', tx: 7, ty: 3 } }],
+    }
+    expect(resolveNpcInteriorPresence(visitor, 'town-hall', 12)).toEqual({ tx: 7, ty: 3 })
+    expect(resolveNpcInteriorPresence(visitor, 'town-hall', 23)).toBeNull()
+  })
+
+  it('is absent everywhere for a schedule-less NPC with no static building', () => {
+    const nobody: HubNpc = { id: 'ghost', name: 'Nobody', sprite: 'x', tx: 0, ty: 0, dialogue: [] }
+    expect(resolveNpcInteriorPresence(nobody, 'card-shop', 12)).toBeNull()
   })
 })

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -48,6 +48,31 @@ export function isNpcInBuilding(npc: HubNpc, buildingId: string, gameHour: numbe
   return loc?.type === 'interior' && loc.buildingId === buildingId
 }
 
+/**
+ * Where an NPC should render inside `buildingId` right now, or null if they
+ * aren't there at all (#2111). An NPC with no `schedule` keeps the original,
+ * always-present behaviour — shown at their static `tx`/`ty` whenever the
+ * player is in their static `building`. An NPC *with* a schedule is shown only
+ * while it currently places them in this exact building, at that schedule
+ * entry's own `tx`/`ty` — which is often not their static spot (a shopkeeper's
+ * `work` post vs. their static position, or a sleep entry pointing at a
+ * different sub-room entirely). Deliberately has no fallback for an hour a
+ * schedule doesn't cover: a gap means "not here," which is also how a gap in
+ * 24-hour coverage gets caught (see npcScheduleIntegrity.test.ts) rather than
+ * silently papered over by defaulting back to their static position.
+ */
+export function resolveNpcInteriorPresence(
+  npc: HubNpc,
+  buildingId: string,
+  gameHour: number,
+): { tx: number; ty: number } | null {
+  if (!npc.schedule?.length) {
+    return npc.building === buildingId ? { tx: npc.tx, ty: npc.ty } : null
+  }
+  const loc = getNpcLocation(npc, gameHour)
+  return loc?.type === 'interior' && loc.buildingId === buildingId ? { tx: loc.tx, ty: loc.ty } : null
+}
+
 export function isBuildingOpen(interior: HubInterior, gameHour: number): boolean {
   if (!interior.hours || interior.hours === 'always') return true
   const { open, close } = interior.hours as { open: number; close: number }


### PR DESCRIPTION
Phase 3 of #2111 — the core "follow an NPC into a building and see them there" ask. Phase 1 (building hours gate NPC routing) shipped as #2112.

## What I found this time corrects something I said in #2112

While researching this phase I re-read `HubTownCanvas.tsx` more carefully and found a block I'd missed — `scheduledVisitors`, which already renders a schedule-driven NPC with no static home (the Elder, Merchant, Fisherman, Dealer…) inside whatever building their schedule currently places them in, activity pose and all. So half of "follow them in" already worked, for that one class, via a cleaner mechanism than I'd assumed existed (a pure `getNpcLocation(npc, hour)` lookup, not the tracked walk-state I'd thought nothing consumed).

**What's actually still broken** is the other class: any NPC *with* a static `building` field was rendered unconditionally whenever the player entered that building — no schedule check at all, even for NPCs carrying a full `schedule`. Checked against live data across all 13 towns: **48 of 113 building-resident NPCs already have a schedule that's currently just ignored for presence** — only consulted for their activity-pose texture while they stand there regardless of what the schedule actually says. Ravenwatch's Gildwyn and Vorn (day/night card-shop shifts, both permanently visible at once) is one instance of a pattern that recurs at scale: Ironhold Keep's castle staff, Royal Palace's king/queen/princess, Millhaven's shopkeepers, Capital City (15 residents).

## The fix

One resolver, `resolveNpcInteriorPresence` (`hubNpcSchedule.ts`), used everywhere an NPC's current interior position needs deciding:
- No schedule → today's behaviour, unchanged (always shown at their static spot).
- Has a schedule → shown **only** while it currently places them in this exact building, at that schedule entry's own `tx, ty` — which is often not their static spot (Gildwyn's `work` entry puts him at (6,3), not his static (4,5)). Deliberately no fallback for an hour the schedule doesn't cover — a gap just means "not here," which doubles as an authoring-gap detector.

This delivers "go to bed" for the first time for a resident: a sleep entry can point at a sub-room (`inn-building-upstairs`) that isn't their static building — the old code had no way to place them anywhere but their one static spot.

Two near-duplicate rendering blocks in `HubTownCanvas.tsx` (residents-by-static-building, schedule-driven visitors) collapse into one driven by this resolver. Folded in along the way, since the surgery touched all three sites anyway:
- **Quest indicators** only ever read the static-resident list, and positioned the `!` marker at the NPC's *static* `tx, ty` even for residents — wrong as soon as a resident can render somewhere else. Now driven by the same resolved list and position.
- `isVisibleAtLevel` (upgrade-level gating) now applies uniformly — the old `scheduledVisitors` path skipped it entirely, so a level-gated visiting NPC could appear inside before its gate was met, even though its exterior sprite was correctly hidden.
- The tap condition now checks `.screen` for both classes — `scheduledVisitors`' copy of the handler was missing it.

## Data: two real 24-hour coverage gaps

The "no fallback on a gap" design is exactly what would make an authoring gap visible — someone quietly vanishing from every building for part of the day rather than a bounced error. Sweeping every scheduled NPC in every town found exactly two:

- **Ravenwatch's Minister Fallow** — a single 00:00–06:00 sleep entry, 18 hours uncovered. Added the missing 06:00–00:00 entry placing him in the church at his existing static (6,1), the tile he was already unconditionally rendered at.
- **Millhaven's Sailor Finn** — only a 06:00–20:00 fishing entry, uncovered overnight. Added a sleep entry at `inn-millhaven-upstairs`, the same shared night lodging four other homeless Millhaven NPCs already use, at a free bed tile alongside them — plus the `sleepDialogue`/`dialogueByActivity.sleep` lines an existing test requires for any NPC with a sleep entry, matching his established voice (the reef, ships going dark).

Both were the *only* violators across all 113 scheduled+resident NPCs in all 13 towns.

## Tests

Unit tests for `resolveNpcInteriorPresence`: a scheduled resident resolves to their shift position rather than their static spot, resolves into a different building entirely when their schedule sends them there (the "follow to bed" case), is absent from their static building while scheduled elsewhere (the Gildwyn/Vorn bug), is absent during a schedule gap with no fallback, and a schedule-less resident keeps the original always-shown behaviour.

New cross-town sweep: every NPC with a schedule covers all 24 hours — confirmed to catch exactly (and only) the two real gaps above before their data fix.

`npm run build` clean; `npm run test` 2430 passed, 0 failures.

## Verified in a browser — partially

Confirmed the app loads Ravenwatch cleanly and the exterior scene renders exactly as before, with no console errors traced to anything I touched (only the expected Firebase/Firestore sandbox noise). I did **not** attempt to walk into a specific building and watch the NPC swap live — reliably automating a path into a specific door on this Pixi canvas (no DOM selectors, camera/pathfinding math) is exactly the expensive, unreliable case this repo's own guidance says not to reach for by default. Confidence here instead rests on the unit test that reproduces the exact Gildwyn/Vorn scenario by name, the exhaustive 13-town data sweep, and the type checker — not a live observation. Worth a manual check before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_