### PR TITLE
Fix upgrade-level gating for interiors whose id differs from their building's

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -21,7 +21,7 @@ import { getAugmentCard, AUGMENT_SPRITE } from '../../game/augments'
 import { createChunkCuller } from '../../utils/chunkCull'
 import { CommanderState } from '../../game/commander'
 import rollbar from '../../rollbar'
-import { FlameColor, FlameType, HubInteractable, HubInterior, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel } from '../../data/hub/loader'
+import { FlameColor, FlameType, HubInteractable, HubInterior, HubInteriorExit, HubLocationBundle, HubNpc, HubQuestBundle, HubStreetGroup, NpcScheduleEntry, isVisibleAtLevel, resolveUpgradeLevelKey } from '../../data/hub/loader'
 import { createAnimalSystem, AnimalSystem, GlowSource, PLAYER_OWNER_ID } from './hubAnimals'
 import { getActivePet } from '../../game/hub/pet'
 import { isInteractableGranted, interactableStoreKey } from '../../game/hub/interactables'
@@ -183,7 +183,7 @@ export function HubTownCanvas({
     HUB_STREET_TILES, HUB_STREET_NONWALKABLE_TILES,
     EXTERIOR_DECOR, HUB_WINDOWS, HUB_POND_TILES, HUB_POND_GROUPS, HUB_BRIDGE_TILES,
     HUB_FESTIVAL_DECOR,
-    HUB_DOORS, HUB_INTERIORS, HUB_NPCS, EXTERIOR_NPCS,
+    HUB_DOORS, HUB_INTERIOR_OWNERS, HUB_INTERIORS, HUB_NPCS, EXTERIOR_NPCS,
     NPC_SPAWN_TILES, AMBIENT_NPC_SPRITES,
    HUB_LOCKED_DOORS, HUB_TREASURES, HUB_INTERACTABLES, HUB_ANIMALS, HUB_CHICKEN_ZONES,
     EXIT_TILES: exitTilesData,
@@ -2068,10 +2068,12 @@ export function HubTownCanvas({
 
       // ── Upgrade-level gating ───────────────────────────────────────────────
       // Interior decor, rooms (exits) and NPCs can be tagged with a minLevel so
-      // they only appear once the building has been upgraded that far. Sub-rooms
-      // (no exterior door) inherit the level of the parent building whose id
-      // prefixes this interior's id.
-      const levelKey = HUB_BUILDINGS.find(b => b.id && buildingId.startsWith(b.id) && b.upgradeKind)?.id ?? buildingId
+      // they only appear once the building has been upgraded that far.
+      // resolveUpgradeLevelKey first tries an exact door-target → owner lookup
+      // (HUB_INTERIOR_OWNERS — a door's target interior id is not always the
+      // owning building's own id), then falls back to the id-prefix guess for
+      // sub-rooms reached only via internal exits (no door of their own).
+      const levelKey = resolveUpgradeLevelKey(buildingId, HUB_BUILDINGS, HUB_INTERIOR_OWNERS)
       const currentLevel = buildingUpgradeLevelsRef?.current[levelKey] ?? 0
       const visibleDecor = interior.decor.filter(d => isVisibleAtLevel(d, currentLevel))
       const staticExits  = (interior.exits ?? []).filter(e => (e.minLevel ?? 0) <= currentLevel)

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -51,6 +51,25 @@ export function isVisibleAtLevel(
   return true
 }
 
+/**
+ * Resolves which building's upgrade level gates a given interior's minLevel
+ * content. Prefers an exact door-target → owner lookup (HUB_INTERIOR_OWNERS
+ * — a door's target interior id is not always the owning building's own id,
+ * e.g. Ravenwatch's "home-building" door → interior "home"). Falls back to
+ * the id-prefix guess for genuine sub-rooms (reached only via an internal
+ * exit, no door of their own, authored with the parent building's own id as
+ * their id prefix — e.g. "townhall-office" under "townhall").
+ */
+export function resolveUpgradeLevelKey(
+  interiorId: string,
+  buildings: Pick<HubBuilding, 'id' | 'upgradeKind'>[],
+  interiorOwners: Record<string, string>,
+): string {
+  return interiorOwners[interiorId]
+    ?? buildings.find(b => b.id && interiorId.startsWith(b.id) && b.upgradeKind)?.id
+    ?? interiorId
+}
+
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 export interface HubArea {
@@ -414,6 +433,9 @@ export interface HubLocationBundle {
   HUB_POND_GROUPS: HubStreetGroup[]
   HUB_BRIDGE_TILES: [number, number][]
   HUB_DOORS: HubDoor[]
+  /** interiorId → id of the upgradeKind building whose level gates that
+   *  interior's minLevel-tagged decor/exits (see resolveUpgradeLevelKey). */
+  HUB_INTERIOR_OWNERS: Record<string, string>
   HUB_INTERIORS: Record<string, HubInterior>
   HUB_NPCS: HubNpc[]
   EXTERIOR_NPCS: HubNpc[]
@@ -565,6 +587,22 @@ const HUB_BUILDING_TILES: [number, number][] = HUB_BUILDINGS.flatMap(b => {
 const _nestedDoors:   HubDoor[]                                              = []
 const _nestedWindows: { tx: number; ty: number; tileId: number }[]           = []
 const _nestedDecor:   { tx: number; ty: number; tileId: number; zlayer?: string }[] = []
+// interiorId → id of the upgradeKind building whose upgrade level gates that
+// interior's minLevel-tagged decor/exits. A door's target interior id is not
+// always the owning building's own id (e.g. Ravenwatch's "home-building"
+// door leads to interior "home") — this preserves that association from
+// config.json before it's discarded, so resolveUpgradeLevelKey can resolve
+// the correct building instead of guessing via id-prefix.
+const _interiorOwners: Record<string, string> = {}
+function recordInteriorOwner(interiorId: string, buildingId: string | undefined, upgradeKind: string | undefined) {
+  if (!buildingId || !upgradeKind) return
+  if (_interiorOwners[interiorId] && _interiorOwners[interiorId] !== buildingId) {
+    const message = `[hub loader] ${HUB_TOWN_NAME}: interior "${interiorId}" claimed as a door target by both "${_interiorOwners[interiorId]}" and "${buildingId}" — upgrade-level gating will use whichever loaded last`
+    console.error(message)
+    rollbar.error(message)
+  }
+  _interiorOwners[interiorId] = buildingId
+}
 for (const b of rawConfig.buildings as RawBuilding[]) {
   const rectList = b.rects ?? (b.rect ? [b.rect] : [])
   if (rectList.length === 0) continue
@@ -572,14 +610,18 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
   if (b.bundleID) {
     _nestedWindows.push(...expandBundleWindows(b.bundleID, ox, oy))
     _nestedDecor.push(...expandBundleDecor(b.bundleID, ox, oy))
-    _nestedDoors.push(...expandBundleDoors(b.bundleID, b.id ?? '', ox, oy))
+    const bundleDoors = expandBundleDoors(b.bundleID, b.id ?? '', ox, oy)
+    _nestedDoors.push(...bundleDoors)
+    for (const d of bundleDoors) recordInteriorOwner(d.buildingId, b.id, b.upgradeKind)
     continue
   }
   for (const d of b.doors ?? []) {
     // The authored position is used as-is, anywhere relative to the building —
     // the door sprite always renders one tile north of it (see
     // buildingRender.ts) unless hideSprite keeps it a fully invisible trigger.
-    _nestedDoors.push({ buildingId: d.buildingId ?? b.id ?? '', tx: ox + d.tx, ty: oy + d.ty, hideSign: d.hideSign, hideSprite: d.hideSprite, hideLabel: d.hideLabel })
+    const targetId = d.buildingId ?? b.id ?? ''
+    _nestedDoors.push({ buildingId: targetId, tx: ox + d.tx, ty: oy + d.ty, hideSign: d.hideSign, hideSprite: d.hideSprite, hideLabel: d.hideLabel })
+    recordInteriorOwner(targetId, b.id, b.upgradeKind)
   }
   for (const w of b.windows ?? [])
     _nestedWindows.push({ tx: ox + w.tx, ty: oy + w.ty, tileId: resolveTileId(w.tileId) })
@@ -636,6 +678,7 @@ const HUB_BRIDGE_TILES: [number, number][] = expandTiles(
 )
 
 const HUB_DOORS: HubDoor[] = [...((rawConfig as unknown as { doors?: HubDoor[] }).doors ?? []), ..._nestedDoors]
+const HUB_INTERIOR_OWNERS: Record<string, string> = _interiorOwners
 
 const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
   Object.entries(rawConfig.interiors).map(([id, raw]) => {
@@ -832,6 +875,7 @@ type RawExitTile = { tx: number; ty: number; screen: string }
     HUB_POND_GROUPS,
     HUB_BRIDGE_TILES,
     HUB_DOORS,
+    HUB_INTERIOR_OWNERS,
     HUB_INTERIORS,
     HUB_NPCS,
     EXTERIOR_NPCS,

--- a/web/src/data/hub/playerHouseConsistency.test.ts
+++ b/web/src/data/hub/playerHouseConsistency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { getHubWorldData } from './hubWorldFactory'
+import { resolveUpgradeLevelKey } from './loader'
 
 const { locationRegistry: LOCATION_REGISTRY } = await getHubWorldData()
 
@@ -40,6 +41,27 @@ describe('player-house tag consistency (all towns)', () => {
           expect(locationData.HUB_INTERIORS[exit.toInteriorId], `${townKey}/${interiorId}'s exit to "${exit.toInteriorId}" has no matching interior`).toBeTruthy()
         })
       }
+    }
+
+    // Regression sentinel for the Ravenwatch "home-building" door → "home"
+    // interior bug: an interior's minLevel-gated decor/exits are only ever
+    // reachable if resolveUpgradeLevelKey resolves it to a real
+    // upgradeKind-tracked building — otherwise the level permanently
+    // defaults to 0 regardless of actual purchase progress, no matter how
+    // upgraded the building really is.
+    for (const [interiorId, interior] of Object.entries(locationData.HUB_INTERIORS)) {
+      const hasGatedContent =
+        interior.decor.some(d => (d.minLevel ?? 0) > 0) ||
+        (interior.exits ?? []).some(e => (e.minLevel ?? 0) > 0)
+      if (!hasGatedContent) continue
+      it(`${townKey}/${interiorId}: minLevel-gated content resolves to a real upgrade-tracked building`, () => {
+        const levelKey = resolveUpgradeLevelKey(interiorId, locationData.HUB_BUILDINGS, locationData.HUB_INTERIOR_OWNERS)
+        const owner = locationData.HUB_BUILDINGS.find(b => b.id === levelKey && b.upgradeKind)
+        expect(
+          owner,
+          `${townKey}/${interiorId} has minLevel-gated decor/exits but its resolved upgrade-level key "${levelKey}" matches no upgradeKind-tracked building — this content can never appear (upgrade level permanently defaults to 0)`,
+        ).toBeTruthy()
+      })
     }
   }
 })


### PR DESCRIPTION
## Summary

Follow-up to #2115, which fixed Ravenwatch's town-hall office door (a `minLevel` gate that could never pass because the building wasn't upgradable at all). While sweeping for that same "unreachable `minLevel` gate" symptom elsewhere, this surfaced a related but structurally different bug: some `minLevel`-gated interior content is unreachable not because the gate is wrong, but because the code resolving *which building's* upgrade level applies to the interior the player is in was guessing, and guessed wrong.

**Root cause**: `HubTownCanvas.tsx` decided which building's upgrade level gates the current interior's `minLevel` decor/exits by string-prefix-matching the interior id against every building's own `id`. That guess only works when the interior id genuinely is the building's own id with a suffix appended (true for sub-rooms like `townhall-office` under `townhall`). It silently breaks whenever a building's *door* leads to an interior whose id is unrelated to the building's own id — confirmed live in Ravenwatch: the building `home-building` (upgradeKind `cottage`) has a door leading to the interior `home`, a shorter, unrelated string. `"home".startsWith("home-building")` is false, so the level lookup fell through to a key nothing ever populates, and permanently defaulted to level 0 — meaning the starter home's `minLevel`-gated decor (world map, coin pile, table set, candelabra, etc.) and its storeroom exit could never appear, no matter how much the player upgraded their cottage.

A full sweep of all 13 towns' data found this id mismatch in exactly one town, four buildings — only `home-building`/`home` currently has any gated content (the other three are dormant, would break the same way the moment anyone authors gated content in them):

| Building id | upgradeKind | door's target interior id | Status |
|---|---|---|---|
| `home-building` | cottage | `home` | **Live bug**, fixed by this PR |
| `card-shop-bldg` | shop | `card-shop` | Latent, guarded by the new test |
| `augment-shop-bldg` | shop | `augment-shop` | Latent, guarded by the new test |
| `church-building` | shrine | `church` | Latent, guarded by the new test |

## Changes

- `web/src/data/hub/loader.ts`: preserve the door→owning-building association from `config.json` at load time (previously captured, then immediately discarded) as a new `HUB_INTERIOR_OWNERS` map. Added `resolveUpgradeLevelKey`, a shared resolver that checks this map first (exact) before falling back to the original prefix guess (still correct and needed for genuine sub-rooms).
- `web/src/components/hub/HubTownCanvas.tsx`: use `resolveUpgradeLevelKey` instead of the inline prefix guess. No other behavior changes — for every building/town where the door target already equals the building's own id (everywhere except the 4 Ravenwatch buildings above), the new resolver returns exactly what the old guess already returned.
- `web/src/data/hub/playerHouseConsistency.test.ts`: added a sweep across all 13 towns asserting every interior with `minLevel`-gated decor/exits resolves to a real, upgrade-tracked building. Verified this assertion fails on the pre-fix code (`ravenwatch/home` resolves to `"home"`, matching no building) and passes after the fix.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2437/2437 passing
- [x] `npm run build` — clean
- [x] Manually confirmed the new regression test fails against the pre-fix resolver logic (reproduces the exact bug) and passes with the fix applied
- [x] Browser smoke test (Ravenwatch): loads and runs with no crash or console errors beyond expected offline-Firebase noise in this sandboxed environment
- [ ] Not verified live: actually purchasing the Ravenwatch cottage upgrade in a running game and watching the gated decor/exit appear — per this repo's own guidance, reliably scripting a specific purchase state + interior visit in this headless canvas is the slow/unreliable case not attempted by default. Rests on the regression test reproducing the exact bug mechanism plus the type checker confirming no other call site was affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_