### PR TITLE
Fix bounty rotation and give wandering NPCs a tap interaction

### DIFF
--- a/web/src/components/hub/BountyBoardModal.stories.tsx
+++ b/web/src/components/hub/BountyBoardModal.stories.tsx
@@ -41,7 +41,7 @@ export const Default: Story = {
 
 // A fixed date whose daily pool deterministically includes both a single-step
 // 'report' bounty and the multi-step 'fresh-fish-for-the-kitchen' bounty.
-const FISH_DAY = new Date('2026-01-08T12:00:00Z')
+const FISH_DAY = new Date('2026-01-02T12:00:00Z')
 
 export const WithAcceptedBounty: Story = {
   args: {

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -57,6 +57,22 @@ const NIGHT_NPC_LIGHT_R  = 2 * T   // small glow radius around each NPC
 const INTERIOR_DARK_INNER = 1.5 * T
 const INTERIOR_DARK_OUTER = 3   * T
 
+// Generic flavor lines for tapping an anonymous wandering NPC — these have
+// no authored identity (just one of a town's ambientNpcSprites), so unlike
+// named NPCs there's no dialogue array to draw from. A short, cosmetic-only
+// speech bubble (no dialogue modal, no game-state change) mirrors how
+// procedural ambient animals respond to a tap (see hubAnimals.ts's FLAVOUR).
+const AMBIENT_NPC_FLAVOUR = [
+  'Lovely day for it.',
+  'Mind where you step.',
+  "Can't stop to chat, sorry!",
+  'Have you seen the notice board?',
+  "Busy, busy — you know how it is.",
+  'Watch yourself out there.',
+  'Off to run an errand.',
+  "I'll catch you later!",
+]
+
 // ── Interactable affordance aura ────────────────────────────────────────────
 // A faint pulsing halo drawn behind tap-reactive objects that own visible decor
 // (stalls, notice boards, chests, forage spots, etc.), so players can spot what's
@@ -1594,6 +1610,12 @@ export function HubTownCanvas({
       // each other if both conditions land on the same NPC at once.
       doorReactionBubble: PIXI.Container | null
       doorReactionTimer:  number
+      // Generic flavor line shown when the player taps this (anonymous,
+      // unauthored) wandering NPC — kept separate from the above so a tap
+      // never clobbers a scared/door reaction, or vice versa.
+      tapBubble:      PIXI.Container | null
+      tapBubbleTimer: number
+      tapLineIdx:     number
     }
 
     const unitNpcs: UnitNpcState[] = []
@@ -1641,7 +1663,13 @@ export function HubTownCanvas({
           scaredBubbleCooldown: 0,
           doorReactionBubble:   null,
           doorReactionTimer:    0,
+          tapBubble:            null,
+          tapBubbleTimer:       0,
+          tapLineIdx:           Math.floor(Math.random() * AMBIENT_NPC_FLAVOUR.length),
         }
+        s.eventMode = 'static'
+        s.cursor    = 'pointer'
+        s.on('pointerdown', (e) => { e.stopPropagation(); showAmbientNpcTapBubble(state) })
         unitNpcs.push(state)
 
         loadAnimFrames(slug, 3)
@@ -1703,7 +1731,16 @@ export function HubTownCanvas({
     // regardless of whether the player is looking), so the leave-timer
     // ticker can find and remove a specific sprite if the player happens to
     // be standing in that exact room when it expires.
-    let interiorVisitorSprites: { record: BuildingVisitor; sprite: PIXI.Sprite }[] = []
+    interface InteriorVisitorSprite {
+      record: BuildingVisitor
+      sprite: PIXI.Sprite
+      // Tap-flavor bubble, same cosmetic-only treatment as exterior ambient
+      // NPCs — added to interiorLayer (not bubbleLayer, which is hidden
+      // while indoors) so it renders in the room.
+      bubble:      PIXI.Container | null
+      bubbleTimer: number
+    }
+    let interiorVisitorSprites: InteriorVisitorSprite[] = []
 
     // Removes an ambient NPC's sprite and any active reaction bubbles, and
     // drops it from unitNpcs — shared by despawn-into-a-building and
@@ -1718,6 +1755,11 @@ export function HubTownCanvas({
         bubbleLayer.removeChild(npc.doorReactionBubble)
         npc.doorReactionBubble = null
         npc.doorReactionTimer = 0
+      }
+      if (npc.tapBubble) {
+        bubbleLayer.removeChild(npc.tapBubble)
+        npc.tapBubble = null
+        npc.tapBubbleTimer = 0
       }
       npc.sprite.parent?.removeChild(npc.sprite)
       const idx = unitNpcs.indexOf(npc)
@@ -1993,7 +2035,13 @@ export function HubTownCanvas({
           scaredBubbleCooldown: 0,
           doorReactionBubble:   null,
           doorReactionTimer:    0,
+          tapBubble:            null,
+          tapBubbleTimer:       0,
+          tapLineIdx:           Math.floor(Math.random() * AMBIENT_NPC_FLAVOUR.length),
         }
+        s.eventMode = 'static'
+        s.cursor    = 'pointer'
+        s.on('pointerdown', (e) => { e.stopPropagation(); showAmbientNpcTapBubble(state) })
         unitNpcs.push(state)
         loadAnimFrames(slug, 3).then(frames => { state.animFrames = frames }).catch(() => {})
       }).catch(() => {})
@@ -2247,6 +2295,11 @@ export function HubTownCanvas({
           bubbleLayer.removeChild(npc.doorReactionBubble)
           npc.doorReactionBubble = null
           npc.doorReactionTimer = 0
+        }
+        if (npc.tapBubble) {
+          bubbleLayer.removeChild(npc.tapBubble)
+          npc.tapBubble = null
+          npc.tapBubbleTimer = 0
         }
       }
 
@@ -2613,7 +2666,18 @@ export function HubTownCanvas({
           s.position.set(spot[0] * T + T / 2, spot[1] * T + T)
           if (record.isGhost) { s.alpha = 0.4; s.tint = 0xaaccff }
           interiorLayer.addChild(s)
-          return { record, sprite: s }
+          const entry: InteriorVisitorSprite = { record, sprite: s, bubble: null, bubbleTimer: 0 }
+          s.eventMode = 'static'
+          s.cursor    = 'pointer'
+          s.on('pointerdown', (e) => {
+            e.stopPropagation()
+            if (entry.bubble) { interiorLayer.removeChild(entry.bubble); entry.bubble = null }
+            const line = AMBIENT_NPC_FLAVOUR[Math.floor(Math.random() * AMBIENT_NPC_FLAVOUR.length)]
+            entry.bubble = createSpeechBubble(line, s.x, s.y)
+            interiorLayer.addChild(entry.bubble)
+            entry.bubbleTimer = 1800
+          })
+          return entry
         })
       }
 
@@ -2840,6 +2904,18 @@ export function HubTownCanvas({
       c.addChild(bg, lbl)
       c.position.set(cx, cy - SPRITE_SIZE - 4)
       return c
+    }
+
+    // Tapping an anonymous wandering NPC shows one cosmetic flavor line —
+    // no dialogue modal, no state — cycling through AMBIENT_NPC_FLAVOUR so
+    // repeat taps on the same NPC don't always show the same line.
+    function showAmbientNpcTapBubble(npc: UnitNpcState): void {
+      if (npc.tapBubble) { bubbleLayer.removeChild(npc.tapBubble); npc.tapBubble = null }
+      const line = AMBIENT_NPC_FLAVOUR[npc.tapLineIdx % AMBIENT_NPC_FLAVOUR.length]
+      npc.tapLineIdx += 1
+      npc.tapBubble = createSpeechBubble(line, npc.sprite.x, npc.sprite.y)
+      bubbleLayer.addChild(npc.tapBubble)
+      npc.tapBubbleTimer = 1800
     }
 
     function createNameTag(name: string, cx: number, cy: number): PIXI.Container {
@@ -3664,6 +3740,18 @@ export function HubTownCanvas({
         interiorDarkTexture.source.update()
       }
 
+      // Interior visitors' tap-flavor bubbles — decay on their own short timer.
+      if (interiorActive) {
+        for (const v of interiorVisitorSprites) {
+          if (!v.bubble) continue
+          v.bubbleTimer -= ticker.deltaMS
+          if (v.bubbleTimer <= 0) {
+            interiorLayer.removeChild(v.bubble)
+            v.bubble = null
+          }
+        }
+      }
+
       // Quest pickup visibility — only show while the associated quest is active
       for (const [pickupId, sprite] of pickupSprites) {
         if (pickedUpRef.current.has(pickupId)) continue
@@ -3744,6 +3832,16 @@ export function HubTownCanvas({
             npc.doorReactionBubble = null
           }
         }
+
+        // Tap-flavor bubble — decays on its own short timer.
+        if (npc.tapBubble) {
+          npc.tapBubbleTimer -= ticker.deltaMS
+          npc.tapBubble.position.set(npc.sprite.x, npc.sprite.y - SPRITE_SIZE)
+          if (npc.tapBubbleTimer <= 0) {
+            bubbleLayer.removeChild(npc.tapBubble)
+            npc.tapBubble = null
+          }
+        }
       }
 
       // Building visitors' stay timer (#2111) — runs regardless of
@@ -3764,7 +3862,9 @@ export function HubTownCanvas({
             if (interiorActive && currentInteriorId === visitBuildingId) {
               const idx = interiorVisitorSprites.findIndex(v => v.record === record)
               if (idx !== -1) {
-                interiorLayer.removeChild(interiorVisitorSprites[idx].sprite)
+                const leaving = interiorVisitorSprites[idx]
+                interiorLayer.removeChild(leaving.sprite)
+                if (leaving.bubble) interiorLayer.removeChild(leaving.bubble)
                 interiorVisitorSprites.splice(idx, 1)
               }
             }

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -33,7 +33,7 @@ import { getActiveFestival } from '../../game/hub/hubCalendar'
 import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
 import { getResolvedRoomStyle } from '../../game/hub/roomStyle'
-import { getDoorwayEntryTile } from '../../game/hub/doorwayEntry'
+import { getDoorwayEntryTile, findExteriorDoorForInterior } from '../../game/hub/doorwayEntry'
 import { computeInteriorShape, hasUnbrokenTopWall } from '../../game/hub/interiorShape'
 import {
   getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
@@ -2133,10 +2133,11 @@ export function HubTownCanvas({
           interiorLayer.removeChild(avatar)
           avatarLayer.addChild(avatar)
           avatarInInterior = false
-          // A purchased room slot (or any hand-authored sub-room) has no
-          // exterior door of its own — its id is `<mainBuildingId>-<slotId>`,
-          // so fall back to the door of the building whose id prefixes it.
-          const door = HUB_DOORS.find(d => d.buildingId === currentInteriorId)
+          // Prefer tracing the exits graph back to a real door (handles a
+          // cave/dungeon complex of several linked, individually-doorless
+          // rooms); fall back to the id-prefix guess for a purchased room
+          // slot, which isn't in HUB_INTERIORS so has no exits to trace.
+          const door = (currentInteriorId ? findExteriorDoorForInterior(currentInteriorId, HUB_DOORS, HUB_INTERIORS) : undefined)
             ?? HUB_DOORS.find(d => !!currentInteriorId && currentInteriorId.startsWith(`${d.buildingId}-`))
           if (door) {
             avatar.x = door.tx * T + T / 2
@@ -2399,37 +2400,42 @@ export function HubTownCanvas({
         renderPathTiles(floorContainer, floorSet, undefined, PATH_TILE.dirt1).catch(() => {})
       })
 
-      // Walls: side columns use default path tiles; top/bottom rows use wallMaterial if set
-      const sideWallSet       = new Set<string>()
-      const horizontalWallSet = new Set<string>()
+      // Walls: a single autotile pass over the WHOLE perimeter. renderPathTiles'
+      // neighbor lookup only sees membership within the one set it's given —
+      // splitting the perimeter across two separate calls (as this used to)
+      // makes each half blind to the other's cells, so a tile right at the
+      // seam picks the wrong variant (e.g. a corner that can't see the
+      // horizontal run it actually connects to renders as a plain vertical
+      // stub instead of a proper corner cap). Only visible at a room's 4
+      // outer corners for a plain rectangle, but at every inner corner of a
+      // carved notch too — unifying into one set/call fixes both.
+      // Every wall cell also gets a purely-visual "+1 row" duplicate above
+      // it, except the columns of a straight top/bottom run (which instead
+      // get their own crown-row treatment below, or nothing extra at all).
+      const isStraightRunCell = (wx: number, wy: number) =>
+        wx > 0 && wx < interior.width - 1 && (wy === 0 || wy === interior.height - 1)
+      const wallRenderSet = new Set<string>(wallSet)
       for (const key of wallSet) {
         const [wx, wy] = key.split(',').map(Number)
-        if (wx > 0 && wx < interior.width - 1 && (wy === 0 || wy === interior.height - 1)) horizontalWallSet.add(key)
-        else {sideWallSet.add(`${wx},${wy-1}`); sideWallSet.add(`${wx},${wy}`)}
+        if (!isStraightRunCell(wx, wy)) wallRenderSet.add(`${wx},${wy - 1}`)
       }
-      // The tile below a left/right exit contributes the exit position to sideWallSet; remove it explicitly
       for (const exit of availableExits) {
-        if (exit.direction === 'left' || exit.direction === 'right') sideWallSet.delete(`${exit.tx},${exit.ty}`)
-        // back exits are at ty=0; the sideWallSet formula adds (wx, -1) and (wx, 0) for ty=0 wall tiles,
-        // but since we deleted (tx, 0) from wallSet before building sideWallSet, nothing to clean up here.
+        if (exit.direction === 'left' || exit.direction === 'right') wallRenderSet.delete(`${exit.tx},${exit.ty}`)
       }
-      renderPathTiles(wallContainer, sideWallSet, undefined, PATH_TILE.wall2).catch(() => {})
+      renderPathTiles(wallContainer, wallRenderSet, undefined, PATH_TILE.wall2).catch(() => {})
 
       // A carve can break the top wall row into a discontinuous run — only
       // theme it (and render the visual-only crown row above) when it's
-      // still unbroken end-to-end; a broken run falls back to the generic
-      // tile for the whole row rather than theming part of it.
+      // still unbroken end-to-end; a broken run keeps the generic tile laid
+      // down above for the whole row rather than theming part of it.
       const wallMaterial  = interior.wallMaterial
       const themedTopRow  = !!wallMaterial && hasUnbrokenTopWall(interior.width, wallSet)
       if (wallMaterial && themedTopRow) {
-        // Bottom row keeps default tile; top row uses middleBottom; a visual-only row above (ty=-1) uses middleTop
-        renderPathTiles(wallContainer, new Set([...horizontalWallSet].filter(k => parseInt(k.split(',')[1]) !== 0)), undefined, PATH_TILE.wall2).catch(() => {})
+        // ty=0 row → middleBottom, drawn over the generic tile already
+        // there; ty=-1 (above room, visual only) → middleTop
         const wTiles = WALL_TILES[wallMaterial]
-        // ty=0 row → middleBottom; ty=-1 (above room, visual only) → middleTop
         const byTileId = new Map<number, [number, number][]>()
-        for (const key of horizontalWallSet) {
-          const [wx, wy] = key.split(',').map(Number)
-          if (wy !== 0) continue
+        for (let wx = 1; wx < interior.width - 1; wx++) {
           const list = byTileId.get(wTiles.middleBottom) ?? []; list.push([wx, 0]); byTileId.set(wTiles.middleBottom, list)
           const topList = byTileId.get(wTiles.middleTop) ?? []; topList.push([wx, -1]); byTileId.set(wTiles.middleTop, topList)
         }
@@ -2444,8 +2450,6 @@ export function HubTownCanvas({
             }
           }).catch(() => {})
         }
-      } else {
-        renderPathTiles(wallContainer, horizontalWallSet, undefined, PATH_TILE.wall2).catch(() => {})
       }
 
       // Decor — split into below (solid/below) and above containers

--- a/web/src/components/mapEditor/EntityInspector.tsx
+++ b/web/src/components/mapEditor/EntityInspector.tsx
@@ -1837,6 +1837,11 @@ function InteriorInspector({
               </div>
             </Field>
             <Field label="Decor items"><span style={{ color: '#aaa' }}>{interior.decor.length} items</span></Field>
+            <Field label="Carved rects">
+              <span style={{ color: '#aaa' }}>
+                {interior.carve?.length ?? 0} {(interior.carve?.length ?? 0) === 1 ? 'rect' : 'rects'} — use the Carve tool to draw or the Delete tool to remove one
+              </span>
+            </Field>
 
             {/* Exits */}
             <Field label={`Exits (${interior.exits?.length ?? 0})`}>

--- a/web/src/components/mapEditor/MapEditor.tsx
+++ b/web/src/components/mapEditor/MapEditor.tsx
@@ -55,7 +55,7 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
     addAnimal, updateAnimal,
     updateTreasure, updateConfig,
     updateArea, updateMapProps, resizeMap,
-    resizeInterior, addInterior, addInteriorExit, updateInteriorProps, updateInteriorExit, removeInteriorExit,
+    resizeInterior, addInterior, addInteriorCarveRect, addInteriorExit, updateInteriorProps, updateInteriorExit, removeInteriorExit,
     addStreet, updateStreetEntry,
     addLockedDoor, updateLockedDoor, deleteLockedDoor,
     undo, redo, markSaved,
@@ -411,6 +411,9 @@ export function MapEditor({ initialMapId = 'ravenwatch', initialFestival = undef
             onAddChickenZone={addChickenZone}
             onAddArea={addArea}
             onAddBuilding={addBuilding}
+            onAddCarveRect={(tx1, ty1, tx2, ty2) => {
+              if (state.activeInteriorId) addInteriorCarveRect(state.activeInteriorId, tx1, ty1, tx2, ty2)
+            }}
             questPickupItems={questDefsData?.pickupItems ?? []}
           />
 

--- a/web/src/components/mapEditor/MapEditorCanvas.tsx
+++ b/web/src/components/mapEditor/MapEditorCanvas.tsx
@@ -16,6 +16,7 @@ import { resolveNpcSprite } from './spriteList'
 import { isSameEntityRef } from './multiSelectHelpers'
 import { getScheduledLocation } from './npcSchedulePreview'
 import { isStairsEntryStale } from '../../game/hub/doorwayEntry'
+import { computeInteriorShape } from '../../game/hub/interiorShape'
 
 const T           = 32
 const INTERIOR_PAD = 10  // tiles of surrounding space around active room in interior view
@@ -109,6 +110,7 @@ interface Props {
   onAddChickenZone:   (tx1: number, ty1: number, tx2: number, ty2: number) => void
   onAddArea:           (tx1: number, ty1: number, tx2: number, ty2: number) => void
   onAddBuilding:       (tx1: number, ty1: number, tx2: number, ty2: number) => void
+  onAddCarveRect:      (tx1: number, ty1: number, tx2: number, ty2: number) => void
   onPlaceBuildingDoor: (buildingIndex: number, absTx: number, absTy: number) => void
   onPlaceBuildingWindow: (buildingIndex: number, absTx: number, absTy: number, tileId: string) => void
   showQuestItems:     boolean
@@ -158,7 +160,7 @@ export function MapEditorCanvas(props: Props) {
 
   // Clear rect draw when tool switches away from a rect-draw tool
   useEffect(() => {
-    const rectTools: ToolMode[] = ['street', 'pond', 'bridge', 'chickenZone', 'area', 'building']
+    const rectTools: ToolMode[] = ['street', 'pond', 'bridge', 'chickenZone', 'area', 'building', 'carve']
     if (!rectTools.includes(tool)) {
       rectDrawRef.current = null
       setRectPreview(null)
@@ -274,6 +276,9 @@ export function MapEditorCanvas(props: Props) {
       } else if (vm !== 'building' && (t === 'street' || t === 'pond' || t === 'bridge' || t === 'chickenZone' || t === 'area' || t === 'building')) {
         rectDrawRef.current = { startTx: tx, startTy: ty, lastTx: tx, lastTy: ty }
         setRectPreviewRef.current({ sx: tx, sy: ty, ex: tx, ey: ty })
+      } else if (t === 'carve' && vm === 'interior' && iid) {
+        rectDrawRef.current = { startTx: tx, startTy: ty, lastTx: tx, lastTy: ty }
+        setRectPreviewRef.current({ sx: tx, sy: ty, ex: tx, ey: ty })
       } else if (t === 'spawn') {
         propsRef.current.onAddNpcSpawnTile(tx, ty)
       }
@@ -326,6 +331,7 @@ export function MapEditorCanvas(props: Props) {
         else if (t === 'chickenZone') propsRef.current.onAddChickenZone(tx1, ty1, tx2, ty2)
         else if (t === 'area')        propsRef.current.onAddArea(tx1, ty1, tx2, ty2)
         else if (t === 'building')    propsRef.current.onAddBuilding(tx1, ty1, tx2, ty2)
+        else if (t === 'carve')       propsRef.current.onAddCarveRect(tx1, ty1, tx2, ty2)
         rectDrawRef.current = null
         setRectPreviewRef.current(null)
       }
@@ -419,11 +425,12 @@ export function MapEditorCanvas(props: Props) {
     drawSelection(selLayer)
 
     // Rect draw preview — drawn above all other layers
-    if (!isInterior && rectPreview) {
+    if ((!isInterior || tool === 'carve') && rectPreview) {
       const { sx, sy, ex, ey } = rectPreview
       const pvGfx = new PIXI.Graphics()
+      const previewColor = tool === 'carve' ? 0xdd3333 : STREET_COLOR
       pvGfx.rect(sx * T, sy * T, (ex - sx + 1) * T, (ey - sy + 1) * T)
-        .fill({ color: STREET_COLOR, alpha: 0.4 })
+        .fill({ color: previewColor, alpha: 0.4 })
         .stroke({ color: 0xf0c040, width: 2 })
       worldContainer.addChild(pvGfx)
     }
@@ -761,15 +768,13 @@ export function MapEditorCanvas(props: Props) {
     return gapSet
   }
 
-  function drawWallsWithGaps(gfx: PIXI.Graphics, width: number, height: number, color: number, gapSet: Set<string>) {
-    for (let tx = 0; tx < width; tx++) {
-      if (!gapSet.has(`${tx},0`))          gfx.rect(tx * T, 0,              T, T).fill(color)
-      if (!gapSet.has(`${tx},1`))          gfx.rect(tx * T, T,              T, T).fill(color)
-      if (!gapSet.has(`${tx},${height-1}`)) gfx.rect(tx * T, (height-1) * T, T, T).fill(color)
-    }
-    for (let ty = 2; ty < height - 1; ty++) {
-      if (!gapSet.has(`0,${ty}`))           gfx.rect(0,              ty * T, T, T).fill(color)
-      if (!gapSet.has(`${width-1},${ty}`))  gfx.rect((width-1) * T, ty * T, T, T).fill(color)
+  // Draws every cell in `wallSet` (from computeInteriorShape — the room's
+  // actual, possibly-carved wall perimeter) that isn't a doorway gap.
+  function drawWallsWithGaps(gfx: PIXI.Graphics, wallSet: Set<string>, color: number, gapSet: Set<string>) {
+    for (const key of wallSet) {
+      if (gapSet.has(key)) continue
+      const [tx, ty] = key.split(',').map(Number)
+      gfx.rect(tx * T, ty * T, T, T).fill(color)
     }
   }
 
@@ -779,6 +784,7 @@ export function MapEditorCanvas(props: Props) {
     width: number,
     container: PIXI.Container,
     gapSet: Set<string>,
+    wallSet: Set<string>,
   ) {
     if (!wallTileId) return
     const wTiles = WALL_TILES[wallTileId as WallMaterial]
@@ -786,6 +792,9 @@ export function MapEditorCanvas(props: Props) {
     const byTile = new Map<number, [number, number][]>()
     for (let tx = 0; tx < width; tx++) {
       if (gapSet.has(`${tx},0`)) continue
+      // A carve that breaks the top row here just skips themed art for that
+      // column, same fallback-to-generic idea HubTownCanvas.tsx uses at runtime.
+      if (!wallSet.has(`${tx},0`)) continue
       const faceId = tx === 0 ? wTiles.leftBottom : tx === width - 1 ? wTiles.rightBottom : wTiles.middleBottom
       const crownId = tx === 0 ? wTiles.leftTop   : tx === width - 1 ? wTiles.rightTop   : wTiles.middleTop
       ;(byTile.get(faceId)  ?? (byTile.set(faceId,  []), byTile.get(faceId)!)).push([tx,  0])
@@ -808,24 +817,25 @@ export function MapEditorCanvas(props: Props) {
     const bg = new PIXI.Graphics()
     bg.rect(0, 0, width * T, height * T).fill(0x5a4a3a)
     container.addChild(bg)
+    const { floorSet, wallSet } = computeInteriorShape(width, height, room.carve)
     if (room.floorTileId) {
       const fid = tileNumericId(room.floorTileId)
       loadTileRef(fid).then(tex => {
         if (renderVersionRef.current !== version) return
-        for (let tx = 0; tx < width; tx++)
-          for (let ty = 0; ty < height; ty++) {
-            const sp = new PIXI.Sprite(tex)
-            sp.x = tx * T; sp.y = ty * T
-            container.addChild(sp)
-          }
+        for (const key of floorSet) {
+          const [tx, ty] = key.split(',').map(Number)
+          const sp = new PIXI.Sprite(tex)
+          sp.x = tx * T; sp.y = ty * T
+          container.addChild(sp)
+        }
       }).catch(() => {})
     }
     const gapSet = buildGapSet(width, height, room.exits)
     const wallColor = room.wallTileId ? (WALL_COLORS[room.wallTileId] ?? 0x3a3a4a) : 0x3a3a4a
     const wallGfx = new PIXI.Graphics()
-    drawWallsWithGaps(wallGfx, width, height, wallColor, gapSet)
+    drawWallsWithGaps(wallGfx, wallSet, wallColor, gapSet)
     container.addChild(wallGfx)
-    renderWallMaterial(version, room.wallTileId, width, container, gapSet)
+    renderWallMaterial(version, room.wallTileId, width, container, gapSet, wallSet)
   }
 
   // ── Building editor rendering ──────────────────────────────────────────────────
@@ -1041,20 +1051,28 @@ export function MapEditorCanvas(props: Props) {
 
     // Compute gapSet before async floor load so the closure can use it
     const gapSet = buildGapSet(width, height, interior.exits)
+    // Room shape (bounding box minus any carve rects) — same computation
+    // HubTownCanvas.tsx uses at runtime, so a carve drawn here previews
+    // exactly what the room will actually look like in-game.
+    const { floorSet, wallSet } = computeInteriorShape(width, height, interior.carve)
 
-    // Floor tiles — skip wall-edge positions unless they're a doorway gap
+    // Floor tiles — one sprite per floorSet cell, plus any doorway gap tiles
     if (interior.floorTileId) {
       const fid = tileNumericId(interior.floorTileId)
       loadTileRef(fid).then(tex => {
         if (renderVersionRef.current !== version) return
-        for (let tx = 0; tx < width; tx++) {
-          for (let ty = 0; ty < height; ty++) {
-            const isEdge = ty <= 1 || ty >= height - 1 || tx === 0 || tx === width - 1
-            if (isEdge && !gapSet.has(`${tx},${ty}`)) continue
-            const sp = new PIXI.Sprite(tex)
-            sp.x = tx * T; sp.y = ty * T
-            groundLayer.addChild(sp)
-          }
+        for (const key of floorSet) {
+          const [tx, ty] = key.split(',').map(Number)
+          const sp = new PIXI.Sprite(tex)
+          sp.x = tx * T; sp.y = ty * T
+          groundLayer.addChild(sp)
+        }
+        for (const key of gapSet) {
+          if (floorSet.has(key)) continue
+          const [tx, ty] = key.split(',').map(Number)
+          const sp = new PIXI.Sprite(tex)
+          sp.x = tx * T; sp.y = ty * T
+          groundLayer.addChild(sp)
         }
       }).catch(() => {})
     }
@@ -1062,9 +1080,23 @@ export function MapEditorCanvas(props: Props) {
     // Walls with gaps at directional exits
     const wallColor = interior.wallTileId ? (WALL_COLORS[interior.wallTileId] ?? 0x3a3a4a) : 0x3a3a4a
     const wallGfx = new PIXI.Graphics()
-    drawWallsWithGaps(wallGfx, width, height, wallColor, gapSet)
+    drawWallsWithGaps(wallGfx, wallSet, wallColor, gapSet)
     groundLayer.addChild(wallGfx)
-    renderWallMaterial(version, interior.wallTileId, width, groundLayer, gapSet)
+    renderWallMaterial(version, interior.wallTileId, width, groundLayer, gapSet, wallSet)
+
+    // Carve rects overlay — selectable/deletable like any other authored
+    // rectangle entity (area, chickenZone, …).
+    ;(interior.carve ?? []).forEach((rect, carveIdx) => {
+      const isSel = isEntitySelected({ type: 'interiorCarve', interiorId: iid, index: carveIdx })
+      const gfx = new PIXI.Graphics()
+      gfx.rect(rect.tx * T, rect.ty * T, rect.w * T, rect.h * T)
+        .fill({ color: 0xdd3333, alpha: isSel ? 0.28 : 0.16 })
+        .stroke({ color: isSel ? 0xf0c040 : 0xdd3333, width: isSel ? 2 : 1 })
+      gfx.eventMode = 'static'; gfx.cursor = 'pointer'
+      gfx.on('pointerdown', (e: PIXI.FederatedPointerEvent) =>
+        handleEntityPointerDown(e, { type: 'interiorCarve', interiorId: iid, index: carveIdx }, rect.tx, rect.ty))
+      groundLayer.addChild(gfx)
+    })
 
     // Outlined markers on up/down exit tiles — clickable & draggable like any
     // other interior entity, so their tx/ty (and via syncReciprocalEntryTile,
@@ -1709,6 +1741,12 @@ function hitTest(
       if ((exits[i].direction === 'up' || exits[i].direction === 'down') && exits[i].tx === tx && exits[i].ty === ty)
         return { type: 'interiorExit', index: i, interiorId: activeInteriorId }
     }
+    const carve = cfg.interiors?.[activeInteriorId]?.carve ?? []
+    for (let i = carve.length - 1; i >= 0; i--) {
+      const r = carve[i]
+      if (tx >= r.tx && tx < r.tx + r.w && ty >= r.ty && ty < r.ty + r.h)
+        return { type: 'interiorCarve', index: i, interiorId: activeInteriorId }
+    }
     if (showInteractables) {
       const interactables = cfg.interactables ?? []
       for (let i = interactables.length - 1; i >= 0; i--) {
@@ -1837,6 +1875,7 @@ function getEntityTx(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems
   if (entity.type === 'animal') return cfg.animals?.[entity.index]?.tx ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.tx ?? 0
   if (entity.type === 'interiorExit') return cfg.interiors?.[entity.interiorId]?.exits?.[entity.index]?.tx ?? 0
+  if (entity.type === 'interiorCarve') return cfg.interiors?.[entity.interiorId]?.carve?.[entity.index]?.tx ?? 0
   if (entity.type === 'buildingLevelDecor') return cfg.buildings?.[entity.buildingIndex]?.levelDecor?.[entity.index]?.tx ?? 0
   if (entity.type === 'buildingDecor') {
     const b = cfg.buildings?.[entity.buildingIndex]
@@ -1897,6 +1936,7 @@ function getEntityTy(cfg: RawMapConfig, entity: SelectedEntity, questPickupItems
   if (entity.type === 'animal') return cfg.animals?.[entity.index]?.ty ?? 0
   if (entity.type === 'interiorDecor') return cfg.interiors?.[entity.interiorId]?.decor[entity.index]?.ty ?? 0
   if (entity.type === 'interiorExit') return cfg.interiors?.[entity.interiorId]?.exits?.[entity.index]?.ty ?? 0
+  if (entity.type === 'interiorCarve') return cfg.interiors?.[entity.interiorId]?.carve?.[entity.index]?.ty ?? 0
   if (entity.type === 'buildingLevelDecor') return cfg.buildings?.[entity.buildingIndex]?.levelDecor?.[entity.index]?.ty ?? 0
   if (entity.type === 'buildingDecor') {
     const b = cfg.buildings?.[entity.buildingIndex]

--- a/web/src/components/mapEditor/MapEditorToolbar.tsx
+++ b/web/src/components/mapEditor/MapEditorToolbar.tsx
@@ -72,6 +72,7 @@ const TOOLS: { mode: ToolMode; label: string; title: string }[] = [
   { mode: 'area',        label: '□', title: 'Draw Area' },
   { mode: 'building',    label: '🏛', title: 'Draw Building' },
   { mode: 'buildingWindow', label: '⊞', title: 'Place Window (building view, with a tile selected)' },
+  { mode: 'carve',       label: '⧉', title: 'Carve a notch out of the active interior (interior view only)' },
 ]
 
 export function MapEditorToolbar({

--- a/web/src/components/mapEditor/mapEditorTypes.ts
+++ b/web/src/components/mapEditor/mapEditorTypes.ts
@@ -3,7 +3,7 @@ import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMateri
 import type { NpcActivity } from '../../data/hub/loader'
 
 
-export type ToolMode = 'select' | 'place' | 'delete' | 'street' | 'pond' | 'bridge' | 'spawn' | 'chickenZone' | 'area' | 'building' | 'buildingWindow'
+export type ToolMode = 'select' | 'place' | 'delete' | 'street' | 'pond' | 'bridge' | 'spawn' | 'chickenZone' | 'area' | 'building' | 'buildingWindow' | 'carve'
 export type Zlayer = 'solid' | 'below' | 'above'
 export type ViewMode = 'exterior' | 'interior' | 'building'
 
@@ -132,6 +132,9 @@ export interface RawInterior {
   floorTileId: string
   wallTileId?: string
   wallMaterial?: string
+  /** Sub-rectangles (local tile coords) subtracted from the width×height box,
+   *  carving an L-shape/notch out of the room — see game/hub/interiorShape.ts. */
+  carve?: Array<{ tx: number; ty: number; w: number; h: number }>
   decor: RawDecorItem[]
   playerDecor?: boolean  // render the player's placed furniture here at runtime (homeLayout.ts) — ships unfurnished
   hours?: { open: number; close: number } | 'always'
@@ -319,6 +322,7 @@ export type SelectedEntity =
   | { type: 'pickupItem'; index: number }
   | { type: 'interiorDecor'; interiorId: string; index: number }
   | { type: 'interiorExit'; interiorId: string; index: number }
+  | { type: 'interiorCarve'; interiorId: string; index: number }
   | { type: 'blockedPath'; index: number }
   | { type: 'lockedDoor'; index: number }
   | { type: 'animal'; index: number }

--- a/web/src/components/mapEditor/multiSelectHelpers.test.ts
+++ b/web/src/components/mapEditor/multiSelectHelpers.test.ts
@@ -22,6 +22,11 @@ describe('isSameEntityRef', () => {
     const b: SelectedEntity = { type: 'interiorDecor', index: 0, interiorId: 'room-b' }
     expect(isSameEntityRef(a, b)).toBe(false)
   })
+  it('returns false for interiorCarve with different interiorId', () => {
+    const a: SelectedEntity = { type: 'interiorCarve', index: 0, interiorId: 'room-a' }
+    const b: SelectedEntity = { type: 'interiorCarve', index: 0, interiorId: 'room-b' }
+    expect(isSameEntityRef(a, b)).toBe(false)
+  })
 })
 
 describe('toggleInSelection', () => {
@@ -85,5 +90,17 @@ describe('applyDeleteEntities', () => {
     const c = applyDeleteEntities(baseConfig, [street0])
     expect(c.pondTiles).toHaveLength(1)
     expect(c.exteriorDecor).toHaveLength(2)
+  })
+  it('deletes an interiorCarve rect from the right room only', () => {
+    const withCarve = {
+      ...baseConfig,
+      interiors: {
+        'room-a': { name: 'A', width: 10, height: 8, floorTileId: 'x', decor: [], carve: [{ tx: 1, ty: 1, w: 2, h: 2 }, { tx: 5, ty: 1, w: 2, h: 2 }] },
+        'room-b': { name: 'B', width: 10, height: 8, floorTileId: 'x', decor: [], carve: [{ tx: 1, ty: 1, w: 2, h: 2 }] },
+      },
+    } as unknown as RawMapConfig
+    const c = applyDeleteEntities(withCarve, [{ type: 'interiorCarve', interiorId: 'room-a', index: 0 }])
+    expect(c.interiors!['room-a'].carve).toEqual([{ tx: 5, ty: 1, w: 2, h: 2 }])
+    expect(c.interiors!['room-b'].carve).toEqual([{ tx: 1, ty: 1, w: 2, h: 2 }])
   })
 })

--- a/web/src/components/mapEditor/multiSelectHelpers.ts
+++ b/web/src/components/mapEditor/multiSelectHelpers.ts
@@ -8,6 +8,7 @@ export function isSameEntityRef(a: SelectedEntity, b: SelectedEntity): boolean {
   if (a.type !== b.type) return false
   if ('index' in a && 'index' in b && (a as {index:number}).index !== (b as {index:number}).index) return false
   if (a.type === 'interiorDecor' && b.type === 'interiorDecor' && a.interiorId !== b.interiorId) return false
+  if (a.type === 'interiorCarve' && b.type === 'interiorCarve' && a.interiorId !== b.interiorId) return false
   if (a.type === 'buildingLevelDecor' && b.type === 'buildingLevelDecor' && a.buildingIndex !== b.buildingIndex) return false
   if (a.type === 'festivalDecor' && b.type === 'festivalDecor' && a.festivalId !== b.festivalId) return false
   return true
@@ -179,6 +180,23 @@ export function applyDeleteEntities(config: RawMapConfig, entities: SelectedEnti
       const room = interiors[roomId]
       if (!room) continue
       interiors = { ...interiors, [roomId]: { ...room, exits: (room.exits ?? []).filter((_, i) => !idxs.has(i)) } }
+    }
+    c = { ...c, interiors }
+  }
+
+  // interiorCarve — group by interiorId
+  const carveRoomMap = new Map<string, Set<number>>()
+  for (const e of entities) {
+    if (e.type !== 'interiorCarve') continue
+    if (!carveRoomMap.has(e.interiorId)) carveRoomMap.set(e.interiorId, new Set())
+    carveRoomMap.get(e.interiorId)!.add(e.index)
+  }
+  if (carveRoomMap.size) {
+    let interiors = { ...c.interiors }
+    for (const [roomId, idxs] of carveRoomMap) {
+      const room = interiors[roomId]
+      if (!room) continue
+      interiors = { ...interiors, [roomId]: { ...room, carve: (room.carve ?? []).filter((_, i) => !idxs.has(i)) } }
     }
     c = { ...c, interiors }
   }

--- a/web/src/components/mapEditor/useMapEditorState.ts
+++ b/web/src/components/mapEditor/useMapEditorState.ts
@@ -266,6 +266,15 @@ function applyMove(prevConfig: RawMapConfig, entity: SelectedEntity, tx: number,
     exits[entity.index] = { ...exits[entity.index], tx, ty }
     const interiors = { ...prevConfig.interiors, [entity.interiorId]: { ...interior, exits } }
     newConfig = { ...prevConfig, interiors: syncReciprocalEntryTile(interiors, entity.interiorId, entity.index) }
+  } else if (entity.type === 'interiorCarve' && prevConfig.interiors?.[entity.interiorId]) {
+    const interior = prevConfig.interiors[entity.interiorId]
+    const carve = [...(interior.carve ?? [])]
+    const r = carve[entity.index]
+    if (!r) return prevConfig
+    const dx = tx - r.tx, dy = ty - r.ty
+    if (dx === 0 && dy === 0) return prevConfig
+    carve[entity.index] = { ...r, tx: r.tx + dx, ty: r.ty + dy }
+    newConfig = { ...prevConfig, interiors: { ...prevConfig.interiors, [entity.interiorId]: { ...interior, carve } } }
   }
   return newConfig
 }
@@ -1435,6 +1444,28 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     })
   }, [])
 
+  // Carves a sub-rectangle out of the room's bounding box — see
+  // game/hub/interiorShape.ts, which HubTownCanvas.tsx and this editor's own
+  // renderInterior both use to trace the resulting floor/wall perimeter.
+  const addInteriorCarveRect = useCallback((interiorId: string, tx1: number, ty1: number, tx2: number, ty2: number) => {
+    setState(s => {
+      const prevConfig = s.configData
+      const interior = prevConfig.interiors?.[interiorId]
+      if (!interior) return s
+      const rect = { tx: tx1, ty: ty1, w: tx2 - tx1 + 1, h: ty2 - ty1 + 1 }
+      const carve = [...(interior.carve ?? []), rect]
+      const newIndex = carve.length - 1
+      return {
+        ...s,
+        configData: { ...prevConfig, interiors: { ...prevConfig.interiors, [interiorId]: { ...interior, carve } } },
+        selectedEntities: [{ type: 'interiorCarve' as const, interiorId, index: newIndex }],
+        undoStack: [...s.undoStack, prevConfig].slice(-MAX_UNDO),
+        redoStack: [],
+        isDirty: true,
+      }
+    })
+  }, [])
+
   const addInteriorExit = useCallback((interiorId: string, exit: InteriorExit) => {
     setState(s => {
       const prevConfig = s.configData
@@ -1799,6 +1830,7 @@ export function useMapEditorState(initialMapId: MapId = 'ravenwatch', initialFes
     resizeMap,
     resizeInterior,
     addInterior,
+    addInteriorCarveRect,
     addInteriorExit,
     updateInteriorProps,
     updateInteriorExit,

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -16,11 +16,13 @@ import {
   isBountyCollectPickup,
   reconcileBountyPickups,
   getActiveBountyStepHint,
+  __setBountyNowOverride,
 } from './bounties'
 import { saveCrystals, loadCrystals } from '../collection'
 import { markPickedUp, isPickedUp } from './pickups'
 import { addRelationshipPoints, getRelationship } from './relationships'
 import { getFriendshipLevel } from './friendship'
+import { recordNpcMet } from './journal'
 
 // In-memory localStorage mock (tests run in node environment)
 const store = new Map<string, string>()
@@ -322,5 +324,99 @@ describe('getActiveBountyStepHint', () => {
     acceptBounty(reportBounty.id)
     completeAllSteps(reportBounty.id)
     expect(getActiveBountyStepHint(reportBounty, id => id)).toBeNull()
+  })
+})
+
+describe('procedural bounties', () => {
+  // Scans a wide date spread so the seeded RNG's pool draw is exercised many
+  // times — matches the pattern the relationship-gated-bounty test already uses.
+  function anyOffered(prefix: string): boolean {
+    for (let day = 1; day <= 90; day++) {
+      if (getDailyBounties(new Date(2027, 0, day)).some(b => b.id.startsWith(prefix))) return true
+    }
+    return false
+  }
+
+  it('never offers a visit/deliver bounty when no NPC has been met', () => {
+    expect(anyOffered('visit:')).toBe(false)
+    expect(anyOffered('deliver:')).toBe(false)
+  })
+
+  it('offers a visit bounty for a met, errand-eligible NPC', () => {
+    recordNpcMet('whistlebone')
+    expect(anyOffered('visit:whistlebone')).toBe(true)
+  })
+
+  it('never offers a visit bounty for an NPC already covered by a hand-authored bounty', () => {
+    recordNpcMet('elder') // targeted by the hand-authored 'clear-the-ratcatchers-debt'
+    expect(anyOffered('visit:elder')).toBe(false)
+  })
+
+  it('offers a deliver bounty between two met NPCs, but not before both are met', () => {
+    recordNpcMet('whistlebone')
+    expect(anyOffered('deliver:whistlebone:')).toBe(false)
+    recordNpcMet('gildwyn')
+    expect(anyOffered('deliver:whistlebone:gildwyn') || anyOffered('deliver:gildwyn:whistlebone')).toBe(true)
+  })
+
+  // findBountyDef regenerates a procedural bounty purely from its id (not
+  // from "is it in today's rotation"), so the full accept/advance/turn-in
+  // flow works by constructing the id directly — no date-scanning needed.
+  it('runs a visit bounty end-to-end via a directly-constructed id', () => {
+    saveCrystals(0)
+    const id = 'visit:whistlebone'
+    acceptBounty(id)
+    expect(getActiveBountyStep(id)?.targetNpcId).toBe('whistlebone')
+    advanceBountyStep(id)
+    expect(getActiveBountyStep(id)).toBeNull()
+    expect(turnInBounty(id)).toBe(20)
+    expect(loadCrystals()).toBe(20)
+    expect(isBountyCompleted(id)).toBe(true)
+  })
+
+  it('runs a deliver bounty end-to-end via a directly-constructed id', () => {
+    saveCrystals(0)
+    const id = 'deliver:whistlebone:gildwyn'
+    acceptBounty(id)
+    expect(getActiveBountyStep(id)?.targetNpcId).toBe('whistlebone')
+    advanceBountyStep(id) // picked up from whistlebone
+    expect(getActiveBountyStep(id)?.targetNpcId).toBe('gildwyn')
+    advanceBountyStep(id) // delivered to gildwyn
+    expect(getActiveBountyStep(id)).toBeNull()
+    expect(turnInBounty(id)).toBe(35)
+    expect(loadCrystals()).toBe(35)
+  })
+
+  // getPendingBountyReport only looks at *today's* rotation (see its own
+  // doc comment), so this needs an actually-offered bounty, not a
+  // directly-constructed id — find a day the RNG offers this exact pair.
+  it('getPendingBountyReport resolves an offered deliver bounty to each step\'s NPC in order', () => {
+    recordNpcMet('whistlebone')
+    recordNpcMet('gildwyn')
+    let offerDay: Date | null = null
+    let deliverId: string | null = null
+    for (let day = 1; day <= 90 && !offerDay; day++) {
+      const d = new Date(2027, 1, day)
+      const found = getDailyBounties(d).find(b => b.id.startsWith('deliver:whistlebone:gildwyn') || b.id.startsWith('deliver:gildwyn:whistlebone'))
+      if (found) { offerDay = d; deliverId = found.id }
+    }
+    expect(offerDay).not.toBeNull()
+    __setBountyNowOverride(offerDay!)
+    const [fromId, toId] = deliverId!.slice('deliver:'.length).split(':')
+    acceptBounty(deliverId!)
+    expect(getPendingBountyReport(fromId)?.id).toBe(deliverId)
+    expect(getPendingBountyReport(toId)).toBeNull()
+    advanceBountyStep(deliverId!)
+    expect(getPendingBountyReport(fromId)).toBeNull()
+    expect(getPendingBountyReport(toId)?.id).toBe(deliverId)
+    __setBountyNowOverride(undefined)
+  })
+
+  it('findBountyDef rejects a garbage procedural-looking id instead of fabricating a bounty', () => {
+    const id = 'visit:not-a-real-npc'
+    acceptBounty(id)
+    // No def resolves for this id, so nothing ever becomes active or turns in.
+    expect(getActiveBountyStep(id)).toBeNull()
+    expect(turnInBounty(id)).toBe(0)
   })
 })

--- a/web/src/game/hub/bounties.test.ts
+++ b/web/src/game/hub/bounties.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
 const DAY = new Date('2026-06-30T12:00:00Z')
 // A date whose daily pool deterministically includes both a 'report'-only
 // bounty and the multi-step 'fresh-fish-for-the-kitchen' 'collect' bounty.
-const FISH_DAY = new Date('2026-01-08T12:00:00Z')
+const FISH_DAY = new Date('2026-01-02T12:00:00Z')
 
 /** Drives every step of a bounty to completion via advanceBountyStep. */
 function completeAllSteps(id: string): void {

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -12,6 +12,8 @@ import type { HubQuestStep, RelationshipGrant } from '../../data/hub/questDefs'
 import { addFriendshipXp, getFriendshipLevel } from './friendship'
 import { getRelationship, grantRelationshipWithRivalry, type RivalNpc } from './relationships'
 import { hashStr, makeSeededRng } from '../seededRandom'
+import { hasMetNpc } from './journal'
+import ravenwatchConfig from '../../data/hub/ravenwatch/config.json'
 
 const KEY = 'jarv_hub_bounties'
 
@@ -111,6 +113,107 @@ const BOUNTY_TEMPLATES: BountyDef[] = [
 
 const BOUNTIES_PER_DAY = 3
 
+// ── Procedural bounties ─────────────────────────────────────────────────────
+//
+// "Check on <npc>" and "deliver a parcel from <npc> to <npc>" errands,
+// generated from Ravenwatch's own NPC roster and gated on hasMetNpc() so a
+// generated bounty is never impossible — met status only ever grows, never
+// shrinks, so an offered/accepted procedural bounty stays completable.
+//
+// These aren't stored anywhere: a procedural id (see PROCEDURAL_ID_RE below)
+// fully describes its bounty, so findBountyDef can regenerate the identical
+// BountyDef from the id alone at any time (accept/progress/turn-in all
+// re-resolve bounties by id, same as the hand-authored ones).
+
+// screen ids that open a core app/progression menu rather than represent a
+// town character the player would run an errand for (contrast with e.g.
+// shop-* or minigame screens, whose NPCs are still fair errand targets).
+const NON_ERRAND_SCREENS = new Set([
+  'campaign', 'endless', 'dailychallenge', 'weeklychallenge', 'quickbattle',
+  'deckbuilder', 'collection-tabs', 'carddraft', 'minigames', 'commander',
+  'hall-of-achievements', 'home-shelf', 'chronicle', 'codex', 'adopt-pet',
+])
+
+// Ids already the target of a hand-authored bounty above — excluded from
+// procedural "visit" candidates to avoid near-duplicate flavor text (still
+// fair game as one side of a procedural "deliver" pair).
+const HAND_AUTHORED_TARGETS = new Set(
+  BOUNTY_TEMPLATES.flatMap(b => b.steps.map(s => s.targetNpcId).filter((id): id is string => !!id)),
+)
+
+interface RavenwatchNpcLite { id: string; name: string; screen?: string }
+const RAVENWATCH_NPCS: RavenwatchNpcLite[] = (ravenwatchConfig.npcs as RavenwatchNpcLite[])
+
+function isErrandEligible(npc: RavenwatchNpcLite): boolean {
+  if (npc.id.endsWith('-int')) return false        // duplicate interior-only copy of an exterior NPC
+  if (npc.id.startsWith('npc_')) return false        // auto-generated id, no authored identity
+  if (npc.screen && NON_ERRAND_SCREENS.has(npc.screen)) return false
+  return true
+}
+
+function npcDisplayName(npcId: string): string {
+  return RAVENWATCH_NPCS.find(n => n.id === npcId)?.name ?? npcId
+}
+
+function buildVisitBounty(npcId: string): BountyDef {
+  const name = npcDisplayName(npcId)
+  return {
+    id: `visit:${npcId}`,
+    title: `Check on ${name}`,
+    desc: `${name} hasn't been seen in a while — stop by and say hello.`,
+    icon: '👋',
+    reward: { crystals: 20 },
+    steps: [{ key: 'report', type: 'report', targetNpcId: npcId, required: 1 }],
+  }
+}
+
+function buildDeliverBounty(fromId: string, toId: string): BountyDef {
+  const fromName = npcDisplayName(fromId)
+  const toName = npcDisplayName(toId)
+  return {
+    id: `deliver:${fromId}:${toId}`,
+    title: 'A Favor Between Friends',
+    desc: `${fromName} has a sealed parcel for ${toName} — pick it up and deliver it.`,
+    icon: '📦',
+    reward: { crystals: 35 },
+    steps: [
+      { key: 'pickup',  type: 'report', targetNpcId: fromId, required: 1 },
+      { key: 'deliver', type: 'report', targetNpcId: toId,   required: 1 },
+    ],
+  }
+}
+
+/** Every procedural bounty a met-NPC set can currently produce. */
+function proceduralBounties(): BountyDef[] {
+  const metEligible = RAVENWATCH_NPCS.filter(n => isErrandEligible(n) && hasMetNpc(n.id))
+  const bounties: BountyDef[] = []
+  for (const npc of metEligible) {
+    if (!HAND_AUTHORED_TARGETS.has(npc.id)) bounties.push(buildVisitBounty(npc.id))
+  }
+  for (const from of metEligible) {
+    for (const to of metEligible) {
+      if (from.id !== to.id) bounties.push(buildDeliverBounty(from.id, to.id))
+    }
+  }
+  return bounties
+}
+
+/** Recognizes a procedural bounty id and regenerates its def — validates
+ *  both npc ids are real Ravenwatch NPCs so a garbage/stale id resolves to
+ *  undefined rather than a broken bounty. */
+function findProceduralBountyDef(id: string): BountyDef | undefined {
+  const isRealNpc = (npcId: string) => RAVENWATCH_NPCS.some(n => n.id === npcId)
+  if (id.startsWith('visit:')) {
+    const npcId = id.slice('visit:'.length)
+    return isRealNpc(npcId) ? buildVisitBounty(npcId) : undefined
+  }
+  if (id.startsWith('deliver:')) {
+    const [fromId, toId] = id.slice('deliver:'.length).split(':')
+    return fromId && toId && isRealNpc(fromId) && isRealNpc(toId) ? buildDeliverBounty(fromId, toId) : undefined
+  }
+  return undefined
+}
+
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 // Story/test-only override for "now", since callers like BountyBoardModal
@@ -156,7 +259,8 @@ function checkBountyPrerequisite(prereq: string): boolean {
 export function getDailyBounties(at?: Date): BountyDef[] {
   const slotKey = getBountySlotKey(at)
   const rng     = makeSeededRng(hashStr(slotKey) ^ 0xfeedbeef)
-  const pool    = BOUNTY_TEMPLATES.filter(b => !b.prerequisite || checkBountyPrerequisite(b.prerequisite))
+  const pool    = [...BOUNTY_TEMPLATES, ...proceduralBounties()]
+    .filter(b => !b.prerequisite || checkBountyPrerequisite(b.prerequisite))
   const result: BountyDef[] = []
   const used    = new Set<number>()
 
@@ -202,7 +306,7 @@ function saveBountyState(state: BountyState): void {
 }
 
 function findBountyDef(id: string): BountyDef | undefined {
-  return BOUNTY_TEMPLATES.find(b => b.id === id)
+  return BOUNTY_TEMPLATES.find(b => b.id === id) ?? findProceduralBountyDef(id)
 }
 
 export function isBountyAccepted(id: string): boolean {

--- a/web/src/game/hub/bounties.ts
+++ b/web/src/game/hub/bounties.ts
@@ -11,6 +11,7 @@ import { isPickedUp, unmarkPickedUp } from './pickups'
 import type { HubQuestStep, RelationshipGrant } from '../../data/hub/questDefs'
 import { addFriendshipXp, getFriendshipLevel } from './friendship'
 import { getRelationship, grantRelationshipWithRivalry, type RivalNpc } from './relationships'
+import { hashStr, makeSeededRng } from '../seededRandom'
 
 const KEY = 'jarv_hub_bounties'
 
@@ -112,22 +113,6 @@ const BOUNTIES_PER_DAY = 3
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
-/** Simple LCG seeded RNG — deterministic for a given seed. */
-function makeSeededRng(seed: number): () => number {
-  let s = seed >>> 0
-  return () => {
-    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
-    return s / 0x100000000
-  }
-}
-
-/** Numeric hash of a string. */
-function dateHash(str: string): number {
-  let h = 0
-  for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0
-  return h
-}
-
 // Story/test-only override for "now", since callers like BountyBoardModal
 // always call getDailyBounties() with no date and have no override prop.
 let nowOverride: Date | undefined
@@ -170,7 +155,7 @@ function checkBountyPrerequisite(prereq: string): boolean {
 /** Returns today's 3 active bounties, deterministically chosen for the day. */
 export function getDailyBounties(at?: Date): BountyDef[] {
   const slotKey = getBountySlotKey(at)
-  const rng     = makeSeededRng(dateHash(slotKey) ^ 0xfeedbeef)
+  const rng     = makeSeededRng(hashStr(slotKey) ^ 0xfeedbeef)
   const pool    = BOUNTY_TEMPLATES.filter(b => !b.prerequisite || checkBountyPrerequisite(b.prerequisite))
   const result: BountyDef[] = []
   const used    = new Set<number>()

--- a/web/src/game/hub/doorwayEntry.test.ts
+++ b/web/src/game/hub/doorwayEntry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getDoorwayEntryTile, findReciprocalStairsExit, isStairsEntryStale, findExteriorDoorForInterior,
+  type ExitLike,
+} from './doorwayEntry'
+
+describe('getDoorwayEntryTile', () => {
+  it('lands opposite a left doorway', () => expect(getDoorwayEntryTile('left', 5, 10, 8)).toEqual([8, 4]))
+  it('lands opposite a right doorway', () => expect(getDoorwayEntryTile('right', 5, 10, 8)).toEqual([1, 4]))
+  it('keeps sourceTx aligned for up/down/front/back', () => {
+    expect(getDoorwayEntryTile('up', 3, 10, 8)).toEqual([3, 6])
+    expect(getDoorwayEntryTile('down', 3, 10, 8)).toEqual([3, 1])
+    expect(getDoorwayEntryTile('front', 3, 10, 8)).toEqual([3, 1])
+    expect(getDoorwayEntryTile('back', 3, 10, 8)).toEqual([3, 6])
+  })
+  it('returns undefined for no/unknown direction', () => {
+    expect(getDoorwayEntryTile(undefined, 3, 10, 8)).toBeUndefined()
+  })
+})
+
+describe('findReciprocalStairsExit / isStairsEntryStale', () => {
+  const interiors = {
+    'downstairs': { exits: [{ tx: 2, ty: 2, toInteriorId: 'upstairs', direction: 'up' as const, entryTx: 5, entryTy: 5 }] },
+    'upstairs':   { exits: [{ tx: 5, ty: 5, toInteriorId: 'downstairs', direction: 'down' as const, entryTx: 2, entryTy: 2 }] },
+  }
+
+  it('finds the reciprocal stairs exit', () => {
+    const exit = interiors.downstairs.exits[0]
+    const rev = findReciprocalStairsExit(interiors, 'downstairs', exit)
+    expect(rev).toEqual(interiors.upstairs.exits[0])
+  })
+
+  it('returns undefined for a non-stairs direction', () => {
+    const leftExit: ExitLike = { tx: 0, ty: 4, toInteriorId: 'upstairs', direction: 'left' }
+    expect(findReciprocalStairsExit(interiors, 'downstairs', leftExit)).toBeUndefined()
+  })
+
+  it('is not stale when entryTx/Ty match the reciprocal door', () => {
+    expect(isStairsEntryStale(interiors, 'downstairs', interiors.downstairs.exits[0])).toBe(false)
+  })
+
+  it('is stale when entryTx/Ty no longer match (door moved)', () => {
+    const stale = { ...interiors.downstairs.exits[0], entryTx: 99 }
+    expect(isStairsEntryStale(interiors, 'downstairs', stale)).toBe(true)
+  })
+})
+
+describe('findExteriorDoorForInterior', () => {
+  const doors = [{ buildingId: 'hollow-entrance', tx: 28, ty: 54 }]
+  const interiors = {
+    'hollow-entrance': {
+      exits: [
+        { tx: 0, ty: 4, toInteriorId: 'hollow-west', direction: 'left' as const },
+        { tx: 10, ty: 4, toInteriorId: 'hollow-east', direction: 'right' as const },
+      ],
+    },
+    'hollow-west': { exits: [{ tx: 9, ty: 4, toInteriorId: 'hollow-entrance', direction: 'right' as const }] },
+    'hollow-east': { exits: [{ tx: 0, ty: 4, toInteriorId: 'hollow-entrance', direction: 'left' as const }] },
+  }
+
+  it('finds the door directly on the room itself', () => {
+    expect(findExteriorDoorForInterior('hollow-entrance', doors, interiors)).toBe(doors[0])
+  })
+
+  it('traces through one hop of the exits graph to a doorless neighbor', () => {
+    expect(findExteriorDoorForInterior('hollow-west', doors, interiors)).toBe(doors[0])
+    expect(findExteriorDoorForInterior('hollow-east', doors, interiors)).toBe(doors[0])
+  })
+
+  it('does not loop forever on a cycle and returns undefined when no door is reachable', () => {
+    const noDoorInteriors = {
+      a: { exits: [{ tx: 0, ty: 0, toInteriorId: 'b', direction: 'left' as const }] },
+      b: { exits: [{ tx: 0, ty: 0, toInteriorId: 'a', direction: 'right' as const }] },
+    }
+    expect(findExteriorDoorForInterior('a', doors, noDoorInteriors)).toBeUndefined()
+  })
+
+  it('returns undefined for a room absent from both doors and interiors', () => {
+    expect(findExteriorDoorForInterior('nowhere', doors, interiors)).toBeUndefined()
+  })
+})

--- a/web/src/game/hub/doorwayEntry.ts
+++ b/web/src/game/hub/doorwayEntry.ts
@@ -57,3 +57,34 @@ export function isStairsEntryStale(
   if (!rev) return false
   return exit.entryTx !== rev.tx || exit.entryTy !== rev.ty
 }
+
+export interface DoorLike {
+  buildingId: string
+}
+
+/** Traces a multi-room complex's exits graph (breadth-first, so the nearest
+ *  door wins) to find the room that actually owns an exterior door. Many
+ *  complexes — a cave with several linked passages, a building's upstairs
+ *  office — have exactly one room with a door of its own; the rest are only
+ *  reachable via each other's `exits`, not via any door directly on them.
+ *  Used to land the player back at the right spot on exiting to the
+ *  exterior from any room in the complex, not just the one with the door. */
+export function findExteriorDoorForInterior<D extends DoorLike>(
+  startId: string,
+  doors: D[],
+  interiors: Record<string, { exits?: ExitLike[] }> | undefined,
+): D | undefined {
+  const visited = new Set<string>()
+  const queue = [startId]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (visited.has(id)) continue
+    visited.add(id)
+    const door = doors.find(d => d.buildingId === id)
+    if (door) return door
+    for (const exit of interiors?.[id]?.exits ?? []) {
+      if (!visited.has(exit.toInteriorId)) queue.push(exit.toInteriorId)
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary

- Fixes the Ravenwatch bounty board always offering (close to) the same 3 quests: `bounties.ts` had its own hand-rolled LCG + string hash, and because the day-key strings ("YYYY-MM-DD") barely change between consecutive days, the seed barely changed either — the RNG's output is a linear function of the seed, so the first bounty slot in particular could stay identical for 50+ days in a row. Swapped in the project's existing well-mixing `hashStr` (FNV-1a) + `makeSeededRng` (Mulberry32) pair from `web/src/game/seededRandom.ts`, already used by the daily/weekly challenge systems — good day-to-day variety with no streaks.
- Gives ambient (anonymous, wandering) NPCs an actual tap interaction. Previously their sprites never had `eventMode`/a `pointerdown` handler wired up at all, so a tap silently fell through to the global "walk toward this tile" handler — indistinguishable from tapping empty ground. They now show a short, cosmetic flavor line in a speech bubble (no dialogue modal, no persisted state), both while wandering outside and while visiting inside a building (a recently-added feature that made them stay visible when they walk indoors) — mirroring the existing tap-for-flavor pattern used for ambient animals.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npm run build`
- [x] `npm run test` (2697 tests passed). `bounties.test.ts`'s `FISH_DAY` constant had to move to a new date since it depends on a specific day's daily-bounty draw — verified the new date still exercises the same 'report'+'collect' bounty combination the tests need.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_