### PR TITLE
Fix quest dialogue auto-dismiss timeout and Ravenwatch town hall office door

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -603,14 +603,6 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     after?.()
   }, [dialogueEvent, dialogueLine])
 
-  // Auto-dismiss dialogue after 15 s
-  useEffect(() => {
-    const hasContent = !!(dialogueEvent?.text ?? dialogueLine)
-    if (!hasContent) return
-    const id = setTimeout(dismissDialogueOnWalkAway, 15_000)
-    return () => clearTimeout(id)
-  }, [dialogueEvent, dialogueLine, dismissDialogueOnWalkAway])
-
   // Auto-dismiss dialogue after the avatar takes 5 steps. Counter resets
   // whenever the dialogue changes.
   const dialogueStepsRef = useRef(0)

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9235,8 +9235,7 @@
           "toInteriorId": "town-hall",
           "entryTx": 1,
           "entryTy": 5,
-          "direction": "right",
-          "minLevel": 1
+          "direction": "right"
         }
       ],
       "wallTileId": "interiorWallStriped"


### PR DESCRIPTION
## Summary

Two unrelated user-reported bugs:

- **Quest dialogue vanished before it could be read.** `HubWorld.tsx` had a blind 15-second `setTimeout` that auto-dismissed the current dialogue (or auto-took its marked "exit" choice) regardless of how much text there was or whether the player was still reading. Removed it entirely. Dialogue still ends naturally in the ways that were already there: walking five steps away still auto-dismisses (so a player who's moved on isn't left with a modal following them around), and the player can close it manually at any time via the existing close button — this just drops the arbitrary clock.
- **Ravenwatch's town hall office had no way back out.** Its exit back to the main town hall room carried a `minLevel: 1` gate, but the `townhall` building has no `upgradeKind` — it isn't upgradable at all, so its resolved level is always `0`. The gate (`1 <= 0`) could never pass, so the door never rendered and anyone who walked into the office was stuck. The entrance the other direction has no such restriction. Removed the stray `minLevel` from the return exit.

While sweeping all 13 towns' interior exits for the same "permanently-unreachable minLevel" pattern (only one other hit, described below and **not fixed in this PR**), I confirmed no other exit anywhere has this exact bug — every other `minLevel`-gated exit resolves against a building that's genuinely upgradable and reachable.

**Found but intentionally not fixed here**: Ravenwatch's starter home (`home` interior → `home-building-storeroom`, `minLevel: 1`) has a similar-looking symptom — the storeroom door can never appear — but a different root cause: the door's `buildingId` is `"home"` while the actual upgradable building's own `id` is `"home-building"`, and the level-gating code resolves a sub-room's building by checking `interiorId.startsWith(building.id)`. `"home".startsWith("home-building")` is false, so the level lookup falls through to a key (`"home"`) that's never populated, and resolves to level 0 forever — same failure mode as the town hall bug, but here the building genuinely is upgradable (`cottage`), so the correct fix is to make the level lookup find it, not to strip the gate. That's a fix to the shared level-resolution logic in `HubTownCanvas.tsx`/`HubWorld.tsx`, not just this one door's data, so it's being raised separately rather than folded into this PR.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2429/2429 passing (Playwright browser-launch error in the output is pre-existing Storybook noise, unrelated)
- [x] `npm run build` — clean
- [ ] Not browser-verified live (headless-canvas door/dialogue interaction is slow/unreliable to script in this environment per this repo's own guidance) — both fixes are small, traceable data/logic corrections confirmed by re-tracing the exact code paths involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_