### PR TITLE
Fix wall-crown overdraw on floor in thick carved wall regions

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -34,7 +34,7 @@ import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
 import { getResolvedRoomStyle } from '../../game/hub/roomStyle'
 import { getDoorwayEntryTile, findExteriorDoorForInterior } from '../../game/hub/doorwayEntry'
-import { computeInteriorShape, topFacingWallRows } from '../../game/hub/interiorShape'
+import { computeInteriorShape, topFacingWallRows, computeWallRenderSet } from '../../game/hub/interiorShape'
 import {
   getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
 } from '../../game/hub/houseRooms'
@@ -2343,6 +2343,18 @@ export function HubTownCanvas({
       // interior.carve is absent.
       const { floorSet: baseFloorSet, wallSet: baseWallSet } = computeInteriorShape(interior.width, interior.height, interior.carve)
 
+      // defaultEntryTile falls back to getDoorwayEntryTile's purely
+      // directional formula when an exit omits explicit entryTx/entryTy —
+      // it has no awareness of interior.carve, so it can land off a carved
+      // room's actual floor. Snap to the nearest real floor tile; mutating
+      // in place also fixes interiorCurrentTile, which already points at
+      // this same array.
+      if (!baseFloorSet.has(`${defaultEntryTile[0]},${defaultEntryTile[1]}`)) {
+        const [nx, ny] = nearestWalkable(defaultEntryTile[0] * T, defaultEntryTile[1] * T, baseFloorSet, T)
+        defaultEntryTile[0] = nx
+        defaultEntryTile[1] = ny
+      }
+
       // Build walkable set
       interiorWalkable = new Set<string>(baseFloorSet)
       if (!isSubRoom) interiorWalkable.add(`${exitTx},${interior.height - 1}`)
@@ -2422,16 +2434,7 @@ export function HubTownCanvas({
       // stub instead of a proper corner cap). Only visible at a room's 4
       // outer corners for a plain rectangle, but at every inner corner of a
       // carved notch too — unifying into one set/call fixes both.
-      // Every wall cell also gets a purely-visual "+1 row" duplicate above
-      // it, except the columns of a straight top/bottom run (which instead
-      // get their own crown-row treatment below, or nothing extra at all).
-      const isStraightRunCell = (wx: number, wy: number) =>
-        wx > 0 && wx < interior.width - 1 && (wy === 0 || wy === interior.height - 1)
-      const wallRenderSet = new Set<string>(wallSet)
-      for (const key of wallSet) {
-        const [wx, wy] = key.split(',').map(Number)
-        if (!isStraightRunCell(wx, wy)) wallRenderSet.add(`${wx},${wy - 1}`)
-      }
+      const wallRenderSet = computeWallRenderSet(interior.width, interior.height, baseFloorSet, wallSet)
       for (const exit of availableExits) {
         if (exit.direction === 'left' || exit.direction === 'right') wallRenderSet.delete(`${exit.tx},${exit.ty}`)
       }

--- a/web/src/game/hub/interiorShape.test.ts
+++ b/web/src/game/hub/interiorShape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeInteriorShape, topFacingWallRows } from './interiorShape'
+import { computeInteriorShape, topFacingWallRows, computeWallRenderSet } from './interiorShape'
 import { getHubWorldData } from '../../data/hub/hubWorldFactory'
 
 // Reference oracle: the plain-rectangle floor/wall formula HubTownCanvas.tsx
@@ -48,6 +48,12 @@ describe('computeInteriorShape — plain rectangle regression', () => {
         const facing = topFacingWallRows(room.width, room.height, floorSet)
         expect(facing.size).toBe(Math.max(0, room.width - 2))
         expect([...facing.values()].every(ty => ty === 0)).toBe(true)
+        // The "+1 row" wall-render duplicate never paints over real floor —
+        // trivially true for every uncarved rectangle (a side wall's north
+        // neighbor is always another wall cell or the true border), but
+        // asserted generically here as a regression guard.
+        const rendered = computeWallRenderSet(room.width, room.height, floorSet, wallSet)
+        for (const key of rendered) expect(floorSet.has(key)).toBe(false)
       })
     }
   }
@@ -123,6 +129,24 @@ describe('computeInteriorShape — carved shapes', () => {
     expect(facing.get(4)).toBe(2)
     expect(facing.get(5)).toBe(2)
     for (const tx of [1, 2, 3, 6, 7, 8]) expect(facing.get(tx)).toBe(0)
+  })
+
+  it('computeWallRenderSet never paints the "+1 row" duplicate over a thick carved wall band\'s north-facing floor', () => {
+    // 10×10 room, rows 5-6 carved out across most of the width — a wall
+    // band 2 tiles thick (not the room's true top/bottom border), with
+    // real floor immediately north of it at row 4. Reproduces the shape
+    // of the bug reported on ravenwatch-sunless-depths: standing on real,
+    // walkable floor that reads as solid wall because a wall sprite got
+    // drawn on top of it.
+    const { floorSet, wallSet } = computeInteriorShape(10, 10, [{ tx: 1, ty: 5, w: 7, h: 2 }])
+    expect(floorSet.has('3,4')).toBe(true)  // real floor just north of the band
+    expect(wallSet.has('3,5')).toBe(true)   // top row of the 2-thick carved band
+
+    const rendered = computeWallRenderSet(10, 10, floorSet, wallSet)
+    for (const key of rendered) expect(floorSet.has(key)).toBe(false)
+    // The naive "always duplicate one row up" version this replaced would
+    // have added '3,4' (and the rest of row 4 under the carve) here.
+    expect(rendered.has('3,4')).toBe(false)
   })
 
   it('carve is a no-op outside the floor domain (border ring, out of bounds)', () => {

--- a/web/src/game/hub/interiorShape.ts
+++ b/web/src/game/hub/interiorShape.ts
@@ -73,3 +73,25 @@ export function topFacingWallRows(width: number, height: number, floorSet: Set<s
   }
   return rows
 }
+
+/** `wallSet` plus a purely-visual "+1 row" duplicate above cells that
+ *  aren't part of a straight top/bottom run — gives side walls and corners
+ *  visual height when rendered with the generic wall2 autotile (top/bottom
+ *  straight runs get their own crown-row treatment elsewhere, or nothing
+ *  extra). Skipped whenever that row is real floor: a carved wall band can
+ *  be more than 1 tile thick, and a wall cell's north neighbor is then
+ *  genuine floor rather than "another wall cell or outside the room" (the
+ *  only two cases this convention predates `carve`) — drawing a wall
+ *  sprite there would paint over floor the avatar can legitimately stand
+ *  on, reading as walking into solid wall despite being collision-correct
+ *  underneath. */
+export function computeWallRenderSet(width: number, height: number, floorSet: Set<string>, wallSet: Set<string>): Set<string> {
+  const isStraightRunCell = (wx: number, wy: number) =>
+    wx > 0 && wx < width - 1 && (wy === 0 || wy === height - 1)
+  const result = new Set<string>(wallSet)
+  for (const key of wallSet) {
+    const [wx, wy] = key.split(',').map(Number)
+    if (!isStraightRunCell(wx, wy) && !floorSet.has(`${wx},${wy - 1}`)) result.add(`${wx},${wy - 1}`)
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

Fixes the "avatar can walk into the bottom wall" bug reported via screenshot on The Sunless Depths.

Investigated with an Explore agent first rather than assuming — the actual finding was that **collision is correct**: `interiorWalkable`/`findInteriorPath` are fully carve-aware, and the room's real floor graph (recomputed from its actual `carve` data) is 100% connected with no gaps. The avatar genuinely is standing on legitimate, walkable floor.

The real bug is in rendering. `HubTownCanvas.tsx`'s wall-render pass draws a decorative "+1 row" crown duplicate above every wall cell that isn't part of a straight top/bottom run — a convention from before `carve` existed, when a wall cell's north neighbor was always either another wall cell or genuinely outside the room. `carve` breaks that assumption: a carved-out wall band can be more than 1 tile thick, so the neighbor can now be real floor — and the duplicate painted a wall sprite directly on top of it. On The Sunless Depths this overdrew 17 real floor cells, including the entire well-traveled corridor strip at `y=9`, right next to the room's own decor.

**Fix**: skip the duplicate whenever the row above is real floor. Extracted the computation into `web/src/game/hub/interiorShape.ts` as `computeWallRenderSet`, matching `computeInteriorShape`/`topFacingWallRows`'s existing pattern, so it's covered by the same 238-room regression sweep — confirmed a true no-op everywhere except the one carved room with a >1-tile-thick wall band.

**Also hardened** `doEnterInterior`'s entry-tile placement, found by the same investigation: it wrote the avatar's position from `defaultEntryTile` with no check the tile was actually walkable. `getDoorwayEntryTile`'s directional fallback (used when an exit omits explicit `entryTx`/`entryTy`) has no `carve` awareness — not the trigger here (this room's inbound exit has an explicit, valid entry), but a real gap for a future carved room. Now snaps to the nearest walkable tile via the existing `nearestWalkable` BFS helper (`web/src/utils/hubPathfinder.ts`), already used elsewhere in this file for exterior tap-to-move.

## Test plan

- [x] Hand-verified against the real shipped data: recomputed The Sunless Depths' wall-render set before/after — confirmed the fix eliminates exactly the 17 clashing cells found (`(1,9)`..`(9,9)` etc.)
- [x] Swept all 238 interiors across every town — confirmed the fix changes output for **only** `ravenwatch-sunless-depths`, a true no-op everywhere else
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2731 tests pass (new dedicated regression test reproduces the thick-wall-band shape and asserts the crown duplicate never lands on floor, plus a generic assertion added to the existing 238-room sweep)
- [x] `npm run build` — succeeds
- Browser walkthrough intentionally skipped per `AGENTS.md` — the fix is a narrow, provably-correct Set-membership guard, verified by direct computation against the exact shipped `carve` data rather than a screenshot

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_