### PR TITLE
NPCs travel between towns via exit tiles (#2111 phase 2)

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -10,6 +10,7 @@ import { loadDailyShopState, isShopItemSold } from '../../game/shopSchedule'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity, getNpcDialoguePool, resolveNpcInteriorPresence } from '../../game/hub/hubNpcSchedule'
+import { recordDeparture, claimArrival } from '../../game/hub/townTravelers'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } from '../../game/sound'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
@@ -1621,6 +1622,23 @@ export function HubTownCanvas({
 
     // Door tiles — NPCs that arrive here despawn (simulate entering a building)
     const doorTileSet = new Set(HUB_DOORS.map(d => `${d.tx},${d.ty}`))
+    // Exit tiles — NPCs that arrive here despawn too, "leaving town" (#2111
+    // point 3). Not folded into the loader's shared NPC_SPAWN_TILES (which only
+    // has authored spawn tiles + doors) since that constant has other
+    // consumers below that shouldn't change meaning; unioned in locally instead
+    // wherever an ambient NPC picks a wander target.
+    const exitTileCoords: [number, number][] = exitTilesData.map(e => [e.tx, e.ty])
+    const exitTileSet = new Set(exitTileCoords.map(([tx, ty]) => `${tx},${ty}`))
+    // A traveler who departed some other town via an exit tile can arrive
+    // here (#2111). Claimed once per mount, deliberately outside the
+    // respawn-to-TARGET_NPC_COUNT cycle below — that cycle would otherwise
+    // silently backfill the same headcount regardless, making the arrival
+    // invisible — so this reads as one extra, distinct "someone just
+    // arrived" NPC walking in from an exit tile.
+    if (exitTileCoords.length > 0 && claimArrival()) {
+      const arrivalTile = exitTileCoords[Math.floor(Math.random() * exitTileCoords.length)]
+      spawnAmbientNpc(arrivalTile)
+    }
     // Spawn tiles that aren't doors — used for respawning so NPCs don't immediately despawn
     const nonDoorSpawnTiles = NPC_SPAWN_TILES.filter(([tx, ty]) => !doorTileSet.has(`${tx},${ty}`))
     // Door tile → the building it belongs to, for the open/closed check below.
@@ -1638,6 +1656,25 @@ export function HubTownCanvas({
     }
     const TARGET_NPC_COUNT = 12
     let respawnTimer = 2000
+
+    // Removes an ambient NPC's sprite and any active reaction bubbles, and
+    // drops it from unitNpcs — shared by despawn-into-a-building and
+    // despawn-via-exit-tile (#2111).
+    function despawnAmbientNpc(npc: UnitNpcState): void {
+      if (npc.scaredBubble) {
+        bubbleLayer.removeChild(npc.scaredBubble)
+        npc.scaredBubble = null
+        npc.scaredBubbleTimer = 0
+      }
+      if (npc.doorReactionBubble) {
+        bubbleLayer.removeChild(npc.doorReactionBubble)
+        npc.doorReactionBubble = null
+        npc.doorReactionTimer = 0
+      }
+      npc.sprite.parent?.removeChild(npc.sprite)
+      const idx = unitNpcs.indexOf(npc)
+      if (idx !== -1) unitNpcs.splice(idx, 1)
+    }
 
     async function processNpcWalkQueue(npc: UnitNpcState) {
       try {
@@ -1669,19 +1706,17 @@ export function HubTownCanvas({
             wanderNpc(npc)
             return
           }
-          if (npc.scaredBubble) {
-            bubbleLayer.removeChild(npc.scaredBubble)
-            npc.scaredBubble = null
-            npc.scaredBubbleTimer = 0
-          }
-          if (npc.doorReactionBubble) {
-            bubbleLayer.removeChild(npc.doorReactionBubble)
-            npc.doorReactionBubble = null
-            npc.doorReactionTimer = 0
-          }
-          npc.sprite.parent?.removeChild(npc.sprite)
-          const idx = unitNpcs.indexOf(npc)
-          if (idx !== -1) unitNpcs.splice(idx, 1)
+          despawnAmbientNpc(npc)
+          return
+        }
+        // Despawn NPCs that reach a town exit tile — they've "left town"
+        // (#2111 point 3). No building to be open/closed for, so this is
+        // unconditional. Credits a shared cross-town counter (townTravelers.ts)
+        // that another town can later draw an arrival from — there's no
+        // per-exit destination data to route a specific departure to.
+        if (exitTileSet.has(`${tx},${ty}`)) {
+          despawnAmbientNpc(npc)
+          recordDeparture()
           return
         }
         processNpcWalkQueue(npc)
@@ -1810,10 +1845,12 @@ export function HubTownCanvas({
       // Never pick a closed building's door as a destination (#2111 point 1) —
       // combined with the isDoorOpen re-check in processNpcWalkQueue, this means
       // a wander only ever ends in "went inside" when that building was open both
-      // when chosen and on arrival.
-      const allOptions = NPC_SPAWN_TILES.filter(
+      // when chosen and on arrival. Exit tiles are folded in here (not part of
+      // the loader's own NPC_SPAWN_TILES) so a wander can occasionally end in
+      // "left town" too (#2111 point 3).
+      const allOptions = ([...NPC_SPAWN_TILES, ...exitTileCoords] as [number, number][]).filter(
         ([tx, ty]) => (tx !== npc.currentTile[0] || ty !== npc.currentTile[1]) && isDoorOpen(tx, ty),
-      ) as [number, number][]
+      )
       if (allOptions.length === 0) return
       // Non-ghost NPCs avoid tiles within 5 tiles of any ghost
       const options = ghosts.length === 0 ? allOptions : (
@@ -1835,9 +1872,11 @@ export function HubTownCanvas({
       if (!npc.isWalking) processNpcWalkQueue(npc)
     }
 
-    function spawnAmbientNpc() {
-      if (nonDoorSpawnTiles.length === 0) return
-      const [tx, ty] = nonDoorSpawnTiles[Math.floor(Math.random() * nonDoorSpawnTiles.length)]
+    // `origin` lets a caller place the spawn at a specific tile (an exit, for
+    // a claimed arrival — #2111) instead of a random non-door spawn tile.
+    function spawnAmbientNpc(origin?: [number, number]) {
+      if (!origin && nonDoorSpawnTiles.length === 0) return
+      const [tx, ty] = origin ?? nonDoorSpawnTiles[Math.floor(Math.random() * nonDoorSpawnTiles.length)]
       const cx = tx * T + T / 2
       const cy = ty * T + T
       const slug = effectiveCards[Math.floor(Math.random() * effectiveCards.length)]

--- a/web/src/game/hub/townTravelers.test.ts
+++ b/web/src/game/hub/townTravelers.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { recordDeparture, claimArrival, getTravelersOnRoad } from './townTravelers'
+
+// In-memory localStorage mock (tests run in node environment) — same pattern
+// as reputation.test.ts / friendship.test.ts.
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
+
+describe('townTravelers default state', () => {
+  it('starts with nobody on the road', () => {
+    expect(getTravelersOnRoad()).toBe(0)
+  })
+
+  it('claimArrival on an empty counter returns false and does not go negative', () => {
+    expect(claimArrival()).toBe(false)
+    expect(getTravelersOnRoad()).toBe(0)
+  })
+})
+
+describe('recordDeparture / claimArrival', () => {
+  it('a departure can be claimed as an arrival, draining the counter to zero', () => {
+    recordDeparture()
+    expect(getTravelersOnRoad()).toBe(1)
+    expect(claimArrival()).toBe(true)
+    expect(getTravelersOnRoad()).toBe(0)
+  })
+
+  it('a claimed traveler cannot be claimed a second time', () => {
+    recordDeparture()
+    expect(claimArrival()).toBe(true)
+    expect(claimArrival()).toBe(false)
+  })
+
+  it('multiple departures queue up and drain one at a time', () => {
+    recordDeparture()
+    recordDeparture()
+    recordDeparture()
+    expect(getTravelersOnRoad()).toBe(3)
+    expect(claimArrival()).toBe(true)
+    expect(getTravelersOnRoad()).toBe(2)
+    expect(claimArrival()).toBe(true)
+    expect(claimArrival()).toBe(true)
+    expect(getTravelersOnRoad()).toBe(0)
+    expect(claimArrival()).toBe(false)
+  })
+
+  it('persists across a fresh load (simulating a page reload)', () => {
+    recordDeparture()
+    recordDeparture()
+    // Nothing in the module holds in-memory state beyond localStorage itself
+    // — every exported function re-reads via load() — so this really is
+    // exercising persistence, not just repeated calls in one session.
+    expect(getTravelersOnRoad()).toBe(2)
+    expect(claimArrival()).toBe(true)
+    expect(getTravelersOnRoad()).toBe(1)
+  })
+})

--- a/web/src/game/hub/townTravelers.ts
+++ b/web/src/game/hub/townTravelers.ts
@@ -1,0 +1,64 @@
+// ─── Ambient travelers between towns (#2111) ────────────────────────────────
+//
+// An anonymous ambient NPC that walks off the map via an exit tile has "left
+// town" — but towns don't simulate concurrently (only one HubTownCanvas is
+// ever mounted at a time), so there's no live journey to animate them
+// through. There's also no per-exit-tile "leads to Millhaven" data and no
+// town-adjacency graph anywhere in the game (the world map is a flat picker),
+// so a departure can't be routed to a specific destination town without
+// inventing geography the game doesn't have.
+//
+// Instead this is one shared, town-agnostic counter: "how many wanderers are
+// currently on the road." A departure from any town increments it; the next
+// town the player visits can claim one as a fresh arrival. Genuine
+// cross-session, cross-town population conservation, just honest about not
+// knowing where any particular traveler went.
+
+import { logError } from '../../logger'
+
+const KEY = 'jarv_hub_travelers'
+
+interface Store {
+  onRoad: number
+}
+
+function load(): Store {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? (JSON.parse(raw) as Store) : { onRoad: 0 }
+  } catch {
+    return { onRoad: 0 }
+  }
+}
+
+function save(data: Store): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(data))
+  } catch (e) {
+    logError('saveTownTravelers failed', { error: String(e) })
+  }
+}
+
+/** An ambient NPC left town via an exit tile. */
+export function recordDeparture(): void {
+  const data = load()
+  data.onRoad += 1
+  save(data)
+}
+
+/** How many wanderers are currently on the road, awaiting an arrival claim. */
+export function getTravelersOnRoad(): number {
+  return load().onRoad
+}
+
+/**
+ * Claim one traveler as arriving in the current town. Returns whether one was
+ * actually available — never drains the counter below zero.
+ */
+export function claimArrival(): boolean {
+  const data = load()
+  if (data.onRoad <= 0) return false
+  data.onRoad -= 1
+  save(data)
+  return true
+}


### PR DESCRIPTION
## Summary

Phase 2 of #2111 ("NPC should also be able to exit a town using the exit tiles"), following Phase 1 (#2112, closed-building routing) and Phase 3 (#2113, following NPCs into buildings).

Ambient (anonymous) NPCs already "enter" buildings by despawning on a door tile. This adds the matching behavior for exit tiles, plus a lightweight simulated-travel mechanic across towns:

- Reaching a town exit tile now despawns an ambient NPC — they've "left town" — the same way reaching an open door does. Deduplicated the two despawn code paths into one `despawnAmbientNpc` helper.
- Exit tiles are now included in `wanderNpc`'s candidate set, so a wander can occasionally choose to leave town, not just enter a building.
- A departure credits a new shared, town-agnostic counter (`townTravelers.ts`, `localStorage`-backed like `reputation.ts`/`friendship.ts`): "how many wanderers are currently on the road." On mount, a town claims one arrival from that counter if available, and spawns it walking in from a random exit tile — deliberately outside the normal respawn-to-`TARGET_NPC_COUNT` cycle, so it reads as a distinct "someone just arrived" moment instead of blending into ambient background NPCs.

**Why a shared counter instead of routing a specific departure to a specific destination town**: every one of the 13 towns' exit tiles is just `{ tx, ty, screen: 'worldmap' }` — there's no per-exit "leads to Millhaven" data and no town-adjacency/unlock graph anywhere in the codebase (the world map is a flat picker). Routing a departure to a specific arrival town would mean inventing geography the game doesn't have. The counter is honest about that: it conserves population across towns and sessions without pretending to know where any particular traveler went.

Named/schedule-driven NPCs and the more ambitious "a specific character travels between towns on a schedule" (issue point 4-adjacent) are unaffected — this is deliberately scoped to the ambient/anonymous NPC population.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2436/2436 passing (the Storybook/Playwright browser-launch error in the output is pre-existing noise, not related to this change)
- [x] `npm run build` — clean
- [x] Browser smoke test (Ravenwatch, seeded `jarv_hub_travelers` counter): with no player interaction, a seeded traveler is claimed exactly once on mount and the counter settles at 0 and stays there — confirms the once-per-mount claim behaves correctly even under React StrictMode's double-invoke in dev. No console/JS errors beyond the expected offline-Firebase noise from this sandboxed environment.
- [ ] Not verified: watching a specific ambient NPC actually walk to and vanish at an exit tile in the live canvas — per this repo's own guidance, reaching a specific in-canvas NPC deterministically is slow/unreliable to script and isn't attempted by default. This rests on the code path being symmetric with the already-verified door-despawn path (same `despawnAmbientNpc` helper, same `isDoorOpen`-style set-membership check) plus the new `townTravelers.test.ts` unit coverage (6 tests) of the counter logic itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_