### PR TITLE
Add cavern entrance beneath Ravenwatch's false grave

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2839,6 +2839,10 @@ export function HubTownCanvas({
           isWalking     = false
           walkQueue     = []
           pendingScreen = null
+          if (door.requiredQuest && !completedQuestIdsRef?.current.has(door.requiredQuest)) {
+            onDoorLockedRef.current?.(door.buildingId, `quest:${door.requiredQuest}`)
+            return
+          }
           onNodeInteractRef.current(`interior:${door.buildingId}`)
           return
         }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -110,6 +110,9 @@ export interface HubDoor {
   hideSprite?: boolean
   /** Hide the floating player-visible name label above the sign. */
   hideLabel?: boolean
+  /** Entry is blocked until this quest id has status 'completed'. Mirrors
+   *  HubInteriorExit.requiredQuest for the exterior-door case. */
+  requiredQuest?: string
 }
 
 export interface DecorGlow {

--- a/web/src/data/hub/questPickupPlacement.test.ts
+++ b/web/src/data/hub/questPickupPlacement.test.ts
@@ -201,3 +201,28 @@ describe('interactable-given quests', () => {
     }
   }
 })
+
+// A door or interior exit can be gated behind requiredQuest (a graveyard
+// entrance that only opens once a quest is solved, a sealed vault). Get the
+// id wrong and there is no error anywhere: the gate just never opens — it
+// shows a generic "sealed" message forever, indistinguishable from working
+// as intended. Swept across every town.
+describe('requiredQuest gates name real quests', () => {
+  for (const [townKey, { locationData, locationQuests }] of Object.entries(locationRegistry)) {
+    const questIds = new Set(locationQuests.HUB_QUEST_DEFS.map(q => q.id))
+    for (const door of locationData.HUB_DOORS) {
+      if (!door.requiredQuest) continue
+      it(`${townKey}/door → "${door.buildingId}": requiredQuest "${door.requiredQuest}" exists`, () => {
+        expect(questIds.has(door.requiredQuest!), `no quest "${door.requiredQuest}" in ${townKey}`).toBe(true)
+      })
+    }
+    for (const [interiorId, interior] of Object.entries(locationData.HUB_INTERIORS)) {
+      for (const exit of interior.exits ?? []) {
+        if (!exit.requiredQuest) continue
+        it(`${townKey}/${interiorId} exit → "${exit.toInteriorId}": requiredQuest "${exit.requiredQuest}" exists`, () => {
+          expect(questIds.has(exit.requiredQuest!), `no quest "${exit.requiredQuest}" in ${townKey}`).toBe(true)
+        })
+      }
+    }
+  }
+})

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -2723,6 +2723,17 @@
       "comment": "Lakeside Cottage"
     }
   ],
+  "doors": [
+    {
+      "tx": 28,
+      "ty": 54,
+      "buildingId": "ravenwatch-hollow-entrance",
+      "hideSign": true,
+      "hideSprite": true,
+      "hideLabel": true,
+      "requiredQuest": "the-false-grave"
+    }
+  ],
   "exteriorDecor": [
     {
       "tx": 21,
@@ -10258,6 +10269,61 @@
           "entryTy": 4,
           "direction": "right"
         }
+      ]
+    },
+    "ravenwatch-hollow-entrance": {
+      "name": "The Buried Hollow",
+      "width": 11,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 5, "ty": 1, "tileId": "largeRock" },
+        { "tx": 2, "ty": 1, "tileId": "smallRock" },
+        { "tx": 8, "ty": 1, "tileId": "smallRock" },
+        { "tx": 2, "ty": 6, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+        { "tx": 8, "ty": 6, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+        { "tx": 5, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 0, "ty": 4, "toInteriorId": "ravenwatch-hollow-tunnel-west", "entryTx": 9, "entryTy": 4, "direction": "left", "label": "A narrow tunnel" },
+        { "tx": 10, "ty": 4, "toInteriorId": "ravenwatch-hollow-tunnel-east", "entryTx": 1, "entryTy": 4, "direction": "right", "label": "A narrow tunnel" }
+      ]
+    },
+    "ravenwatch-hollow-tunnel-west": {
+      "name": "The West Passage",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 1, "ty": 1, "tileId": "largeRock" },
+        { "tx": 8, "ty": 1, "tileId": "smallRock" },
+        { "tx": 1, "ty": 6, "tileId": "smallRock" },
+        { "tx": 8, "ty": 6, "tileId": "largeRock" },
+        { "tx": 4, "ty": 3, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+        { "tx": 6, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 9, "ty": 4, "toInteriorId": "ravenwatch-hollow-entrance", "entryTx": 1, "entryTy": 4, "direction": "right", "label": "Back to the hollow" }
+      ]
+    },
+    "ravenwatch-hollow-tunnel-east": {
+      "name": "The East Passage",
+      "width": 10,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "decor": [
+        { "tx": 2, "ty": 1, "tileId": "largeRock" },
+        { "tx": 8, "ty": 1, "tileId": "smallRock" },
+        { "tx": 2, "ty": 6, "tileId": "smallRock" },
+        { "tx": 7, "ty": 6, "tileId": "largeRock" },
+        { "tx": 5, "ty": 3, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+        { "tx": 3, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 0, "ty": 4, "toInteriorId": "ravenwatch-hollow-entrance", "entryTx": 9, "entryTy": 4, "direction": "left", "label": "Back to the hollow" }
       ]
     }
   },

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -6386,6 +6386,25 @@
         "decor": [],
         "npcs": []
       }
+    },
+    {
+      "id": "ravenwatch-false-grave-hole",
+      "blockedTiles": [],
+      "questId": "the-false-grave",
+      "blocked": {
+        "decor": [],
+        "npcs": []
+      },
+      "cleared": {
+        "decor": [
+          {
+            "tx": 28,
+            "ty": 53,
+            "tileId": "hole"
+          }
+        ],
+        "npcs": []
+      }
     }
   ],
   "dialogues": [


### PR DESCRIPTION
## Summary

User request: after finishing the quest at Ravenwatch's false-grave gravestone, the player should be able to tap the "hole" left behind and descend into an underground cavern.

This content was already half-built and clearly intended: the `ravenwatch-false-grave` interactable already has a dialogue line ("The gravestone falls into a hole below"), offers the chain quest `the-false-grave`, and vanishes off-map once tapped. The quest's own `offerDialogue` already describes "a cavern with multiple visible tunnels heading in opposite directions," and the completion dialogue explains someone dug up into the graveyard from below — but none of that payoff existed until now; completing the quest set nothing except its own `completed` status.

## Changes

- **`web/src/data/hub/loader.ts` / `HubTownCanvas.tsx`**: added `requiredQuest?: string` to `HubDoor` (exterior building entrances), mirroring the field `HubInteriorExit` already has for room-to-room transitions. The check reuses the existing `completedQuestIdsRef`/`onDoorLockedRef` plumbing (which already had a generic "quest:"-prefixed locked message) — no new UI code.
- **`web/src/data/hub/ravenwatch/config.json` / `questDefs.json`**: 
  - A `BlockedPath` entry swaps in a "hole" decor tile at the grave's old spot once `the-false-grave` completes — the same mechanism already used for 8 other gated spots in Ravenwatch.
  - A new hidden door, one tile south of the hole and gated by `requiredQuest`, leads into a new 3-room cavern (`ravenwatch-hollow-entrance` plus two dead-end tunnel branches west/east), modeled directly on Gearford's existing mine-tunnel interiors.
  - The door and the hole decor deliberately sit on *different* tiles: a `BlockedPath`'s cleared decor tile gets marked solid for pathfinding, which would make a door on that same tile permanently unreachable.
- **`web/src/data/hub/questPickupPlacement.test.ts`**: added a cross-town regression sweep asserting every `requiredQuest` (on both `HubDoor` and `HubInteriorExit`) names a real quest — this field had zero coverage before (not even for the pre-existing Aldous's-hidden-passage case), and a typo'd id today just permanently locks a door with a generic message and no error anywhere.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2447/2447 passing (10 more than baseline, from the new sweep)
- [x] `npm run build` — clean
- [x] Browser smoke test: Ravenwatch loads with no console errors beyond expected offline-Firebase noise in this sandboxed environment
- [ ] Not verified live: walking the full sequence (accept → turn in to the Elder then Minister Fallow → watch the hole appear → enter → walk both tunnels → exit back to the same graveyard tile). Per this repo's own guidance, scripting a specific multi-step quest-completion state reliably in this headless canvas is the slow/unreliable case not attempted by default — this rests on the new regression test plus careful line-by-line tracing of the actual render/pathfinding code involved (door-to-building matching, the sign-placement collision, the auto-generated return exit's tile math) done during planning, not just assumption.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_