### PR TITLE
Keep the themed stone back wall in carved interiors

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -34,7 +34,7 @@ import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
 import { getResolvedRoomStyle } from '../../game/hub/roomStyle'
 import { getDoorwayEntryTile, findExteriorDoorForInterior } from '../../game/hub/doorwayEntry'
-import { computeInteriorShape, hasUnbrokenTopWall } from '../../game/hub/interiorShape'
+import { computeInteriorShape, topFacingWallRows } from '../../game/hub/interiorShape'
 import {
   getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
 } from '../../game/hub/houseRooms'
@@ -2424,20 +2424,22 @@ export function HubTownCanvas({
       }
       renderPathTiles(wallContainer, wallRenderSet, undefined, PATH_TILE.wall2).catch(() => {})
 
-      // A carve can break the top wall row into a discontinuous run — only
-      // theme it (and render the visual-only crown row above) when it's
-      // still unbroken end-to-end; a broken run keeps the generic tile laid
-      // down above for the whole row rather than theming part of it.
-      const wallMaterial  = interior.wallMaterial
-      const themedTopRow  = !!wallMaterial && hasUnbrokenTopWall(interior.width, baseFloorSet)
-      if (wallMaterial && themedTopRow) {
-        // ty=0 row → middleBottom, drawn over the generic tile already
-        // there; ty=-1 (above room, visual only) → middleTop
+      // The themed back wall follows the room's carved silhouette per column
+      // rather than requiring one unbroken run: each column's facing wall is
+      // the tile directly above its topmost floor cell, so a carve steps the
+      // facade down around the notch instead of dropping it for the whole
+      // row (which left the entire back wall on the near-black generic tile).
+      const wallMaterial = interior.wallMaterial
+      if (wallMaterial) {
+        // facing row → middleBottom, drawn over the generic tile already
+        // there; one row above it → middleTop. For an uncarved column that's
+        // ty=0 and ty=-1 (the latter above the room, visual only) exactly as
+        // before; a carved column lands both a row or more further down.
         const wTiles = WALL_TILES[wallMaterial]
         const byTileId = new Map<number, [number, number][]>()
-        for (let wx = 1; wx < interior.width - 1; wx++) {
-          const list = byTileId.get(wTiles.middleBottom) ?? []; list.push([wx, 0]); byTileId.set(wTiles.middleBottom, list)
-          const topList = byTileId.get(wTiles.middleTop) ?? []; topList.push([wx, -1]); byTileId.set(wTiles.middleTop, topList)
+        for (const [wx, wy] of topFacingWallRows(interior.width, interior.height, baseFloorSet)) {
+          const list = byTileId.get(wTiles.middleBottom) ?? []; list.push([wx, wy]); byTileId.set(wTiles.middleBottom, list)
+          const topList = byTileId.get(wTiles.middleTop) ?? []; topList.push([wx, wy - 1]); byTileId.set(wTiles.middleTop, topList)
         }
         for (const [tileId, positions] of byTileId) {
           loadTileRef(tileId).then(tex => {
@@ -2785,12 +2787,14 @@ export function HubTownCanvas({
       if (interiorDarkSprite) { interiorLayer.removeChild(interiorDarkSprite); interiorDarkTexture?.destroy(true); interiorDarkSprite = null }
       interiorDarkTopOffset = 0
       if (interior.dark) {
-        // themedTopRow rooms render a purely decorative wall row one tile
+        // wallMaterial rooms render a purely decorative wall row one tile
         // above the room (ty=-1, see the wall-render block above) — grow
         // the overlay by one tile of height at the top only so that row
         // gets darkened too; every other edge stays exactly at the room's
-        // bounding box.
-        interiorDarkTopOffset = themedTopRow ? T : 0
+        // bounding box. Any column whose facing wall sits at ty=0 puts art
+        // up there, so this keys off the material alone rather than trying
+        // to predict which columns a carve stepped down.
+        interiorDarkTopOffset = wallMaterial ? T : 0
         const iw = interior.width * T, ih = interior.height * T + interiorDarkTopOffset
         interiorDarkCanvas = document.createElement('canvas')
         interiorDarkCanvas.width  = Math.ceil(iw / NIGHT_CANVAS_SCALE)

--- a/web/src/game/hub/interiorShape.test.ts
+++ b/web/src/game/hub/interiorShape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeInteriorShape, hasUnbrokenTopWall } from './interiorShape'
+import { computeInteriorShape, topFacingWallRows } from './interiorShape'
 import { getHubWorldData } from '../../data/hub/hubWorldFactory'
 
 // Reference oracle: the plain-rectangle floor/wall formula HubTownCanvas.tsx
@@ -42,7 +42,12 @@ describe('computeInteriorShape — plain rectangle regression', () => {
         const { floorSet, wallSet } = computeInteriorShape(room.width, room.height)
         expect(setEqual(floorSet, oldFloorSet(room.width, room.height))).toBe(true)
         expect(setEqual(wallSet, oldWallSet(room.width, room.height))).toBe(true)
-        expect(hasUnbrokenTopWall(room.width, floorSet)).toBe(true)
+        // Every column faces from row 0 — equivalent to the old "top row is
+        // unbroken" check, so themed back-wall output is unchanged for all
+        // already-authored (uncarved) rooms.
+        const facing = topFacingWallRows(room.width, room.height, floorSet)
+        expect(facing.size).toBe(Math.max(0, room.width - 2))
+        expect([...facing.values()].every(ty => ty === 0)).toBe(true)
       })
     }
   }
@@ -95,7 +100,11 @@ describe('computeInteriorShape — carved shapes', () => {
     for (const key of ['6,0', '6,1', '6,2', '7,0', '7,1', '8,0', '8,1', '9,0', '9,1']) {
       expect(wallSet.has(key)).toBe(true)
     }
-    expect(hasUnbrokenTopWall(10, floorSet)).toBe(false)
+    // The themed back wall steps down around the notch instead of being
+    // dropped: columns left of the carve still face from row 0, the carved
+    // columns face from row 2 (their topmost remaining floor is ty=3).
+    expect([...topFacingWallRows(10, 8, floorSet).entries()].sort((a, b) => a[0] - b[0]))
+      .toEqual([[1, 0], [2, 0], [3, 0], [4, 0], [5, 0], [6, 2], [7, 2], [8, 2]])
 
     for (let tx = 0; tx < 10; tx++)
       for (let ty = 0; ty < 8; ty++) {
@@ -106,6 +115,14 @@ describe('computeInteriorShape — carved shapes', () => {
     // Floor continues normally below the notch and on the untouched side.
     expect(floorSet.has('8,3')).toBe(true)
     expect(floorSet.has('1,1')).toBe(true)
+  })
+
+  it('a landlocked carve steps only the columns it covers', () => {
+    const { floorSet } = computeInteriorShape(10, 8, [{ tx: 4, ty: 1, w: 2, h: 2 }])
+    const facing = topFacingWallRows(10, 8, floorSet)
+    expect(facing.get(4)).toBe(2)
+    expect(facing.get(5)).toBe(2)
+    for (const tx of [1, 2, 3, 6, 7, 8]) expect(facing.get(tx)).toBe(0)
   })
 
   it('carve is a no-op outside the floor domain (border ring, out of bounds)', () => {

--- a/web/src/game/hub/interiorShape.ts
+++ b/web/src/game/hub/interiorShape.ts
@@ -58,17 +58,18 @@ export function computeInteriorShape(width: number, height: number, carve?: Carv
   return { floorSet, wallSet }
 }
 
-/** True when every tile of the room's top interior floor row (ty=1, columns
- *  1..width-2) is present in `floorSet` — i.e. the row right under the top
- *  wall is unbroken. A carve that reaches that row breaks this, and callers
- *  should fall back to generic wall art (and skip the visual-only crown row
- *  above the room) for the whole top row rather than theming part of it.
- *  Checks the floor row rather than the wall row itself: `wallSet`'s row 0
- *  is always fully populated (every bounding-box cell is wall or floor), so
- *  it can no longer signal whether a carve broke the row underneath it. */
-export function hasUnbrokenTopWall(width: number, floorSet: Set<string>): boolean {
+/** For each interior column, the row of the wall tile that faces the room
+ *  from the north — the tile directly above that column's topmost floor
+ *  cell. Every column answers 0 for a plain rectangle; a carve biting into
+ *  the top of a column steps its facing wall further down, so a themed back
+ *  wall can follow the notch instead of being dropped for the whole row.
+ *  Columns with no floor at all (carved away end to end) are omitted. */
+export function topFacingWallRows(width: number, height: number, floorSet: Set<string>): Map<number, number> {
+  const rows = new Map<number, number>()
   for (let tx = 1; tx < width - 1; tx++) {
-    if (!floorSet.has(`${tx},1`)) return false
+    for (let ty = 1; ty < height - 1; ty++) {
+      if (floorSet.has(`${tx},${ty}`)) { rows.set(tx, ty - 1); break }
+    }
   }
-  return true
+  return rows
 }


### PR DESCRIPTION
## Summary

The East Passage's northern/back wall rendered as a flat near-black texture instead of the 2-tile-high stone facade every other interior gets. Confirmed against live build `24d2e56`, so this was current-code behavior.

The wall was rendering the whole time — it was drawing `PATH_TILE.wall2` (`public/world/[A]_type3/[A]Wall-Up2_pipo.png`), a sheet that is almost entirely near-black, which is why it read as an unlit hole next to the torch-lit floor.

**Root cause:** the themed facade was gated on `hasUnbrokenTopWall`, an all-or-nothing check. East Passage's carve (`tx:6, ty:0, w:4, h:3`) breaks the top floor row, so the gate failed and the *entire* back wall lost its stone art — including columns 1-5, which are perfectly ordinary unbroken wall. This was the rule the original carved-interiors design deliberately chose ("any row broken by a carve falls back to the generic wall2 autotile for that entire row"); in practice losing the facade entirely looks far worse than the seam it was avoiding.

**Fix:** the facade now follows the carved silhouette per column. Each column's facing wall is the tile directly above its topmost floor cell, so the stonework steps down around a notch instead of disappearing. `hasUnbrokenTopWall` is replaced by `topFacingWallRows(width, height, floorSet)` in `interiorShape.ts`.

For East Passage this resolves to columns 1-5 → row 0, columns 6-8 → row 2. The carved cells themselves take the facade, so the notch reads as a stepped stone wall rather than dark rock.

Also switches the darkness overlay's top-row extension from the removed flag to `wallMaterial`, which additionally darkens the decorative crown row above a carved room's corner columns — previously sitting at full brightness outside the overlay (the two bright blocks visible above the room in the report screenshot).

## No change to existing rooms

For an uncarved column `topFacingWallRows` resolves to `ty=0` / `ty=-1`, exactly the old hardcoded values. The 238-room regression sweep asserts every column of every existing interior maps to row 0 — precisely equivalent to the old `hasUnbrokenTopWall === true` — so themed output for all already-authored rooms is unchanged.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2720 pass, including 243 shape tests (238-room sweep + carve cases)
- [x] `npm run build` — succeeds
- [x] New assertions cover the shipped East Passage shape (columns 1-5 → 0, 6-8 → 2) and a landlocked carve (only the covered columns step down)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_