### PR TITLE
Fix themed wall facade sealing back-wall door gaps

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -34,7 +34,7 @@ import { loadHomeLayout } from '../../game/hub/homeLayout'
 import { getFurnitureTileOffsets } from '../../game/hub/furnitureTiles'
 import { getResolvedRoomStyle } from '../../game/hub/roomStyle'
 import { getDoorwayEntryTile, findExteriorDoorForInterior } from '../../game/hub/doorwayEntry'
-import { computeInteriorShape, topFacingWallRows, computeWallRenderSet } from '../../game/hub/interiorShape'
+import { computeInteriorShape, computeWallRenderSet, facadePaintPositions } from '../../game/hub/interiorShape'
 import {
   getPurchasedSlotIds, getRoomSlotDef, buildMainRoomExit, parseSlotBuildingId, synthesizeSlotInterior,
 } from '../../game/hub/houseRooms'
@@ -2453,7 +2453,13 @@ export function HubTownCanvas({
         // before; a carved column lands both a row or more further down.
         const wTiles = WALL_TILES[wallMaterial]
         const byTileId = new Map<number, [number, number][]>()
-        for (const [wx, wy] of topFacingWallRows(interior.width, interior.height, baseFloorSet)) {
+        // Exclude back-wall door columns — a back door already punches a
+        // real gap in the generic wall2 pass above; painting the facade
+        // there too would seal it back up with a solid-looking wall tile.
+        const backExitTiles: [number, number][] = availableExits
+          .filter(e => e.direction === 'back')
+          .map(e => [e.tx, e.ty])
+        for (const [wx, wy] of facadePaintPositions(interior.width, interior.height, baseFloorSet, backExitTiles)) {
           const list = byTileId.get(wTiles.middleBottom) ?? []; list.push([wx, wy]); byTileId.set(wTiles.middleBottom, list)
           const topList = byTileId.get(wTiles.middleTop) ?? []; topList.push([wx, wy - 1]); byTileId.set(wTiles.middleTop, topList)
         }

--- a/web/src/game/hub/interiorShape.test.ts
+++ b/web/src/game/hub/interiorShape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeInteriorShape, topFacingWallRows, computeWallRenderSet } from './interiorShape'
+import { computeInteriorShape, topFacingWallRows, computeWallRenderSet, facadePaintPositions } from './interiorShape'
 import { getHubWorldData } from '../../data/hub/hubWorldFactory'
 
 // Reference oracle: the plain-rectangle floor/wall formula HubTownCanvas.tsx
@@ -54,6 +54,15 @@ describe('computeInteriorShape — plain rectangle regression', () => {
         // asserted generically here as a regression guard.
         const rendered = computeWallRenderSet(room.width, room.height, floorSet, wallSet)
         for (const key of rendered) expect(floorSet.has(key)).toBe(false)
+        // The themed facade never paints over a back-wall door's tile —
+        // regression guard for a real, previously-shipped bug that sealed
+        // the door shut on every themed room with a back exit (35 of the
+        // 238 interiors, discovered via a live bug report on one of them).
+        const backExitTiles: [number, number][] = (room.exits ?? [])
+          .filter(e => e.direction === 'back')
+          .map(e => [e.tx, e.ty])
+        const facade = facadePaintPositions(room.width, room.height, floorSet, backExitTiles)
+        for (const [bx, by] of backExitTiles) expect(facade.get(bx)).not.toBe(by)
       })
     }
   }
@@ -154,5 +163,33 @@ describe('computeInteriorShape — carved shapes', () => {
     const without = computeInteriorShape(10, 8)
     expect(setEqual(withCarve.floorSet, without.floorSet)).toBe(true)
     expect(setEqual(withCarve.wallSet, without.wallSet)).toBe(true)
+  })
+})
+
+describe('facadePaintPositions', () => {
+  it("excludes a back-wall door's column, unlike topFacingWallRows alone (Gildwyn's Card Emporium's real shape)", () => {
+    // 13×9 plain rectangle, back door at (6,0) — the exact shape and door
+    // position shipped on ravenwatch/card-shop. Reported live: the themed
+    // facade painted a solid wall tile over the door, sealing it shut even
+    // though the generic wall2 pass correctly left a gap there.
+    const { floorSet } = computeInteriorShape(13, 9)
+    const unfiltered = topFacingWallRows(13, 9, floorSet)
+    expect(unfiltered.get(6)).toBe(0) // the bug: the door's own column gets a facade tile
+
+    const filtered = facadePaintPositions(13, 9, floorSet, [[6, 0]])
+    expect(filtered.has(6)).toBe(false)
+    // Every other column is untouched.
+    for (let tx = 1; tx <= 11; tx++) {
+      if (tx === 6) continue
+      expect(filtered.get(tx)).toBe(unfiltered.get(tx))
+    }
+    expect(filtered.size).toBe(unfiltered.size - 1)
+  })
+
+  it('is a no-op when there is no back-wall door', () => {
+    const { floorSet } = computeInteriorShape(10, 8)
+    const unfiltered = topFacingWallRows(10, 8, floorSet)
+    const filtered = facadePaintPositions(10, 8, floorSet, [])
+    expect(filtered).toEqual(unfiltered)
   })
 })

--- a/web/src/game/hub/interiorShape.ts
+++ b/web/src/game/hub/interiorShape.ts
@@ -95,3 +95,26 @@ export function computeWallRenderSet(width: number, height: number, floorSet: Se
   }
   return result
 }
+
+/** `topFacingWallRows` filtered to exclude any column where a `back`-
+ *  direction door lives — the paint positions for a room's themed wall
+ *  facade (crown row above, face row at the wall). `topFacingWallRows` is
+ *  purely geometric with no concept of doors, so on its own it paints a
+ *  facade tile at a back door's column too; a back door already punches a
+ *  real gap in the generic wall2 autotile pass (`computeWallRenderSet`),
+ *  so painting the facade there as well seals that gap back up with a
+ *  solid-looking wall tile. */
+export function facadePaintPositions(
+  width: number,
+  height: number,
+  floorSet: Set<string>,
+  backExitTiles: Iterable<readonly [number, number]>,
+): Map<number, number> {
+  const excluded = new Set([...backExitTiles].map(([tx, ty]) => `${tx},${ty}`))
+  const rows = topFacingWallRows(width, height, floorSet)
+  const result = new Map<number, number>()
+  for (const [wx, wy] of rows) {
+    if (!excluded.has(`${wx},${wy}`)) result.set(wx, wy)
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

Fixes a rendering bug reported via screenshot on "Gildwyn's Card Emporium": a door on the rear (north/"back") wall no longer left a clean gap — the whole wall above it rendered as one wide flat strip instead of wall texture with a single door-sized opening.

**Root cause**: `topFacingWallRows` (`web/src/game/hub/interiorShape.ts`) is purely geometric — for every column, the row of the wall tile facing it from the north — with no concept of doors. `doEnterInterior` (`HubTownCanvas.tsx`) painted the themed wall facade at every one of those positions unconditionally, including whichever column a `back`-direction door sits at. The generic `wall2` autotile pass already correctly left the door's gap open; the facade paint (a separate, later pass drawn on top of it) sealed that gap back up with a solid-looking tile.

This predates this session's carve/lake work — traced to `3bc95ea`, which collaterally dropped an implicit door exclusion an earlier version of this loop had. It wasn't caught by the existing 238-room regression sweep because that sweep only unit-tests `topFacingWallRows` in isolation (correct by its own contract — it was never meant to know about doors); the bug is in how `doEnterInterior` wires that output together with a room's `exits`, wiring that lives entirely in `HubTownCanvas.tsx`.

**Blast radius, checked before calling this fixed**: swept every interior in every town — **35 of 238 rooms** have both a themed `wallMaterial` and a back-wall door, and all 35 had their door sealed shut by this bug (Gildwyn's was just the one someone happened to walk into: The Harbour Office, The Games Hall, The Royal Library, several Capital City shops, Gravemoor's catacombs, The Throne Hall, and more).

**Fix**: `facadePaintPositions`, a new export in `interiorShape.ts` filtering `topFacingWallRows` against back-exit tiles — mirroring the exclusion already applied to the `wall2` pass. Resolves all 35 affected rooms, changes nothing for the other 203.

## Test plan

- [x] Hand-verified against Gildwyn's real shipped data (13×9, back door at `tx:6,ty:0`) — confirmed the unfiltered function paints column 6, the fix excludes it, every other column unchanged
- [x] Swept all 238 interiors across every town — confirmed the fix resolves the door-seal on exactly the 35 affected rooms and changes output for no others
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run test` — 2745 tests pass, including a new `facadePaintPositions` describe block (reproducing Gildwyn's exact shape, plus a no-op check with no back door) and a new assertion added to the existing 238-room sweep (no back-exit door tile is ever painted by the facade)
- [x] `npm run build` — succeeds
- Browser walkthrough intentionally skipped per `AGENTS.md` — the fix is a narrow, provably-correct filter verified by direct computation against real shipped data across all 238 rooms

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euzmp9GxmUZ3RNxBAM5UZf)_