### PR TITLE
Show build ID alongside build time in Settings

### DIFF
--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -766,6 +766,14 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
           </div>
           <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
             <div>
+              <div className="settings-label">Build ID</div>
+              <div className="settings-sublabel">
+                {import.meta.env.VITE_GIT_SHA ? import.meta.env.VITE_GIT_SHA.slice(0, 7) : 'local build'}
+              </div>
+            </div>
+          </div>
+          <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+            <div>
               <div className="settings-label">Tileset art</div>
               <div className="settings-sublabel">
                 <a href="https://pipoya.itch.io/" target="_blank" rel="noreferrer">Pipoya</a>


### PR DESCRIPTION
## Summary

- Adds a "Build ID" row to the Settings screen's ABOUT section, right under the existing "Build" (timestamp) row.
- Reads `import.meta.env.VITE_GIT_SHA`, which the deploy workflow already sets to `${{ github.sha }}` on every GitHub Pages deploy and which was already typed in `vite-env.d.ts`, but never actually read anywhere in the app.
- Shows the short (7-char) SHA when present, or `local build` when the var is unset (local dev builds).

This lets the deployed build's commit be checked directly instead of only having a timestamp to go on — useful for confirming whether a reported bug is present in the currently-deployed code or was already fixed in a merged-but-not-yet-deployed commit.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run build` — succeeds; confirmed via a build with `VITE_GIT_SHA` set that the SHA gets embedded and correctly sliced to 7 chars
- [x] `npm run test` — all 2719 existing tests pass (no new tests needed; this is a static text row with no logic to unit test)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_