### PR TITLE
Fix tapping the grave hole not entering the cavern

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2937,6 +2937,23 @@ export function HubTownCanvas({
           return
         }
 
+        // A door with no building footprint of its own (e.g. a hole in the
+        // ground) isn't covered by the buildingSet check above. Its door
+        // sprite conventionally renders one tile north of its trigger tile —
+        // and any associated ground decor (a visible "hole") sits there too
+        // — so a tap landing on either that tile or the trigger tile itself
+        // should route precisely onto the trigger, the same as tapping a
+        // normal building's door. Without this, nearestWalkable's fallback
+        // below can land one tile off if the decor tile itself is solid
+        // (e.g. via a BlockedPath), silently failing to enter.
+        const tappedDoor = HUB_DOORS.find(
+          d => (d.tx === tapTx && d.ty === tapTy) || (d.tx === tapTx && d.ty - 1 === tapTy),
+        )
+        if (tappedDoor) {
+          startWalk([tappedDoor.tx, tappedDoor.ty])
+          return
+        }
+
         const node = EXTERIOR_NPCS.find(n => n.tx === tapTx && n.ty === tapTy && n.screen)
         // Ambient crowd NPCs have no hit area of their own, so a tap landing
         // directly on one falls through here — snap to the nearest free tile


### PR DESCRIPTION
## Summary

User report: tapping the grave hole in Ravenwatch doesn't enter the cavern, but tapping one tile below it does.

Root cause: `HUB_DOORS.find(...)`-based routing only special-cases taps that land inside a building's footprint (`buildingSet`) — for those, the tap routes to the nearest door regardless of exact position. The cavern's door has no building footprint (it's a hole in open ground, not a building), so tapping it fell through to the general `nearestWalkable` fallback. That fallback finds the nearest *walkable* tile to the tap — but the hole's own tile is deliberately marked solid (`BlockedPath`'s cleared decor is added to the solid set for pathfinding, so the avatar can't stand on top of the pit graphic), so it doesn't reliably resolve to the door's exact trigger tile one tile south, where the visual hole's door actually sits.

## Fix

Generalizes rather than special-cases: any tap landing on a door's trigger tile, or the tile its sprite/visual cue conventionally occupies one tile north (the same offset every other door sprite already uses), now routes precisely to that door — mirroring the existing building-tile rule. This fixes the cavern door and would also fix the same class of bug for any other footprint-less hidden door (e.g. the existing gatehouses).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2447/2447 passing
- [x] Browser smoke test: loads with no console errors beyond expected offline-Firebase noise in this sandboxed environment
- [ ] Not verified live: actually tapping the hole tile in a running game and confirming entry. Per this repo's own guidance, reliably scripting a tap-to-specific-tile interaction against this headless canvas is the slow/unreliable case not attempted by default — this rests on tracing the exact tap-handling code path (confirmed the hole's door lacks a building footprint, confirmed the new check's tile math matches the door's actual placement).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_