### PR TITLE
Ravenwatch Games Hall: Vault Guard quest chain, room decor, and vault gold

### DIFF
--- a/web/src/data/hub/config.ts
+++ b/web/src/data/hub/config.ts
@@ -239,6 +239,18 @@ export interface RawNpc {
 
   /** Ids of other same-town NPCs this NPC dislikes — befriending one raises this NPC's own 'rival' track. */
   dislikes?: string[]
+
+  /** Alternate tile position + dialogue used once `requireQuest` is completed —
+   *  e.g. a guard stepping off a chokepoint tile once the gating quest chain
+   *  resolves. Position and dialogue overrides are independently optional; a
+   *  variant with only `dialogue` set changes what's said without moving the
+   *  NPC. */
+  questVariant?: {
+    requireQuest: string
+    tx?: number
+    ty?: number
+    dialogue?: string[]
+  }
 }
 
 export interface RawLockedDoor {

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -241,6 +241,16 @@ export interface HubNpc {
   dislikedGiftItemIds?: string[]
   /** Ids of other same-town NPCs this NPC dislikes — befriending one raises this NPC's own 'rival' track. */
   dislikes?: string[]
+  /** Alternate tile position + dialogue used once `requireQuest` is completed —
+   *  e.g. a guard stepping off a chokepoint tile once the gating quest chain
+   *  resolves. Checked in resolveNpcInteriorPresence (position) and
+   *  getNpcDialoguePool (dialogue), both hubNpcSchedule.ts. */
+  questVariant?: {
+    requireQuest: string
+    tx?: number
+    ty?: number
+    dialogue?: string[]
+  }
 }
 
 export type HubAnimalType =

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -9870,11 +9870,126 @@
       "wallTileId": "interiorWallWhite"
     },
     "arcade-building-w-2": {
-      "name": "arcade-building-w-2",
+      "name": "The Prize Wheel",
       "width": 15,
       "height": 11,
       "floorTileId": "yellowCarpetFloor",
-      "decor": [],
+      "decor": [
+        {
+          "tx": 1,
+          "ty": 1,
+          "tileId": "rugTopLeft",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 1,
+          "tileId": "rugTopMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 1,
+          "tileId": "rugTopRight",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 2,
+          "tileId": "rugMidLeft",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 2,
+          "tileId": "rugMidMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 2,
+          "tileId": "rugMidRight",
+          "zlayer": "below"
+        },
+        {
+          "tx": 1,
+          "ty": 3,
+          "tileId": "rugBottomLeft",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 3,
+          "tileId": "rugBottomMid",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 3,
+          "tileId": "rugBottomRight",
+          "zlayer": "below"
+        },
+        {
+          "tx": 10,
+          "ty": 9,
+          "tileId": "counterTopHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 9,
+          "tileId": "counterTopHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 9,
+          "tileId": "pileOfSacks",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 12,
+          "ty": 9,
+          "tileId": "counterTopHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 12,
+          "ty": 9,
+          "tileId": "chest",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 6,
+          "ty": 5,
+          "tileId": "roundTable",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 5,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 5,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 13,
+          "ty": -1,
+          "tileId": "paintingLandscapeTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 13,
+          "ty": 0,
+          "tileId": "paintingLandscapeBottom",
+          "zlayer": "solid"
+        }
+      ],
       "exits": [
         {
           "tx": 0,
@@ -9896,11 +10011,116 @@
       "wallTileId": "interiorWallStriped"
     },
     "arcade-building-w-3": {
-      "name": "arcade-building-w-3",
+      "name": "The Concourse",
       "width": 15,
       "height": 11,
       "floorTileId": "yellowCarpetFloor",
-      "decor": [],
+      "carve": [
+        {
+          "tx": 6,
+          "ty": 1,
+          "w": 3,
+          "h": 2
+        }
+      ],
+      "decor": [
+        {
+          "tx": 4,
+          "ty": -1,
+          "tileId": "bannerTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 0,
+          "tileId": "bannerBot",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": -1,
+          "tileId": "bannerTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": 0,
+          "tileId": "bannerBot",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "counterTopMahoganyHorizontalLeft",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 4,
+          "tileId": "counterTopMahoganyHorizontalMiddle",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 11,
+          "ty": 4,
+          "tileId": "pileOfCoins",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 12,
+          "ty": 4,
+          "tileId": "counterTopMahoganyHorizontalRight",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "roundTableWithCloth",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 4,
+          "tileId": "playingCard",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "roundTable",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 6,
+          "tileId": "dice",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 6,
+          "tileId": "stool",
+          "zlayer": "below"
+        }
+      ],
       "exits": [
         {
           "tx": 7,
@@ -9930,7 +10150,7 @@
       "wallTileId": "interiorWallStriped"
     },
     "arcade-building-w-4": {
-      "name": "arcade-building-w-4",
+      "name": "The Back Room",
       "width": 15,
       "height": 11,
       "floorTileId": "redCarpetFloor",
@@ -9940,6 +10160,54 @@
           "ty": 2,
           "tileId": "stepsUpFromLeft",
           "zlayer": "below"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "roundTableWithCloth",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "pileOfSilverCoins",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 4,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 9,
+          "ty": 4,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 2,
+          "ty": 6,
+          "tileId": "candlestickLitTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 2,
+          "ty": 7,
+          "tileId": "candlestickLitBottom",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 12,
+          "ty": 2,
+          "tileId": "lanternTopLit",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 12,
+          "ty": 3,
+          "tileId": "lanternBotLit",
+          "zlayer": "solid"
         },
         {
           "tx": 5,
@@ -10008,16 +10276,87 @@
           "toInteriorId": "arcade-building-w-vault",
           "direction": "down",
           "entryTx": 2,
-          "entryTy": 1
+          "entryTy": 1,
+          "requiredQuest": "vault-guard-stand-down",
+          "label": "Vault stairs (guarded)"
         }
       ]
     },
     "arcade-building-w-5": {
-      "name": "arcade-building-w-5",
+      "name": "The Card Room",
       "width": 15,
       "height": 11,
       "floorTileId": "redCarpetFloor",
-      "decor": [],
+      "carve": [
+        {
+          "tx": 11,
+          "ty": 1,
+          "w": 3,
+          "h": 2
+        }
+      ],
+      "decor": [
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "roundTableWithCloth",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 6,
+          "tileId": "playingCard",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 6,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 6,
+          "ty": 6,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 5,
+          "ty": 7,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 9,
+          "ty": 4,
+          "tileId": "roundTable",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 8,
+          "ty": 4,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 10,
+          "ty": 4,
+          "tileId": "stool",
+          "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": -1,
+          "tileId": "paintingLandscapeTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 3,
+          "ty": 0,
+          "tileId": "paintingLandscapeBottom",
+          "zlayer": "solid"
+        }
+      ],
       "exits": [
         {
           "tx": 0,
@@ -10039,7 +10378,7 @@
       "wallTileId": "interiorWallWhite"
     },
     "arcade-building-w-vault": {
-      "name": "Arcade - Vault",
+      "name": "The Counting Room",
       "width": 10,
       "height": 8,
       "floorTileId": "stoneFloor",
@@ -10055,6 +10394,54 @@
           "ty": 0,
           "tileId": "woodStepsUpRightTop",
           "zlayer": "below"
+        },
+        {
+          "tx": 3,
+          "ty": 4,
+          "tileId": "strongChest",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 4,
+          "tileId": "pileOfGoldCoins",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 5,
+          "ty": 3,
+          "tileId": "pileOfSilverCoins",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 3,
+          "tileId": "pileOfCopperCoins",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 1,
+          "tileId": "candlestickLitTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 4,
+          "ty": 2,
+          "tileId": "candlestickLitBottom",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 1,
+          "tileId": "candlestickLitTop",
+          "zlayer": "solid"
+        },
+        {
+          "tx": 7,
+          "ty": 2,
+          "tileId": "candlestickLitBottom",
+          "zlayer": "solid"
         }
       ],
       "wallTileId": "darkStone",
@@ -12588,6 +12975,18 @@
       "title": "A moss-covered chest hidden in the forest",
       "reward": {
         "crystals": 30
+      }
+    },
+    {
+      "id": "arcade-vault-hoard",
+      "buildingId": "arcade-building-w-vault",
+      "tx": 6,
+      "ty": 4,
+      "tileId": "goldChest",
+      "collectedTileId": "openGoldChest",
+      "title": "The Games Hall's hidden hoard",
+      "reward": {
+        "crystals": 50
       }
     },
     {

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -12416,9 +12416,19 @@
       "tx": 5,
       "ty": 1,
       "dialogue": [
-        "Hello!"
+        "Vault's closed to visitors. Zev's orders — nobody past this point without a vouch.",
+        "Three vouches, Commander. That's the price of trust in this hall these days."
       ],
-      "building": "arcade-building-w-4"
+      "building": "arcade-building-w-4",
+      "questVariant": {
+        "requireQuest": "vault-guard-stand-down",
+        "tx": 4,
+        "ty": 3,
+        "dialogue": [
+          "Go on through, Commander. Zev, Aggie, and Juno all vouched for you — good enough for me.",
+          "Vault's all yours now. Try not to spend it all on the fruit machine."
+        ]
+      }
     },
     {
       "id": "whistlebone",

--- a/web/src/data/hub/ravenwatch/questDefs.json
+++ b/web/src/data/hub/ravenwatch/questDefs.json
@@ -3373,6 +3373,131 @@
       }
     },
     {
+      "id": "vault-guard-the-guards-doubt",
+      "title": "The Guard's Doubt",
+      "type": "fetch",
+      "giverNpcId": "games-host-zev",
+      "receiverNpcId": "marble-master-int",
+      "prerequisite": "quest:zev-games-hall-stands",
+      "offerDialogue": "Ever since word of the rigged games got out, I've kept a guard posted on the vault stairs — can't have just anyone wandering down there. He won't stand aside for a stranger, though. Three of my own dealers need to vouch for you first. Start with Aggie the Roller, in the back room.",
+      "activeDialogue": "Find Aggie the Roller in the back room and let her get a look at you.",
+      "completeDialogue": "Zev sent you, did he? Fine — I'm short a few marbles that rolled loose during last night's tournament. Fetch them and I'll vouch for you.",
+      "steps": [
+        {
+          "key": "report-aggie",
+          "type": "report",
+          "targetNpcId": "marble-master-int",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "unlock": "vault-guard-aggies-marbles"
+      }
+    },
+    {
+      "id": "vault-guard-aggies-marbles",
+      "title": "Aggie's Marbles",
+      "type": "lost-items",
+      "giverNpcId": "marble-master-int",
+      "receiverNpcId": "marble-master-int",
+      "prerequisite": "quest:vault-guard-the-guards-doubt",
+      "offerDialogue": "Three good marbles rolled off during the tournament and I haven't had a spare minute to chase them down. Find them for me and I'll put in a word with the guard.",
+      "activeDialogue": "Check under the tables — one in the marble race room, the rest scattered back here. They roll further than you'd think.",
+      "completeDialogue": "All three, not a scratch on them. I'll tell the guard you're worth trusting. Juno really runs this floor, though — you'll want her vouch too.",
+      "steps": [
+        {
+          "key": "marbles",
+          "type": "collect",
+          "pickupIds": [
+            "loose-marble-1",
+            "loose-marble-2",
+            "loose-marble-3"
+          ],
+          "required": 3,
+          "itemName": "Lucky Marble",
+          "itemIcon": "🔵"
+        }
+      ],
+      "reward": {
+        "crystals": 40,
+        "friendship": {
+          "marble-master-int": 15
+        },
+        "unlock": "vault-guard-junos-jam"
+      }
+    },
+    {
+      "id": "vault-guard-junos-jam",
+      "title": "Juno's Jam",
+      "type": "chain",
+      "giverNpcId": "reels-remy-int",
+      "receiverNpcId": "games-host-zev",
+      "prerequisite": "quest:vault-guard-aggies-marbles",
+      "offerDialogue": "Aggie vouches for you? Fine by me. My fruit machine's been spitting jammed tokens all week — somebody's skimming the reels. Clear the jam, bring me the tokens, and you'll have my vouch too.",
+      "activeDialogue": {
+        "tokens": "The jammed tokens should be caught somewhere around the machines here in the back room.",
+        "report-zev": "Take the cleared tokens to Zev — he'll want to see the evidence himself."
+      },
+      "completeDialogue": "Clean tokens, no tampering — that's two vouches now. Go tell the guard himself. He'll listen once he knows the whole floor trusts you.",
+      "steps": [
+        {
+          "key": "tokens",
+          "type": "collect",
+          "pickupIds": [
+            "jammed-reel-token-1",
+            "jammed-reel-token-2"
+          ],
+          "required": 2,
+          "itemName": "Reel Token",
+          "itemIcon": "🪙"
+        },
+        {
+          "key": "report-zev",
+          "type": "report",
+          "targetNpcId": "games-host-zev",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 45,
+        "friendship": {
+          "reels-remy-int": 15
+        },
+        "unlock": "vault-guard-stand-down"
+      }
+    },
+    {
+      "id": "vault-guard-stand-down",
+      "title": "Stand Down",
+      "type": "fetch",
+      "giverNpcId": "games-host-zev",
+      "receiverNpcId": "npc_1786260907308",
+      "prerequisite": "quest:vault-guard-junos-jam",
+      "offerDialogue": "Aggie and Juno both vouch for you — good enough for me. Go tell the guard himself he can stand down. He's stubborn, but he'll listen once he knows the whole floor trusts you.",
+      "activeDialogue": "Go tell the Vault Guard he can stand down.",
+      "completeDialogue": "...Zev's word, Aggie's word, and Juno's, all for you? Fine. Fine! I've been standing on this same tile for months anyway. Go on, Commander — the vault's yours. Try not to take all of it at once.",
+      "steps": [
+        {
+          "key": "report-guard",
+          "type": "report",
+          "targetNpcId": "npc_1786260907308",
+          "required": 1
+        }
+      ],
+      "reward": {
+        "crystals": 60,
+        "friendship": {
+          "games-host-zev": 20
+        },
+        "relationship": {
+          "npc_1786260907308": {
+            "track": "ally",
+            "points": 15
+          }
+        }
+      }
+    },
+    {
       "id": "orin-champions-stand",
       "title": "Champions' Stand",
       "type": "chain",
@@ -6003,6 +6128,46 @@
       "tileId": "basketOrPeppers",
       "questId": "grimbles-final-feast",
       "building": "inn-building"
+    },
+    {
+      "id": "loose-marble-1",
+      "tx": 3,
+      "ty": 8,
+      "tileId": "coin",
+      "questId": "vault-guard-aggies-marbles",
+      "building": "arcade-building-w-1"
+    },
+    {
+      "id": "loose-marble-2",
+      "tx": 11,
+      "ty": 7,
+      "tileId": "coin",
+      "questId": "vault-guard-aggies-marbles",
+      "building": "arcade-building-w-4"
+    },
+    {
+      "id": "loose-marble-3",
+      "tx": 13,
+      "ty": 8,
+      "tileId": "coin",
+      "questId": "vault-guard-aggies-marbles",
+      "building": "arcade-building-w-1"
+    },
+    {
+      "id": "jammed-reel-token-1",
+      "tx": 3,
+      "ty": 8,
+      "tileId": "coin",
+      "questId": "vault-guard-junos-jam",
+      "building": "arcade-building-w-4"
+    },
+    {
+      "id": "jammed-reel-token-2",
+      "tx": 1,
+      "ty": 8,
+      "tileId": "coin",
+      "questId": "vault-guard-junos-jam",
+      "building": "arcade-building-w-4"
     }
   ],
   "friendshipDialogue": {

--- a/web/src/game/hub/hubNpcSchedule.test.ts
+++ b/web/src/game/hub/hubNpcSchedule.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { getNpcActivity, getNpcDialoguePool, isNpcAsleep, NPC_ACTIVITIES, resolveNpcInteriorPresence } from './hubNpcSchedule'
+import { setQuestStatus } from './quests'
 import type { HubNpc } from '../../data/hub/loader'
+
+// In-memory localStorage mock (tests run in node environment)
+const store = new Map<string, string>()
+beforeEach(() => {
+  store.clear()
+  globalThis.localStorage = {
+    getItem:    (k: string) => store.get(k) ?? null,
+    setItem:    (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear:      () => { store.clear() },
+    key:        (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size },
+  } as Storage
+})
 
 const npc: HubNpc = {
   id: 'baker', name: 'Baker', sprite: 'hub-npc-merchant', tx: 5, ty: 5, dialogue: [],
@@ -190,5 +205,61 @@ describe('resolveNpcInteriorPresence', () => {
       ],
     }
     expect(resolveNpcInteriorPresence(traveler, 'card-shop', 12)).toBeNull()
+  })
+
+  describe('questVariant', () => {
+    const guard: HubNpc = {
+      id: 'guard', name: 'Vault Guard', sprite: 'hub-npc-guard', tx: 5, ty: 1, dialogue: ['Halt.'],
+      building: 'vault-room',
+      questVariant: { requireQuest: 'stand-down', tx: 4, ty: 3, dialogue: ['Go on through.'] },
+    }
+
+    it('stays at the base tile while the gating quest is incomplete', () => {
+      expect(resolveNpcInteriorPresence(guard, 'vault-room', 12)).toEqual({ tx: 5, ty: 1 })
+    })
+
+    it('moves to the variant tile once the gating quest is completed', () => {
+      setQuestStatus('stand-down', 'completed')
+      expect(resolveNpcInteriorPresence(guard, 'vault-room', 12)).toEqual({ tx: 4, ty: 3 })
+    })
+
+    it('stays at the base tile when the gating quest is merely active', () => {
+      setQuestStatus('stand-down', 'active')
+      expect(resolveNpcInteriorPresence(guard, 'vault-room', 12)).toEqual({ tx: 5, ty: 1 })
+    })
+
+    it('leaves position unchanged when the variant sets no tx/ty', () => {
+      const dialogueOnly: HubNpc = { ...guard, questVariant: { requireQuest: 'stand-down', dialogue: ['Go on through.'] } }
+      setQuestStatus('stand-down', 'completed')
+      expect(resolveNpcInteriorPresence(dialogueOnly, 'vault-room', 12)).toEqual({ tx: 5, ty: 1 })
+    })
+
+    it('is still absent from an unrelated building even with an active variant', () => {
+      setQuestStatus('stand-down', 'completed')
+      expect(resolveNpcInteriorPresence(guard, 'other-room', 12)).toBeNull()
+    })
+  })
+})
+
+describe('getNpcDialoguePool — questVariant', () => {
+  const guard: HubNpc = {
+    id: 'guard', name: 'Vault Guard', sprite: 'hub-npc-guard', tx: 5, ty: 1,
+    dialogue: ['Halt.'],
+    questVariant: { requireQuest: 'stand-down', dialogue: ['Go on through.'] },
+  }
+
+  it('returns the flat dialogue while the gating quest is incomplete', () => {
+    expect(getNpcDialoguePool(guard, 12)).toBe(guard.dialogue)
+  })
+
+  it('returns the variant dialogue once the gating quest is completed', () => {
+    setQuestStatus('stand-down', 'completed')
+    expect(getNpcDialoguePool(guard, 12)).toEqual(['Go on through.'])
+  })
+
+  it('falls back to flat dialogue when the variant has no dialogue of its own', () => {
+    const positionOnly: HubNpc = { ...guard, questVariant: { requireQuest: 'stand-down', tx: 4, ty: 3 } }
+    setQuestStatus('stand-down', 'completed')
+    expect(getNpcDialoguePool(positionOnly, 12)).toBe(positionOnly.dialogue)
   })
 })

--- a/web/src/game/hub/hubNpcSchedule.ts
+++ b/web/src/game/hub/hubNpcSchedule.ts
@@ -1,6 +1,12 @@
 import { hourInRange } from './hubClock'
 import { isCampaignComplete } from '../questline'
+import { getQuestState } from './quests'
 import type { HubNpc, HubInterior, NpcScheduleEntry, NpcActivity } from '../../data/hub/loader'
+
+/** True once the NPC's `questVariant.requireQuest` has been completed. */
+function isQuestVariantActive(npc: HubNpc): boolean {
+  return !!npc.questVariant && getQuestState(npc.questVariant.requireQuest).status === 'completed'
+}
 
 /**
  * Canonical list of NPC activities (single source of truth for editor dropdowns
@@ -31,6 +37,7 @@ export function getNpcActivity(npc: HubNpc, gameHour: number): NpcActivity | nul
  *  post-campaign lines once campaign 1 is complete, otherwise the flat
  *  `dialogue` array. */
 export function getNpcDialoguePool(npc: HubNpc, gameHour: number): string[] {
+  if (isQuestVariantActive(npc) && npc.questVariant!.dialogue?.length) return npc.questVariant!.dialogue
   const activity = getNpcActivity(npc, gameHour)
   const pool = activity ? npc.dialogueByActivity?.[activity] : undefined
   if (pool?.length) return pool
@@ -66,11 +73,17 @@ export function resolveNpcInteriorPresence(
   buildingId: string,
   gameHour: number,
 ): { tx: number; ty: number } | null {
-  if (!npc.schedule?.length) {
-    return npc.building === buildingId ? { tx: npc.tx, ty: npc.ty } : null
+  const base = !npc.schedule?.length
+    ? (npc.building === buildingId ? { tx: npc.tx, ty: npc.ty } : null)
+    : (() => {
+        const loc = getNpcLocation(npc, gameHour)
+        return loc?.type === 'interior' && loc.buildingId === buildingId ? { tx: loc.tx, ty: loc.ty } : null
+      })()
+  if (!base) return null
+  if (isQuestVariantActive(npc) && npc.questVariant!.tx != null && npc.questVariant!.ty != null) {
+    return { tx: npc.questVariant!.tx, ty: npc.questVariant!.ty }
   }
-  const loc = getNpcLocation(npc, gameHour)
-  return loc?.type === 'interior' && loc.buildingId === buildingId ? { tx: loc.tx, ty: loc.ty } : null
+  return base
 }
 
 export function isBuildingOpen(interior: HubInterior, gameHour: number): boolean {


### PR DESCRIPTION
## Summary

- Adds a four-part quest chain (`vault-guard-the-guards-doubt` → `aggies-marbles` → `junos-jam` → `stand-down`) that gates the arcade Vault Guard in building w-4, tying into Games Host Zev's existing games-hall arc and reusing Aggie the Roller and Jackpot Juno as vouching NPCs. Once the finale completes, the guard steps aside and lets the player through.
- Adds a small, on-pattern engine feature — `HubNpc.questVariant` (`requireQuest` + optional `tx`/`ty`/`dialogue`) — consumed by `resolveNpcInteriorPresence`/`getNpcDialoguePool` in `hubNpcSchedule.ts`, so an interior NPC can change tile and/or dialogue once a named quest completes. No existing mechanism supported this (the exterior-only `blockedPaths` system doesn't reach interiors).
- Names and decorates the four previously-placeholder Games Hall rooms (w-2 "The Prize Wheel", w-3 "The Concourse", w-4 "The Back Room", w-5 "The Card Room") around the minigame NPCs each already hosts, and carves shallow notches into w-3 and w-5 for shape interest via the existing `carve` mechanic.
- Renames the vault to "The Counting Room", dresses it with chest/coin-pile decor, and fills it with a real reward: a 50-crystal treasure chest, plus a `requiredQuest` gate on the vault stairs as defense-in-depth alongside the guard's own tile-block.

## Test plan

- [x] `npm run build` (typecheck + Vite build) passes clean
- [x] `npm run test` — 2754/2754 tests passed (the Playwright `chrome-headless-shell` cleanup error is known noise per `AGENTS.md`, not a regression)
- [x] Targeted runs of `interiorShape.test.ts`, `questPickupPlacement.test.ts`, `npcScheduleIntegrity.test.ts`, `npcDialogueCoverage.test.ts`, and the new `questVariant` cases in `hubNpcSchedule.test.ts` all pass
- [x] Simulated both new `carve` rectangles (w-3, w-5) confirming zero floor voids
- [ ] Manual in-browser walkthrough (guard blocks → complete the 4-quest chain → guard relocates on re-entry → vault opens and grants crystals) — not run this session; logic is covered by the automated placement/reference tests above


---
_Generated by [Claude Code](https://claude.ai/code/session_015DL5cfWG12iGjmpUtBa9kE)_