### PR TITLE
Phase 4 of #2111: named NPCs traveling between towns

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -12,7 +12,10 @@
 |---|---|---|
 | `web/src/data/hub/config.json` | Map geometry, buildings, doors, NPCs (incl. each NPC's own `innRumours`), exterior decor, interiors, windows, interactables | parsed by `loader.ts` |
 | `web/src/data/hub/questDefs.json` | Quests, pickup items, blocked paths, friendship dialogue, dialogue trees, relationship dialogue, conversation topics (§7g) | parsed by `loader.ts` and `questDefs.ts` |
-| `web/src/data/hub/loader.ts` | Parses both JSON files; exports all map/NPC/item/path data | `MAP_W`, `MAP_H`, `AVATAR_START`, `HUB_AREAS`, `HUB_STREET_TILES`, `HUB_BUILDINGS`, `HUB_DOORS`, `HUB_INTERIORS`, `EXTERIOR_DECOR`, `HUB_NPCS`, `EXTERIOR_NPCS`, `INTERIOR_NPCS`, `HUB_PICKUP_ITEMS`, `HUB_BLOCKED_PATHS`, `HUB_LOCKED_DOORS`, … |
+| `web/src/data/hub/loader.ts` | Parses both JSON files; exports all map/NPC/item/path data | `MAP_W`, `MAP_H`, `AVATAR_START`, `HUB_AREAS`, `HUB_STREET_TILES`, `HUB_BUILDINGS`, `HUB_DOORS`, `HUB_INTERIOR_OWNERS`, `HUB_INTERIORS`, `EXTERIOR_DECOR`, `HUB_NPCS`, `EXTERIOR_NPCS`, `INTERIOR_NPCS`, `HUB_PICKUP_ITEMS`, `HUB_BLOCKED_PATHS`, `HUB_LOCKED_DOORS`, … |
+| `web/src/data/hub/mapIds.ts` | Canonical town-id space and display names (dependency-free, so `loader.ts` can reference `MapId` without cycling through `hubWorldFactory.ts`) | `MapId`, `TOWN_LABELS`, `townLabel` |
+| `web/src/game/hub/hubNpcSchedule.ts` | Pure schedule-resolution logic — where/what an NPC is doing right now, building-hours gating (§9) | `getNpcLocation`, `getNpcActivity`, `getNpcDialoguePool`, `isNpcAsleep`, `isNpcInBuilding`, `resolveNpcInteriorPresence`, `isBuildingOpen`, `NPC_ACTIVITIES` |
+| `web/src/game/hub/npcLocator.ts` | Resolves an NPC's current world-map tile/name for minimap pins and the Town Directory — including "away, visiting X" for a traveling NPC (§9) | `resolveNpcPlace`, `buildingWorldTile`, `pickupWorldTile`, `areaNameForTile` |
 | `web/src/data/hub/questDefs.ts` | Parses `questDefs.json`; exports quest definitions and dialogue | `HUB_QUEST_DEFS`, `FRIENDSHIP_DIALOGUE` |
 | `web/src/game/hub/quests.ts` | Quest progress/status persistence (localStorage) | `getQuestState`, `setQuestStatus`, `incrementQuestProgress`, `getQuestProgress`, `resetQuest` |
 | `web/src/game/hub/pickups.ts` | Pickup state persistence (localStorage) | `getPickedUpIds`, `markPickedUp`, `isPickedUp`, `unmarkPickedUp` |
@@ -1484,9 +1487,10 @@ schedules and activities are also editable in the in-app map editor
 |---|---|---|---|
 | `startHour` / `endHour` | `number` (0–23) | ✓ | Half-open `[start, end)` game-hour window. **Wraps midnight** when `start > end` (e.g. `20 → 0`). The first matching entry wins; cover all 24 hours to avoid gaps. |
 | `activity` | `NpcActivity` | | Visible activity at this stop (see list below). Omit for "just stand there". |
-| `location.type` | `"exterior"` \| `"interior"` | ✓ | Where the NPC is during this window. |
-| `location.tx` / `ty` | `number` | ✓ | Exterior: absolute hub coords. Interior: coords within that building's room grid. |
+| `location.type` | `"exterior"` \| `"interior"` \| `"travel"` | ✓ | Where the NPC is during this window. `"travel"` means away in another town entirely — see "Traveling between towns" below. |
+| `location.tx` / `ty` | `number` | exterior/interior only | Exterior: absolute hub coords. Interior: coords within that building's room grid. `"travel"` entries have neither — nothing to render here. |
 | `location.buildingId` | `string` | interior only | Building `id` the NPC waits inside. The exterior sprite hides; if the player enters that building the NPC renders inside (its activity pose shows there too). |
+| `location.town` | `MapId` | travel only | The town the NPC is currently visiting — see "Traveling between towns" below. |
 | `homeBed` | `{ buildingId, tx, ty }` | | Reserved sleeping spot reference (used by night logic). |
 | `dialogueByActivity` | `Partial<Record<NpcActivity, string[]>>` | | Optional activity-specific dialogue pools, e.g. `{ "sleep": ["Zzz..."] }`. When the NPC's current scheduled activity has a non-empty entry here, `getNpcDialoguePool()` cycles those lines instead of the flat `dialogue` array (tap dialogue and ambient speech bubbles both use it). NPCs without a matching entry keep using `dialogue`, so this is fully backward compatible. |
 | `sleepDialogue` | `string` | | Line shown (as plain narration, no Talk/Give/quest options) when the NPC is tapped while `sleep`ing per its schedule (§7d). Defaults to a generic "💤 {name} is fast asleep." when omitted. |
@@ -1530,6 +1534,39 @@ workflow in `AGENTS.md` (32×32 SVG, create/commit/push one at a time).
 4. Run `npm run test` (loader + schedule tests) and `npm run build`.
 5. Verify in-game: at the relevant hours the NPC is at its post in its activity
    pose; the pose reverts to the base sprite while it walks at an hour boundary.
+
+### Traveling between towns (#2111 phase 4)
+
+A `"travel"` schedule entry means the NPC is genuinely away — not just hidden
+in a building, but visiting a *different, specific* town — during that window.
+There is no cross-town NPC registry at runtime: each town's `config.json` npcs
+array is the only source of truth for who's rendered/interactable there. So
+for a traveling NPC to actually appear somewhere else, **their full `HubNpc`
+record (same `id`, `name`, `sprite`, non-empty `dialogue`) must be separately
+authored in the destination town's own `config.json`**, with a matching
+`"travel"` entry pointing back home for the hours they're away. The shared
+`id` is the only link between the two records — NPC ids are globally unique
+across all 13 towns by convention, and friendship/relationship/journal state
+is already keyed by id alone with no town scoping, so this is safe.
+
+Both records need a schedule that covers all 24 hours between them: the home
+record's `"travel"` window should match exactly the hours the visiting
+record's own `"exterior"`/`"interior"` entries cover, and vice versa. Nothing
+enforces this automatically at load time — `web/src/data/hub/npcTravelIntegrity.test.ts`
+sweeps every town and asserts every `"travel"` entry names a real town whose
+own copy of the NPC actually resolves present (not itself traveling) during
+the claimed hours. Run it (part of `npm run test`) after authoring or editing
+any travel schedule.
+
+Worked example: Trader Pell splits his day between Thornwood Camp (home,
+`thornwoodcamp/config.json`) and Ironhold Keep (`ironholdkeep/config.json`,
+a second, separately-authored record with the same `id: "trader-pell"` and
+its own short visiting-specific dialogue lines).
+
+Quest turn-in is unaffected either way — it already resolves purely by
+scanning `allQuestDefs` for a step addressed to the tapped NPC's id,
+regardless of which town's config the tap happened in or which town the NPC
+nominally calls home (see §14 below).
 
 ---
 

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1336,6 +1336,10 @@ export function HubTownCanvas({
       walkQueue: [number, number][]
       isWalking: boolean
       isInside: boolean
+      // Away in another town per a 'travel' schedule entry (#2111 phase 4) —
+      // hidden here the same way isInside hides them, but with no door to
+      // eventually emerge from since there was no in-town walk to begin with.
+      isTraveling: boolean
       currentBuildingId: string | null
       animFrame: number
       animTimer: number
@@ -1387,6 +1391,7 @@ export function HubTownCanvas({
         walkQueue: [],
         isWalking: false,
         isInside: initLoc?.type === 'interior',
+        isTraveling: initLoc?.type === 'travel',
         currentBuildingId: initLoc?.type === 'interior' ? initLoc.buildingId : null,
         animFrame: 0,
         animTimer: 0,
@@ -1410,7 +1415,7 @@ export function HubTownCanvas({
       })
       npcLayer.addChild(npcContainer)
       namedNpcContainers.set(npc.id, npcContainer)
-      if (walkState.isInside) npcContainer.visible = false
+      if (walkState.isInside || walkState.isTraveling) npcContainer.visible = false
       // Gate exterior NPCs that only appear once an associated building is upgraded.
       if (npc.levelBuildingId) {
         const min = npc.minLevel ?? 1
@@ -1799,13 +1804,24 @@ export function HubTownCanvas({
             container.visible = true
             ws.isInside = false
             ws.currentBuildingId = null
+          } else if (ws.isTraveling) {
+            // Returning from a trip — there's no in-town door to emerge from
+            // (unlike a building), so reappear directly at the scheduled tile
+            // instead of pathing from a stale pre-trip position.
+            sprite.x = destTx * T + T / 2
+            sprite.y = destTy * T + T
+            ws.currentTx = destTx
+            ws.currentTy = destTy
+            container.zIndex = sprite.y
+            container.visible = true
+            ws.isTraveling = false
           }
 
           effectiveSet.add(`${destTx},${destTy}`)
           const path = findPath([ws.currentTx, ws.currentTy], [destTx, destTy], effectiveSet)
           ws.walkQueue = path.length > 1 ? path.slice(1) : []
           await processNamedNpcWalkQueue(ws, container)
-        } else {
+        } else if (newLoc.type === 'interior') {
           // Going inside a building — walk to door then hide
           const door = HUB_DOORS.find(d => d.buildingId === newLoc.buildingId)
           if (door) {
@@ -1817,6 +1833,15 @@ export function HubTownCanvas({
           container.visible = false
           ws.isInside = true
           ws.currentBuildingId = newLoc.buildingId
+        } else {
+          // Leaving on a trip (newLoc.type === 'travel') — no in-town
+          // destination tile to walk toward (mirrors why townTravelers.ts's
+          // ambient departures don't route to a target town either), so hide
+          // immediately rather than pathing anywhere.
+          container.visible = false
+          ws.isTraveling = true
+          ws.isInside = false
+          ws.currentBuildingId = null
         }
       } finally {
         ws.isWalking = false

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -529,6 +529,7 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     // the map origin — resolve indoors NPCs explicitly and skip when unplaceable.
     const npcPinTile = (npc: HubNpc): { tx: number; ty: number } | null => {
       const place = resolveNpcPlace(npc, gameHour, locationData)
+      if (place.awayTown) return null  // traveling — no in-town tile to pin
       return place.interiorId
         ? buildingWorldTile(place.interiorId, locationData)
         : { tx: place.tx, ty: place.ty }

--- a/web/src/components/hub/TownDirectory.tsx
+++ b/web/src/components/hub/TownDirectory.tsx
@@ -78,7 +78,8 @@ export function TownDirectoryContent({ onClose, locationData, pinnedNpcId, onTog
                     <button
                       className={`town-directory__pin-btn${pinned ? ' town-directory__pin-btn--on' : ''}`}
                       onClick={() => onTogglePin(npc.id)}
-                      title={pinned ? 'Hide on minimap' : 'Show on minimap'}
+                      disabled={!!place.awayTown}
+                      title={place.awayTown ? "Traveling — can't be pinned right now" : pinned ? 'Hide on minimap' : 'Show on minimap'}
                     >
                       {pinned ? '📌 Pinned' : '📍 Show on map'}
                     </button>

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -539,7 +539,7 @@ function DecorInspector({
 }
 
 function NpcInspector({
-  npc, entity, buildingIds, interiorIds, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation,
+  npc, entity, buildingIds, interiorIds, onMove, onDelete, onDialogueChange, onUpdate, onPickLocation, mapId,
 }: {
   npc: RawNpc
   entity: SelectedEntity & { type: 'npc' }
@@ -552,6 +552,7 @@ function NpcInspector({
   onDialogueChange: (d: string[]) => void
   onUpdate: (partial: Partial<RawNpc>) => void
   onPickLocation?: () => void
+  mapId: MapId
 }) {
   return (
     <div>
@@ -596,7 +597,7 @@ function NpcInspector({
         />
         <div style={{ color: '#666', fontSize: 10, marginTop: 2 }}>Opens a screen/modal (e.g. 'adopt-pet') via a dialogue choice, in addition to dialogue.</div>
       </Field>
-      <NpcScheduleEditor npc={npc} interiorIds={interiorIds} onUpdate={onUpdate} />
+      <NpcScheduleEditor npc={npc} interiorIds={interiorIds} onUpdate={onUpdate} mapId={mapId} />
       <Field label="Min Building Level">
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <input
@@ -660,11 +661,12 @@ const NPC_ACTIVITIES: NpcActivity[] = ['work', 'eat', 'idle-chat', 'sleep', 'swe
 type NpcScheduleEntry = NonNullable<RawNpc['schedule']>[number]
 
 function NpcScheduleEditor({
-  npc, interiorIds, onUpdate,
+  npc, interiorIds, onUpdate, mapId,
 }: {
   npc: RawNpc
   interiorIds: string[]
   onUpdate: (partial: Partial<RawNpc>) => void
+  mapId: MapId
 }) {
   const inp: React.CSSProperties = {
     background: '#111', border: '1px solid #444', color: '#eee',
@@ -681,7 +683,11 @@ function NpcScheduleEditor({
   return (
     <Field label="Schedule">
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-        {entries.map((entry, i) => (
+        {entries.map((entry, i) => {
+          const loc = entry.location
+          const prevTx = 'tx' in loc ? loc.tx : 0
+          const prevTy = 'ty' in loc ? loc.ty : 0
+          return (
           <div key={i} style={{ border: '1px solid #333', borderRadius: 4, padding: 6, background: '#181818' }}>
             <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
               <label style={{ fontSize: 10, color: '#888' }}>Start</label>
@@ -699,41 +705,60 @@ function NpcScheduleEditor({
             </div>
             <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
               <select
-                value={entry.location.type}
+                value={loc.type}
                 style={{ ...inp, width: 76 }}
                 onChange={e => {
-                  const type = e.target.value as 'exterior' | 'interior'
-                  updateEntry(i, {
-                    location: type === 'exterior'
-                      ? { type: 'exterior', tx: entry.location.tx, ty: entry.location.ty }
-                      : { type: 'interior', buildingId: interiorIds[0] ?? '', tx: entry.location.tx, ty: entry.location.ty },
-                  })
+                  const type = e.target.value as 'exterior' | 'interior' | 'travel'
+                  if (type === 'exterior') {
+                    updateEntry(i, { location: { type: 'exterior', tx: prevTx, ty: prevTy } })
+                  } else if (type === 'interior') {
+                    updateEntry(i, { location: { type: 'interior', buildingId: interiorIds[0] ?? '', tx: prevTx, ty: prevTy } })
+                  } else {
+                    const destination = (Object.keys(TOWN_LABELS) as MapId[]).find(id => id !== mapId) ?? mapId
+                    updateEntry(i, { location: { type: 'travel', town: destination } })
+                  }
                 }}
               >
                 <option value="exterior">exterior</option>
                 <option value="interior">interior</option>
+                <option value="travel">traveling</option>
               </select>
-              {entry.location.type === 'interior' && (
+              {loc.type === 'interior' && (
                 <select
-                  value={entry.location.buildingId}
+                  value={loc.buildingId}
                   style={{ ...inp, flex: 1 }}
-                  onChange={e => updateEntry(i, { location: { ...entry.location, type: 'interior', buildingId: e.target.value } as NpcScheduleEntry['location'] })}
+                  onChange={e => updateEntry(i, { location: { type: 'interior', buildingId: e.target.value, tx: loc.tx, ty: loc.ty } })}
                 >
-                  {!interiorIds.includes(entry.location.buildingId) && entry.location.buildingId && (
-                    <option value={entry.location.buildingId}>{entry.location.buildingId} (unknown room)</option>
+                  {!interiorIds.includes(loc.buildingId) && loc.buildingId && (
+                    <option value={loc.buildingId}>{loc.buildingId} (unknown room)</option>
                   )}
                   {interiorIds.map(id => <option key={id} value={id}>{id}</option>)}
                 </select>
               )}
-              <label style={{ fontSize: 10, color: '#888' }}>X</label>
-              <input type="number" value={entry.location.tx} style={{ ...inp, width: 44 }}
-                onChange={e => updateEntry(i, { location: { ...entry.location, tx: Number(e.target.value) } as NpcScheduleEntry['location'] })} />
-              <label style={{ fontSize: 10, color: '#888' }}>Y</label>
-              <input type="number" value={entry.location.ty} style={{ ...inp, width: 44 }}
-                onChange={e => updateEntry(i, { location: { ...entry.location, ty: Number(e.target.value) } as NpcScheduleEntry['location'] })} />
+              {loc.type === 'travel' ? (
+                <select
+                  value={loc.town}
+                  style={{ ...inp, flex: 1 }}
+                  onChange={e => updateEntry(i, { location: { type: 'travel', town: e.target.value as MapId } })}
+                >
+                  {(Object.entries(TOWN_LABELS) as [MapId, string][])
+                    .filter(([id]) => id !== mapId)
+                    .map(([id, label]) => <option key={id} value={id}>{label}</option>)}
+                </select>
+              ) : (
+                <>
+                  <label style={{ fontSize: 10, color: '#888' }}>X</label>
+                  <input type="number" value={loc.tx} style={{ ...inp, width: 44 }}
+                    onChange={e => updateEntry(i, { location: { ...loc, tx: Number(e.target.value) } })} />
+                  <label style={{ fontSize: 10, color: '#888' }}>Y</label>
+                  <input type="number" value={loc.ty} style={{ ...inp, width: 44 }}
+                    onChange={e => updateEntry(i, { location: { ...loc, ty: Number(e.target.value) } })} />
+                </>
+              )}
             </div>
           </div>
-        ))}
+          )
+        })}
         <button
           style={addBtn}
           onClick={() => setEntries([...entries, {
@@ -3445,6 +3470,7 @@ export function EntityInspector({
             onDialogueChange={d => onDialogueChange(selectedEntity.index, d)}
             onUpdate={partial => onUpdateNpc(selectedEntity.index, partial)}
             onPickLocation={onPickLocation ? () => onPickLocation('npc', selectedEntity.index) : undefined}
+            mapId={mapId}
           />
         </div>
       </div>

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -1832,7 +1832,7 @@ function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems
   if (entity.type === 'npc') {
     const npc = cfg.npcs?.[entity.index]
     const scheduled = npc && previewHour != null ? getScheduledLocation(npc, previewHour) : null
-    return scheduled?.tx ?? npc?.tx ?? 0
+    return (scheduled && 'tx' in scheduled ? scheduled.tx : undefined) ?? npc?.tx ?? 0
   }
   if (entity.type === 'animal') return cfg.animals?.[entity.index]?.tx ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.tx ?? 0
@@ -1892,7 +1892,7 @@ function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems
   if (entity.type === 'npc') {
     const npc = cfg.npcs?.[entity.index]
     const scheduled = npc && previewHour != null ? getScheduledLocation(npc, previewHour) : null
-    return scheduled?.ty ?? npc?.ty ?? 0
+    return (scheduled && 'ty' in scheduled ? scheduled.ty : undefined) ?? npc?.ty ?? 0
   }
   if (entity.type === 'animal') return cfg.animals?.[entity.index]?.ty ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.ty ?? 0

--- a/web/src/components/mapEditor/entityRefs.ts
+++ b/web/src/components/mapEditor/entityRefs.ts
@@ -11,6 +11,7 @@ import { QUEST_DEFS_BY_MAP } from '../../data/hub/hubTownRawQuestConfigs'
 import type { RawMapConfig } from './mapEditorTypes'
 import { RAW_CONFIGS } from './useMapEditorState'
 import hubItems from '../../data/hubItems.json'
+import { TOWN_LABELS, townLabel } from '../../data/hub/mapIds'
 
 export interface RefOption {
   value: string
@@ -18,25 +19,7 @@ export interface RefOption {
   group?: string
 }
 
-export const TOWN_LABELS: Record<MapId, string> = {
-  ravenwatch: 'Ravenwatch',
-  millhaven: 'Millhaven',
-  ironholdkeep: 'Ironhold Keep',
-  thornwoodcamp: 'Thornwood Camp',
-  capitalcity: 'Capital City',
-  royalpalace: 'Royal Palace',
-  saltmereport: 'Saltmere Port',
-  gearford: 'Gearford',
-  harrowfield: 'Harrowfield',
-  appleford: 'Appleford',
-  gravemoor: 'Gravemoor',
-  hollowmere: 'Hollowmere',
-  dreadspirecitadel: 'Dreadspire Citadel',
-}
-
-export function townLabel(map: MapId): string {
-  return TOWN_LABELS[map] ?? map
-}
+export { TOWN_LABELS, townLabel }
 
 const ALL_MAPS = Object.keys(TOWN_LABELS) as MapId[]
 

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -119,6 +119,7 @@ export interface RawNpc {
     location:
       | { type: 'exterior'; tx: number; ty: number }
       | { type: 'interior'; buildingId: string; tx: number; ty: number }
+      | { type: 'travel'; town: MapId }
   }>
   homeBed?: { buildingId: string; tx: number; ty: number }
   innRumours?: Array<{ id: string; text: string }>

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -6,7 +6,7 @@ import { SpriteSearchPicker } from '../SpritePicker'
 import { AnimalEditor } from './AnimalEditor'
 import type { MapId } from '../../../data/hub/hubWorldFactory'
 import { EntityRefPicker, EntityRefMultiPicker } from '../EntityRefPicker'
-import { buildingRefOptions, interiorRefOptions, questRefOptions, dialogueTreeRefOptions, conversationTopicRefOptions, type RefOption } from '../entityRefs'
+import { buildingRefOptions, interiorRefOptions, questRefOptions, dialogueTreeRefOptions, conversationTopicRefOptions, TOWN_LABELS, type RefOption } from '../entityRefs'
 import { SCREEN_IDS } from '../EntityInspector'
 
 // Screens reachable from an NPC's dialogue: the standard SCREEN_IDS list, plus
@@ -76,13 +76,16 @@ const BTN_PICK: React.CSSProperties = {
 
 type ScheduleRow = NonNullable<RawNpc['schedule']>[number]
 
-function ScheduleEditor({ schedule, onChange, interiors }: {
+function ScheduleEditor({ schedule, onChange, interiors, currentMapId }: {
   schedule: ScheduleRow[]
   onChange: (s: ScheduleRow[]) => void
   /** Interior room ids (not building ids) — a schedule's interior location is
    *  matched against configData.interiors keys at runtime, and multi-room
    *  buildings have extra rooms whose id differs from the building's own id. */
   interiors: RefOption[]
+  /** The town being edited — excluded from the 'travel' destination picker
+   *  (an NPC can't travel to the town they're already in). */
+  currentMapId: MapId
 }) {
   function update(i: number, partial: Partial<ScheduleRow>) {
     onChange(schedule.map((r, idx) => idx === i ? { ...r, ...partial } as ScheduleRow : r))
@@ -93,7 +96,13 @@ function ScheduleEditor({ schedule, onChange, interiors }: {
 
   return (
     <div>
-      {schedule.map((row, i) => (
+      {schedule.map((row, i) => {
+        const loc = row.location
+        // A row's previous tx/ty (when switching away from exterior/interior)
+        // is carried over as a convenience default; 'travel' has none to draw from.
+        const prevTx = 'tx' in loc ? loc.tx : 0
+        const prevTy = 'ty' in loc ? loc.ty : 0
+        return (
         <div key={i} style={{ background: '#1a1a3e', border: '1px solid #2a2a5a', borderRadius: 3, padding: 6, marginBottom: 4 }}>
           <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
             <label style={{ color: '#888', fontSize: 10 }}>From</label>
@@ -108,32 +117,52 @@ function ScheduleEditor({ schedule, onChange, interiors }: {
           </div>
           <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
             <select
-              value={row.location.type}
+              value={loc.type}
               onChange={e => {
-                const type = e.target.value as 'exterior' | 'interior'
-                setLocation(i, type === 'exterior'
-                  ? { type: 'exterior', tx: row.location.tx, ty: row.location.ty }
-                  : { type: 'interior', buildingId: '', tx: row.location.tx, ty: row.location.ty })
+                const type = e.target.value as 'exterior' | 'interior' | 'travel'
+                if (type === 'exterior') {
+                  setLocation(i, { type: 'exterior', tx: prevTx, ty: prevTy })
+                } else if (type === 'interior') {
+                  setLocation(i, { type: 'interior', buildingId: '', tx: prevTx, ty: prevTy })
+                } else {
+                  const destination = (Object.keys(TOWN_LABELS) as MapId[]).find(id => id !== currentMapId) ?? currentMapId
+                  setLocation(i, { type: 'travel', town: destination })
+                }
               }}
               style={{ padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 10 }}
             >
               <option value="exterior">Exterior</option>
               <option value="interior">Interior</option>
+              <option value="travel">Traveling</option>
             </select>
-            {row.location.type === 'interior' && (
+            {loc.type === 'interior' && (
               <div style={{ width: 110 }}>
-                <EntityRefPicker value={row.location.buildingId} options={interiors} placeholder="room…"
-                  onChange={v => setLocation(i, { ...row.location, type: 'interior', buildingId: v })} />
+                <EntityRefPicker value={loc.buildingId} options={interiors} placeholder="room…"
+                  onChange={v => setLocation(i, { type: 'interior', buildingId: v, tx: loc.tx, ty: loc.ty })} />
               </div>
             )}
-            <label style={{ color: '#888', fontSize: 10 }}>X</label>
-            <input type="number" value={row.location.tx}
-              onChange={e => setLocation(i, { ...row.location, tx: Number(e.target.value) })}
-              style={{ ...NUM, width: 44 }} />
-            <label style={{ color: '#888', fontSize: 10 }}>Y</label>
-            <input type="number" value={row.location.ty}
-              onChange={e => setLocation(i, { ...row.location, ty: Number(e.target.value) })}
-              style={{ ...NUM, width: 44 }} />
+            {loc.type === 'travel' ? (
+              <select
+                value={loc.town}
+                onChange={e => setLocation(i, { type: 'travel', town: e.target.value as MapId })}
+                style={{ padding: '2px 5px', background: '#111', border: '1px solid #444', color: '#eee', borderRadius: 3, fontSize: 10 }}
+              >
+                {(Object.entries(TOWN_LABELS) as [MapId, string][])
+                  .filter(([id]) => id !== currentMapId)
+                  .map(([id, label]) => <option key={id} value={id}>{label}</option>)}
+              </select>
+            ) : (
+              <>
+                <label style={{ color: '#888', fontSize: 10 }}>X</label>
+                <input type="number" value={loc.tx}
+                  onChange={e => setLocation(i, { ...loc, tx: Number(e.target.value) })}
+                  style={{ ...NUM, width: 44 }} />
+                <label style={{ color: '#888', fontSize: 10 }}>Y</label>
+                <input type="number" value={loc.ty}
+                  onChange={e => setLocation(i, { ...loc, ty: Number(e.target.value) })}
+                  style={{ ...NUM, width: 44 }} />
+              </>
+            )}
             <label style={{ color: '#888', fontSize: 10 }}>Activity</label>
             <select
               value={row.activity ?? ''}
@@ -145,7 +174,8 @@ function ScheduleEditor({ schedule, onChange, interiors }: {
             </select>
           </div>
         </div>
-      ))}
+        )
+      })}
       <button style={BTN_ADD} onClick={() => onChange([...schedule, { startHour: 8, endHour: 17, location: { type: 'exterior', tx: 0, ty: 0 } }])}>
         + Add time slot
       </button>
@@ -212,11 +242,12 @@ function InnRumoursEditor({ rumours, onChange }: {
 
 // ── NpcFullEditor ─────────────────────────────────────────────────────────────
 
-function NpcFullEditor({ npc, opts, onUpdate, onPickLocation }: {
+function NpcFullEditor({ npc, opts, onUpdate, onPickLocation, mapId }: {
   npc: RawNpc
   opts: NpcRefOpts
   onUpdate: (partial: Partial<RawNpc>) => void
   onPickLocation?: () => void
+  mapId: MapId
 }) {
   const questReceiveArr: string[] = Array.isArray(npc.questReceive)
     ? npc.questReceive
@@ -307,6 +338,7 @@ function NpcFullEditor({ npc, opts, onUpdate, onPickLocation }: {
         <ScheduleEditor
           schedule={npc.schedule ?? []}
           interiors={opts.interiors}
+          currentMapId={mapId}
           onChange={s => onUpdate({ schedule: s.length > 0 ? s : undefined })}
         />
       </Field>
@@ -433,6 +465,7 @@ export function NpcEditor({
               opts={refOpts}
               onUpdate={partial => onUpdateNpc(i, partial)}
               onPickLocation={() => onPickLocation('npc', i)}
+              mapId={mapId}
             />
           )}
         </div>

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -167,13 +167,18 @@ export interface RawInteriorNPCLocation {
         ty: number
 }
 
+export interface RawTravelNPCLocation {
+  type: string
+  town: string
+}
+
 export interface RawNpcScheduleEntry {
   startHour: number
   endHour: number
   /** Loose raw type; the typed `NpcActivity` union lives in loader.ts. */
   activity?: string
 
-  location: RawExteriorNPCLocation | RawInteriorNPCLocation
+  location: RawExteriorNPCLocation | RawInteriorNPCLocation | RawTravelNPCLocation
 }
 
 export interface RawNpc {

--- a/web/src/data/hub/hubWorldFactory.ts
+++ b/web/src/data/hub/hubWorldFactory.ts
@@ -1,6 +1,7 @@
 import { createHubLocationData, createHubQuestData, HubLocationBundle, HubQuestBundle } from "./loader";
 import type { RawConfig } from './config'
 import { HubQuestDef, RawQuestConfig } from "./questDefs";
+import type { MapId } from './mapIds'
 
 export interface RawQuestPickupItem {
   id: string
@@ -18,20 +19,7 @@ export interface RawQuestPickupItem {
   glowRadius?: number
   pulse?: boolean
 }
-export type MapId =
-  | 'ravenwatch'
-  | 'ironholdkeep'
-  | 'millhaven'
-  | 'thornwoodcamp'
-  | 'capitalcity'
-  | 'royalpalace'
-  | 'saltmereport'
-  | 'gearford'
-  | 'harrowfield'
-  | 'appleford'
-  | 'gravemoor'
-  | 'hollowmere'
-  | 'dreadspirecitadel'
+export type { MapId } from './mapIds'
 export type QuestDefsJson = { pickupItems?: RawQuestPickupItem[]; [key: string]: unknown }
 
 export interface LocationEntry {
@@ -90,7 +78,7 @@ const QUEST_LOADERS: Record<MapId, () => Promise<{ default: RawQuestConfig }>> =
 }
 
 /** locationKey (App.tsx/world-map convention) for each MapId. */
-const LOCATION_KEY_BY_MAP_ID: Record<MapId, string> = {
+export const LOCATION_KEY_BY_MAP_ID: Record<MapId, string> = {
   ravenwatch:        'ravenwatch',
   ironholdkeep:      'ironhold-keep',
   millhaven:         'millhaven',

--- a/web/src/data/hub/ironholdkeep/config.json
+++ b/web/src/data/hub/ironholdkeep/config.json
@@ -2880,6 +2880,29 @@
       "dislikedGiftItemIds": [
         "pressed-flower"
       ]
+    },
+    {
+      "id": "trader-pell",
+      "name": "Trader Pell",
+      "sprite": "hub-npc-trader",
+      "tx": 9,
+      "ty": 24,
+      "dialogue": [
+        "Made it to Ironhold in one piece — road's clear past the bend.",
+        "Back to Thornwood Camp by nightfall, if you need anything before I go."
+      ],
+      "schedule": [
+        {
+          "startHour": 9,
+          "endHour": 17,
+          "location": { "type": "exterior", "tx": 9, "ty": 24 }
+        },
+        {
+          "startHour": 17,
+          "endHour": 9,
+          "location": { "type": "travel", "town": "thornwoodcamp" }
+        }
+      ]
     }
   ],
   "interiors": {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -6,6 +6,7 @@ import { ConversationTopicDef, DialogueTree, FriendshipDialogue, HubQuestDef, Ra
 import { FlameColor, FlameType, RawAnimal, RawConfig, RawInteractable } from './config'
 export type { FlameColor, FlameType } from './config'
 import rollbar from '../../rollbar'
+import type { MapId } from './mapIds'
 
 const WALL_MATERIAL_NAMES = new Set<string>(Object.keys(WALL_TILES))
 const ROOF_MATERIAL_NAMES = new Set<string>(Object.keys(ROOF_TILES))
@@ -178,6 +179,10 @@ export interface NpcScheduleEntry {
   location:
     | { type: 'exterior'; tx: number; ty: number }
     | { type: 'interior'; buildingId: string; tx: number; ty: number }
+    /** Not physically present in this town right now — away visiting `town`.
+     *  Requires a matching HubNpc record (same id) authored in that town's
+     *  own config.json, resolving them present there for the same hours. */
+    | { type: 'travel'; town: MapId }
 }
 
 export interface HubNpc {

--- a/web/src/data/hub/mapIds.ts
+++ b/web/src/data/hub/mapIds.ts
@@ -1,0 +1,40 @@
+// The canonical, lowercase-hyphenated town-id space, and their display names.
+// Deliberately zero-dependency (no imports) — loader.ts needs MapId for
+// NpcScheduleEntry's 'travel' location type, and hubWorldFactory.ts already
+// imports from loader.ts, so a shared, dependency-free home for MapId avoids
+// a circular import between the two.
+
+export type MapId =
+  | 'ravenwatch'
+  | 'ironholdkeep'
+  | 'millhaven'
+  | 'thornwoodcamp'
+  | 'capitalcity'
+  | 'royalpalace'
+  | 'saltmereport'
+  | 'gearford'
+  | 'harrowfield'
+  | 'appleford'
+  | 'gravemoor'
+  | 'hollowmere'
+  | 'dreadspirecitadel'
+
+export const TOWN_LABELS: Record<MapId, string> = {
+  ravenwatch: 'Ravenwatch',
+  millhaven: 'Millhaven',
+  ironholdkeep: 'Ironhold Keep',
+  thornwoodcamp: 'Thornwood Camp',
+  capitalcity: 'Capital City',
+  royalpalace: 'Royal Palace',
+  saltmereport: 'Saltmere Port',
+  gearford: 'Gearford',
+  harrowfield: 'Harrowfield',
+  appleford: 'Appleford',
+  gravemoor: 'Gravemoor',
+  hollowmere: 'Hollowmere',
+  dreadspirecitadel: 'Dreadspire Citadel',
+}
+
+export function townLabel(map: MapId): string {
+  return TOWN_LABELS[map] ?? map
+}

--- a/web/src/data/hub/npcTravelIntegrity.test.ts
+++ b/web/src/data/hub/npcTravelIntegrity.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { getHubWorldData, LOCATION_KEY_BY_MAP_ID } from './hubWorldFactory'
+import { hourInRange } from '../../game/hub/hubClock'
+import type { MapId } from './mapIds'
+
+// Guard for #2111 phase 4: a 'travel' schedule entry names the town an NPC
+// should actually be found in. For the game to genuinely place them there —
+// not just hide them at home — that destination town's own config.json must
+// separately author a full HubNpc record with the same id, present (not
+// itself traveling) during the hours the home-town side claims they're away.
+// There's no cross-town NPC registry at runtime to enforce this automatically
+// (each town's HUB_NPCS is strictly that town's own data), so a typo'd
+// destination or an un-mirrored schedule fails silently: the NPC just vanishes
+// with nowhere to reappear. Swept across every town.
+const { locationRegistry } = await getHubWorldData()
+
+const MAP_ID_BY_LOCATION_KEY: Record<string, MapId> = Object.fromEntries(
+  (Object.entries(LOCATION_KEY_BY_MAP_ID) as [MapId, string][]).map(([mapId, key]) => [key, mapId]),
+)
+
+describe('NPC travel entries target a real town with a matching present record', () => {
+  for (const [townKey, { locationData }] of Object.entries(locationRegistry)) {
+    const ownMapId = MAP_ID_BY_LOCATION_KEY[townKey]
+    for (const npc of locationData.HUB_NPCS) {
+      for (const entry of npc.schedule ?? []) {
+        if (entry.location.type !== 'travel') continue
+        const destTown = entry.location.town
+        const destKey = LOCATION_KEY_BY_MAP_ID[destTown] as string | undefined
+
+        it(`${townKey}/${npc.id}: travels to a real, different town`, () => {
+          expect(destTown, `${npc.id} is marked traveling to their own town (${townKey})`).not.toBe(ownMapId)
+          expect(destKey && locationRegistry[destKey], `no such town "${destTown}"`).toBeTruthy()
+        })
+
+        if (!destKey || !locationRegistry[destKey]) continue
+
+        it(`${townKey}/${npc.id}: has a matching record in "${destTown}" actually present ${entry.startHour}–${entry.endHour}`, () => {
+          const destNpc = locationRegistry[destKey].locationData.HUB_NPCS.find(n => n.id === npc.id)
+          expect(destNpc, `no NPC with id "${npc.id}" authored in ${destTown}'s config.json`).toBeTruthy()
+          if (!destNpc) return
+
+          const badHours: number[] = []
+          for (let h = 0; h < 24; h++) {
+            if (!hourInRange(h, entry.startHour, entry.endHour)) continue
+            const destLoc = destNpc.schedule?.find(e => hourInRange(h, e.startHour, e.endHour))?.location
+            if (!destLoc || destLoc.type === 'travel') badHours.push(h)
+          }
+          expect(
+            badHours,
+            `${npc.id} is marked traveling to ${destTown} at hour(s) ${badHours.join(', ')}, but their ` +
+            `${destTown} record doesn't resolve them present there then`,
+          ).toEqual([])
+        })
+      }
+    }
+  }
+})

--- a/web/src/data/hub/thornwoodcamp/config.json
+++ b/web/src/data/hub/thornwoodcamp/config.json
@@ -524,6 +524,18 @@
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
         "chicken-feed"
+      ],
+      "schedule": [
+        {
+          "startHour": 9,
+          "endHour": 17,
+          "location": { "type": "travel", "town": "ironholdkeep" }
+        },
+        {
+          "startHour": 17,
+          "endHour": 9,
+          "location": { "type": "exterior", "tx": 5, "ty": 30 }
+        }
       ]
     },
     {

--- a/web/src/game/hub/hubNpcSchedule.test.ts
+++ b/web/src/game/hub/hubNpcSchedule.test.ts
@@ -176,4 +176,19 @@ describe('resolveNpcInteriorPresence', () => {
     const nobody: HubNpc = { id: 'ghost', name: 'Nobody', sprite: 'x', tx: 0, ty: 0, dialogue: [] }
     expect(resolveNpcInteriorPresence(nobody, 'card-shop', 12)).toBeNull()
   })
+
+  it('is absent from a building while a travel entry is active (#2111 phase 4)', () => {
+    // No code change was needed for this — a 'travel' entry is truthy but
+    // matches neither branch of the type check below, so it already resolves
+    // to absent by construction. This test documents that so a future
+    // refactor can't silently regress it.
+    const traveler: HubNpc = {
+      ...shopkeeper,
+      schedule: [
+        { startHour: 9, endHour: 17, location: { type: 'travel', town: 'millhaven' } },
+        { startHour: 17, endHour: 9, location: { type: 'interior', buildingId: 'card-shop', tx: 6, ty: 3 } },
+      ],
+    }
+    expect(resolveNpcInteriorPresence(traveler, 'card-shop', 12)).toBeNull()
+  })
 })

--- a/web/src/game/hub/npcLocator.test.ts
+++ b/web/src/game/hub/npcLocator.test.ts
@@ -88,4 +88,12 @@ describe('resolveNpcPlace', () => {
     const npc: HubNpc = { ...base, tx: 50, ty: 50 }
     expect(resolveNpcPlace(npc, 12, loc)).toEqual({ name: 'Testville', tx: 50, ty: 50 })
   })
+
+  it('resolves a traveling NPC to "away", not their static position or a pinnable tile', () => {
+    const npc: HubNpc = { ...base, schedule: [{ startHour: 9, endHour: 17, location: { type: 'travel', town: 'millhaven' } }] }
+    const place = resolveNpcPlace(npc, 12, loc)
+    expect(place.awayTown).toBe('millhaven')
+    expect(place.interiorId).toBeUndefined()
+    expect(place.name).toContain('Millhaven')
+  })
 })

--- a/web/src/game/hub/npcLocator.ts
+++ b/web/src/game/hub/npcLocator.ts
@@ -1,5 +1,7 @@
 import type { HubArea, HubLocationBundle, HubNpc, HubPickupItem } from '../../data/hub/loader'
 import { getNpcLocation } from './hubNpcSchedule'
+import type { MapId } from '../../data/hub/mapIds'
+import { townLabel } from '../../data/hub/mapIds'
 
 const T = 32
 
@@ -11,6 +13,11 @@ export interface NpcPlace {
   ty: number
   /** Set when the NPC is currently inside a building interior. */
   interiorId?: string
+  /** Set when the NPC currently resolves to a 'travel' entry — not physically
+   *  present anywhere on this town's map right now. tx/ty are the NPC's
+   *  static home position (a placeholder, not a real pin) — callers should
+   *  treat awayTown as the signal to skip placing a pin. */
+  awayTown?: MapId
 }
 
 /** Name of the area whose rect contains the centre of tile (tx, ty), or null. */
@@ -89,6 +96,9 @@ export function resolveNpcPlace(npc: HubNpc, gameHour: number, loc: HubLocationB
   if (sched?.type === 'interior') return interior(sched.buildingId, sched.tx, sched.ty)
   if (sched?.type === 'exterior') {
     return { name: areaNameForTile(sched.tx, sched.ty, loc.HUB_AREAS) ?? loc.HUB_TOWN_NAME, tx: sched.tx, ty: sched.ty }
+  }
+  if (sched?.type === 'travel') {
+    return { name: `Away — visiting ${townLabel(sched.town)}`, tx: npc.tx, ty: npc.ty, awayTown: sched.town }
   }
 
   // No schedule entry for this hour — use the NPC's base placement.


### PR DESCRIPTION
## Summary

The last unstarted piece of issue #2111. Prior phases shipped: building `hours` gating NPC routing (#2112), one resolver deciding NPC interior presence (#2113), and anonymous ambient NPCs leaving town via exit tiles into a shared "on the road" counter (#2114). This phase extends the idea to *named* NPCs: a specific character can now be scheduled to genuinely travel to — and be found in — a second, specific town during certain hours, not just vanish.

## Design

- **New schedule-location type**: `NpcScheduleEntry.location` gains a third variant, `{ type: 'travel'; town: MapId }`, alongside the existing `'exterior'`/`'interior'`. Mirrored in the two other places this union is independently redeclared (the map editor's `RawNpc` type, and the raw JSON validator in `config.ts`) so all three stay in sync.
- **`MapId` extraction**: previously declared inline in `hubWorldFactory.ts`, which already imports from `loader.ts` — `loader.ts` needed `MapId` too, so importing back would cycle. Moved `MapId` (plus the map editor's duplicated `TOWN_LABELS`/`townLabel`) into a new dependency-free `web/src/data/hub/mapIds.ts`; both files now re-export from it. Pure refactor, verified as a no-op before touching any behavior.
- **Rendering**: `resolveNpcInteriorPresence` already treated a `'travel'` entry as absent with no code change needed (same "gap = not here" design from Phase 3) — added a test documenting that. `walkNamedNpc` had a real latent bug the new type exposed: its two-way branch treated *any* non-exterior location as "enter a building," which would have set a traveling NPC's `currentBuildingId` to `undefined` with no door to ever emerge from. Restructured into an explicit three-way branch, including a return-from-trip case (no door to emerge from, so the NPC reappears directly at the newly-scheduled tile).
- **Minimap/Town Directory**: `resolveNpcPlace` had a related gap — a matched-but-unhandled location type fell through to the same fallback used for "no schedule info at all," which would show a traveling NPC pinned at home. Added an explicit branch and a new `NpcPlace.awayTown` field; `HubWorld.tsx` skips placing a pin when set, and the Town Directory shows "Away — visiting X" with its pin button disabled instead of one that would silently do nothing.
- **Map editor**: added a "Traveling" option with a destination-town dropdown to both places a schedule entry's location is edited.
- **Illustrative content**: Trader Pell (Thornwood Camp) already had dialogue about traveling between towns but no mechanism behind it — he now splits his day between his existing Thornwood Camp spot and a new stub record near Ironhold Keep's Gatehouse (same id, matching schedule, short visiting-specific dialogue).
- **Authoring model**: deliberately plain duplication (a full `HubNpc` record in each town, linked only by the shared id) rather than a new data-sharing mechanism — there's no cross-town NPC registry at runtime, ids are already globally unique, and friendship/relationship/journal state is already flat and id-keyed. A new cross-town test enforces the two paired records stay honest instead of relying on convention.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2455/2455 passing (Playwright browser-launch error in output is pre-existing Storybook noise)
- [x] `npm run build` — clean
- [x] Verified the new `npcTravelIntegrity.test.ts` actually catches a broken pairing: temporarily mismatched Trader Pell's two records, confirmed the expected failure, reverted
- [x] Browser smoke test: loads with no console errors beyond expected offline-Firebase noise in this sandboxed environment; all 13 towns' data (including Thornwood Camp and Ironhold Keep) already parses cleanly through the same loader pipeline exercised by every data-integrity test
- [ ] Not verified live: watching Trader Pell actually walk between the two towns at the scheduled hour. The game clock has no debug override and scripting a specific-hour visit reliably in this headless canvas is the slow/unreliable case this session has consistently avoided by default — rests on the new regression test plus line-by-line verification of the exact render/pathfinding code done during planning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_