### PR TITLE
Add underground lake with cave-exclusive fish beyond the East Passage

### DIFF
--- a/web/src/app/routes/HubRoutes.tsx
+++ b/web/src/app/routes/HubRoutes.tsx
@@ -136,6 +136,15 @@ export function HubRoutes() {
         </OverlayScreen>
       )}
 
+      {/* The underground lake's fishing spot — same rod/bait gate as
+          hub-fishing (checked in HubWorld's handleNodeInteract), but a
+          cave-exclusive catch table (Fishing.tsx's variant prop). */}
+      {screen === 'hub-fishing-cave' && (
+        <OverlayScreen title="🎣 FISHING" onBack={() => setScreen('hubworld')}>
+          <Fishing rewardMode="catch" variant="cave" onDone={() => setScreen('hubworld')} />
+        </OverlayScreen>
+      )}
+
       {screen === 'theatre' && (
         <OverlayScreen title="🎭 CROWN THEATRE" onBack={() => setScreen('hubworld')}>
           <TheatreScreen onBack={() => setScreen('hubworld')} />

--- a/web/src/app/screens.ts
+++ b/web/src/app/screens.ts
@@ -68,6 +68,7 @@ export type Screen =
   | 'hubworld'
   | 'hub-minigame'
   | 'hub-fishing'
+  | 'hub-fishing-cave'
   | 'casino'
   | 'theatre'
   | 'worldmap'

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -2361,6 +2361,9 @@ export function HubTownCanvas({
         interiorWalkable.add(`${exit.tx},${exit.ty}`)
         exitByTile.set(`${exit.tx},${exit.ty}`, exit)
       }
+      // A lake blocks walking like any other solid obstacle — fished from
+      // the shore, not waded into.
+      for (const p of interior.pond ?? []) interiorWalkable.delete(`${p.tx},${p.ty}`)
 
       // Floor tile set (all inner tiles + exit door tiles)
       const floorSet = new Set<string>(baseFloorSet)
@@ -2382,6 +2385,16 @@ export function HubTownCanvas({
       const floorContainer = new PIXI.Container()
       const wallContainer  = new PIXI.Container()
       interiorLayer.addChild(floorContainer, wallContainer)
+
+      // Lake surface — same autotile pond art (and useCanal=true blob shape,
+      // not a thin canal) the exterior world renders ponds with, drawn over
+      // the floor tiles underneath it.
+      if (interior.pond?.length) {
+        const pondSet = new Set(interior.pond.map(p => `${p.tx},${p.ty}`))
+        const pondContainer = new PIXI.Container()
+        interiorLayer.addChild(pondContainer)
+        renderPathTiles(pondContainer, pondSet, undefined, PATH_TILE.water7, true).catch(() => {})
+      }
 
       // Floor: proper interior tile from base chip sheet (wood, stone, parquet, etc.)
       const floorTileId  = interior.floorTileId ?? 288

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -153,6 +153,7 @@ const SCREEN_ENTER_LABEL: Record<string, string> = {
   'home-shelf':      'Look at the shelf?',
   fishing:           'Cast a line?',
   'hub-fishing':     'Cast a line?',
+  'hub-fishing-cave': 'Cast a line into the dark water?',
   marble:            'Play marbles?',
   marblerace:        'Watch a marble race?',
   regatta:           'Race a skiff in the regatta?',
@@ -669,9 +670,11 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     }
     // Hub fishing is gated on owning a rod and holding at least 1 bait.
     // Both are global hub-items, so a rod bought in Millhaven works at any
-    // town's fishing spot. Bait is consumed per cast inside Fishing.tsx,
-    // not on entry.
-    if (screen === 'hub-fishing') {
+    // town's fishing spot — including the underground lake's cave variant
+    // (hub-fishing-cave), which uses the same rod/bait but a different catch
+    // table (Fishing.tsx's variant prop). Bait is consumed per cast inside
+    // Fishing.tsx, not on entry.
+    if (screen === 'hub-fishing' || screen === 'hub-fishing-cave') {
       if (!hasHubItem('fishing-rod')) {
         setDialogueEvent({ speakerName: '', text: "You can't fish without a rod. Millhaven's harbour stall sells them." })
         return

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -12,7 +12,7 @@ import { SCREEN_IDS } from '../EntityInspector'
 // Screens reachable from an NPC's dialogue: the standard SCREEN_IDS list, plus
 // special dispatcher keywords handled directly in HubWorld.tsx's
 // handleNodeInteract (not full-blown screens, e.g. modals / one-off flows).
-const NPC_SCREEN_KEYWORDS = ['adopt-pet', 'town-upgrades', 'bounty-board', 'worldmap', 'campaign', 'endless', 'hub-fishing', 'commander']
+const NPC_SCREEN_KEYWORDS = ['adopt-pet', 'town-upgrades', 'bounty-board', 'worldmap', 'campaign', 'endless', 'hub-fishing', 'hub-fishing-cave', 'commander']
 const NPC_SCREEN_OPTIONS = Array.from(new Set([...SCREEN_IDS, ...NPC_SCREEN_KEYWORDS])).sort()
 
 export type { PickKind } from '../mapEditorTypes'

--- a/web/src/components/minigames/Fishing.test.ts
+++ b/web/src/components/minigames/Fishing.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { FISH_TIERS, CAVE_FISH_TIERS, TIER_HUB_ITEM, CAVE_TIER_HUB_ITEM } from './Fishing'
+import HUB_ITEMS from '../../data/hubItems.json'
+
+const hubItemIds = new Set(HUB_ITEMS.map(i => i.id))
+
+describe.each([
+  ['river', FISH_TIERS, TIER_HUB_ITEM],
+  ['cave', CAVE_FISH_TIERS, CAVE_TIER_HUB_ITEM],
+] as const)('%s fish tiers', (_variant, tiers, tierHubItem) => {
+  it('chances sum to exactly 100', () => {
+    expect(tiers.reduce((sum, t) => sum + t.chance, 0)).toBe(100)
+  })
+
+  it('has a distinct tier label per entry', () => {
+    expect(new Set(tiers.map(t => t.tier)).size).toBe(tiers.length)
+  })
+
+  it('gives every tier a hub-item mapping that resolves to a real item', () => {
+    const missing = tiers.filter(t => !tierHubItem[t.tier])
+    expect(missing.map(t => t.tier)).toEqual([])
+    for (const t of tiers) expect(hubItemIds.has(tierHubItem[t.tier])).toBe(true)
+  })
+
+  it('never gives a tier an empty species name list', () => {
+    expect(tiers.every(t => t.names.length > 0)).toBe(true)
+  })
+})
+
+it('cave and river tiers use disjoint hub-items and tier labels', () => {
+  const riverTiers = new Set(FISH_TIERS.map(t => t.tier))
+  const caveTiers = new Set(CAVE_FISH_TIERS.map(t => t.tier))
+  for (const t of caveTiers) expect(riverTiers.has(t)).toBe(false)
+
+  const riverItems = new Set(Object.values(TIER_HUB_ITEM))
+  const caveItems = new Set(Object.values(CAVE_TIER_HUB_ITEM))
+  for (const id of caveItems) expect(riverItems.has(id)).toBe(false)
+})

--- a/web/src/components/minigames/Fishing.tsx
+++ b/web/src/components/minigames/Fishing.tsx
@@ -23,7 +23,7 @@ interface FishTier {
   chance: number
 }
 
-const FISH_TIERS: FishTier[] = [
+export const FISH_TIERS: FishTier[] = [
   {
     tier: 'Tiddler', icon: '🐟',
     names: ['Minnow', 'Dace', 'Gudgeon', 'Bleak', 'Stickleback'],
@@ -52,6 +52,43 @@ const FISH_TIERS: FishTier[] = [
   {
     tier: 'Legendary', icon: '✨',
     names: ['Ancient Sturgeon', 'Dragon Carp', 'Leviathan Eel', 'World Record Bass', 'Fracture Fish'],
+    minG: 25000, maxG: 50000, minCm: 150, maxCm: 200, minT: 150, maxT: 250, chance: 1,
+  },
+]
+
+// Cave-lake variant — same weights/ranges as FISH_TIERS (reuse the already-
+// tuned balance), reskinned as pale, blind, deep-water species for the
+// underground lake fishing spot. Distinct tier labels double as the key
+// into CAVE_TIER_HUB_ITEM below, so they must not collide with FISH_TIERS'.
+export const CAVE_FISH_TIERS: FishTier[] = [
+  {
+    tier: 'Blindling', icon: '🐟',
+    names: ['Blind Loach', 'Pale Minnow', 'Cave Gudgeon', 'Sunken Bleak', 'Milk-eye'],
+    minG: 100,   maxG: 500,   minCm: 8,   maxCm: 25,  minT: 2,   maxT: 6,   chance: 40,
+  },
+  {
+    tier: 'Cave-dweller', icon: '🐠',
+    names: ['Stone Roach', 'Grotto Perch', 'Cavefin', 'Hollow Bream', 'Root-eel'],
+    minG: 500,   maxG: 2000,  minCm: 25,  maxCm: 45,  minT: 8,   maxT: 18,  chance: 30,
+  },
+  {
+    tier: 'Deep Lurker', icon: '🐡',
+    names: ['Stone Eel', 'Barbless Carp', 'Echo Catfish', 'Drip-fed Zander', 'Lantern Barbel'],
+    minG: 2000,  maxG: 5000,  minCm: 45,  maxCm: 70,  minT: 22,  maxT: 40,  chance: 15,
+  },
+  {
+    tier: 'Ancient', icon: '🦈',
+    names: ['Sunless Pike', 'Deepwater Sturgeon', 'Cistern Bass', 'Old Blind Catfish', 'Wellspring Eel'],
+    minG: 5000,  maxG: 12000, minCm: 70,  maxCm: 110, minT: 42,  maxT: 75,  chance: 9,
+  },
+  {
+    tier: 'Abyssal', icon: '🏆',
+    names: ['Abyssal Carp', 'Monster of the Hollow', 'Cavern Titan', 'Sightless Leviathan', 'Great Root-eel'],
+    minG: 12000, maxG: 25000, minCm: 110, maxCm: 150, minT: 80,  maxT: 130, chance: 5,
+  },
+  {
+    tier: 'Sunless', icon: '✨',
+    names: ['The Sunless One'],
     minG: 25000, maxG: 50000, minCm: 150, maxCm: 200, minT: 150, maxT: 250, chance: 1,
   },
 ]
@@ -92,11 +129,11 @@ function rand(min: number, max: number) {
   return Math.floor(min + Math.random() * (max - min))
 }
 
-function rollFish(): FishCatch {
+function rollFish(tiers: FishTier[]): FishCatch {
   const roll = Math.random() * 100
   let cum = 0
-  let tier = FISH_TIERS[0]
-  for (const t of FISH_TIERS) {
+  let tier = tiers[0]
+  for (const t of tiers) {
     cum += t.chance
     if (roll < cum) { tier = t; break }
   }
@@ -116,9 +153,13 @@ function formatWeight(g: number): string {
 }
 
 // Hub-mode catches become hub-items, keyed by fish tier (see hubItems.json).
-const TIER_HUB_ITEM: Record<string, string> = {
+export const TIER_HUB_ITEM: Record<string, string> = {
   Tiddler: 'fish-tiddler', Small: 'fish-small', Medium: 'fish-medium',
   Large: 'fish-large', Trophy: 'fish-trophy', Legendary: 'fish-legendary',
+}
+export const CAVE_TIER_HUB_ITEM: Record<string, string> = {
+  Blindling: 'cave-fish-blindling', 'Cave-dweller': 'cave-fish-dweller', 'Deep Lurker': 'cave-fish-lurker',
+  Ancient: 'cave-fish-ancient', Abyssal: 'cave-fish-abyssal', Sunless: 'cave-fish-sunless',
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -129,10 +170,17 @@ interface Props {
    *  'catch': hub-world mode — the caught fish is added to the hub-item
    *  inventory instead, and no tickets are ever awarded. */
   rewardMode?: 'tickets' | 'catch'
+  /** 'river' (default): the standard Tiddler→Legendary tiers used at every
+   *  ordinary fishing spot. 'cave': the pale, blind cave-lake species —
+   *  same weights/ranges, exclusive hub-items — used only at the
+   *  underground lake's fishing spot. */
+  variant?: 'river' | 'cave'
 }
 
-export function Fishing({ onDone, rewardMode = 'tickets' }: Props) {
+export function Fishing({ onDone, rewardMode = 'tickets', variant = 'river' }: Props) {
   const usesBait = rewardMode === 'catch'
+  const tiers = variant === 'cave' ? CAVE_FISH_TIERS : FISH_TIERS
+  const tierHubItem = variant === 'cave' ? CAVE_TIER_HUB_ITEM : TIER_HUB_ITEM
 
   const [phase, setPhase]   = useState<Phase>('idle')
   const [result, setResult] = useState<Catch | null>(null)
@@ -190,7 +238,7 @@ export function Fishing({ onDone, rewardMode = 'tickets' }: Props) {
   }
 
   function buildCatch(): Catch {
-    if (Math.random() >= 0.05) return rollFish()
+    if (Math.random() >= 0.05) return rollFish(tiers)
     // 5% special
     if (Math.random() < 0.5) {
       const item = ITEMS_DATA[rand(0, ITEMS_DATA.length)]
@@ -212,7 +260,7 @@ export function Fishing({ onDone, rewardMode = 'tickets' }: Props) {
     } else if (c.kind === 'card') {
       addCardsToCollection([{ cardName: c.name, count: 1 }])
     } else if (rewardMode === 'catch') {
-      const hubItemId = TIER_HUB_ITEM[c.tier]
+      const hubItemId = tierHubItem[c.tier]
       if (hubItemId) {
         try { addHubItem(hubItemId, 1) }
         catch (e) { logError('Fishing: addHubItem failed', { error: String(e) }) }

--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -157,6 +157,11 @@ export interface RawInterior {
    *  wallTileId's top wall run falls back to the generic wall tile for
    *  that whole run — no map-editor UI yet, hand-author and verify in-game. */
   carve?: Array<{ tx: number; ty: number; w: number; h: number }>
+  /** Local tile coordinates rendered as open water (the same autotile pond
+   *  art the exterior world uses) instead of floor, and excluded from the
+   *  walkable set — a lake the player can stand at the edge of and fish,
+   *  but not walk into. */
+  pond?: Array<{ tx: number; ty: number }>
 }
 
 

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -174,6 +174,10 @@ export interface HubInterior {
    *  computeInteriorShape (game/hub/interiorShape.ts), which HubTownCanvas.tsx
    *  uses to trace the resulting floor/wall sets. */
   carve?: Array<{ tx: number; ty: number; w: number; h: number }>
+  /** Local tile coordinates rendered as open water instead of floor, and
+   *  excluded from the walkable set — see HubTownCanvas.tsx's pond render
+   *  pass, which reuses the exterior world's autotile pond art. */
+  pond?: Array<{ tx: number; ty: number }>
 }
 
 /** Visible activity an NPC performs while at a scheduled location. */
@@ -721,6 +725,7 @@ const HUB_INTERIORS: Record<string, HubInterior> = Object.fromEntries(
         playerDecor: rawAny.playerDecor as boolean | undefined,
         dark:        rawAny.dark as boolean | undefined,
         carve:       rawAny.carve as Array<{ tx: number; ty: number; w: number; h: number }> | undefined,
+        pond:        rawAny.pond as Array<{ tx: number; ty: number }> | undefined,
       } satisfies HubInterior,
     ]
   })

--- a/web/src/data/hub/questPickupPlacement.test.ts
+++ b/web/src/data/hub/questPickupPlacement.test.ts
@@ -76,6 +76,19 @@ describe('Ravenwatch quest pickups', () => {
   })
 })
 
+describe('Ravenwatch interior lakes', () => {
+  it('keeps every pond tile on actual floor, never a wall or carved-out cell', () => {
+    const bad = Object.entries(loc.HUB_INTERIORS).flatMap(([id, room]) => {
+      if (!room.pond?.length) return []
+      const { floorSet } = computeInteriorShape(room.width, room.height, room.carve)
+      return room.pond
+        .filter(p => !floorSet.has(`${p.tx},${p.ty}`))
+        .map(p => `${id} (${p.tx},${p.ty})`)
+    })
+    expect(bad).toEqual([])
+  })
+})
+
 describe('Ravenwatch quest targets', () => {
   it('delivers only to NPCs or animals that exist in the town', () => {
     // Delivery steps pointing at an animal (the stray cat) resolve through

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -10327,7 +10327,66 @@
         { "tx": 3, "ty": 5, "tileId": "skull" }
       ],
       "exits": [
-        { "tx": 0, "ty": 4, "toInteriorId": "ravenwatch-hollow-entrance", "entryTx": 9, "entryTy": 4, "direction": "left", "label": "Back to the hollow" }
+        { "tx": 0, "ty": 4, "toInteriorId": "ravenwatch-hollow-entrance", "entryTx": 9, "entryTy": 4, "direction": "left", "label": "Back to the hollow" },
+        { "tx": 9, "ty": 4, "toInteriorId": "ravenwatch-deep-passage-1", "entryTx": 1, "entryTy": 5, "direction": "right", "label": "A narrow crack in the rock" }
+      ]
+    },
+    "ravenwatch-deep-passage-1": {
+      "name": "The Deep Passage",
+      "width": 6,
+      "height": 10,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "dark": true,
+      "decor": [
+        { "tx": 2, "ty": 2, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+        { "tx": 3, "ty": 4, "tileId": "smallRock" },
+        { "tx": 2, "ty": 6, "tileId": "largeRock" }
+      ],
+      "exits": [
+        { "tx": 0, "ty": 5, "toInteriorId": "ravenwatch-hollow-tunnel-east", "entryTx": 8, "entryTy": 4, "direction": "left", "label": "Back the way you came" },
+        { "tx": 3, "ty": 9, "toInteriorId": "ravenwatch-deep-passage-2", "entryTx": 3, "entryTy": 1, "direction": "front", "label": "The passage bends onward" }
+      ]
+    },
+    "ravenwatch-deep-passage-2": {
+      "name": "The Sunken Passage",
+      "width": 8,
+      "height": 8,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "dark": true,
+      "decor": [
+        { "tx": 2, "ty": 3, "tileId": "largeRock" },
+        { "tx": 5, "ty": 2, "tileId": "floorLantern", "glow": true, "glowRadius": 2 },
+        { "tx": 2, "ty": 5, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 3, "ty": 0, "toInteriorId": "ravenwatch-deep-passage-1", "entryTx": 3, "entryTy": 8, "direction": "back", "label": "Back the way you came" },
+        { "tx": 7, "ty": 4, "toInteriorId": "ravenwatch-underground-lake", "entryTx": 1, "entryTy": 5, "direction": "right", "label": "The air turns cold and damp" }
+      ]
+    },
+    "ravenwatch-underground-lake": {
+      "name": "The Sunless Lake",
+      "width": 12,
+      "height": 10,
+      "floorTileId": "darkStoneFloor",
+      "wallTileId": "darkStone",
+      "dark": true,
+      "pond": [
+        { "tx": 6, "ty": 3 }, { "tx": 7, "ty": 3 }, { "tx": 8, "ty": 3 },
+        { "tx": 5, "ty": 4 }, { "tx": 6, "ty": 4 }, { "tx": 7, "ty": 4 }, { "tx": 8, "ty": 4 }, { "tx": 9, "ty": 4 },
+        { "tx": 5, "ty": 5 }, { "tx": 6, "ty": 5 }, { "tx": 7, "ty": 5 }, { "tx": 8, "ty": 5 }, { "tx": 9, "ty": 5 },
+        { "tx": 6, "ty": 6 }, { "tx": 7, "ty": 6 }, { "tx": 8, "ty": 6 }
+      ],
+      "decor": [
+        { "tx": 3, "ty": 2, "tileId": "largeRock" },
+        { "tx": 9, "ty": 2, "tileId": "smallRock" },
+        { "tx": 2, "ty": 7, "tileId": "floorLantern", "glow": true, "glowRadius": 3 },
+        { "tx": 9, "ty": 7, "tileId": "floorLantern", "glow": true, "glowRadius": 3 },
+        { "tx": 5, "ty": 7, "tileId": "skull" }
+      ],
+      "exits": [
+        { "tx": 0, "ty": 5, "toInteriorId": "ravenwatch-deep-passage-2", "entryTx": 6, "entryTy": 4, "direction": "left", "label": "Back through the passage" }
       ]
     }
   },
@@ -11449,6 +11508,25 @@
         "ravenwatch-fishing-hole-2-topic-auto-1"
       ],
       "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
+    },
+    {
+      "id": "ravenwatch-cave-angler",
+      "name": "Old Marrow",
+      "sprite": "hub-npc-fisherman",
+      "tx": 4,
+      "ty": 5,
+      "building": "ravenwatch-underground-lake",
+      "screen": "hub-fishing-cave",
+      "dialogue": [
+        "Been fishing this lake longer than I can rightly recall. Never seen the bottom of it.",
+        "Whatever's down there doesn't mind the dark. Neither do I, anymore.",
+        "Careful what you reel in. Some of it's never seen the sun, and it shows."
+      ],
+      "favoriteGiftItemId": "cave-fish-sunless",
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
         "silk-ribbon"

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -78,6 +78,48 @@
     "category": "material"
   },
   {
+    "id": "cave-fish-blindling",
+    "name": "Blindling",
+    "icon": "🐟",
+    "desc": "A pale, eyeless little thing. It's never seen the sun, and never will.",
+    "category": "material"
+  },
+  {
+    "id": "cave-fish-dweller",
+    "name": "Cave-dweller",
+    "icon": "🐠",
+    "desc": "It flinches from the torchlight. Something down here always does.",
+    "category": "material"
+  },
+  {
+    "id": "cave-fish-lurker",
+    "name": "Deep Lurker",
+    "icon": "🐡",
+    "desc": "Pulled up from black water. Best not to think about how deep.",
+    "category": "material"
+  },
+  {
+    "id": "cave-fish-ancient",
+    "name": "Ancient",
+    "icon": "🦈",
+    "desc": "Older than the passage above it, by the look of those scars.",
+    "category": "material"
+  },
+  {
+    "id": "cave-fish-abyssal",
+    "name": "Abyssal",
+    "icon": "🏆",
+    "desc": "A monster of the hollow. It shouldn't fit through the passage it came from.",
+    "category": "material"
+  },
+  {
+    "id": "cave-fish-sunless",
+    "name": "The Sunless One",
+    "icon": "✨",
+    "desc": "No one who fishes the underground lake truly expects to land this.",
+    "category": "material"
+  },
+  {
     "id": "fancy-hat",
     "name": "Fancy Hat",
     "icon": "🎩",


### PR DESCRIPTION
## Summary

A long winding passage branches off "The East Passage" (`ravenwatch-hollow-tunnel-east`) in the Buried Hollow, ending in a hidden underground lake with rare, lake-exclusive fish.

- **New rooms** (`web/src/data/hub/ravenwatch/config.json`): East Passage gets a second exit (east wall) into `ravenwatch-deep-passage-1` → `ravenwatch-deep-passage-2` → `ravenwatch-underground-lake` ("The Sunless Lake") — 3 new rooms, 4 hops from the real exterior door, varying exit directions for a genuine bend in the passage (comparable depth to Gravemoor's existing catacombs complex).
- **Lake rendering**: new optional `pond` field on interior data (`config.ts`/`loader.ts`), rendered in `HubTownCanvas.tsx` by reusing the *exact* autotile pond call the exterior world already uses for ponds (`renderPathTiles(..., PATH_TILE.water7, true)`) — real blended water art, not a repeated static sprite — and subtracted from the walkable set so the lake blocks movement like any other obstacle.
- **Cave-exclusive fish**: `Fishing.tsx` gains a `variant?: 'river' | 'cave'` prop (default `'river'`, so every existing fishing spot is byte-for-byte unchanged). The cave variant reuses the exact tuned tier weights/ranges but reskins them as 6 pale, blind cave species (Blindling → the legendary "Sunless One"), each with its own hub-item (`web/src/data/hubItems.json`). A new `hub-fishing-cave` screen (`HubRoutes.tsx`, `HubWorld.tsx`, `screens.ts`) routes to it, gated on the same rod/bait as every other fishing spot.
- New NPC `ravenwatch-cave-angler` ("Old Marrow") sits at the lake's edge.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2733 tests pass (up from 2723 pre-change), including:
  - a new `Fishing.test.ts` validating both tier tables (chances sum to 100, every tier has a hub-item that exists in `hubItems.json`, cave/river tiers and items are disjoint)
  - a new `questPickupPlacement.test.ts` check that every interior's `pond` tiles land on real floor (never a wall or carved-out cell)
- [x] `npm run build` — succeeds
- [x] Hand-verified (Node script against the real config data) that all 3 new rooms' exit graphs correctly BFS-resolve back to the Buried Hollow's real exterior door, and that every new room's entry-landing coordinates land within bounds
- Browser walkthrough intentionally skipped per `AGENTS.md` ("don't reach for [browser verification] by default... not for logic/data changes") — this change reuses already-proven rendering code paths (the pond call is identical to the exterior pond renderer already live in production; floor/wall/decor/exit rendering is the same code path used by the other 241 rooms) rather than introducing new rendering logic.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_