### PR TITLE
Make ambient NPCs visible inside buildings they enter

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -1662,6 +1662,24 @@ export function HubTownCanvas({
     const TARGET_NPC_COUNT = 12
     let respawnTimer = 2000
 
+    // Ambient NPCs who've walked into a building's open door don't just
+    // vanish — they linger inside for a while, visible if the player follows
+    // them in, before letting themselves back out. Keyed by buildingId,
+    // in-memory only (ambient NPCs were never persisted across reloads to
+    // begin with). Reuses the sprite's already-loaded texture directly
+    // rather than re-resolving a slug, since UnitNpcState never stored one.
+    interface BuildingVisitor { texture: PIXI.Texture; isGhost: boolean; leaveAt: number }
+    const buildingVisitors = new Map<string, BuildingVisitor[]>()
+    const VISITOR_STAY_MS_MIN = 20_000
+    const VISITOR_STAY_MS_MAX = 55_000
+    // Live sprites for the current building's visitors — populated in
+    // doEnterInterior, cleared in doExitInterior. Separate from
+    // buildingVisitors itself (which tracks every building's occupants
+    // regardless of whether the player is looking), so the leave-timer
+    // ticker can find and remove a specific sprite if the player happens to
+    // be standing in that exact room when it expires.
+    let interiorVisitorSprites: { record: BuildingVisitor; sprite: PIXI.Sprite }[] = []
+
     // Removes an ambient NPC's sprite and any active reaction bubbles, and
     // drops it from unitNpcs — shared by despawn-into-a-building and
     // despawn-via-exit-tile (#2111).
@@ -1710,6 +1728,22 @@ export function HubTownCanvas({
             npc.isWalking = false
             wanderNpc(npc)
             return
+          }
+          // Record them as a visitor inside this building before despawning
+          // the exterior sprite, so they can be seen if the player follows
+          // them in, and so they eventually let themselves back out (#2111
+          // — "when an npc enters a building we should be able to follow
+          // them in, and see the npc in the building", extended to ambient
+          // wandering NPCs, not just named ones).
+          const enteredBuildingId = doorBuildingByTile.get(`${tx},${ty}`)
+          if (enteredBuildingId) {
+            const visitors = buildingVisitors.get(enteredBuildingId) ?? []
+            visitors.push({
+              texture: npc.sprite.texture,
+              isGhost: npc.isGhost,
+              leaveAt: Date.now() + VISITOR_STAY_MS_MIN + Math.random() * (VISITOR_STAY_MS_MAX - VISITOR_STAY_MS_MIN),
+            })
+            buildingVisitors.set(enteredBuildingId, visitors)
           }
           despawnAmbientNpc(npc)
           return
@@ -2042,6 +2076,7 @@ export function HubTownCanvas({
         interiorLayer.visible = false
         interiorLayer.removeChildren()
         interiorAnimals.length = 0
+        interiorVisitorSprites = []
         currentInteriorId  = null
         currentInteriorObj = null
         highlightGfx.clear()
@@ -2535,6 +2570,29 @@ export function HubTownCanvas({
             loadAnimFrames(baseSlug, 3).then(f => { ia.frames = f }).catch(() => {})
             if (da.type === 'cat') loadTextureUrl(`${base}sprites/animal-cat-sleep.svg`).then(t => { ia.sleepTex = t }).catch(() => {})
           }).catch(() => {})
+        })
+      }
+
+      // Ambient wandering NPCs currently "inside" this building (#2111) —
+      // visible for the rest of their stay if the player follows them in.
+      // Reuses the texture each already had outside — no new texture load,
+      // no identity, just a body standing somewhere in the room. Positioning
+      // is static for now (no in-room wandering), same tradeoff the denned
+      // animals above don't fully avoid either (neither reserves its tile
+      // against the other, so an occasional overlap is possible but rare
+      // given how few of either are usually present in one small room).
+      {
+        const visitors = buildingVisitors.get(buildingId) ?? []
+        const freeTiles = Array.from(interiorWalkable).map(k => k.split(',').map(Number) as [number, number])
+        interiorVisitorSprites = visitors.map((record, i) => {
+          const spot = freeTiles[(i * 5 + 2) % Math.max(1, freeTiles.length)] ?? [1, 1]
+          const s = new PIXI.Sprite(record.texture)
+          s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
+          s.anchor.set(0.5, 1)
+          s.position.set(spot[0] * T + T / 2, spot[1] * T + T)
+          if (record.isGhost) { s.alpha = 0.4; s.tint = 0xaaccff }
+          interiorLayer.addChild(s)
+          return { record, sprite: s }
         })
       }
 
@@ -3579,6 +3637,35 @@ export function HubTownCanvas({
             bubbleLayer.removeChild(npc.doorReactionBubble)
             npc.doorReactionBubble = null
           }
+        }
+      }
+
+      // Building visitors' stay timer (#2111) — runs regardless of
+      // interiorActive, since a visitor's stay can expire while the player
+      // is nowhere near that building. On expiry: if the player happens to
+      // be inside that exact room right now, remove the live sprite; either
+      // way, let them back out into the world at that building's door, if
+      // it's still open (if the building closed in the meantime, they just
+      // silently stay — indistinguishable from having wandered off inside,
+      // out of sight).
+      {
+        const _nowMs = Date.now()
+        for (const [visitBuildingId, visitors] of buildingVisitors) {
+          for (let i = visitors.length - 1; i >= 0; i--) {
+            const record = visitors[i]
+            if (record.leaveAt > _nowMs) continue
+            visitors.splice(i, 1)
+            if (interiorActive && currentInteriorId === visitBuildingId) {
+              const idx = interiorVisitorSprites.findIndex(v => v.record === record)
+              if (idx !== -1) {
+                interiorLayer.removeChild(interiorVisitorSprites[idx].sprite)
+                interiorVisitorSprites.splice(idx, 1)
+              }
+            }
+            const door = HUB_DOORS.find(d => d.buildingId === visitBuildingId)
+            if (door && isDoorOpen(door.tx, door.ty)) spawnAmbientNpc([door.tx, door.ty])
+          }
+          if (visitors.length === 0) buildingVisitors.delete(visitBuildingId)
         }
       }
 


### PR DESCRIPTION
## Summary

User report: "I'm not seeing wandering NPCs inside buildings after they go in." Confirmed — ambient (anonymous, wandering) NPCs have always just despawned instantly on reaching an open door, with zero trace kept. Named/scheduled NPCs got real "follow them in and see them" support in an earlier phase of #2111; ambient NPCs never did.

## Design

Ambient NPCs have no identity (no `HubNpc` record, no dialogue, no schedule) — they're anonymous sprites cycling through a shared card/sprite pool, and the game only simulates one town at a time. So this is scoped as a lightweight, in-memory "building occupancy" system rather than anything persistent or schedule-driven:

- On reaching an open door, before the exterior sprite is despawned (as before), its already-loaded texture is recorded as a visitor of that building — keyed by `buildingId`, with a randomized 20–55s stay.
- If the player enters that building while a visit is active, the visitor renders inside at a free tile, using the same texture it had outside — no new asset load, no identity, just a body that's actually there.
- A per-frame timer — independent of whether the player is anywhere near that building — expires stays and lets the NPC back out at the door (respawning a fresh exterior sprite there), removing the live interior sprite too if the player happens to be standing in that exact room when it happens.

Deliberately scoped to static positioning inside (no in-room wandering behavior) — the core ask was visibility ("see the npc in the building"), and adding a full in-room movement/behavior system on top would be substantially more engine work for a purely cosmetic upgrade. Flagging this scoping choice explicitly in case a fuller version is wanted later.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2455/2455 passing
- [x] `npm run build` — clean
- [x] Browser smoke test: loaded and let ambient NPCs wander for 15s (long enough for several to reach doors and become building visitors, exercising the new recording path) with no console errors beyond expected offline-Firebase noise in this sandboxed environment
- [ ] Not verified live: actually following a specific ambient NPC through a door and watching it stand there, or watching one walk back out after its ~20-55s stay expires. Per this repo's own guidance, reliably scripting "wait for a specific anonymous NPC to path into a specific door, then follow it in" in this headless canvas is exactly the slow/unreliable interaction this session has consistently avoided scripting by default — this rests on the code closely mirroring the already-working, already-tested patterns for named-NPC interior rendering and denned-animal interior rendering (same texture/positioning/container conventions), plus the crash-free extended smoke test above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_