### PR TITLE
Fix carved interiors leaving a textureless void at a notch's tip

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2429,7 +2429,7 @@ export function HubTownCanvas({
       // still unbroken end-to-end; a broken run keeps the generic tile laid
       // down above for the whole row rather than theming part of it.
       const wallMaterial  = interior.wallMaterial
-      const themedTopRow  = !!wallMaterial && hasUnbrokenTopWall(interior.width, wallSet)
+      const themedTopRow  = !!wallMaterial && hasUnbrokenTopWall(interior.width, baseFloorSet)
       if (wallMaterial && themedTopRow) {
         // ty=0 row → middleBottom, drawn over the generic tile already
         // there; ty=-1 (above room, visual only) → middleTop

--- a/web/src/game/hub/interiorShape.test.ts
+++ b/web/src/game/hub/interiorShape.test.ts
@@ -42,7 +42,7 @@ describe('computeInteriorShape — plain rectangle regression', () => {
         const { floorSet, wallSet } = computeInteriorShape(room.width, room.height)
         expect(setEqual(floorSet, oldFloorSet(room.width, room.height))).toBe(true)
         expect(setEqual(wallSet, oldWallSet(room.width, room.height))).toBe(true)
-        expect(hasUnbrokenTopWall(room.width, wallSet)).toBe(true)
+        expect(hasUnbrokenTopWall(room.width, floorSet)).toBe(true)
       })
     }
   }
@@ -70,41 +70,38 @@ describe('computeInteriorShape — carved shapes', () => {
       }
   })
 
-  it('a carve reaching the box outer floor ring can leave a few cells void (documented behavior)', () => {
+  it('a carve reaching the box outer floor ring leaves no voids — the tip fills in as wall', () => {
     // Notch bites into the left-edge floor column (tx=1, adjacent to the
-    // tx=0 wall column) — the corner and part of that wall column lose
-    // every floor neighbor.
+    // tx=0 wall column) — the corner and part of that wall column used to
+    // lose every floor neighbor and render as a bare void; now every
+    // bounding-box cell that isn't floor is wall, so the whole notch reads
+    // as solid rock, including its tip.
     const { floorSet, wallSet } = computeInteriorShape(10, 8, [{ tx: 1, ty: 1, w: 2, h: 3 }])
-    const voids: string[] = []
-    for (let tx = 0; tx < 10; tx++)
-      for (let ty = 0; ty < 8; ty++) {
-        const key = `${tx},${ty}`
-        if (!floorSet.has(key) && !wallSet.has(key)) voids.push(key)
-      }
-    expect(voids.sort()).toEqual(['0,0', '0,1', '0,2', '1,0', '1,1', '1,2'].sort())
+    for (const key of ['0,0', '0,1', '0,2', '1,0', '1,1', '1,2']) {
+      expect(floorSet.has(key)).toBe(false)
+      expect(wallSet.has(key)).toBe(true)
+    }
   })
 
-  it('an edge-touching corner notch (the shipped worked-example shape) traces a real L-boundary, breaks the top wall row, and voids only the tip', () => {
+  it('an edge-touching corner notch (the shipped worked-example shape) traces a real L-boundary and breaks the top wall row, with zero voids', () => {
     // Same shape authored on ravenwatch-hollow-tunnel-east: a corner bite
-    // that actually reaches the room's right/top boundary, so the room's
-    // outer silhouette is genuinely smaller there (most of the bitten area
-    // renders as solid wall — reading as rock filling the notch — with a
-    // small void right at the tip where no cell has a floor neighbor left).
+    // that actually reaches the room's right/top boundary. The whole
+    // bitten area — including its tip, which used to have no remaining
+    // floor neighbor and render as a bare void — now reads as solid
+    // wall/rock filling the notch.
     const { floorSet, wallSet } = computeInteriorShape(10, 8, [{ tx: 6, ty: 0, w: 4, h: 3 }])
 
     expect(floorSet.has('6,1')).toBe(false)
-    expect(wallSet.has('6,0')).toBe(true)
-    expect(wallSet.has('6,1')).toBe(true)   // notch mostly reads as solid wall/rock
-    expect(wallSet.has('6,2')).toBe(true)
-    expect(hasUnbrokenTopWall(10, wallSet)).toBe(false)
+    for (const key of ['6,0', '6,1', '6,2', '7,0', '7,1', '8,0', '8,1', '9,0', '9,1']) {
+      expect(wallSet.has(key)).toBe(true)
+    }
+    expect(hasUnbrokenTopWall(10, floorSet)).toBe(false)
 
-    const voids: string[] = []
     for (let tx = 0; tx < 10; tx++)
       for (let ty = 0; ty < 8; ty++) {
         const key = `${tx},${ty}`
-        if (!floorSet.has(key) && !wallSet.has(key)) voids.push(key)
+        expect(floorSet.has(key) || wallSet.has(key), `(${tx},${ty}) is void`).toBe(true)
       }
-    expect(voids.sort()).toEqual(['7,0', '7,1', '8,0', '8,1', '9,0', '9,1'].sort())
 
     // Floor continues normally below the notch and on the untouched side.
     expect(floorSet.has('8,3')).toBe(true)

--- a/web/src/game/hub/interiorShape.ts
+++ b/web/src/game/hub/interiorShape.ts
@@ -10,39 +10,22 @@ export interface InteriorShape {
    *  minus any carved-out cells). Does not include exit/door openings —
    *  callers add those back the same way they do for a plain rectangle. */
   floorSet: Set<string>
-  /** Every tile that borders a floor tile (8-directionally) but isn't one
-   *  itself — the wall ring, generalized to trace a carved perimeter. For a
-   *  plain rectangle (no carve) this reproduces the same ring a fixed
-   *  four-edge loop would produce. */
+  /** Every bounding-box tile that isn't floor — the wall ring, generalized
+   *  to also fill in a carved notch. For a plain rectangle (no carve) this
+   *  reproduces the same ring a fixed four-edge loop would produce; for a
+   *  carve, every removed cell (down to the notch's furthest tip, even one
+   *  that reaches the box's outer edge) reads as solid wall/rock filling
+   *  the gap, so there's never a cell that's neither floor nor wall. */
   wallSet: Set<string>
 }
 
-const NEIGHBORS_8: ReadonlyArray<readonly [number, number]> = [
-  [-1, -1], [0, -1], [1, -1],
-  [-1,  0],          [1,  0],
-  [-1,  1], [0,  1], [1,  1],
-]
-
 /**
  * Computes a room's floor and wall tile sets from its bounding box, minus
- * any `carve` rectangles subtracted from the interior. 8-directional (not
- * 4-directional) adjacency is required so the box's four true corner tiles
- * — only ever diagonally adjacent to an interior cell — still get a wall,
- * matching the plain-rectangle behavior exactly when `carve` is empty.
- *
- * A carved cell becomes a wall tile as long as some neighbor (even
- * diagonally) is still floor — which is the desired look: the bitten-out
- * area reads as solid rock/wall filling the notch, the same way the box's
- * outer ring always has been wall. Only a carve that reaches all the way
- * into the room's outermost floor ring (column 1, column width-2, row 1,
- * or row height-2) can leave a few cells at the very tip with no floor
- * neighbor left at all — neither floor nor wall. Those render as nothing
- * (the room's dark backdrop shows through), a minor cosmetic gap right at
- * the notch's tip rather than a defect — expected for a boundary notch
- * that genuinely reaches the room's edge (an L-shape), and invisible in
- * `dark: true` rooms. A carve that stays landlocked (not reaching any box
- * edge) never produces this, but then reads as an internal wall/pillar
- * obstacle rather than a boundary notch.
+ * any `carve` rectangles subtracted from the interior. Every cell in the
+ * box is exactly one of floor or wall — a carved-out region always renders
+ * as solid wall/rock filling the notch, including cells at the very tip of
+ * a notch that reaches the box's outer edge, which used to have no
+ * remaining floor neighbor and rendered as a bare, textureless void.
  */
 export function computeInteriorShape(width: number, height: number, carve?: CarveRect[]): InteriorShape {
   const carvedSet = new Set<string>()
@@ -68,24 +51,24 @@ export function computeInteriorShape(width: number, height: number, carve?: Carv
   for (let tx = 0; tx < width; tx++) {
     for (let ty = 0; ty < height; ty++) {
       const key = `${tx},${ty}`
-      if (floorSet.has(key)) continue
-      for (const [dx, dy] of NEIGHBORS_8) {
-        if (floorSet.has(`${tx + dx},${ty + dy}`)) { wallSet.add(key); break }
-      }
+      if (!floorSet.has(key)) wallSet.add(key)
     }
   }
 
   return { floorSet, wallSet }
 }
 
-/** True when every tile of the room's top wall row (ty=0, columns
- *  1..width-2) is present in `wallSet` — i.e. an unbroken straight run. A
- *  carve that touches the top row anywhere breaks this, and callers should
- *  fall back to generic wall art (and skip the visual-only crown row above
- *  the room) for the whole row rather than theming part of it. */
-export function hasUnbrokenTopWall(width: number, wallSet: Set<string>): boolean {
+/** True when every tile of the room's top interior floor row (ty=1, columns
+ *  1..width-2) is present in `floorSet` — i.e. the row right under the top
+ *  wall is unbroken. A carve that reaches that row breaks this, and callers
+ *  should fall back to generic wall art (and skip the visual-only crown row
+ *  above the room) for the whole top row rather than theming part of it.
+ *  Checks the floor row rather than the wall row itself: `wallSet`'s row 0
+ *  is always fully populated (every bounding-box cell is wall or floor), so
+ *  it can no longer signal whether a carve broke the row underneath it. */
+export function hasUnbrokenTopWall(width: number, floorSet: Set<string>): boolean {
   for (let tx = 1; tx < width - 1; tx++) {
-    if (!wallSet.has(`${tx},0`)) return false
+    if (!floorSet.has(`${tx},1`)) return false
   }
   return true
 }


### PR DESCRIPTION
## Summary

Root-causes and fixes the East Passage "no wall texture at all" report from a code/data investigation (no browser needed — the void was reproducible by hand-tracing `computeInteriorShape`'s algorithm against the room's actual carve data).

- `computeInteriorShape` previously marked a carved cell as wall only when it was 8-directionally adjacent to remaining floor. For a notch that reaches the room's outer edge — `ravenwatch-hollow-tunnel-east`'s corner bite, the exact shape shipped for the Buried Hollow — a handful of cells at the notch's tip end up with **no** floor neighbor left at all, so they were neither floor nor wall. Nothing gets rendered there: a genuine gap in tile coverage, not a stale-deploy artifact. This was actually a known, deliberately-tested tradeoff (`interiorShape.test.ts` called it out as "voids only the tip", reasoned as "invisible in dark rooms") — the user's screenshots prove that assumption wrong: standing near it, the darkness overlay lights the surrounding tiles while the void itself stays pitch black.
- Fix: `wallSet` is now simply every bounding-box cell that isn't floor — a carved notch always reads as solid wall/rock, all the way to its tip, with zero possible voids.
- `hasUnbrokenTopWall` used to check whether the top wall row (`wallSet`, `ty=0`) was fully populated — but with the fix above, that row is now *always* fully populated (every cell is wall-or-floor by construction), so it can no longer signal whether a carve broke the row. Switched it to check the floor row directly underneath (`ty=1`), which is the actual signal for whether a carve should skip themed wall material for that row.
- Updated `interiorShape.test.ts` to assert zero voids instead of documenting the old (now-fixed) void behavior.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — all 2719 tests pass, including the updated `interiorShape.test.ts` carve-shape assertions
- [x] `npm run build` — succeeds
- [x] Hand-traced the exact `ravenwatch-hollow-tunnel-east` carve (`{tx:6, ty:0, w:4, h:3}` on a 10×8 room) through both the old and new algorithm to confirm the 6-cell void (`7,0` / `7,1` / `8,0` / `8,1` / `9,0` / `9,1`) is eliminated and every cell is now floor-or-wall

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_