### PR TITLE
Fix interior darkness top-row gap; support carved (non-rectangular) rooms

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -34,6 +34,7 @@ import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
 import { getResolvedRoomStyle } from '../../game/hub/roomStyle'
 import { getDoorwayEntryTile } from '../../game/hub/doorwayEntry'
+import { computeInteriorShape, hasUnbrokenTopWall } from '../../game/hub/interiorShape'
 import {
   getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
 } from '../../game/hub/houseRooms'
@@ -304,6 +305,11 @@ export function HubTownCanvas({
     let interiorDarkCtx:     CanvasRenderingContext2D | null = null
     let interiorDarkTexture: PIXI.Texture | null = null
     let interiorDarkSprite:  PIXI.Sprite | null = null
+    // T when the overlay was grown to also cover the visual-only crown wall
+    // row rendered above the room (ty=-1, themed rooms with an unbroken top
+    // wall run only); 0 otherwise. Read by the punch-hole ticker below to
+    // keep its avatar/glow coordinates aligned with the sprite's origin.
+    let interiorDarkTopOffset = 0
     let interiorGlowSources: GlowSource[] = []
     // Keep legacy aliases so existing code below compiles unchanged
     const npcLayer    = spriteLayer
@@ -2278,11 +2284,13 @@ export function HubTownCanvas({
       for (const entry of exteriorInteractables.values()) { if (entry.indicator) entry.indicator.visible = false }
       for (const s of npcNameTags) { s.tag.visible = false; s.phase = 'hidden'; s.wasInRange = false; s.bubbleReady = false }
 
+      // Room shape (bounding box minus any carved-out notches) — see
+      // interiorShape.ts. Reproduces a plain rectangle exactly when
+      // interior.carve is absent.
+      const { floorSet: baseFloorSet, wallSet: baseWallSet } = computeInteriorShape(interior.width, interior.height, interior.carve)
+
       // Build walkable set
-      interiorWalkable = new Set<string>()
-      for (let tx = 1; tx < interior.width - 1; tx++)
-        for (let ty = 1; ty < interior.height - 1; ty++)
-          interiorWalkable.add(`${tx},${ty}`)
+      interiorWalkable = new Set<string>(baseFloorSet)
       if (!isSubRoom) interiorWalkable.add(`${exitTx},${interior.height - 1}`)
       for (const d of visibleDecor) {
         if (!d.zlayer || d.zlayer === 'solid') interiorWalkable.delete(`${d.tx},${d.ty}`)
@@ -2301,10 +2309,7 @@ export function HubTownCanvas({
       }
 
       // Floor tile set (all inner tiles + exit door tiles)
-      const floorSet = new Set<string>()
-      for (let tx = 1; tx < interior.width - 1; tx++)
-        for (let ty = 1; ty < interior.height - 1; ty++)
-          floorSet.add(`${tx},${ty}`)
+      const floorSet = new Set<string>(baseFloorSet)
       if (!isSubRoom) floorSet.add(`${exitTx},${interior.height - 1}`)  // exit door opening
       for (const exit of availableExits) {
         if (exit.direction === 'left' || exit.direction === 'right' ||
@@ -2312,15 +2317,7 @@ export function HubTownCanvas({
       }
 
       // Wall tile set (border, minus exit door openings)
-      const wallSet = new Set<string>()
-      for (let tx = 0; tx < interior.width; tx++) {
-        wallSet.add(`${tx},0`)
-        wallSet.add(`${tx},${interior.height - 1}`)
-      }
-      for (let ty = 1; ty < interior.height - 1; ty++) {
-        wallSet.add(`0,${ty}`)
-        wallSet.add(`${interior.width - 1},${ty}`)
-      }
+      const wallSet = new Set<string>(baseWallSet)
       if (!isSubRoom) wallSet.delete(`${exitTx},${interior.height - 1}`)  // open bottom door gap
       for (const exit of availableExits) {
         if (exit.direction === 'left' || exit.direction === 'right' ||
@@ -2336,27 +2333,14 @@ export function HubTownCanvas({
       const floorTileId  = interior.floorTileId ?? 288
       loadTileRef(floorTileId).then(floorTex => {
         if (!interiorActive || currentInteriorId !== buildingId) return
-        for (let tx = 1; tx < interior.width - 1; tx++) {
-          for (let ty = 1; ty < interior.height - 1; ty++) {
-            const s = new PIXI.Sprite(floorTex)
-            s.position.set(tx * T, ty * T)
-            floorContainer.addChild(s)
-          }
-        }
-        // Exit door tile also gets floor (only for ground-level rooms with a bottom door)
-        if (!isSubRoom) {
-          const exitFloor = new PIXI.Sprite(floorTex)
-          exitFloor.position.set(exitTx * T, (interior.height - 1) * T)
-          floorContainer.addChild(exitFloor)
-        }
-        // Wall-gap exits need explicit floor tiles (they're outside the inner loop)
-        for (const exit of availableExits) {
-          if (exit.direction === 'left' || exit.direction === 'right' ||
-              exit.direction === 'front' || exit.direction === 'back') {
-            const s = new PIXI.Sprite(floorTex)
-            s.position.set(exit.tx * T, exit.ty * T)
-            floorContainer.addChild(s)
-          }
+        // floorSet already includes the exit door opening and any wall-gap
+        // exit tiles (added above), so a single pass covers all of it —
+        // and naturally skips any carved-out cells.
+        for (const key of floorSet) {
+          const [tx, ty] = key.split(',').map(Number)
+          const s = new PIXI.Sprite(floorTex)
+          s.position.set(tx * T, ty * T)
+          floorContainer.addChild(s)
         }
       }).catch(() => {
         renderPathTiles(floorContainer, floorSet, undefined, PATH_TILE.dirt1).catch(() => {})
@@ -2378,10 +2362,16 @@ export function HubTownCanvas({
       }
       renderPathTiles(wallContainer, sideWallSet, undefined, PATH_TILE.wall2).catch(() => {})
 
-      if (interior.wallMaterial) {
+      // A carve can break the top wall row into a discontinuous run — only
+      // theme it (and render the visual-only crown row above) when it's
+      // still unbroken end-to-end; a broken run falls back to the generic
+      // tile for the whole row rather than theming part of it.
+      const wallMaterial  = interior.wallMaterial
+      const themedTopRow  = !!wallMaterial && hasUnbrokenTopWall(interior.width, wallSet)
+      if (wallMaterial && themedTopRow) {
         // Bottom row keeps default tile; top row uses middleBottom; a visual-only row above (ty=-1) uses middleTop
         renderPathTiles(wallContainer, new Set([...horizontalWallSet].filter(k => parseInt(k.split(',')[1]) !== 0)), undefined, PATH_TILE.wall2).catch(() => {})
-        const wTiles = WALL_TILES[interior.wallMaterial]
+        const wTiles = WALL_TILES[wallMaterial]
         // ty=0 row → middleBottom; ty=-1 (above room, visual only) → middleTop
         const byTileId = new Map<number, [number, number][]>()
         for (const key of horizontalWallSet) {
@@ -2725,8 +2715,15 @@ export function HubTownCanvas({
       // above. Torn down in doExitInterior; also cleared here defensively in
       // case entry into a new room happens without an intervening exit.
       if (interiorDarkSprite) { interiorLayer.removeChild(interiorDarkSprite); interiorDarkTexture?.destroy(true); interiorDarkSprite = null }
+      interiorDarkTopOffset = 0
       if (interior.dark) {
-        const iw = interior.width * T, ih = interior.height * T
+        // themedTopRow rooms render a purely decorative wall row one tile
+        // above the room (ty=-1, see the wall-render block above) — grow
+        // the overlay by one tile of height at the top only so that row
+        // gets darkened too; every other edge stays exactly at the room's
+        // bounding box.
+        interiorDarkTopOffset = themedTopRow ? T : 0
+        const iw = interior.width * T, ih = interior.height * T + interiorDarkTopOffset
         interiorDarkCanvas = document.createElement('canvas')
         interiorDarkCanvas.width  = Math.ceil(iw / NIGHT_CANVAS_SCALE)
         interiorDarkCanvas.height = Math.ceil(ih / NIGHT_CANVAS_SCALE)
@@ -2735,6 +2732,7 @@ export function HubTownCanvas({
         interiorDarkSprite = new PIXI.Sprite(interiorDarkTexture)
         interiorDarkSprite.width     = iw
         interiorDarkSprite.height    = ih
+        interiorDarkSprite.position.set(0, -interiorDarkTopOffset)
         interiorDarkSprite.eventMode = 'none'
         interiorLayer.addChild(interiorDarkSprite)
       }
@@ -3637,8 +3635,9 @@ export function HubTownCanvas({
         interiorDarkCtx.fillStyle = 'rgba(0,0,0,0.92)'
         interiorDarkCtx.fillRect(0, 0, cw, ch)
         interiorDarkCtx.globalCompositeOperation = 'destination-out'
-        // Avatar torch
-        const ax = avatar.x * cs, ay = avatar.y * cs
+        // Avatar torch — +interiorDarkTopOffset keeps this aligned with the
+        // sprite's origin, which may sit one tile above local y=0 (see setup above)
+        const ax = avatar.x * cs, ay = (avatar.y + interiorDarkTopOffset) * cs
         const innerR = INTERIOR_DARK_INNER * cs, outerR = INTERIOR_DARK_OUTER * cs
         const torchGrad = interiorDarkCtx.createRadialGradient(ax, ay, innerR, ax, ay, outerR)
         torchGrad.addColorStop(0, 'rgba(0,0,0,1)')
@@ -3651,7 +3650,7 @@ export function HubTownCanvas({
         const _glowMs = performance.now()
         const _pulse  = (seed: number) => 0.8 + 0.2 * Math.sin(_glowMs / 500 + seed)
         for (const g of interiorGlowSources) {
-          const gx = g.x * cs, gy = g.y * cs
+          const gx = g.x * cs, gy = (g.y + interiorDarkTopOffset) * cs
           const gr = (g.pulse ? g.radius * _pulse(g.x + g.y) : g.radius) * cs
           const glowGrad = interiorDarkCtx.createRadialGradient(gx, gy, 0, gx, gy, gr)
           glowGrad.addColorStop(0, 'rgba(0,0,0,1)')

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -151,6 +151,12 @@ export interface RawInterior {
   playerDecor?: boolean
   /** Render this room unlit except near the avatar's torch and glow-flagged decor. */
   dark?: boolean
+  /** Sub-rectangles (local tile coords) subtracted from the room's
+   *  width×height bounding box, carving an L-shape/notch out of an
+   *  otherwise-rectangular room. A carved edge that breaks a themed
+   *  wallTileId's top wall run falls back to the generic wall tile for
+   *  that whole run — no map-editor UI yet, hand-author and verify in-game. */
+  carve?: Array<{ tx: number; ty: number; w: number; h: number }>
 }
 
 

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -170,6 +170,10 @@ export interface HubInterior {
    *  glow-flagged decor — a dedicated interior-scoped punch-hole overlay,
    *  independent of the exterior day/night cycle (see HubTownCanvas.tsx). */
   dark?: boolean
+  /** Sub-rectangles subtracted from the width×height box — see
+   *  computeInteriorShape (game/hub/interiorShape.ts), which HubTownCanvas.tsx
+   *  uses to trace the resulting floor/wall sets. */
+  carve?: Array<{ tx: number; ty: number; w: number; h: number }>
 }
 
 /** Visible activity an NPC performs while at a scheduled location. */
@@ -716,6 +720,7 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         ambianceId: rawAny.ambianceId as string | undefined,
         playerDecor: rawAny.playerDecor as boolean | undefined,
         dark:        rawAny.dark as boolean | undefined,
+        carve:       rawAny.carve as Array<{ tx: number; ty: number; w: number; h: number }> | undefined,
       } satisfies HubInterior,
     ]
   })

--- a/web/src/data/hub/questPickupPlacement.test.ts
+++ b/web/src/data/hub/questPickupPlacement.test.ts
@@ -3,6 +3,7 @@ import { createHubLocationData, createHubQuestData } from './loader'
 import type { RawConfig } from './config'
 import type { RawQuestConfig } from './questDefs'
 import { buildingWorldTile, pickupWorldTile } from '../../game/hub/npcLocator'
+import { computeInteriorShape } from '../../game/hub/interiorShape'
 import { getHubWorldData } from './hubWorldFactory'
 import ravenwatchConfig from './ravenwatch/config.json'
 import ravenwatchQuests from './ravenwatch/questDefs.json'
@@ -60,15 +61,18 @@ describe('Ravenwatch quest pickups', () => {
     expect(bad.map(p => `${p.id} @ ${p.building}`)).toEqual([])
   })
 
-  it('keeps indoor items off the interior wall ring so they stay reachable', () => {
-    // Interiors are walkable on 1..width-2 / 1..height-2 (HubTownCanvas builds the
-    // walkable set that way); the outer ring is wall.
-    const inWall = interior.filter(p => {
+  it('keeps indoor items on actual floor so they stay reachable', () => {
+    // computeInteriorShape's floorSet is the walkable interior — the wall
+    // ring for a plain rectangle, but also excludes any tile carved out by
+    // room.carve (HubInterior.carve), which the old width/height-ring-only
+    // arithmetic here wouldn't have caught.
+    const offFloor = interior.filter(p => {
       const room = loc.HUB_INTERIORS[p.building!]
       if (!room) return false
-      return p.tx < 1 || p.ty < 1 || p.tx > room.width - 2 || p.ty > room.height - 2
+      const { floorSet } = computeInteriorShape(room.width, room.height, room.carve)
+      return !floorSet.has(`${p.tx},${p.ty}`)
     })
-    expect(inWall.map(p => `${p.id} @ ${p.building} (${p.tx},${p.ty})`)).toEqual([])
+    expect(offFloor.map(p => `${p.id} @ ${p.building} (${p.tx},${p.ty})`)).toEqual([])
   })
 })
 

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -10317,9 +10317,10 @@
       "floorTileId": "darkStoneFloor",
       "wallTileId": "darkStone",
       "dark": true,
+      "carve": [{ "tx": 6, "ty": 0, "w": 4, "h": 3 }],
       "decor": [
         { "tx": 2, "ty": 1, "tileId": "largeRock" },
-        { "tx": 8, "ty": 1, "tileId": "smallRock" },
+        { "tx": 8, "ty": 3, "tileId": "smallRock" },
         { "tx": 2, "ty": 6, "tileId": "smallRock" },
         { "tx": 7, "ty": 6, "tileId": "largeRock" },
         { "tx": 5, "ty": 3, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },

--- a/web/src/game/hub/interiorShape.test.ts
+++ b/web/src/game/hub/interiorShape.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { computeInteriorShape, hasUnbrokenTopWall } from './interiorShape'
+import { getHubWorldData } from '../../data/hub/hubWorldFactory'
+
+// Reference oracle: the plain-rectangle floor/wall formula HubTownCanvas.tsx
+// used before computeInteriorShape existed, copied verbatim. computeInteriorShape
+// must reproduce this exactly for every existing interior (carve absent) —
+// a regression guard against the generalized algorithm silently changing
+// behavior for the 238 already-authored rooms.
+function oldFloorSet(width: number, height: number): Set<string> {
+  const s = new Set<string>()
+  for (let tx = 1; tx < width - 1; tx++)
+    for (let ty = 1; ty < height - 1; ty++)
+      s.add(`${tx},${ty}`)
+  return s
+}
+function oldWallSet(width: number, height: number): Set<string> {
+  const s = new Set<string>()
+  for (let tx = 0; tx < width; tx++) {
+    s.add(`${tx},0`)
+    s.add(`${tx},${height - 1}`)
+  }
+  for (let ty = 1; ty < height - 1; ty++) {
+    s.add(`0,${ty}`)
+    s.add(`${width - 1},${ty}`)
+  }
+  return s
+}
+
+function setEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const k of a) if (!b.has(k)) return false
+  return true
+}
+
+const { locationRegistry } = await getHubWorldData()
+
+describe('computeInteriorShape — plain rectangle regression', () => {
+  for (const [townKey, { locationData }] of Object.entries(locationRegistry)) {
+    for (const [id, room] of Object.entries(locationData.HUB_INTERIORS)) {
+      it(`${townKey}/${id}: matches the old rectangle formula`, () => {
+        const { floorSet, wallSet } = computeInteriorShape(room.width, room.height)
+        expect(setEqual(floorSet, oldFloorSet(room.width, room.height))).toBe(true)
+        expect(setEqual(wallSet, oldWallSet(room.width, room.height))).toBe(true)
+        expect(hasUnbrokenTopWall(room.width, wallSet)).toBe(true)
+      })
+    }
+  }
+})
+
+describe('computeInteriorShape — carved shapes', () => {
+  it('carves a fully-walled "pillar" hole out of the middle of the floor with no voids', () => {
+    // 10×8 room, a 2×2 bite in the middle of the top floor row — inset one
+    // tile clear of every box edge, so it should be a clean walled pocket.
+    const { floorSet, wallSet } = computeInteriorShape(10, 8, [{ tx: 4, ty: 1, w: 2, h: 2 }])
+
+    for (const key of ['4,1', '5,1', '4,2', '5,2']) {
+      expect(floorSet.has(key)).toBe(false)
+      expect(wallSet.has(key)).toBe(true)
+    }
+    expect(floorSet.has('3,1')).toBe(true)
+    expect(floorSet.has('6,1')).toBe(true)
+    expect(floorSet.has('3,3')).toBe(true)
+    expect(floorSet.has('6,3')).toBe(true)
+
+    for (let tx = 0; tx < 10; tx++)
+      for (let ty = 0; ty < 8; ty++) {
+        const key = `${tx},${ty}`
+        expect(floorSet.has(key) || wallSet.has(key), `(${tx},${ty}) is void`).toBe(true)
+      }
+  })
+
+  it('a carve reaching the box outer floor ring can leave a few cells void (documented behavior)', () => {
+    // Notch bites into the left-edge floor column (tx=1, adjacent to the
+    // tx=0 wall column) — the corner and part of that wall column lose
+    // every floor neighbor.
+    const { floorSet, wallSet } = computeInteriorShape(10, 8, [{ tx: 1, ty: 1, w: 2, h: 3 }])
+    const voids: string[] = []
+    for (let tx = 0; tx < 10; tx++)
+      for (let ty = 0; ty < 8; ty++) {
+        const key = `${tx},${ty}`
+        if (!floorSet.has(key) && !wallSet.has(key)) voids.push(key)
+      }
+    expect(voids.sort()).toEqual(['0,0', '0,1', '0,2', '1,0', '1,1', '1,2'].sort())
+  })
+
+  it('an edge-touching corner notch (the shipped worked-example shape) traces a real L-boundary, breaks the top wall row, and voids only the tip', () => {
+    // Same shape authored on ravenwatch-hollow-tunnel-east: a corner bite
+    // that actually reaches the room's right/top boundary, so the room's
+    // outer silhouette is genuinely smaller there (most of the bitten area
+    // renders as solid wall — reading as rock filling the notch — with a
+    // small void right at the tip where no cell has a floor neighbor left).
+    const { floorSet, wallSet } = computeInteriorShape(10, 8, [{ tx: 6, ty: 0, w: 4, h: 3 }])
+
+    expect(floorSet.has('6,1')).toBe(false)
+    expect(wallSet.has('6,0')).toBe(true)
+    expect(wallSet.has('6,1')).toBe(true)   // notch mostly reads as solid wall/rock
+    expect(wallSet.has('6,2')).toBe(true)
+    expect(hasUnbrokenTopWall(10, wallSet)).toBe(false)
+
+    const voids: string[] = []
+    for (let tx = 0; tx < 10; tx++)
+      for (let ty = 0; ty < 8; ty++) {
+        const key = `${tx},${ty}`
+        if (!floorSet.has(key) && !wallSet.has(key)) voids.push(key)
+      }
+    expect(voids.sort()).toEqual(['7,0', '7,1', '8,0', '8,1', '9,0', '9,1'].sort())
+
+    // Floor continues normally below the notch and on the untouched side.
+    expect(floorSet.has('8,3')).toBe(true)
+    expect(floorSet.has('1,1')).toBe(true)
+  })
+
+  it('carve is a no-op outside the floor domain (border ring, out of bounds)', () => {
+    const withCarve = computeInteriorShape(10, 8, [{ tx: -5, ty: -5, w: 3, h: 3 }])
+    const without = computeInteriorShape(10, 8)
+    expect(setEqual(withCarve.floorSet, without.floorSet)).toBe(true)
+    expect(setEqual(withCarve.wallSet, without.wallSet)).toBe(true)
+  })
+})

--- a/web/src/game/hub/interiorShape.ts
+++ b/web/src/game/hub/interiorShape.ts
@@ -1,0 +1,91 @@
+export interface CarveRect {
+  tx: number
+  ty: number
+  w: number
+  h: number
+}
+
+export interface InteriorShape {
+  /** Walkable interior tiles (the room's inner 1..width-2 × 1..height-2 box,
+   *  minus any carved-out cells). Does not include exit/door openings —
+   *  callers add those back the same way they do for a plain rectangle. */
+  floorSet: Set<string>
+  /** Every tile that borders a floor tile (8-directionally) but isn't one
+   *  itself — the wall ring, generalized to trace a carved perimeter. For a
+   *  plain rectangle (no carve) this reproduces the same ring a fixed
+   *  four-edge loop would produce. */
+  wallSet: Set<string>
+}
+
+const NEIGHBORS_8: ReadonlyArray<readonly [number, number]> = [
+  [-1, -1], [0, -1], [1, -1],
+  [-1,  0],          [1,  0],
+  [-1,  1], [0,  1], [1,  1],
+]
+
+/**
+ * Computes a room's floor and wall tile sets from its bounding box, minus
+ * any `carve` rectangles subtracted from the interior. 8-directional (not
+ * 4-directional) adjacency is required so the box's four true corner tiles
+ * — only ever diagonally adjacent to an interior cell — still get a wall,
+ * matching the plain-rectangle behavior exactly when `carve` is empty.
+ *
+ * A carved cell becomes a wall tile as long as some neighbor (even
+ * diagonally) is still floor — which is the desired look: the bitten-out
+ * area reads as solid rock/wall filling the notch, the same way the box's
+ * outer ring always has been wall. Only a carve that reaches all the way
+ * into the room's outermost floor ring (column 1, column width-2, row 1,
+ * or row height-2) can leave a few cells at the very tip with no floor
+ * neighbor left at all — neither floor nor wall. Those render as nothing
+ * (the room's dark backdrop shows through), a minor cosmetic gap right at
+ * the notch's tip rather than a defect — expected for a boundary notch
+ * that genuinely reaches the room's edge (an L-shape), and invisible in
+ * `dark: true` rooms. A carve that stays landlocked (not reaching any box
+ * edge) never produces this, but then reads as an internal wall/pillar
+ * obstacle rather than a boundary notch.
+ */
+export function computeInteriorShape(width: number, height: number, carve?: CarveRect[]): InteriorShape {
+  const carvedSet = new Set<string>()
+  if (carve) {
+    for (const c of carve) {
+      const x0 = Math.max(1, c.tx), x1 = Math.min(width - 2, c.tx + c.w - 1)
+      const y0 = Math.max(1, c.ty), y1 = Math.min(height - 2, c.ty + c.h - 1)
+      for (let tx = x0; tx <= x1; tx++)
+        for (let ty = y0; ty <= y1; ty++)
+          carvedSet.add(`${tx},${ty}`)
+    }
+  }
+
+  const floorSet = new Set<string>()
+  for (let tx = 1; tx < width - 1; tx++) {
+    for (let ty = 1; ty < height - 1; ty++) {
+      const key = `${tx},${ty}`
+      if (!carvedSet.has(key)) floorSet.add(key)
+    }
+  }
+
+  const wallSet = new Set<string>()
+  for (let tx = 0; tx < width; tx++) {
+    for (let ty = 0; ty < height; ty++) {
+      const key = `${tx},${ty}`
+      if (floorSet.has(key)) continue
+      for (const [dx, dy] of NEIGHBORS_8) {
+        if (floorSet.has(`${tx + dx},${ty + dy}`)) { wallSet.add(key); break }
+      }
+    }
+  }
+
+  return { floorSet, wallSet }
+}
+
+/** True when every tile of the room's top wall row (ty=0, columns
+ *  1..width-2) is present in `wallSet` — i.e. an unbroken straight run. A
+ *  carve that touches the top row anywhere breaks this, and callers should
+ *  fall back to generic wall art (and skip the visual-only crown row above
+ *  the room) for the whole row rather than theming part of it. */
+export function hasUnbrokenTopWall(width: number, wallSet: Set<string>): boolean {
+  for (let tx = 1; tx < width - 1; tx++) {
+    if (!wallSet.has(`${tx},0`)) return false
+  }
+  return true
+}


### PR DESCRIPTION
## Summary

- Fixes a reported bug where "The West Passage" cave room's darkness overlay didn't darken the fully-lit decorative wall row above the room's real top wall — the overlay's canvas/sprite never extended up into it. It now grows by one tile at the top when that row exists (themed room, unbroken top wall run), with matching coordinate offsets in the per-frame punch-hole redraw.
- Adds support for non-rectangular ("carved") interior rooms, requested for the Buried Hollow cave and for buildings generally. A new `carve` field on `HubInterior`/`RawInterior` subtracts sub-rectangles from a room's bounding box; a new pure module (`web/src/game/hub/interiorShape.ts`) generalizes the floor/wall-tile computation to trace the resulting perimeter (already-shape-agnostic pathfinding and the generic wall autotile needed no changes). Straight wall runs on a themed room keep their wallTileId art; a run broken by a carve falls back to the generic wall tile for that whole row.
- Ships a worked example: "The East Passage" cave room now has an L-shaped notch carved out of its top-right corner (`ravenwatch-hollow-tunnel-east`), with its one colliding decor entry relocated onto solid floor.
- Updates `questPickupPlacement.test.ts`'s reachability check to be floor-set-aware (catches an item placed inside a carved-out hole, which the old bounding-box-ring arithmetic couldn't).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npm run build`
- [x] `npm run test` (2697 tests passed, including a new 238-room regression sweep in `interiorShape.test.ts` asserting the generalized algorithm reproduces the old hardcoded rectangle formula exactly when no room defines `carve`)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_