### PR TITLE
Give the Buried Hollow darkness, treasure, and a talking skeleton

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -49,6 +49,12 @@ const NPC_BLOCK_WAIT_MAX_MS  = 900   // give up waiting and try to reroute after
 const NIGHT_LIGHT_INNER  = 4 * T   // fully lit within this radius of avatar
 const NIGHT_LIGHT_OUTER  = 7 * T   // fully dark beyond this radius
 const NIGHT_NPC_LIGHT_R  = 2 * T   // small glow radius around each NPC
+// A dark interior (HubInterior.dark) is typically only a handful of tiles
+// across — reusing the exterior torch radii above would light most of a room
+// this small from any position, defeating the point. Scaled down so the
+// avatar's own light stays a modest personal bubble instead.
+const INTERIOR_DARK_INNER = 1.5 * T
+const INTERIOR_DARK_OUTER = 3   * T
 
 // ── Interactable affordance aura ────────────────────────────────────────────
 // A faint pulsing halo drawn behind tap-reactive objects that own visible decor
@@ -286,6 +292,19 @@ export function HubTownCanvas({
     nightSprite.height    = MAP_H
     nightSprite.visible   = false
     nightSprite.eventMode = 'none'  // overlay must not block pointer events on game objects
+    // Interior darkness overlay (HubInterior.dark) — same punch-hole technique as
+    // the exterior night pass above, but scoped to whichever room is currently
+    // active: its own small canvas sized to that room's own pixel dimensions
+    // (rooms are tiny compared to the exterior map, so a fresh canvas per entry
+    // is cheap), rebuilt in doEnterInterior and torn down in doExitInterior.
+    // Deliberately independent of the exterior nightSprite/decorGlows — that
+    // pipeline runs only while !interiorActive and its light sources are in
+    // exterior map-pixel coordinates, not room-local ones.
+    let interiorDarkCanvas:  HTMLCanvasElement | null = null
+    let interiorDarkCtx:     CanvasRenderingContext2D | null = null
+    let interiorDarkTexture: PIXI.Texture | null = null
+    let interiorDarkSprite:  PIXI.Sprite | null = null
+    let interiorGlowSources: GlowSource[] = []
     // Keep legacy aliases so existing code below compiles unchanged
     const npcLayer    = spriteLayer
     const avatarLayer = spriteLayer
@@ -2044,6 +2063,8 @@ export function HubTownCanvas({
         interiorAnimals.length = 0
         currentInteriorId  = null
         currentInteriorObj = null
+        if (interiorDarkSprite) { interiorDarkTexture?.destroy(true); interiorDarkSprite = null; interiorDarkCanvas = null; interiorDarkCtx = null; interiorDarkTexture = null }
+        interiorGlowSources = []
         highlightGfx.clear()
         stopInteriorAudio()  // resume town theme + drop ambiance
         onExitInteriorRef.current?.()
@@ -2059,6 +2080,12 @@ export function HubTownCanvas({
     // ── Interior enter ─────────────────────────────────────────────────────────
     const doEnterInterior = (buildingId: string, entryTx?: number, entryTy?: number, direction?: HubInteriorExit['direction'], sourceTx?: number) => {
       try {
+      // Fresh per-room light-source list for the interior darkness overlay
+      // (HubInterior.dark) — repopulated below as decor is collected, read
+      // once the room finishes building. Reset here so re-entering a
+      // different room never carries over a prior room's glow sources.
+      interiorGlowSources = []
+
       // Locked door check — block entry if key not in inventory
       const lock = HUB_LOCKED_DOORS.find(l => l.buildingId === buildingId)
       if (lock && !doorKeysRef.current?.has(lock.lockedBy)) {
@@ -2356,7 +2383,11 @@ export function HubTownCanvas({
           const list = byTileId.get(d.tileId) ?? []
           list.push([d.tx, d.ty])
           byTileId.set(d.tileId, list)
-          if (d.glow) decorGlows.push({ x: d.tx * T + T / 2, y: d.ty * T + T / 2, radius: (d.glowRadius ?? 2) * T, pulse: !!d.pulse })
+          if (d.glow) {
+            const glowSource = { x: d.tx * T + T / 2, y: d.ty * T + T / 2, radius: (d.glowRadius ?? 2) * T, pulse: !!d.pulse }
+            decorGlows.push(glowSource)
+            interiorGlowSources.push(glowSource)
+          }
           if (d.flame) {
             const fx = d.tx * T + T / 2, fy = d.ty * T + T * FLAME_ANCHOR_Y
             collectFlame(flames, decorGlows, !!d.glow, target, fx, fy, fx, fy, d.flameType, d.flameColor, d.ty)
@@ -2629,6 +2660,26 @@ export function HubTownCanvas({
       // above decor — added after avatar so it renders on top
       interiorLayer.addChild(decorAboveContainer)
       renderDecorItems(visibleDecor.filter(d => d.zlayer === 'above'), decorAboveContainer)
+
+      // Interior darkness overlay (HubInterior.dark) — added last so it renders
+      // on top of everything else in the room; punched with holes each frame
+      // (see the ticker below) around the avatar and any glow decor collected
+      // above. Torn down in doExitInterior; also cleared here defensively in
+      // case entry into a new room happens without an intervening exit.
+      if (interiorDarkSprite) { interiorLayer.removeChild(interiorDarkSprite); interiorDarkTexture?.destroy(true); interiorDarkSprite = null }
+      if (interior.dark) {
+        const iw = interior.width * T, ih = interior.height * T
+        interiorDarkCanvas = document.createElement('canvas')
+        interiorDarkCanvas.width  = Math.ceil(iw / NIGHT_CANVAS_SCALE)
+        interiorDarkCanvas.height = Math.ceil(ih / NIGHT_CANVAS_SCALE)
+        interiorDarkCtx = interiorDarkCanvas.getContext('2d')!
+        interiorDarkTexture = PIXI.Texture.from(interiorDarkCanvas)
+        interiorDarkSprite = new PIXI.Sprite(interiorDarkTexture)
+        interiorDarkSprite.width     = iw
+        interiorDarkSprite.height    = ih
+        interiorDarkSprite.eventMode = 'none'
+        interiorLayer.addChild(interiorDarkSprite)
+      }
 
       // Scroll viewport to center on interior
       onAvatarMoveRef.current(intOffX + defaultEntryTile[0] * T + T / 2, intOffY + defaultEntryTile[1] * T + T / 2)
@@ -3498,6 +3549,45 @@ export function HubTownCanvas({
         } // end _nightDirty
       } else {
         nightSprite.visible = false
+      }
+
+      // Interior darkness overlay (HubInterior.dark) — redrawn every frame
+      // while active; rooms are small so, unlike the exterior pass above,
+      // this skips the dirty-check optimization for simplicity.
+      if (interiorActive && currentInteriorObj?.dark && interiorDarkSprite && interiorDarkCtx && interiorDarkCanvas && interiorDarkTexture && avatar) {
+        const cw = interiorDarkCanvas.width
+        const ch = interiorDarkCanvas.height
+        const cs = 1 / NIGHT_CANVAS_SCALE
+        interiorDarkCtx.clearRect(0, 0, cw, ch)
+        interiorDarkCtx.fillStyle = 'rgba(0,0,0,0.92)'
+        interiorDarkCtx.fillRect(0, 0, cw, ch)
+        interiorDarkCtx.globalCompositeOperation = 'destination-out'
+        // Avatar torch
+        const ax = avatar.x * cs, ay = avatar.y * cs
+        const innerR = INTERIOR_DARK_INNER * cs, outerR = INTERIOR_DARK_OUTER * cs
+        const torchGrad = interiorDarkCtx.createRadialGradient(ax, ay, innerR, ax, ay, outerR)
+        torchGrad.addColorStop(0, 'rgba(0,0,0,1)')
+        torchGrad.addColorStop(1, 'rgba(0,0,0,0)')
+        interiorDarkCtx.fillStyle = torchGrad
+        interiorDarkCtx.beginPath()
+        interiorDarkCtx.arc(ax, ay, outerR, 0, Math.PI * 2)
+        interiorDarkCtx.fill()
+        // Glow decor (lanterns, etc.) collected for this room on entry
+        const _glowMs = performance.now()
+        const _pulse  = (seed: number) => 0.8 + 0.2 * Math.sin(_glowMs / 500 + seed)
+        for (const g of interiorGlowSources) {
+          const gx = g.x * cs, gy = g.y * cs
+          const gr = (g.pulse ? g.radius * _pulse(g.x + g.y) : g.radius) * cs
+          const glowGrad = interiorDarkCtx.createRadialGradient(gx, gy, 0, gx, gy, gr)
+          glowGrad.addColorStop(0, 'rgba(0,0,0,1)')
+          glowGrad.addColorStop(1, 'rgba(0,0,0,0)')
+          interiorDarkCtx.fillStyle = glowGrad
+          interiorDarkCtx.beginPath()
+          interiorDarkCtx.arc(gx, gy, gr, 0, Math.PI * 2)
+          interiorDarkCtx.fill()
+        }
+        interiorDarkCtx.globalCompositeOperation = 'source-over'
+        interiorDarkTexture.source.update()
       }
 
       // Quest pickup visibility — only show while the associated quest is active

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -149,6 +149,8 @@ export interface RawInterior {
   ambianceId?: string
   /** Render the player's placed furniture (homeLayout.ts) here at runtime — see furnitureTiles.ts. */
   playerDecor?: boolean
+  /** Render this room unlit except near the avatar's torch and glow-flagged decor. */
+  dark?: boolean
 }
 
 

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -166,6 +166,10 @@ export interface HubInterior {
   ambianceId?: string
   /** Render the player's placed furniture (homeLayout.ts) here at runtime — see furnitureTiles.ts. */
   playerDecor?: boolean
+  /** Render this room unlit except near the avatar's own torch and any
+   *  glow-flagged decor — a dedicated interior-scoped punch-hole overlay,
+   *  independent of the exterior day/night cycle (see HubTownCanvas.tsx). */
+  dark?: boolean
 }
 
 /** Visible activity an NPC performs while at a scheduled location. */
@@ -711,6 +715,7 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         musicId:    rawAny.musicId as string | undefined,
         ambianceId: rawAny.ambianceId as string | undefined,
         playerDecor: rawAny.playerDecor as boolean | undefined,
+        dark:        rawAny.dark as boolean | undefined,
       } satisfies HubInterior,
     ]
   })

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -10277,6 +10277,7 @@
       "height": 8,
       "floorTileId": "darkStoneFloor",
       "wallTileId": "darkStone",
+      "dark": true,
       "decor": [
         { "tx": 5, "ty": 1, "tileId": "largeRock" },
         { "tx": 2, "ty": 1, "tileId": "smallRock" },
@@ -10296,6 +10297,7 @@
       "height": 8,
       "floorTileId": "darkStoneFloor",
       "wallTileId": "darkStone",
+      "dark": true,
       "decor": [
         { "tx": 1, "ty": 1, "tileId": "largeRock" },
         { "tx": 8, "ty": 1, "tileId": "smallRock" },
@@ -10314,6 +10316,7 @@
       "height": 8,
       "floorTileId": "darkStoneFloor",
       "wallTileId": "darkStone",
+      "dark": true,
       "decor": [
         { "tx": 2, "ty": 1, "tileId": "largeRock" },
         { "tx": 8, "ty": 1, "tileId": "smallRock" },
@@ -12348,6 +12351,21 @@
         "Hello!"
       ],
       "building": "arcade-building-w-4"
+    },
+    {
+      "id": "whistlebone",
+      "name": "Whistlebone",
+      "sprite": "skeleton",
+      "tx": 5,
+      "ty": 5,
+      "building": "ravenwatch-hollow-tunnel-east",
+      "dialogue": [
+        "Down here so long the worms gave up on me. Rude of them, honestly.",
+        "Someone dug that hole up top. Wasn't me — I came in through the honest way. However long ago that was.",
+        "Mind the dark past the lantern-light. I've had a very long time to notice what else lives down here, and it isn't friendly."
+      ],
+      "questGive": "the-nameless-bones",
+      "questReceive": "the-nameless-bones"
     }
   ],
   "ambientNpcSprites": [
@@ -12550,6 +12568,21 @@
         "crystals": 10
       },
       "buildingId": "town-hall"
+    },
+    {
+      "id": "hollow-tunnel-chest",
+      "tx": 6,
+      "ty": 2,
+      "tileId": "chest",
+      "collectedTileId": "openChest",
+      "title": "A chest left behind in the dark",
+      "reward": {
+        "crystals": 40,
+        "consumables": [
+          { "id": "health_potion", "quantity": 2 }
+        ]
+      },
+      "buildingId": "ravenwatch-hollow-tunnel-west"
     }
   ],
   "interactables": [

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -4006,6 +4006,41 @@
           "cartographer-bram": 10
         }
       }
+    },
+    {
+      "id": "the-nameless-bones",
+      "title": "The Nameless Bones",
+      "type": "fetch",
+      "giverNpcId": "whistlebone",
+      "receiverNpcId": "whistlebone",
+      "offerDialogue": "One thing I'd want back, if a living soul ever wandered down here. A signet ring — west of here, past the rocks. Bring it and I'd have a name again, at least to myself.",
+      "activeDialogue": "The ring's somewhere in the west passage. I'd look myself, but I seem to be all out of legs that still answer.",
+      "completeDialogue": "That's the one. Been so long I'd half forgotten the crest myself. Take this for the trouble — I've no use for crystals down here, and even less for that.",
+      "steps": [
+        {
+          "key": "ring",
+          "type": "collect",
+          "pickupIds": ["whistlebone-signet-ring"],
+          "required": 1,
+          "itemName": "Signet Ring",
+          "itemIcon": "💍"
+        },
+        {
+          "key": "deliver",
+          "type": "deliver",
+          "targetNpcId": "whistlebone",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "collectible": {
+          "id": "whistlebone-ring",
+          "name": "Nameless Signet Ring",
+          "icon": "💍",
+          "desc": "Returned to the one it belonged to, who wanted nothing more than to be remembered by it."
+        }
+      }
     }
   ],
   "pickupItems": [
@@ -5853,6 +5888,14 @@
       "tileId": "pendant",
       "questId": "trader-provenance",
       "chain": "trader-marked-curio"
+    },
+    {
+      "id": "whistlebone-signet-ring",
+      "tx": 3,
+      "ty": 5,
+      "tileId": "goldRing",
+      "questId": "the-nameless-bones",
+      "building": "ravenwatch-hollow-tunnel-west"
     }
   ],
   "friendshipDialogue": {


### PR DESCRIPTION
## Summary

Follow-up to the Buried Hollow cavern (previously merged): it worked but felt dull — bare rooms, no reward, no one to talk to. Adds all three things requested:

- **Darkness.** No interior in the game has ever actually been dark before — the existing night-dimming pass (the canvas overlay that punches transparent light-holes around the avatar's torch) only ever ran while outside; `glow`/`flame` flags on interior decor have been visually inert this whole time. Added a real per-room darkness overlay (`HubInterior.dark`), reusing the exact same punch-hole technique but scoped to whichever room is active, with its own smaller light radii tuned for room-sized spaces (the exterior torch radius would nearly light up a room this size from any position) and its own light-source list rebuilt fresh per room. All three hollow interiors are now flagged `dark: true`.
- **Treasure.** A chest in the west passage (crystals + potions), using the same `chest`/`openChest` convention every other treasure in the game uses.
- **A talking skeleton NPC / quest giver.** Whistlebone, standing near the one working lantern in the east passage — gives "The Nameless Bones," a small fetch quest for a signet ring hidden in the west passage, rewarding crystals and a collectible.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2455/2455 passing, including the existing cross-town quest/pickup-placement integrity sweeps (giver/receiver validity, pickup id resolution, interior tile bounds) applied to all the new content with no changes needed
- [x] `npm run build` — clean
- [x] Browser smoke test: loads with no console errors beyond expected offline-Firebase noise in this sandboxed environment
- [ ] Not verified live: actually walking into the dark room and confirming the lighting looks right, collecting the chest, and completing Whistlebone's quest end-to-end. Per this repo's own guidance, reliably scripting a multi-step tap-and-walk sequence into a specific interior in this headless canvas is the slow/unreliable case not attempted by default — the darkness rendering mirrors the working exterior night-overlay implementation closely (same technique, same coordinate math, just room-scoped), and the new content is validated the same way all this game's existing quest/pickup/treasure data is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_