### PR TITLE
Wandering hub town NPCs: unique names, composite tinted bodies, and a much deeper dialogue pool

### DIFF
--- a/web/public/sprites/townsfolk-apron-accent-1.svg
+++ b/web/public/sprites/townsfolk-apron-accent-1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — accent layer, walk frame 1 -->
+  <rect x="13.4" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="17" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="12.2" y="16.6" width="7.6" height="8" rx="1.2" fill="#ffffff"/>
+  <rect x="10.85" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="17.65" y="25.1" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-accent-2.svg
+++ b/web/public/sprites/townsfolk-apron-accent-2.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — accent layer, walk frame 2 -->
+  <rect x="13.4" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="17" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="12.2" y="16.6" width="7.6" height="8" rx="1.2" fill="#ffffff"/>
+  <rect x="12.15" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="16.35" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-accent-3.svg
+++ b/web/public/sprites/townsfolk-apron-accent-3.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — accent layer, walk frame 3 -->
+  <rect x="13.4" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="17" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="12.2" y="16.6" width="7.6" height="8" rx="1.2" fill="#ffffff"/>
+  <rect x="13.45" y="25.1" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="15.05" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-accent.svg
+++ b/web/public/sprites/townsfolk-apron-accent.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — accent layer, neutral stand -->
+  <rect x="13.4" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="17" y="14.2" width="1.6" height="3" rx="0.8" fill="#ffffff"/>
+  <rect x="12.2" y="16.6" width="7.6" height="8" rx="1.2" fill="#ffffff"/>
+  <rect x="12.15" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="16.35" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-outfit-1.svg
+++ b/web/public/sprites/townsfolk-apron-outfit-1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — outfit layer, walk frame 1 -->
+  <rect x="8.4" y="13" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="20.8" y="17" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="11.1" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="17.9" y="23" width="3" height="4.4" rx="1" fill="#ffffff"/>
+  <rect x="10.2" y="14" width="11.6" height="9.6" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-outfit-2.svg
+++ b/web/public/sprites/townsfolk-apron-outfit-2.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — outfit layer, walk frame 2 -->
+  <rect x="8.4" y="15" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="20.8" y="15" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="12.4" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="16.6" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="10.2" y="14" width="11.6" height="9.6" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-outfit-3.svg
+++ b/web/public/sprites/townsfolk-apron-outfit-3.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — outfit layer, walk frame 3 -->
+  <rect x="8.4" y="17" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="20.8" y="13" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="13.7" y="23" width="3" height="4.4" rx="1" fill="#ffffff"/>
+  <rect x="15.3" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="10.2" y="14" width="11.6" height="9.6" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-apron-outfit.svg
+++ b/web/public/sprites/townsfolk-apron-outfit.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- work clothes under a heavy apron — outfit layer, neutral stand -->
+  <rect x="8.4" y="15" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="20.8" y="15" width="2.8" height="5.4" rx="1.4" fill="#ffffff"/>
+  <rect x="12.4" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="16.6" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="10.2" y="14" width="11.6" height="9.6" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-face.svg
+++ b/web/public/sprites/townsfolk-face.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- eyes — untinted so they stay dark against any skin tone -->
+  <rect x="13.4" y="8" width="1.8" height="2" rx="0.9" fill="#2a1a0a"/>
+  <rect x="16.8" y="8" width="1.8" height="2" rx="0.9" fill="#2a1a0a"/>
+</svg>

--- a/web/public/sprites/townsfolk-hair-bun.svg
+++ b/web/public/sprites/townsfolk-hair-bun.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- hair gathered into a top bun -->
+  <circle cx="16" cy="3.4" r="2.4" fill="#ffffff"/>
+  <rect x="11.2" y="4.2" width="9.6" height="3.6" rx="1.8" fill="#ffffff"/>
+  <rect x="11.2" y="6.2" width="1.9" height="2.6" rx="0.95" fill="#ffffff"/>
+  <rect x="18.9" y="6.2" width="1.9" height="2.6" rx="0.95" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-hair-curly.svg
+++ b/web/public/sprites/townsfolk-hair-curly.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- curly mop -->
+  <circle cx="12.4" cy="5.4" r="2.4" fill="#ffffff"/>
+  <circle cx="16" cy="4.2" r="2.6" fill="#ffffff"/>
+  <circle cx="19.6" cy="5.4" r="2.4" fill="#ffffff"/>
+  <circle cx="11.6" cy="7.6" r="1.8" fill="#ffffff"/>
+  <circle cx="20.4" cy="7.6" r="1.8" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-hair-long.svg
+++ b/web/public/sprites/townsfolk-hair-long.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- long hair falling past the shoulders -->
+  <rect x="11" y="3.4" width="10" height="4.2" rx="2.1" fill="#ffffff"/>
+  <rect x="10.6" y="6" width="2.4" height="9" rx="1.2" fill="#ffffff"/>
+  <rect x="19" y="6" width="2.4" height="9" rx="1.2" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-hair-short.svg
+++ b/web/public/sprites/townsfolk-hair-short.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- cropped hair -->
+  <rect x="11" y="3.6" width="10" height="4" rx="2" fill="#ffffff"/>
+  <rect x="11" y="6" width="2.2" height="3.2" rx="1.1" fill="#ffffff"/>
+  <rect x="19.8" y="6" width="2.2" height="3.2" rx="1.1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-hat-cap.svg
+++ b/web/public/sprites/townsfolk-hat-cap.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- flat cap with a short peak -->
+  <rect x="11" y="3.2" width="10" height="3.4" rx="1.7" fill="#ffffff"/>
+  <ellipse cx="19.6" cy="6.4" rx="3.4" ry="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-hat-hood.svg
+++ b/web/public/sprites/townsfolk-hat-hood.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- raised hood — three panels framing the face rather than covering it -->
+  <rect x="10.4" y="2.2" width="11.2" height="4.2" rx="2.1" fill="#ffffff"/>
+  <rect x="9.8" y="4" width="2.6" height="9" rx="1.3" fill="#ffffff"/>
+  <rect x="19.6" y="4" width="2.6" height="9" rx="1.3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-hat-wide.svg
+++ b/web/public/sprites/townsfolk-hat-wide.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- wide-brimmed traveller hat -->
+  <ellipse cx="16" cy="6.2" rx="7.4" ry="1.8" fill="#ffffff"/>
+  <rect x="12.4" y="1.6" width="7.2" height="4.8" rx="1.6" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-accent-1.svg
+++ b/web/public/sprites/townsfolk-robe-accent-1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — accent layer, walk frame 1 -->
+  <rect x="13.2" y="13.8" width="5.6" height="2.4" rx="1.2" fill="#ffffff"/>
+  <rect x="10" y="19.8" width="12" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="9" y="26.2" width="12" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="10.85" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="17.65" y="25.1" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-accent-2.svg
+++ b/web/public/sprites/townsfolk-robe-accent-2.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — accent layer, walk frame 2 -->
+  <rect x="13.2" y="13.8" width="5.6" height="2.4" rx="1.2" fill="#ffffff"/>
+  <rect x="10" y="19.8" width="12" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="10" y="26.2" width="12" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="12.15" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="16.35" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-accent-3.svg
+++ b/web/public/sprites/townsfolk-robe-accent-3.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — accent layer, walk frame 3 -->
+  <rect x="13.2" y="13.8" width="5.6" height="2.4" rx="1.2" fill="#ffffff"/>
+  <rect x="10" y="19.8" width="12" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="11" y="26.2" width="12" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="13.45" y="25.1" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="15.05" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-accent.svg
+++ b/web/public/sprites/townsfolk-robe-accent.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — accent layer, neutral stand -->
+  <rect x="13.2" y="13.8" width="5.6" height="2.4" rx="1.2" fill="#ffffff"/>
+  <rect x="10" y="19.8" width="12" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="10" y="26.2" width="12" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="12.15" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="16.35" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-outfit-1.svg
+++ b/web/public/sprites/townsfolk-robe-outfit-1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — outfit layer, walk frame 1 -->
+  <rect x="8.2" y="13" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="21.2" y="17" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="10" y="14" width="12" height="14.4" rx="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-outfit-2.svg
+++ b/web/public/sprites/townsfolk-robe-outfit-2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — outfit layer, walk frame 2 -->
+  <rect x="8.2" y="15" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="21.2" y="15" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="10" y="14" width="12" height="14.4" rx="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-outfit-3.svg
+++ b/web/public/sprites/townsfolk-robe-outfit-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — outfit layer, walk frame 3 -->
+  <rect x="8.2" y="17" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="21.2" y="13" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="10" y="14" width="12" height="14.4" rx="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-robe-outfit.svg
+++ b/web/public/sprites/townsfolk-robe-outfit.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- full-length robe — outfit layer, neutral stand -->
+  <rect x="8.2" y="15" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="21.2" y="15" width="2.6" height="8" rx="1.3" fill="#ffffff"/>
+  <rect x="10" y="14" width="12" height="14.4" rx="3" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-shadow.svg
+++ b/web/public/sprites/townsfolk-shadow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- ground shadow — untinted, carries its own alpha -->
+  <ellipse cx="16" cy="29" rx="6" ry="2" fill="rgba(0,0,0,0.22)"/>
+</svg>

--- a/web/public/sprites/townsfolk-skin.svg
+++ b/web/public/sprites/townsfolk-skin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- head + neck; tinted with the skin tone. Fixed across every body and walk frame -->
+  <rect x="14.4" y="12.6" width="3.2" height="2.2" rx="1" fill="#ffffff"/>
+  <circle cx="16" cy="9" r="5" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-accent-1.svg
+++ b/web/public/sprites/townsfolk-tunic-accent-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — accent layer, walk frame 1 -->
+  <rect x="13" y="13.8" width="6" height="1.8" rx="0.9" fill="#ffffff"/>
+  <rect x="10.4" y="20.4" width="11.2" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="10.85" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="17.65" y="25.1" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-accent-2.svg
+++ b/web/public/sprites/townsfolk-tunic-accent-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — accent layer, walk frame 2 -->
+  <rect x="13" y="13.8" width="6" height="1.8" rx="0.9" fill="#ffffff"/>
+  <rect x="10.4" y="20.4" width="11.2" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="12.15" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="16.35" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-accent-3.svg
+++ b/web/public/sprites/townsfolk-tunic-accent-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — accent layer, walk frame 3 -->
+  <rect x="13" y="13.8" width="6" height="1.8" rx="0.9" fill="#ffffff"/>
+  <rect x="10.4" y="20.4" width="11.2" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="13.45" y="25.1" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="15.05" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-accent.svg
+++ b/web/public/sprites/townsfolk-tunic-accent.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — accent layer, neutral stand -->
+  <rect x="13" y="13.8" width="6" height="1.8" rx="0.9" fill="#ffffff"/>
+  <rect x="10.4" y="20.4" width="11.2" height="2.2" rx="0.6" fill="#ffffff"/>
+  <rect x="12.15" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+  <rect x="16.35" y="26.7" width="3.5" height="2.4" rx="1" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-outfit-1.svg
+++ b/web/public/sprites/townsfolk-tunic-outfit-1.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — outfit layer, walk frame 1 -->
+  <rect x="8.6" y="13" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="20.8" y="17" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="11.1" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="17.9" y="23" width="3" height="4.4" rx="1" fill="#ffffff"/>
+  <rect x="10.4" y="14" width="11.2" height="9.4" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-outfit-2.svg
+++ b/web/public/sprites/townsfolk-tunic-outfit-2.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — outfit layer, walk frame 2 -->
+  <rect x="8.6" y="15" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="20.8" y="15" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="12.4" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="16.6" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="10.4" y="14" width="11.2" height="9.4" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-outfit-3.svg
+++ b/web/public/sprites/townsfolk-tunic-outfit-3.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — outfit layer, walk frame 3 -->
+  <rect x="8.6" y="17" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="20.8" y="13" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="13.7" y="23" width="3" height="4.4" rx="1" fill="#ffffff"/>
+  <rect x="15.3" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="10.4" y="14" width="11.2" height="9.4" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/public/sprites/townsfolk-tunic-outfit.svg
+++ b/web/public/sprites/townsfolk-tunic-outfit.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- short tunic and trousers — outfit layer, neutral stand -->
+  <rect x="8.6" y="15" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="20.8" y="15" width="2.6" height="7.4" rx="1.3" fill="#ffffff"/>
+  <rect x="12.4" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="16.6" y="23" width="3" height="6" rx="1" fill="#ffffff"/>
+  <rect x="10.4" y="14" width="11.2" height="9.4" rx="2.4" fill="#ffffff"/>
+</svg>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -11,6 +11,14 @@ import { PATH_TILE } from '../../data/tiles/tileIndex'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity, getNpcDialoguePool, resolveNpcInteriorPresence } from '../../game/hub/hubNpcSchedule'
 import { recordDeparture, claimArrival } from '../../game/hub/townTravelers'
+import { createAmbientRoster, buildUnitSlugPool } from '../../game/hub/ambientNpcIdentity'
+import type { AmbientNpcIdentity, AmbientNpcLook } from '../../game/hub/ambientNpcIdentity'
+import { townsfolkLayers } from '../../data/townsfolk'
+import type { TownsfolkLayer } from '../../data/townsfolk'
+import {
+  SCARED_PHRASES, makeAmbientLineCursor, nextAmbientLine,
+} from '../../game/hub/ambientDialogue'
+import type { AmbientLineContext, AmbientLineCursor, AmbientSituation } from '../../game/hub/ambientDialogue'
 import { getGameHour, getGameMinute } from '../../game/hub/hubClock'
 import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } from '../../game/sound'
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
@@ -57,21 +65,17 @@ const NIGHT_NPC_LIGHT_R  = 2 * T   // small glow radius around each NPC
 const INTERIOR_DARK_INNER = 1.5 * T
 const INTERIOR_DARK_OUTER = 3   * T
 
-// Generic flavor lines for tapping an anonymous wandering NPC — these have
-// no authored identity (just one of a town's ambientNpcSprites), so unlike
-// named NPCs there's no dialogue array to draw from. A short, cosmetic-only
-// speech bubble (no dialogue modal, no game-state change) mirrors how
-// procedural ambient animals respond to a tap (see hubAnimals.ts's FLAVOUR).
-const AMBIENT_NPC_FLAVOUR = [
-  'Lovely day for it.',
-  'Mind where you step.',
-  "Can't stop to chat, sorry!",
-  'Have you seen the notice board?',
-  "Busy, busy — you know how it is.",
-  'Watch yourself out there.',
-  'Off to run an errand.',
-  "I'll catch you later!",
-]
+// Wandering ("ambient") NPCs have no authored identity in a town's config —
+// they're minted at spawn by game/hub/ambientNpcIdentity.ts, which gives each a
+// name no other live wanderer holds and a look that's either a tinted composite
+// townsfolk (data/townsfolk.ts) or one of the game's unit-card sprites. Tapping
+// one shows a name-prefixed flavour line from game/hub/ambientDialogue.ts: a
+// cosmetic-only speech bubble, no dialogue modal and no game-state change, the
+// same treatment procedural ambient animals get (hubAnimals.ts's FLAVOUR).
+
+// How ghostly wanderers render: every layer of a ghost's look drops to this
+// tint, so a ghost reads as a ghost rather than as a townsperson in a nice coat.
+const GHOST_TINT = 0xaaccff
 
 // ── Interactable affordance aura ────────────────────────────────────────────
 // A faint pulsing halo drawn behind tap-reactive objects that own visible decor
@@ -1585,15 +1589,30 @@ export function HubTownCanvas({
       return !!s && s.wasInRange && !s.bubbleReady
     }
 
-    // ── Card-unit NPCs ─────────────────────────────────────────────────────────
-    const SCARED_PHRASES = [
-      'Did you see that?!', 'Is someone there…?', 'Something is wrong…',
-      'A ghost!! A ghost!!', "Did it just get cold?", 'Please no please no',
-      "What was THAT?!", "I can't feel my legs…", 'Run!! RUN!!',
-    ]
+    // ── Wandering ("ambient") NPCs ─────────────────────────────────────────────
+
+    // One cosmetic sibling sprite of a wanderer's base sprite — a coat, a head,
+    // a hat — tinted independently and glued to the base every frame. Card-unit
+    // wanderers have none of these; composite townsfolk have five or six. Same
+    // shape as hubAnimals.ts's TexturedLayer, for the same reason.
+    interface NpcLookLayer {
+      sprite:    PIXI.Sprite
+      /** Draw order relative to the base sprite. */
+      z:         number
+      /** Walk frames, when this layer animates with the body. */
+      frames:    PIXI.Texture[]
+      staticTex: PIXI.Texture
+    }
 
     interface UnitNpcState {
+      identity:           AmbientNpcIdentity
+      /** This wanderer's personal walk through the flavour-line pool. */
+      lines:              AmbientLineCursor
       sprite:             PIXI.Sprite
+      /** Cosmetic layers stacked on `sprite`, ordered back to front. */
+      layers:             NpcLookLayer[]
+      /** True until they finish the walk in from the road (#2111 arrivals). */
+      justArrived:        boolean
       currentTile:        [number, number]
       walkQueue:          [number, number][]
       isWalking:          boolean
@@ -1615,68 +1634,123 @@ export function HubTownCanvas({
       // never clobbers a scared/door reaction, or vice versa.
       tapBubble:      PIXI.Container | null
       tapBubbleTimer: number
-      tapLineIdx:     number
     }
 
     const unitNpcs: UnitNpcState[] = []
-    const cards = unitCardsRef.current ?? []
 
-    const effectiveCards = cards.length > 0
-      ? cards
-      : AMBIENT_NPC_SPRITES.length > 0 ? AMBIENT_NPC_SPRITES : ['hub-avatar']
-    const spawnCount = Math.min(NPC_SPAWN_TILES.length, Math.max(effectiveCards.length * 3, 4))
-    const slots = NPC_SPAWN_TILES.slice(0, spawnCount)
+    // The sprite pool wanderers can be dressed in. `unitCards` is now the whole
+    // unit-card catalog rather than just the player's deck, so the town isn't a
+    // dozen copies of whatever you happen to be playing; the town's own
+    // ambientNpcSprites still come first so Millhaven keeps its fishermen.
+    // Entries may be display names ('Arc.Tower') or bare slugs — loadSpriteTexture
+    // runs both through spriteSlug, so the two are interchangeable here.
+    const ambientRoster = createAmbientRoster({
+      seed: locationKey,
+      unitSlugs: buildUnitSlugPool(AMBIENT_NPC_SPRITES, unitCardsRef.current ?? [], locationKey),
+    })
 
-    slots.forEach(([tx, ty], i) => {
-      const slug = effectiveCards[i % effectiveCards.length]
-      const cx = tx * T + T / 2
-      const cy = ty * T + T
+    /** The layer stack for a look: townsfolk composite them, card units don't. */
+    function lookLayerSpec(look: AmbientNpcLook): { base: TownsfolkLayer; overlays: TownsfolkLayer[] } {
+      if (look.kind === 'townsfolk') return townsfolkLayers(look)
+      return { base: { slug: look.slug, tint: 0xffffff, animated: true, z: 0 }, overlays: [] }
+    }
 
-      const texPromise = cards.length > 0
-        ? loadSpriteTexture(slug).catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`))
-        : loadTextureUrl(`${base}sprites/${slug}.svg`).catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`))
+    /**
+     * Builds a wanderer's body at (cx, cy): the base sprite, which owns the hit
+     * area and the walk cycle, plus its tinted cosmetic siblings. Every texture
+     * is awaited up front so no layer is ever sized against an empty texture;
+     * walk frames stream in afterwards. Overlays whose art fails to load are
+     * dropped rather than falling back — a missing hat is better than a hat
+     * shaped like the placeholder avatar. Returns null if the app went away
+     * while loading.
+     */
+    async function buildLookSprites(
+      look: AmbientNpcLook, cx: number, cy: number, parent: PIXI.Container, isGhost: boolean,
+    ): Promise<{ sprite: PIXI.Sprite; layers: NpcLookLayer[] } | null> {
+      const spec = lookLayerSpec(look)
+      const [baseTex, overlayTexs] = await Promise.all([
+        loadSpriteTexture(spec.base.slug).catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`)),
+        Promise.all(spec.overlays.map(o => loadSpriteTexture(o.slug).catch(() => null))),
+      ])
+      if (app.renderer == null) return null
 
-      texPromise.then(tex => {
-        if (app.renderer == null) return
-        const isGhost = Math.random() < (isNightRef.current ? 0.10 : 0.01)
+      const make = (tex: PIXI.Texture, tint: number): PIXI.Sprite => {
         const s = new PIXI.Sprite(tex)
         s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
         s.anchor.set(0.5, 1)
         s.position.set(cx, cy)
-        s.zIndex = cy
+        s.tint  = isGhost ? GHOST_TINT : tint
         s.alpha = isGhost ? 0.4 : 1.0
-        if (isGhost) s.tint = 0xaaccff
-        npcLayer.addChild(s)
+        return s
+      }
 
-        const state: UnitNpcState = {
-          sprite:               s,
-          currentTile:          [tx, ty],
-          walkQueue:            [],
-          isWalking:            false,
-          wanderTimer:          500 + Math.random() * 500,
-          animFrames:           [],
-          animTimer:            0,
-          animFrame:            0,
-          isGhost:              isGhost,
-          scaredBubble:         null,
-          scaredBubbleTimer:    0,
-          scaredBubbleCooldown: 0,
-          doorReactionBubble:   null,
-          doorReactionTimer:    0,
-          tapBubble:            null,
-          tapBubbleTimer:       0,
-          tapLineIdx:           Math.floor(Math.random() * AMBIENT_NPC_FLAVOUR.length),
-        }
-        s.eventMode = 'static'
-        s.cursor    = 'pointer'
-        s.on('pointerdown', (e) => { e.stopPropagation(); showAmbientNpcTapBubble(state) })
-        unitNpcs.push(state)
+      const sprite = make(baseTex, spec.base.tint)
+      sprite.zIndex = cy
+      const layers: NpcLookLayer[] = spec.overlays
+        .map((o, i) => ({ o, tex: overlayTexs[i] }))
+        .filter((e): e is { o: TownsfolkLayer; tex: PIXI.Texture } => e.tex != null)
+        .map(({ o, tex }) => {
+          const s = make(tex, o.tint)
+          s.zIndex = cy + o.z
+          s.eventMode = 'none'  // cosmetic only — taps must reach the body beneath
+          const layer: NpcLookLayer = { sprite: s, z: o.z, frames: [], staticTex: tex }
+          // Walk frames for the layers that move with the body (a composite
+          // townsfolk's outfit and accent). Head-attached layers never move, so
+          // they stay on their single static texture — see data/townsfolk.ts.
+          if (o.animated) loadAnimFrames(o.slug, 3).then(f => { layer.frames = f }).catch(() => {})
+          return layer
+        })
 
-        loadAnimFrames(slug, 3)
-          .then(frames => { state.animFrames = frames })
-          .catch(() => {})
-      })
-    })
+      // Parent back to front. spriteLayer sorts by zIndex, but interiorLayer
+      // doesn't sort at all — there, insertion order alone is the draw order.
+      for (const l of layers) if (l.z < 0) parent.addChild(l.sprite)
+      parent.addChild(sprite)
+      for (const l of layers) if (l.z >= 0) parent.addChild(l.sprite)
+
+      return { sprite, layers }
+    }
+
+    /** The world state that colours what a wanderer has to say right now.
+     *  Weather is re-resolved rather than cached — it's the same call the
+     *  weather overlay makes (§12), and a tap is far too rare to be worth
+     *  keeping a copy in sync with. */
+    function ambientLineContext(isGhost: boolean, situation: AmbientSituation): AmbientLineContext {
+      return {
+        isNight: isNightRef.current,
+        weather: resolveWeather(HUB_WEATHER, HUB_ENV),
+        isGhost,
+        situation,
+      }
+    }
+
+    /** What a wanderer is up to, for the purposes of what they'll say. They
+     *  despawn the instant they step onto a door tile, so "at the door" has to
+     *  be read from where they're headed rather than where they are. */
+    function situationFor(npc: UnitNpcState): AmbientSituation {
+      if (npc.justArrived) return 'arriving'
+      const dest = npc.walkQueue[npc.walkQueue.length - 1]
+      if (dest && doorTileSet.has(`${dest[0]},${dest[1]}`)) return 'doorway'
+      return 'street'
+    }
+
+    /** Keeps a wanderer's cosmetic layers glued to its body. */
+    function syncNpcLookLayers(npc: UnitNpcState): void {
+      for (const l of npc.layers) {
+        l.sprite.position.copyFrom(npc.sprite.position)
+        l.sprite.scale.copyFrom(npc.sprite.scale)
+        l.sprite.alpha = npc.sprite.alpha
+      }
+    }
+
+    /** Advances the body and every animated layer to the same walk frame, so a
+     *  composite townsfolk's coat and belt stride with the legs underneath. */
+    function setNpcAnimFrame(npc: UnitNpcState, frame: number): void {
+      npc.sprite.texture = npc.animFrames[frame] ?? npc.sprite.texture
+      for (const l of npc.layers) {
+        if (l.frames.length === 0) continue
+        l.sprite.texture = l.frames[frame] ?? l.staticTex
+      }
+    }
 
     // Door tiles — NPCs that arrive here despawn (simulate entering a building)
     const doorTileSet = new Set(HUB_DOORS.map(d => `${d.tx},${d.ty}`))
@@ -1695,7 +1769,7 @@ export function HubTownCanvas({
     // arrived" NPC walking in from an exit tile.
     if (exitTileCoords.length > 0 && claimArrival()) {
       const arrivalTile = exitTileCoords[Math.floor(Math.random() * exitTileCoords.length)]
-      spawnAmbientNpc(arrivalTile)
+      spawnAmbientNpc({ origin: arrivalTile, arriving: true })
     }
     // Spawn tiles that aren't doors — used for respawning so NPCs don't immediately despawn
     const nonDoorSpawnTiles = NPC_SPAWN_TILES.filter(([tx, ty]) => !doorTileSet.has(`${tx},${ty}`))
@@ -1715,13 +1789,25 @@ export function HubTownCanvas({
     const TARGET_NPC_COUNT = 12
     let respawnTimer = 2000
 
+    // Seed the town's population. The old count scaled with the size of the
+    // sprite pool, which now means the whole card catalog — TARGET_NPC_COUNT is
+    // the headcount the respawn cycle maintains anyway, so start there.
+    for (const origin of NPC_SPAWN_TILES.slice(0, Math.min(NPC_SPAWN_TILES.length, TARGET_NPC_COUNT))) {
+      spawnAmbientNpc({ origin, initial: true })
+    }
+
     // Ambient NPCs who've walked into a building's open door don't just
     // vanish — they linger inside for a while, visible if the player follows
     // them in, before letting themselves back out. Keyed by buildingId,
     // in-memory only (ambient NPCs were never persisted across reloads to
-    // begin with). Reuses the sprite's already-loaded texture directly
-    // rather than re-resolving a slug, since UnitNpcState never stored one.
-    interface BuildingVisitor { texture: PIXI.Texture; isGhost: boolean; leaveAt: number }
+    // begin with). Their identity travels with them, so the person who comes
+    // back out of the bakery is the person who went in.
+    interface BuildingVisitor {
+      identity: AmbientNpcIdentity
+      lines:    AmbientLineCursor
+      isGhost:  boolean
+      leaveAt:  number
+    }
     const buildingVisitors = new Map<string, BuildingVisitor[]>()
     const VISITOR_STAY_MS_MIN = 20_000
     const VISITOR_STAY_MS_MAX = 55_000
@@ -1734,6 +1820,8 @@ export function HubTownCanvas({
     interface InteriorVisitorSprite {
       record: BuildingVisitor
       sprite: PIXI.Sprite
+      /** The visitor's cosmetic look layers, so they can be torn down together. */
+      layers: NpcLookLayer[]
       // Tap-flavor bubble, same cosmetic-only treatment as exterior ambient
       // NPCs — added to interiorLayer (not bubbleLayer, which is hidden
       // while indoors) so it renders in the room.
@@ -1742,10 +1830,11 @@ export function HubTownCanvas({
     }
     let interiorVisitorSprites: InteriorVisitorSprite[] = []
 
-    // Removes an ambient NPC's sprite and any active reaction bubbles, and
+    // Removes an ambient NPC's sprites and any active reaction bubbles, and
     // drops it from unitNpcs — shared by despawn-into-a-building and
-    // despawn-via-exit-tile (#2111).
-    function despawnAmbientNpc(npc: UnitNpcState): void {
+    // despawn-via-exit-tile (#2111). `keepIdentity` holds their name in reserve
+    // for the walk back out of a building; everything else frees it.
+    function despawnAmbientNpc(npc: UnitNpcState, keepIdentity = false): void {
       if (npc.scaredBubble) {
         bubbleLayer.removeChild(npc.scaredBubble)
         npc.scaredBubble = null
@@ -1762,13 +1851,25 @@ export function HubTownCanvas({
         npc.tapBubbleTimer = 0
       }
       npc.sprite.parent?.removeChild(npc.sprite)
+      for (const l of npc.layers) l.sprite.parent?.removeChild(l.sprite)
+      npc.layers.length = 0
+      // Hand the name back so somebody else in town can have it later. A
+      // wanderer who's stepped into a building keeps theirs — the roster is
+      // released when they finally leave for good, not while they're indoors.
+      if (!keepIdentity) ambientRoster.release(npc.identity.id)
       const idx = unitNpcs.indexOf(npc)
       if (idx !== -1) unitNpcs.splice(idx, 1)
     }
 
     async function processNpcWalkQueue(npc: UnitNpcState) {
       try {
-        if (npc.walkQueue.length === 0) { npc.isWalking = false; return }
+        if (npc.walkQueue.length === 0) {
+          npc.isWalking = false
+          // They've finished the walk in from the road; from here they're just
+          // another townsperson going about their day.
+          npc.justArrived = false
+          return
+        }
         npc.isWalking = true
         const [tx, ty] = npc.walkQueue.shift()!
         const targetX  = tx * T + T / 2
@@ -1806,11 +1907,14 @@ export function HubTownCanvas({
           if (enteredBuildingId) {
             const visitors = buildingVisitors.get(enteredBuildingId) ?? []
             visitors.push({
-              texture: npc.sprite.texture,
-              isGhost: npc.isGhost,
+              identity: npc.identity,
+              lines:    npc.lines,
+              isGhost:  npc.isGhost,
               leaveAt: Date.now() + VISITOR_STAY_MS_MIN + Math.random() * (VISITOR_STAY_MS_MAX - VISITOR_STAY_MS_MIN),
             })
             buildingVisitors.set(enteredBuildingId, visitors)
+            despawnAmbientNpc(npc, true)
+            return
           }
           despawnAmbientNpc(npc)
           return
@@ -1998,34 +2102,45 @@ export function HubTownCanvas({
       if (!npc.isWalking) processNpcWalkQueue(npc)
     }
 
-    // `origin` lets a caller place the spawn at a specific tile (an exit, for
-    // a claimed arrival — #2111) instead of a random non-door spawn tile.
-    function spawnAmbientNpc(origin?: [number, number]) {
+    /**
+     * The one way a wanderer comes into the world — used for the town's initial
+     * population, for the respawn cycle that keeps it topped up, for a traveller
+     * arriving from another town, and for somebody stepping back out of a shop.
+     *
+     * `origin` places the spawn at a specific tile instead of a random non-door
+     * spawn tile. `identity` reuses an existing person (walking back out of a
+     * building) rather than minting a new one. `arriving` marks a traveller
+     * fresh off the road, which colours what they say until they stop walking.
+     * `initial` only affects how soon they first wander, so the town isn't
+     * completely still for the first couple of seconds after it loads.
+     */
+    function spawnAmbientNpc(opts: {
+      origin?:   [number, number]
+      identity?: AmbientNpcIdentity
+      /** Carries a returning wanderer's place in their line pool back out. */
+      lines?:    AmbientLineCursor
+      arriving?: boolean
+      initial?:  boolean
+      isGhost?:  boolean
+    } = {}): void {
+      const { origin, arriving = false, initial = false } = opts
       if (!origin && nonDoorSpawnTiles.length === 0) return
       const [tx, ty] = origin ?? nonDoorSpawnTiles[Math.floor(Math.random() * nonDoorSpawnTiles.length)]
-      const cx = tx * T + T / 2
-      const cy = ty * T + T
-      const slug = effectiveCards[Math.floor(Math.random() * effectiveCards.length)]
-      const texPromise = cards.length > 0
-        ? loadSpriteTexture(slug).catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`))
-        : loadTextureUrl(`${base}sprites/${slug}.svg`).catch(() => loadTextureUrl(`${base}sprites/hub-avatar.svg`))
-      texPromise.then(tex => {
-        if (app.renderer == null) return
-        const isGhost = Math.random() < (isNightRef.current ? 0.10 : 0.01)
-        const s = new PIXI.Sprite(tex)
-        s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
-        s.anchor.set(0.5, 1)
-        s.position.set(cx, cy)
-        s.zIndex = cy
-        s.alpha = isGhost ? 0.4 : 1.0
-        if (isGhost) s.tint = 0xaaccff
-        npcLayer.addChild(s)
+      const identity = opts.identity ?? ambientRoster.mint()
+      const isGhost  = opts.isGhost ?? (Math.random() < (isNightRef.current ? 0.10 : 0.01))
+
+      buildLookSprites(identity.look, tx * T + T / 2, ty * T + T, npcLayer, isGhost).then(built => {
+        if (!built) return
         const state: UnitNpcState = {
-          sprite:               s,
+          identity,
+          lines:                opts.lines ?? makeAmbientLineCursor(identity.id, ambientLineContext(isGhost, arriving ? 'arriving' : 'street')),
+          sprite:               built.sprite,
+          layers:               built.layers,
+          justArrived:          arriving,
           currentTile:          [tx, ty],
           walkQueue:            [],
           isWalking:            false,
-          wanderTimer:          1000 + Math.random() * 2000,
+          wanderTimer:          initial ? 500 + Math.random() * 500 : 1000 + Math.random() * 2000,
           animFrames:           [],
           animTimer:            0,
           animFrame:            0,
@@ -2037,14 +2152,15 @@ export function HubTownCanvas({
           doorReactionTimer:    0,
           tapBubble:            null,
           tapBubbleTimer:       0,
-          tapLineIdx:           Math.floor(Math.random() * AMBIENT_NPC_FLAVOUR.length),
         }
-        s.eventMode = 'static'
-        s.cursor    = 'pointer'
-        s.on('pointerdown', (e) => { e.stopPropagation(); showAmbientNpcTapBubble(state) })
+        built.sprite.eventMode = 'static'
+        built.sprite.cursor    = 'pointer'
+        built.sprite.on('pointerdown', (e) => { e.stopPropagation(); showAmbientNpcTapBubble(state) })
         unitNpcs.push(state)
-        loadAnimFrames(slug, 3).then(frames => { state.animFrames = frames }).catch(() => {})
-      }).catch(() => {})
+        loadAnimFrames(lookLayerSpec(identity.look).base.slug, 3)
+          .then(frames => { state.animFrames = frames })
+          .catch(() => {})
+      }).catch(e => rollbar.error('[HubTownCanvas] spawnAmbientNpc failed', { error: String(e) }))
     }
 
     // ── Exterior walk state ────────────────────────────────────────────────────
@@ -2676,36 +2792,46 @@ export function HubTownCanvas({
       }
 
       // Ambient wandering NPCs currently "inside" this building (#2111) —
-      // visible for the rest of their stay if the player follows them in.
-      // Reuses the texture each already had outside — no new texture load,
-      // no identity, just a body standing somewhere in the room. Positioning
-      // is static for now (no in-room wandering), same tradeoff the denned
-      // animals above don't fully avoid either (neither reserves its tile
-      // against the other, so an occasional overlap is possible but rare
-      // given how few of either are usually present in one small room).
+      // visible for the rest of their stay if the player follows them in, and
+      // recognisably the same person who walked in: same name, same composite
+      // look, same place in their line pool. Positioning is static for now (no
+      // in-room wandering), same tradeoff the denned animals above don't fully
+      // avoid either (neither reserves its tile against the other, so an
+      // occasional overlap is possible but rare given how few of either are
+      // usually present in one small room).
       {
         const visitors = buildingVisitors.get(buildingId) ?? []
         const freeTiles = Array.from(interiorWalkable).map(k => k.split(',').map(Number) as [number, number])
-        interiorVisitorSprites = visitors.map((record, i) => {
+        const enteredInteriorId = buildingId
+        interiorVisitorSprites = []
+        visitors.forEach((record, i) => {
           const spot = freeTiles[(i * 5 + 2) % Math.max(1, freeTiles.length)] ?? [1, 1]
-          const s = new PIXI.Sprite(record.texture)
-          s.width = SPRITE_SIZE; s.height = SPRITE_SIZE
-          s.anchor.set(0.5, 1)
-          s.position.set(spot[0] * T + T / 2, spot[1] * T + T)
-          if (record.isGhost) { s.alpha = 0.4; s.tint = 0xaaccff }
-          interiorLayer.addChild(s)
-          const entry: InteriorVisitorSprite = { record, sprite: s, bubble: null, bubbleTimer: 0 }
-          s.eventMode = 'static'
-          s.cursor    = 'pointer'
-          s.on('pointerdown', (e) => {
-            e.stopPropagation()
-            if (entry.bubble) { interiorLayer.removeChild(entry.bubble); entry.bubble = null }
-            const line = AMBIENT_NPC_FLAVOUR[Math.floor(Math.random() * AMBIENT_NPC_FLAVOUR.length)]
-            entry.bubble = createSpeechBubble(line, s.x, s.y)
-            interiorLayer.addChild(entry.bubble)
-            entry.bubbleTimer = 1800
-          })
-          return entry
+          buildLookSprites(
+            record.identity.look, spot[0] * T + T / 2, spot[1] * T + T, interiorLayer, record.isGhost,
+          ).then(built => {
+            // The player may have walked back out while this was loading.
+            if (!built || !interiorActive || currentInteriorId !== enteredInteriorId) {
+              built?.sprite.parent?.removeChild(built.sprite)
+              for (const l of built?.layers ?? []) l.sprite.parent?.removeChild(l.sprite)
+              return
+            }
+            const s = built.sprite
+            const entry: InteriorVisitorSprite = {
+              record, sprite: s, layers: built.layers, bubble: null, bubbleTimer: 0,
+            }
+            s.eventMode = 'static'
+            s.cursor    = 'pointer'
+            s.on('pointerdown', (e) => {
+              e.stopPropagation()
+              if (entry.bubble) { interiorLayer.removeChild(entry.bubble); entry.bubble = null }
+              const ctx  = ambientLineContext(record.isGhost, 'indoors')
+              const line = nextAmbientLine(record.lines, record.identity.id, ctx)
+              entry.bubble = createSpeechBubble(`${record.identity.name}: ${line}`, s.x, s.y)
+              interiorLayer.addChild(entry.bubble)
+              entry.bubbleTimer = 2600
+            })
+            interiorVisitorSprites.push(entry)
+          }).catch(() => {})
         })
       }
 
@@ -2936,16 +3062,17 @@ export function HubTownCanvas({
       return c
     }
 
-    // Tapping an anonymous wandering NPC shows one cosmetic flavor line —
-    // no dialogue modal, no state — cycling through AMBIENT_NPC_FLAVOUR so
-    // repeat taps on the same NPC don't always show the same line.
+    // Tapping a wandering NPC shows one cosmetic flavour line prefixed with
+    // their name — no dialogue modal, no state. Each wanderer walks its own
+    // shuffle of the pool (ambientDialogue.ts), so repeat taps on the same
+    // person keep turning up lines they haven't said yet.
     function showAmbientNpcTapBubble(npc: UnitNpcState): void {
       if (npc.tapBubble) { bubbleLayer.removeChild(npc.tapBubble); npc.tapBubble = null }
-      const line = AMBIENT_NPC_FLAVOUR[npc.tapLineIdx % AMBIENT_NPC_FLAVOUR.length]
-      npc.tapLineIdx += 1
-      npc.tapBubble = createSpeechBubble(line, npc.sprite.x, npc.sprite.y)
+      const ctx  = ambientLineContext(npc.isGhost, situationFor(npc))
+      const line = nextAmbientLine(npc.lines, npc.identity.id, ctx)
+      npc.tapBubble = createSpeechBubble(`${npc.identity.name}: ${line}`, npc.sprite.x, npc.sprite.y)
       bubbleLayer.addChild(npc.tapBubble)
-      npc.tapBubbleTimer = 1800
+      npc.tapBubbleTimer = 2600
     }
 
     function createNameTag(name: string, cx: number, cy: number): PIXI.Container {
@@ -3419,7 +3546,11 @@ export function HubTownCanvas({
       }
       for (const npc of unitNpcs) {
         const nz = npc.sprite.y
-        if (nz !== npc.sprite.zIndex) { npc.sprite.zIndex = nz; zDirty = true }
+        if (nz !== npc.sprite.zIndex) {
+          npc.sprite.zIndex = nz
+          for (const l of npc.layers) l.sprite.zIndex = nz + l.z
+          zDirty = true
+        }
       }
       if (zDirty) { spriteLayer.sortChildren(); worldLayer.sortChildren() }
 
@@ -3797,10 +3928,10 @@ export function HubTownCanvas({
           if (npc.animTimer <= 0) {
             npc.animTimer = 200
             npc.animFrame = (npc.animFrame + 1) % npc.animFrames.length
-            npc.sprite.texture = npc.animFrames[npc.animFrame]
+            setNpcAnimFrame(npc, npc.animFrame)
           }
         } else if (!npc.isWalking && npc.animFrames.length > 0 && npc.animFrame !== 0) {
-          npc.sprite.texture = npc.animFrames[0]
+          setNpcAnimFrame(npc, 0)
           npc.animFrame = 0
           npc.animTimer = 0
         }
@@ -3808,6 +3939,9 @@ export function HubTownCanvas({
         if (npc.isGhost) {
           npc.sprite.alpha = 0.25 + 0.2 * Math.sin(performance.now() / 600 + npc.currentTile[0])
         }
+        // Cosmetic layers ride along with the body every frame — position,
+        // facing and the ghost pulse above all have to reach them.
+        syncNpcLookLayers(npc)
 
         if (!npc.isWalking) {
           npc.wanderTimer -= ticker.deltaMS
@@ -3894,12 +4028,24 @@ export function HubTownCanvas({
               if (idx !== -1) {
                 const leaving = interiorVisitorSprites[idx]
                 interiorLayer.removeChild(leaving.sprite)
+                for (const l of leaving.layers) interiorLayer.removeChild(l.sprite)
                 if (leaving.bubble) interiorLayer.removeChild(leaving.bubble)
                 interiorVisitorSprites.splice(idx, 1)
               }
             }
             const door = HUB_DOORS.find(d => d.buildingId === visitBuildingId)
-            if (door && isDoorOpen(door.tx, door.ty)) spawnAmbientNpc([door.tx, door.ty])
+            if (door && isDoorOpen(door.tx, door.ty)) {
+              // The same person walks back out — name, look and all.
+              spawnAmbientNpc({
+                origin: [door.tx, door.ty], identity: record.identity,
+                lines: record.lines, isGhost: record.isGhost,
+              })
+            } else {
+              // The building shut while they were inside, so they're staying
+              // put out of sight. Free the name rather than reserving it for a
+              // wanderer who will never reappear.
+              ambientRoster.release(record.identity.id)
+            }
           }
           if (visitors.length === 0) buildingVisitors.delete(visitBuildingId)
         }

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -18,7 +18,7 @@ import { canHearRumourToday, recordRumourHeard } from '../../game/hub/rumourCool
 import { setDialogueFlag, hasDialogueFlag, markNodeSeen } from '../../game/hub/dialogueFlags'
 import { getQuestState, setQuestStatus, incrementQuestProgress, getQuestProgress, resetQuest } from '../../game/hub/quests'
 import { getHeardConvoIds, markConvoHeard, resetHeardConvoIds } from '../../game/hub/innConvos'
-import { loadDeck, loadCollection, loadCrystals, saveCrystals, addCardsToCollection, addAugmentInstance, CRYSTAL_PACK_COST } from '../../game/collection'
+import { loadCollection, loadCrystals, saveCrystals, addCardsToCollection, addAugmentInstance, CRYSTAL_PACK_COST } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
 import { CommanderState } from '../../game/commander'
 import { loadSkipIntro } from '../screens/SettingsScreen'
@@ -473,14 +473,16 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   const petActionRef     = useRef<{ sendPetFetching: (onReturn: () => void) => boolean; givePetAffection: () => void; setPetAccessory: (assetId: string | null) => void } | null>(null)
   const playerName = loadPlayerName()
 
-  const unitCards = useMemo(() => {
-    const deck    = loadDeck()
-    const catalog = getCardCatalog()
-    const names   = new Set(deck.map(e => e.cardName))
-    return catalog
-      .filter(c => c.cardType === 'unit' && names.has(c.name))
-      .map(c => c.name)
-  }, [])
+  // The sprite pool the town's wandering NPCs can be dressed in. This used to
+  // be the player's deck — a dozen names — so every town was the same handful
+  // of bodies over and over, and looked it. The whole unit catalog is several
+  // hundred sprites, and the canvas weights each town's own ambientNpcSprites
+  // to the front of it, so towns keep their character without the crowd
+  // repeating (see game/hub/ambientNpcIdentity.ts's buildUnitSlugPool).
+  const unitCards = useMemo(
+    () => getCardCatalog().filter(c => c.cardType === 'unit').map(c => c.name),
+    [],
+  )
 
   // Secret #9 — Wrong Save File: rare title-screen glitch showing fake stats
   const [wrongSave, setWrongSave] = useState<{ cards: number; crystals: number; deck: number } | null>(null)

--- a/web/src/components/minigames/citybuilder/walkerTypes.ts
+++ b/web/src/components/minigames/citybuilder/walkerTypes.ts
@@ -2,6 +2,7 @@ import {
   CityCell, CityState, CITY_ROWS, CITY_COLS,
   cityDefense, getNeighbourIndices, spawnerUnitCount, getCityFoodScore,
 } from '../../../game/cityBuilder'
+import { RESIDENT_FIRST_NAMES } from '../../../game/names'
 
 export type TaskType = 'idle' | 'resting' | 'eating' | 'patrolling' | 'gathering' | 'visiting' | 'playing' | 'chatting' | 'farming'
 
@@ -57,20 +58,6 @@ export interface ResidentThought {
   thought:  string
   happy:    boolean
 }
-
-const RESIDENT_FIRST_NAMES = [
-  'Bob', 'Grak', 'Mira', 'Thorin', 'Zyx', 'Elda', 'Fang', 'Nix', 'Wren', 'Dusk',
-  'Pip', 'Crux', 'Vale', 'Sorn', 'Brix', 'Holt', 'Vera', 'Kurn', 'Dex', 'Ori',
-  'Sable', 'Flint', 'Rook', 'Ivy', 'Bryn', 'Quill', 'Ash', 'Moss', 'Thorn', 'Lark',
-  'Grit', 'Nyx', 'Rune', 'Cora', 'Drake', 'Frey', 'Vex', 'Sage', 'Onyx', 'Luna',
-  'Zara', 'Kade', 'Ember', 'Riven', 'Sylas', 'Jade', 'Dorian', 'Nyssa', 'Orin', 'Soren',
-  'Tess', 'Galen', 'Vira', 'Kira', 'Bram', 'Lena', 'Zane', 'Mara', 'Rhea', 'Dax',
-  'Cyrus', 'Elara', 'Fen', 'Nora', 'Vaughn', 'Sia', 'Kieran', 'Lyra', 'Eira', 'Zev',
-  'Mina', 'Thane', 'Vela', 'Kass', 'Dara', 'Orion', 'Faye', 'Gideon', 'Lira', 'Kara',
-  'Elys', 'Kael', 'Varyn', 'Selene', 'Torik', 'Xara', 'Brakka', 'Zephyr', 'Isolde', 'Malric',
-  'Tavra', 'Voren', 'Calyx', 'Seraph', 'Nymer', 'Talon', 'Velric', 'Auren', 'Morwen', 'Zyra',
-  'Graham', 'Rob', 'Jarv', 'Jason',
-]
 
 export function residentName(unitName: string, cellIndex: number, unitIndex: number): string {
   const seed = cellIndex * 17 + unitIndex * 31

--- a/web/src/data/townsfolk.test.ts
+++ b/web/src/data/townsfolk.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  TOWNSFOLK_BODIES, TOWNSFOLK_HAIR, TOWNSFOLK_HATS,
+  SKIN_TONES, HAIR_COLOURS, OUTFIT_COLOURS, ACCENT_COLOURS, HAT_COLOURS,
+  townsfolkLayers, allTownsfolkSlugs, type TownsfolkLook,
+} from './townsfolk'
+
+const SPRITES = join(dirname(fileURLToPath(import.meta.url)), '../../public/sprites')
+
+const LOOK: TownsfolkLook = {
+  body: 'tunic', hair: 'short', hat: 'cap',
+  skin: 0xf0c9a0, outfit: 0x4a6fa5, accent: 0xd4af37, hairColour: 0x2a1a0a, hatColour: 0x8b5e3c,
+}
+
+describe('townsfolkLayers', () => {
+  it('uses the outfit as the base sprite, since it owns the hit area', () => {
+    expect(townsfolkLayers(LOOK).base).toEqual({
+      slug: 'townsfolk-tunic-outfit', tint: 0x4a6fa5, animated: true, z: 0,
+    })
+  })
+
+  it('draws the shadow behind the base and every other layer in front of it', () => {
+    const { overlays } = townsfolkLayers(LOOK)
+    const shadow = overlays.find(l => l.slug === 'townsfolk-shadow')!
+    expect(shadow.z).toBeLessThan(0)
+    for (const l of overlays.filter(o => o !== shadow)) expect(l.z).toBeGreaterThan(0)
+  })
+
+  it('orders head layers skin → face → hair → hat', () => {
+    const z = Object.fromEntries(townsfolkLayers(LOOK).overlays.map(l => [l.slug, l.z]))
+    expect(z['townsfolk-skin']).toBeLessThan(z['townsfolk-face'])
+    expect(z['townsfolk-face']).toBeLessThan(z['townsfolk-hair-short'])
+    expect(z['townsfolk-hair-short']).toBeLessThan(z['townsfolk-hat-cap'])
+  })
+
+  it('omits the hat layer entirely when bare-headed', () => {
+    const { overlays } = townsfolkLayers({ ...LOOK, hat: undefined })
+    expect(overlays.some(l => l.slug.startsWith('townsfolk-hat-'))).toBe(false)
+  })
+
+  it('animates only the body layers — head layers are frameless by design', () => {
+    const { base, overlays } = townsfolkLayers(LOOK)
+    expect(base.animated).toBe(true)
+    const animated = overlays.filter(l => l.animated).map(l => l.slug)
+    expect(animated).toEqual(['townsfolk-tunic-accent'])
+  })
+
+  it('leaves the shadow and eyes untinted so they keep their own colours', () => {
+    const { overlays } = townsfolkLayers(LOOK)
+    for (const slug of ['townsfolk-shadow', 'townsfolk-face']) {
+      expect(overlays.find(l => l.slug === slug)!.tint).toBe(0xffffff)
+    }
+  })
+
+  it('never emits two layers at the same depth', () => {
+    const { base, overlays } = townsfolkLayers(LOOK)
+    const zs = [base.z, ...overlays.map(l => l.z)]
+    expect(new Set(zs).size).toBe(zs.length)
+  })
+})
+
+describe('townsfolk art on disk', () => {
+  it('ships every sprite the catalog can reference', () => {
+    const missing = allTownsfolkSlugs().filter(s => !existsSync(join(SPRITES, `${s}.svg`)))
+    expect(missing).toEqual([])
+  })
+
+  it('ships -1/-2/-3 walk frames for exactly the animated layers', () => {
+    for (const body of TOWNSFOLK_BODIES) {
+      for (const part of ['outfit', 'accent']) {
+        for (const frame of [1, 2, 3]) {
+          expect(existsSync(join(SPRITES, `townsfolk-${body}-${part}-${frame}.svg`))).toBe(true)
+        }
+      }
+    }
+    // Head-attached layers must NOT have frames — the head never moves, and a
+    // stray frame file would silently start animating it out of sync.
+    for (const slug of ['townsfolk-skin', 'townsfolk-face', 'townsfolk-hair-short', 'townsfolk-hat-cap']) {
+      expect(existsSync(join(SPRITES, `${slug}-1.svg`))).toBe(false)
+    }
+  })
+
+  it('fills tinted layers with plain white so sprite.tint can colour them', () => {
+    const tinted = allTownsfolkSlugs().filter(s => s !== 'townsfolk-shadow' && s !== 'townsfolk-face')
+    for (const slug of tinted) {
+      const svg = readFileSync(join(SPRITES, `${slug}.svg`), 'utf8')
+      const fills = [...svg.matchAll(/fill="([^"]+)"/g)].map(m => m[1])
+      expect(fills.length).toBeGreaterThan(0)
+      expect(fills.every(f => f === '#ffffff')).toBe(true)
+    }
+  })
+
+  it('keeps the head in the same place across every body and walk frame', () => {
+    // The whole shared-head-layer scheme rests on this: if a body ever moves
+    // its shoulders, the frameless skin/hair/hat layers detach from it.
+    const shoulderY = (svg: string) =>
+      [...svg.matchAll(/<rect[^>]*y="([\d.]+)"[^>]*height="([\d.]+)"/g)]
+        .map(m => Number(m[1])).filter(y => y >= 13 && y <= 15)
+    for (const body of TOWNSFOLK_BODIES) {
+      const frames = ['', '-1', '-2', '-3'].map(f =>
+        shoulderY(readFileSync(join(SPRITES, `townsfolk-${body}-outfit${f}.svg`), 'utf8')))
+      // The torso rect starts at y=14 in every frame of every body.
+      for (const ys of frames) expect(ys).toContain(14)
+    }
+  })
+})
+
+describe('townsfolk palettes', () => {
+  it('offers enough of each colour that a town of a dozen rarely repeats', () => {
+    for (const palette of [SKIN_TONES, HAIR_COLOURS, OUTFIT_COLOURS, ACCENT_COLOURS, HAT_COLOURS]) {
+      expect(palette.length).toBeGreaterThanOrEqual(7)
+      expect(new Set(palette).size).toBe(palette.length)
+    }
+  })
+
+  it('yields millions of distinct looks from a few dozen files', () => {
+    // Bare-headed is one option; each hat style multiplies by its colours too.
+    const headwear = 1 + TOWNSFOLK_HATS.length * HAT_COLOURS.length
+    const combos = TOWNSFOLK_BODIES.length * TOWNSFOLK_HAIR.length * headwear
+      * SKIN_TONES.length * OUTFIT_COLOURS.length * ACCENT_COLOURS.length * HAIR_COLOURS.length
+    expect(combos).toBeGreaterThan(1_000_000)
+  })
+})

--- a/web/src/data/townsfolk.ts
+++ b/web/src/data/townsfolk.ts
@@ -1,0 +1,118 @@
+// Townsfolk composite sprite catalog. A wandering hub-town NPC that isn't a
+// card unit is assembled from several 32x32 sprite layers stacked as PIXI
+// siblings, each tinted independently — the same trick the pet coat patterns
+// and accessories use (see data/petPatterns.ts, data/petAccessories.ts and
+// hubAnimals.ts's patternLayers/applyAccessorySprite). A handful of layers and
+// a few palettes give millions of distinct-looking townsfolk without an artist
+// drawing a single one of them.
+//
+// Art lives at web/public/sprites/townsfolk-*.svg. Two authoring rules make the
+// whole thing work — break either and the layers come apart:
+//
+//   1. Every body places the head at the SAME coordinates, so the head-attached
+//      layers (skin, face, hair, hat) are shared across all bodies instead of
+//      being redrawn per body.
+//   2. Walk frames animate arms, legs and hems ONLY — the head and shoulders
+//      never move. (The older hand-drawn hub-npc-*.svg frames bob the whole
+//      body 1px; these deliberately don't.) That's why head-attached layers
+//      ship a single frameless SVG and only the body layers have -1/-2/-3.
+//
+// Tinted layers are filled #ffffff so sprite.tint colours them; untinted layers
+// (the shadow's soft black, the eyes' dark brown) carry their own colours and
+// are left at the default white tint.
+
+export const TOWNSFOLK_BODIES = ['tunic', 'robe', 'apron'] as const
+export const TOWNSFOLK_HAIR   = ['short', 'long', 'bun', 'curly'] as const
+export const TOWNSFOLK_HATS   = ['cap', 'wide', 'hood'] as const
+
+export type TownsfolkBody = typeof TOWNSFOLK_BODIES[number]
+export type TownsfolkHair = typeof TOWNSFOLK_HAIR[number]
+export type TownsfolkHat  = typeof TOWNSFOLK_HATS[number]
+
+export interface TownsfolkLook {
+  body:       TownsfolkBody
+  hair:       TownsfolkHair
+  /** Bare-headed when absent. */
+  hat?:       TownsfolkHat
+  skin:       number
+  outfit:     number
+  accent:     number
+  hairColour: number
+  hatColour:  number
+}
+
+export interface TownsfolkLayer {
+  /** Sprite filename stem, without the -1/-2/-3 frame suffix. */
+  slug:      string
+  /** PIXI tint; 0xffffff leaves the SVG's own colours alone. */
+  tint:      number
+  /** Whether `${slug}-1/-2/-3.svg` exist and should animate with the walk cycle. */
+  animated:  boolean
+  /** Draw order relative to the base sprite's zIndex. */
+  z:         number
+}
+
+// ── Palettes ────────────────────────────────────────────────────────────────
+// Deliberately muted and earthy: a dozen of these are on screen at once, and
+// saturated clothing would pull the eye away from named NPCs and interactables.
+
+export const SKIN_TONES = [
+  0xffdcbc, 0xf0c9a0, 0xd9a273, 0xb87f4d, 0xa9713f, 0x7a4a26, 0x5a3418, 0x402410,
+]
+
+export const HAIR_COLOURS = [
+  0x2a1a0a, 0x4a3018, 0x6b4020, 0x8b5e3c, 0xc8a050, 0xa83a3a, 0xe8e0d8, 0x9aa0a6,
+]
+
+export const OUTFIT_COLOURS = [
+  0x4a6fa5, 0x3a5a6b, 0x4a8b5c, 0x6b7f3a, 0x8b4a4a, 0xa5793a,
+  0x6b4a8b, 0x8b6f5e, 0x5c6b7a, 0xa55a7a, 0x3f7a6b, 0x7a6a3a,
+]
+
+export const ACCENT_COLOURS = [
+  0xd4af37, 0xe8e0d8, 0x2a2a2a, 0xc05a5a, 0x5ac0a0, 0x8b5e3c,
+  0x6b4020, 0xb0b8c0, 0xe0b050, 0x4a4a5a,
+]
+
+export const HAT_COLOURS = [
+  0x8b5e3c, 0x2a2a2a, 0x6b4020, 0x4a5a6b, 0xa5793a, 0x5a6b4a, 0xc05a5a, 0xe8e0d8,
+]
+
+// ── Layer assembly ──────────────────────────────────────────────────────────
+
+const UNTINTED = 0xffffff
+
+/**
+ * The full ordered layer stack for a look. `base` is the sprite that owns the
+ * hit area and the walk animation (the outfit — the largest silhouette, so it
+ * makes the best tap target); `overlays` are cosmetic siblings glued to it,
+ * ordered back to front by their `z` offset.
+ */
+export function townsfolkLayers(look: TownsfolkLook): { base: TownsfolkLayer; overlays: TownsfolkLayer[] } {
+  const overlays: TownsfolkLayer[] = [
+    { slug: 'townsfolk-shadow',                tint: UNTINTED,        animated: false, z: -0.2 },
+    { slug: `townsfolk-${look.body}-accent`,   tint: look.accent,     animated: true,  z:  0.1 },
+    { slug: 'townsfolk-skin',                  tint: look.skin,       animated: false, z:  0.2 },
+    { slug: 'townsfolk-face',                  tint: UNTINTED,        animated: false, z:  0.3 },
+    { slug: `townsfolk-hair-${look.hair}`,     tint: look.hairColour, animated: false, z:  0.4 },
+  ]
+  if (look.hat) {
+    overlays.push({ slug: `townsfolk-hat-${look.hat}`, tint: look.hatColour, animated: false, z: 0.5 })
+  }
+  return {
+    base: { slug: `townsfolk-${look.body}-outfit`, tint: look.outfit, animated: true, z: 0 },
+    overlays,
+  }
+}
+
+/** Every sprite stem the townsfolk catalog can ever reference — used by tests
+ *  to assert the art on disk matches the data. */
+export function allTownsfolkSlugs(): string[] {
+  const slugs = ['townsfolk-shadow', 'townsfolk-skin', 'townsfolk-face']
+  for (const body of TOWNSFOLK_BODIES) {
+    slugs.push(`townsfolk-${body}-outfit`, `townsfolk-${body}-accent`)
+  }
+  for (const hair of TOWNSFOLK_HAIR) slugs.push(`townsfolk-hair-${hair}`)
+  for (const hat of TOWNSFOLK_HATS) slugs.push(`townsfolk-hat-${hat}`)
+  return slugs
+}

--- a/web/src/game/hub/ambientDialogue.test.ts
+++ b/web/src/game/hub/ambientDialogue.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AMBIENT_LINES_GENERIC, DAY_LINES, NIGHT_LINES, GHOST_LINES,
+  ARRIVAL_LINES, DOORWAY_LINES, INDOOR_LINES, RAIN_LINES, SNOW_LINES, FOG_LINES,
+  SCARED_PHRASES,
+  ambientLinePool, contextKey, makeAmbientLineCursor, nextAmbientLine,
+  type AmbientLineContext,
+} from './ambientDialogue'
+
+const ctx = (over: Partial<AmbientLineContext> = {}): AmbientLineContext => ({
+  isNight: false, weather: 'clear', isGhost: false, situation: 'street', ...over,
+})
+
+const ALL_POOLS = {
+  AMBIENT_LINES_GENERIC, DAY_LINES, NIGHT_LINES, GHOST_LINES,
+  ARRIVAL_LINES, DOORWAY_LINES, INDOOR_LINES, RAIN_LINES, SNOW_LINES, FOG_LINES,
+  SCARED_PHRASES,
+}
+
+describe('line pools', () => {
+  it('replaces the old eight-line pool with a substantial one', () => {
+    expect(AMBIENT_LINES_GENERIC.length).toBeGreaterThanOrEqual(100)
+  })
+
+  it('has no duplicate line within any pool', () => {
+    for (const [name, pool] of Object.entries(ALL_POOLS)) {
+      expect(new Set(pool).size, name).toBe(pool.length)
+    }
+  })
+
+  it('has no blank or untrimmed lines', () => {
+    for (const [name, pool] of Object.entries(ALL_POOLS)) {
+      for (const line of pool) {
+        expect(line.trim(), name).toBe(line)
+        expect(line.length, name).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('keeps lines short enough for a speech bubble', () => {
+    for (const pool of Object.values(ALL_POOLS)) {
+      for (const line of pool) expect(line.length).toBeLessThanOrEqual(70)
+    }
+  })
+})
+
+describe('ambientLinePool', () => {
+  it('layers day lines onto the generic pool by day', () => {
+    const pool = ambientLinePool(ctx())
+    expect(pool).toEqual(expect.arrayContaining([...AMBIENT_LINES_GENERIC, ...DAY_LINES]))
+    expect(pool).not.toEqual(expect.arrayContaining(NIGHT_LINES))
+  })
+
+  it('swaps in night lines after dark', () => {
+    const pool = ambientLinePool(ctx({ isNight: true }))
+    expect(pool).toEqual(expect.arrayContaining(NIGHT_LINES))
+    for (const line of DAY_LINES) expect(pool).not.toContain(line)
+  })
+
+  it('adds weather lines only for weather that is actually happening', () => {
+    expect(ambientLinePool(ctx({ weather: 'rain' }))).toEqual(expect.arrayContaining(RAIN_LINES))
+    const clear = ambientLinePool(ctx({ weather: 'clear' }))
+    for (const line of [...RAIN_LINES, ...SNOW_LINES, ...FOG_LINES]) expect(clear).not.toContain(line)
+  })
+
+  it('drops weather lines indoors, where nobody can see the sky', () => {
+    const pool = ambientLinePool(ctx({ weather: 'snow', situation: 'indoors' }))
+    for (const line of SNOW_LINES) expect(pool).not.toContain(line)
+    expect(pool).toEqual(expect.arrayContaining(INDOOR_LINES))
+  })
+
+  it('adds situation lines for arriving and doorway wanderers', () => {
+    expect(ambientLinePool(ctx({ situation: 'arriving' }))).toEqual(expect.arrayContaining(ARRIVAL_LINES))
+    expect(ambientLinePool(ctx({ situation: 'doorway' }))).toEqual(expect.arrayContaining(DOORWAY_LINES))
+  })
+
+  it('lets ghosts speak only ghost lines', () => {
+    const pool = ambientLinePool(ctx({ isGhost: true, isNight: true, weather: 'fog' }))
+    expect(pool).toEqual(GHOST_LINES)
+  })
+})
+
+describe('contextKey', () => {
+  it('changes when any context field changes', () => {
+    const base = contextKey(ctx())
+    for (const over of [
+      { isNight: true }, { weather: 'fog' as const }, { isGhost: true }, { situation: 'indoors' as const },
+    ]) {
+      expect(contextKey(ctx(over))).not.toBe(base)
+    }
+  })
+})
+
+describe('nextAmbientLine', () => {
+  it('walks the whole pool before repeating anything', () => {
+    const c = ctx()
+    const cursor = makeAmbientLineCursor('npc-1', c)
+    const size = cursor.queue.length
+    const seen = Array.from({ length: size }, () => nextAmbientLine(cursor, 'npc-1', c))
+    expect(new Set(seen).size).toBe(size)
+  })
+
+  it('reshuffles on wrap instead of replaying the same order', () => {
+    const c = ctx()
+    const cursor = makeAmbientLineCursor('npc-2', c)
+    const size = cursor.queue.length
+    const first = Array.from({ length: size }, () => nextAmbientLine(cursor, 'npc-2', c))
+    const second = Array.from({ length: size }, () => nextAmbientLine(cursor, 'npc-2', c))
+    expect(second).not.toEqual(first)
+    expect(new Set(second).size).toBe(size)
+  })
+
+  it('never repeats the previous line across the wrap', () => {
+    const c = ctx()
+    for (const seed of ['a', 'b', 'c', 'd', 'e']) {
+      const cursor = makeAmbientLineCursor(seed, c)
+      let last = ''
+      for (let i = 0; i <= cursor.queue.length; i++) {
+        const line = nextAmbientLine(cursor, seed, c)
+        expect(line).not.toBe(last)
+        last = line
+      }
+    }
+  })
+
+  it('rebuilds the queue when the context changes', () => {
+    const cursor = makeAmbientLineCursor('npc-3', ctx())
+    nextAmbientLine(cursor, 'npc-3', ctx())
+    const line = nextAmbientLine(cursor, 'npc-3', ctx({ isGhost: true }))
+    expect(GHOST_LINES).toContain(line)
+    expect(cursor.idx).toBe(1)
+  })
+
+  it('gives two wanderers in the same context different line orders', () => {
+    const c = ctx()
+    const a = makeAmbientLineCursor('npc-a', c)
+    const b = makeAmbientLineCursor('npc-b', c)
+    expect(a.queue).not.toEqual(b.queue)
+    expect([...a.queue].sort()).toEqual([...b.queue].sort())
+  })
+
+  it('is deterministic for a given wanderer', () => {
+    const c = ctx({ isNight: true, weather: 'snow' })
+    expect(makeAmbientLineCursor('npc-4', c).queue).toEqual(makeAmbientLineCursor('npc-4', c).queue)
+  })
+
+  it('recovers if a cursor is somehow left with an empty queue', () => {
+    const c = ctx()
+    const cursor = makeAmbientLineCursor('npc-5', c)
+    cursor.queue = []
+    expect(typeof nextAmbientLine(cursor, 'npc-5', c)).toBe('string')
+  })
+})

--- a/web/src/game/hub/ambientDialogue.ts
+++ b/web/src/game/hub/ambientDialogue.ts
@@ -1,0 +1,374 @@
+// ─── Flavour lines for wandering hub-town NPCs ──────────────────────────────
+//
+// Wanderers are anonymous townsfolk, so unlike named NPCs they have no authored
+// dialogue array in a town's config.json and no dialogue modal — tapping one
+// pops a single cosmetic speech bubble and changes no game state. This used to
+// draw on eight hardcoded lines shared by every NPC in every town, which a
+// player exhausted in about a minute.
+//
+// Now there's a large generic pool plus smaller pools layered on by context
+// (time of day, weather, whether the NPC is a ghost, and what they're doing).
+// Each wanderer walks a seeded shuffle of the merged pool, so repeat taps on
+// the same person keep producing new lines rather than looping a short list.
+//
+// Nothing here imports PIXI or reads storage — it's pure data plus a cursor, so
+// it tests without a canvas.
+
+import { hashStr, makeSeededRng, seededShuffle } from '../seededRandom'
+import type { WeatherType } from './weather'
+
+/** What the wanderer is doing when tapped. */
+export type AmbientSituation =
+  | 'street'    // out walking the town
+  | 'arriving'  // just walked in from an exit tile, fresh off the road
+  | 'doorway'   // standing at a building's door, about to head in
+  | 'indoors'   // tapped inside a building they'd wandered into
+
+export interface AmbientLineContext {
+  isNight:   boolean
+  weather:   WeatherType
+  isGhost:   boolean
+  situation: AmbientSituation
+}
+
+// ── Generic pool ────────────────────────────────────────────────────────────
+// Everyday townsfolk chatter: errands, gossip, weather, opinions about the
+// player's line of work. Kept short — the speech bubble wraps at 160px.
+
+export const AMBIENT_LINES_GENERIC = [
+  'Lovely day for it.',
+  'Mind where you step.',
+  "Can't stop to chat, sorry!",
+  'Have you seen the notice board?',
+  'Busy, busy — you know how it is.',
+  'Watch yourself out there.',
+  'Off to run an errand.',
+  "I'll catch you later!",
+  'Morning! Or afternoon. One of those.',
+  "You're that duellist everyone talks about, aren't you?",
+  'Heard the arena was packed last night.',
+  'My cousin swears by a good wall. I say build two.',
+  "Crystals don't spend themselves.",
+  'Somebody left a cart in the middle of the road again.',
+  'The bread here is better than it has any right to be.',
+  "Don't buy the cheap packs. Learn from my mistakes.",
+  'I keep meaning to take up fishing.',
+  "There's a queue at the shop. There's always a queue.",
+  'Nice cloak. Is that new?',
+  "If you're looking for the inn, it's the loud one.",
+  'I lost a whole afternoon at the card tables. Worth it.',
+  'They say a dragon card turned up in a common pack. Rubbish, obviously.',
+  "My knees say rain. My knees are usually right.",
+  'Have you tried the stew? Do try the stew.',
+  "Someone's chickens are loose. Again.",
+  'The roads are safer than they were, I will say that.',
+  "I've a bounty to hand in, if I can find the desk.",
+  'Not from around here, are you?',
+  'Everything costs double what it did last season.',
+  "I'd help, but I've a delivery to make.",
+  'Careful past the well. It gets slippery.',
+  "You look like someone with somewhere to be.",
+  'Best of luck out there. Genuinely.',
+  'They repaired the fence at last. Only took a year.',
+  "My deck's all structures. I know, I know.",
+  'A good day for staying out of trouble.',
+  "Did you hear? No? Never mind then.",
+  'I owe the innkeeper money. Keep that between us.',
+  "There's a card sharp working the square. Allegedly.",
+  'My sister moved to the capital. Says it smells.',
+  "You get used to the noise from the arena.",
+  'Somebody ought to sweep this street.',
+  "I've never won a single bounty. Not one.",
+  'The theatre is doing that play again. The long one.',
+  "Mind the puddle — deeper than it looks.",
+  'They say the harbour master hoards relics.',
+  "I only came out for bread. Now look at me.",
+  'A merchant tried to sell me a cursed amulet. Tried.',
+  "Everyone's a strategist until the mana runs out.",
+  'Have a good one!',
+  "I'm told the pet shelter has kittens again.",
+  'You should see this place during a festival.',
+  "Ask the elder. He knows things. Some of them true.",
+  'My neighbour plays nothing but goblins. Nothing.',
+  "That's a fine looking companion you've got there.",
+  'Prices at the augment shop are daylight robbery.',
+  "I keep hearing something under the floorboards.",
+  'Careful who you trade with down by the docks.',
+  "Been meaning to fix that gate for weeks.",
+  'You lot make it look easy, you duellists.',
+  "There's a trick to the casino. I haven't found it.",
+  'Long day. Long week, really.',
+  "I saw a rare card once. Held it and everything.",
+  'They reckon the campaign is going well. They always reckon that.',
+  "Nothing ever happens here. Which is fine by me.",
+  'I could sleep for a week.',
+  "You didn't hear it from me, but the shop restocks at dawn.",
+  'The mason wants three hundred crystals. Three hundred!',
+  "Every year the winters get longer.",
+  'Watch the cobbles by the fountain, they lift.',
+  "My boy wants to be a commander. I've told him.",
+  'Somebody stole my washing off the line.',
+  "There's talk of bandits on the north road. Talk, mind.",
+  'I did try the arena once. Once was plenty.',
+  "The blacksmith's apprentice is better than the blacksmith.",
+  'Good to see a friendly face.',
+  "I've walked this square ten thousand times.",
+  "Coin in, coin out. That's the trade.",
+  "You're braver than me, and I'm not being polite.",
+  'They keep promising a new well.',
+  "I sold a relic for a song. Still think about it.",
+  'Careful, the herald bites. Figuratively.',
+  "There's a decent forage spot past the trees.",
+  'Do you ever just stop and look at the sky?',
+  "I hear the theatre pays well if you can act.",
+  "Nobody reads the notice board. I read the notice board.",
+  'That was a good harvest, all things considered.',
+  "You'd think they'd pave the whole square.",
+  'I traded my best card for a hat. No regrets.',
+  "Something's off about that new shop.",
+  'The guards are useless but they mean well.',
+  "I'm not lost. I'm taking the long way.",
+  'Bit of exercise never hurt anyone.',
+  "My luck at the tables is legendary. Badly legendary.",
+  'They say the old keep is haunted. They say a lot.',
+  "I'd invite you in, but the place is a state.",
+  'Ever tried building a farm first? Changes everything.',
+  "You can smell the forge from here.",
+  'One of these days I will learn to swim.',
+  "The cartographer charges by the mile. The mile!",
+  'Nice to see the streets busy again.',
+  "I've a cousin in every town, if you can believe it.",
+  'Just off to feed the chickens.',
+  "That bell rings at the strangest hours.",
+  'Fair trade is the only trade.',
+  "Do you know, I've never left this valley.",
+  'Somebody give that dog a home.',
+  "Mind how you go.",
+  'I heard they found something in the ruins.',
+  "The market's thin this week.",
+  "Whole town turns out when there's a duel.",
+  "I'd rather mend a fence than fight a troll.",
+  'You want the shop with the blue door, not the green.',
+  "Been on my feet since dawn.",
+  'They still owe me for last month.',
+  "Quiet is underrated, I always say.",
+  "If you find a lost key, it's mine.",
+  "The kids have been drawing on the walls again.",
+  'Pleasure. Truly.',
+]
+
+// ── Context pools ───────────────────────────────────────────────────────────
+
+export const DAY_LINES = [
+  'Good light today. Makes a difference.',
+  "The market's open, if you're quick.",
+  'Everyone out at once, as usual.',
+  "I've a full day ahead of me.",
+  'Shop opens on the hour, not before.',
+  'Washing out, sun up. Perfect.',
+  "The square's lovely this time of day.",
+  'Off to work. As one is.',
+  'Half the town is queuing for something.',
+  "Best get on before the crowds.",
+  'Deliveries all morning. My back knows it.',
+  "Fine day to be outdoors, wouldn't you say?",
+]
+
+export const NIGHT_LINES = [
+  "Late to be wandering, isn't it?",
+  "I'd be home by now if I had any sense.",
+  'The lamps need trimming again.',
+  "Don't go past the walls after dark.",
+  'Quiet, this hour. I like it.',
+  "Something's been howling out east.",
+  'Watch is late. Watch is always late.',
+  "Can't sleep. Never can.",
+  'The inn is the only place still lit.',
+  "Mind the steps, you'll not see them.",
+  'Everything looks different at night.',
+  "I heard footsteps behind me. Twice.",
+  'Nearly walked into you there.',
+  "Stars are out, at least.",
+  'Only fools and duellists are up this late.',
+  "I'll not be out here long, I promise you that.",
+]
+
+export const RAIN_LINES = [
+  'Soaked through, and it is only midday.',
+  "Told you my knees were right.",
+  'Rain like this ruins a good cloak.',
+  "The gutters can't take it.",
+  'Third day of this. Third!',
+  "Good weather for ducks and nobody else.",
+  'I left the washing out. I know. I know.',
+  "Mind the puddles, they're deeper than they look.",
+]
+
+export const SNOW_LINES = [
+  "Can't feel my hands.",
+  'Snow this early is a bad sign.',
+  "The road north will be shut by morning.",
+  'Pretty until you have to walk in it.',
+  "We'll be burning furniture by midwinter.",
+  'Kids love it. Nobody else does.',
+  "Careful, there's ice under that.",
+  'I have three coats on and it is not enough.',
+]
+
+export const FOG_LINES = [
+  "Can't see the far side of the square.",
+  'I walked into a cart. A whole cart.',
+  "Fog like this, anything could be out there.",
+  'Sounds carry strangely in it.',
+  "Is that you? It is you. Good.",
+  'I do not like fog. Never have.',
+  "Stay on the path and you'll be fine.",
+  'It burns off by noon. Usually.',
+]
+
+export const GHOST_LINES = [
+  'Cold… so cold…',
+  "Have you seen my house? It was here…",
+  'I only meant to stay one more night…',
+  "…is it still autumn?",
+  'Nobody remembers the name.',
+  "I keep walking the same street…",
+  'Do you hear the bell too?',
+  "I was owed money. I am still owed money.",
+  'Something took the long road with me…',
+  "…you can see me?",
+  'The door was open. It should not have been open.',
+  "Tell them I got home. Tell them.",
+]
+
+export const ARRIVAL_LINES = [
+  'Just off the road — what a journey.',
+  "First time in this town. Where's the inn?",
+  'Three days of walking. Three.',
+  "Somewhere to sleep, that's all I want.",
+  'Is the market still open?',
+  "I've come a long way. Longer than planned.",
+  'Roads were quieter than I expected.',
+  "New town, same aching feet.",
+  'Do they take outside coin here?',
+  "Point me at the nearest hot meal.",
+]
+
+export const DOORWAY_LINES = [
+  'Just popping in.',
+  "Hope they're still serving.",
+  'After you — no, go on.',
+  "I'll only be a moment.",
+  'Told them I would be here at noon.',
+  "Wish me luck in there.",
+  'This had better be open.',
+  "Mind the step on the way in.",
+]
+
+export const INDOOR_LINES = [
+  'Warmer in here, at least.',
+  "Been waiting ages to be served.",
+  'They know me here.',
+  "Do you know what you're ordering?",
+  'I come in mostly for the quiet.',
+  "Prices went up again. Of course they did.",
+  'Shake the rain off before you come further in.',
+  "I'll be out of your way in a moment.",
+  'Best seat in the place, this.',
+  "Don't tell them I'm here.",
+]
+
+/** Scared reactions when a ghost drifts too close — kept separate from the tap
+ *  pools so a fright never clobbers a tap line, or vice versa. */
+export const SCARED_PHRASES = [
+  'Did you see that?!', 'Is someone there…?', 'Something is wrong…',
+  'A ghost!! A ghost!!', 'Did it just get cold?', 'Please no please no',
+  'What was THAT?!', "I can't feel my legs…", 'Run!! RUN!!',
+  'That was not a person.', 'I am going home. Right now.',
+  'Tell me you saw it too!', 'Nope. Nope. Nope.',
+  'It went straight through the wall!',
+]
+
+// ── Pool assembly ───────────────────────────────────────────────────────────
+
+const WEATHER_LINES: Record<WeatherType, string[]> = {
+  clear: [],
+  rain:  RAIN_LINES,
+  snow:  SNOW_LINES,
+  fog:   FOG_LINES,
+}
+
+const SITUATION_LINES: Record<AmbientSituation, string[]> = {
+  street:   [],
+  arriving: ARRIVAL_LINES,
+  doorway:  DOORWAY_LINES,
+  indoors:  INDOOR_LINES,
+}
+
+/**
+ * The lines a wanderer can say in this context. Ghosts speak only their own
+ * pool — a ghost complaining about bread prices undercuts the whole effect.
+ * Everyone else gets the generic pool plus whatever context applies; weather
+ * lines are dropped indoors, where the speaker can't see the sky.
+ */
+export function ambientLinePool(ctx: AmbientLineContext): string[] {
+  if (ctx.isGhost) return GHOST_LINES
+  const pool = [
+    ...AMBIENT_LINES_GENERIC,
+    ...(ctx.isNight ? NIGHT_LINES : DAY_LINES),
+    ...SITUATION_LINES[ctx.situation],
+  ]
+  if (ctx.situation !== 'indoors') pool.push(...WEATHER_LINES[ctx.weather])
+  return pool
+}
+
+/** Identifies a context for cache purposes — when this changes, a wanderer's
+ *  queue is rebuilt so the new pool actually gets used. */
+export function contextKey(ctx: AmbientLineContext): string {
+  return `${ctx.isGhost ? 'g' : '-'}${ctx.isNight ? 'n' : 'd'}:${ctx.weather}:${ctx.situation}`
+}
+
+/** A wanderer's position in its personal shuffle of the pool. */
+export interface AmbientLineCursor {
+  queue: string[]
+  idx:   number
+  key:   string
+}
+
+export function makeAmbientLineCursor(seed: number | string, ctx: AmbientLineContext): AmbientLineCursor {
+  const s = typeof seed === 'number' ? seed : hashStr(seed)
+  return {
+    queue: seededShuffle(ambientLinePool(ctx), makeSeededRng(s ^ 0xd1a109)),
+    idx:   0,
+    key:   contextKey(ctx),
+  }
+}
+
+/**
+ * The wanderer's next line, advancing (and where needed rebuilding) its cursor.
+ * Reshuffles on wrap rather than replaying the same order forever, and never
+ * repeats the line that just ended the previous pass.
+ */
+export function nextAmbientLine(
+  cursor: AmbientLineCursor,
+  seed: number | string,
+  ctx: AmbientLineContext,
+): string {
+  const s = typeof seed === 'number' ? seed : hashStr(seed)
+  const key = contextKey(ctx)
+  if (key !== cursor.key || cursor.queue.length === 0) {
+    const fresh = makeAmbientLineCursor(s, ctx)
+    cursor.queue = fresh.queue
+    cursor.idx   = 0
+    cursor.key   = key
+  } else if (cursor.idx >= cursor.queue.length) {
+    const last = cursor.queue[cursor.queue.length - 1]
+    let reshuffled = seededShuffle(cursor.queue, makeSeededRng((s ^ 0xd1a109) + cursor.queue.length))
+    if (reshuffled.length > 1 && reshuffled[0] === last) {
+      reshuffled = [reshuffled[1], reshuffled[0], ...reshuffled.slice(2)]
+    }
+    cursor.queue = reshuffled
+    cursor.idx   = 0
+  }
+  return cursor.queue[cursor.idx++]
+}

--- a/web/src/game/hub/ambientNpcIdentity.test.ts
+++ b/web/src/game/hub/ambientNpcIdentity.test.ts
@@ -132,9 +132,9 @@ describe('buildUnitSlugPool', () => {
   })
 
   it('shuffles the catalog deterministically per seed', () => {
-    const args = [[] as string[], ['a', 'b', 'c', 'd', 'e', 'f']] as const
-    expect(buildUnitSlugPool(...args, 'x')).toEqual(buildUnitSlugPool(...args, 'x'))
-    expect(buildUnitSlugPool(...args, 'x')).not.toEqual(buildUnitSlugPool(...args, 'y'))
+    const catalog = ['a', 'b', 'c', 'd', 'e', 'f']
+    expect(buildUnitSlugPool([], catalog, 'x')).toEqual(buildUnitSlugPool([], catalog, 'x'))
+    expect(buildUnitSlugPool([], catalog, 'x')).not.toEqual(buildUnitSlugPool([], catalog, 'y'))
   })
 
   it('copes with no preferred sprites and no catalog', () => {

--- a/web/src/game/hub/ambientNpcIdentity.test.ts
+++ b/web/src/game/hub/ambientNpcIdentity.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { createAmbientRoster, buildUnitSlugPool } from './ambientNpcIdentity'
+import { RESIDENT_FIRST_NAMES, WANDERER_SURNAMES } from '../names'
+import {
+  TOWNSFOLK_BODIES, TOWNSFOLK_HAIR, TOWNSFOLK_HATS,
+  SKIN_TONES, HAIR_COLOURS, OUTFIT_COLOURS, ACCENT_COLOURS, HAT_COLOURS,
+} from '../../data/townsfolk'
+
+const UNITS = ['knight', 'archer', 'goblin', 'wizard', 'farmer']
+
+const mintMany = (n: number, seed: string | number = 'ravenwatch', unitSlugs = UNITS) => {
+  const roster = createAmbientRoster({ seed, unitSlugs })
+  return { roster, npcs: Array.from({ length: n }, () => roster.mint()) }
+}
+
+describe('createAmbientRoster names', () => {
+  it('never gives two live wanderers the same name', () => {
+    const { npcs } = mintMany(60)
+    expect(new Set(npcs.map(n => n.name)).size).toBe(60)
+  })
+
+  it('gives every wanderer a distinct id', () => {
+    const { npcs } = mintMany(60)
+    expect(new Set(npcs.map(n => n.id)).size).toBe(60)
+  })
+
+  it('draws both halves of the name from the shared pools', () => {
+    for (const npc of mintMany(30).npcs) {
+      const [first, surname] = npc.name.split(' ')
+      expect(RESIDENT_FIRST_NAMES).toContain(first)
+      expect(WANDERER_SURNAMES).toContain(surname)
+    }
+  })
+
+  it('frees a released name for reuse', () => {
+    const roster = createAmbientRoster({ seed: 'millhaven', unitSlugs: UNITS })
+    const first = roster.mint()
+    roster.release(first.id)
+    expect(roster.size()).toBe(0)
+    // Exhausting the pool would be impractical, so assert the bookkeeping
+    // instead: the released name is no longer held against anyone.
+    const rest = Array.from({ length: 40 }, () => roster.mint())
+    expect(new Set(rest.map(n => n.name)).size).toBe(40)
+  })
+
+  it('ignores a release for an unknown id', () => {
+    const roster = createAmbientRoster({ seed: 1, unitSlugs: UNITS })
+    roster.mint()
+    roster.release('not-a-wanderer')
+    expect(roster.size()).toBe(1)
+  })
+})
+
+describe('createAmbientRoster determinism', () => {
+  it('produces an identical roster for the same seed', () => {
+    expect(mintMany(20, 'gearford').npcs).toEqual(mintMany(20, 'gearford').npcs)
+  })
+
+  it('produces a different roster for a different seed', () => {
+    const a = mintMany(20, 'gearford').npcs.map(n => n.name)
+    const b = mintMany(20, 'appleford').npcs.map(n => n.name)
+    expect(a).not.toEqual(b)
+  })
+
+  it('accepts a numeric seed as readily as a string one', () => {
+    expect(mintMany(5, 12345).npcs).toEqual(mintMany(5, 12345).npcs)
+  })
+})
+
+describe('createAmbientRoster looks', () => {
+  it('mixes composite townsfolk with card-unit sprites', () => {
+    const kinds = new Set(mintMany(40).npcs.map(n => n.look.kind))
+    expect(kinds).toEqual(new Set(['townsfolk', 'unit']))
+  })
+
+  it('only ever dresses unit wanderers in slugs it was given', () => {
+    for (const npc of mintMany(40).npcs) {
+      if (npc.look.kind === 'unit') expect(UNITS).toContain(npc.look.slug)
+    }
+  })
+
+  it('falls back to all-townsfolk when a town has no sprite pool at all', () => {
+    const { npcs } = mintMany(20, 'dreadspire', [])
+    expect(npcs.every(n => n.look.kind === 'townsfolk')).toBe(true)
+  })
+
+  it('honours townsfolkShare at its extremes', () => {
+    const all = createAmbientRoster({ seed: 1, unitSlugs: UNITS, townsfolkShare: 1 })
+    const none = createAmbientRoster({ seed: 1, unitSlugs: UNITS, townsfolkShare: 0 })
+    expect(Array.from({ length: 20 }, () => all.mint()).every(n => n.look.kind === 'townsfolk')).toBe(true)
+    expect(Array.from({ length: 20 }, () => none.mint()).every(n => n.look.kind === 'unit')).toBe(true)
+  })
+
+  it('builds every townsfolk look out of catalog parts and palette colours', () => {
+    for (const npc of mintMany(80).npcs) {
+      if (npc.look.kind !== 'townsfolk') continue
+      const l = npc.look
+      expect(TOWNSFOLK_BODIES).toContain(l.body)
+      expect(TOWNSFOLK_HAIR).toContain(l.hair)
+      if (l.hat !== undefined) expect(TOWNSFOLK_HATS).toContain(l.hat)
+      expect(SKIN_TONES).toContain(l.skin)
+      expect(OUTFIT_COLOURS).toContain(l.outfit)
+      expect(ACCENT_COLOURS).toContain(l.accent)
+      expect(HAIR_COLOURS).toContain(l.hairColour)
+      expect(HAT_COLOURS).toContain(l.hatColour)
+    }
+  })
+
+  it('leaves some townsfolk bare-headed and hats others', () => {
+    const hats = mintMany(80).npcs
+      .filter(n => n.look.kind === 'townsfolk')
+      .map(n => (n.look.kind === 'townsfolk' ? n.look.hat : undefined))
+    expect(hats.some(h => h === undefined)).toBe(true)
+    expect(hats.some(h => h !== undefined)).toBe(true)
+  })
+})
+
+describe('buildUnitSlugPool', () => {
+  it("puts the town's own sprites first so towns keep their character", () => {
+    const pool = buildUnitSlugPool(['fisherman', 'merchant'], ['knight', 'goblin', 'archer'], 'millhaven')
+    expect(pool.slice(0, 2)).toEqual(['fisherman', 'merchant'])
+    expect(pool).toHaveLength(5)
+  })
+
+  it('drops duplicates without disturbing preference order', () => {
+    const pool = buildUnitSlugPool(['knight', 'knight'], ['archer', 'knight'], 1)
+    expect(pool).toEqual(['knight', 'archer'])
+  })
+
+  it('drops empty slugs', () => {
+    expect(buildUnitSlugPool([''], ['', 'archer'], 1)).toEqual(['archer'])
+  })
+
+  it('shuffles the catalog deterministically per seed', () => {
+    const args = [[] as string[], ['a', 'b', 'c', 'd', 'e', 'f']] as const
+    expect(buildUnitSlugPool(...args, 'x')).toEqual(buildUnitSlugPool(...args, 'x'))
+    expect(buildUnitSlugPool(...args, 'x')).not.toEqual(buildUnitSlugPool(...args, 'y'))
+  })
+
+  it('copes with no preferred sprites and no catalog', () => {
+    expect(buildUnitSlugPool([], [], 1)).toEqual([])
+  })
+})

--- a/web/src/game/hub/ambientNpcIdentity.ts
+++ b/web/src/game/hub/ambientNpcIdentity.ts
@@ -1,0 +1,154 @@
+// ─── Identity for wandering hub-town NPCs ───────────────────────────────────
+//
+// The town's wandering ("ambient") NPCs used to be pure rendering state: no id,
+// no name, and a sprite picked from whatever unit cards happened to be in the
+// player's deck. This mints them an identity instead — a name nobody else in
+// town shares, and a look that's either a tinted composite townsfolk (see
+// data/townsfolk.ts) or one of the game's several hundred unit-card sprites.
+//
+// Deliberately free of PIXI and of anything that touches localStorage: a roster
+// is a plain seeded generator, so it can be unit-tested and reasoned about
+// without a canvas. A roster lives for one town visit — wanderers were never
+// persisted across reloads, and giving them save-file presence isn't the goal.
+
+import { hashStr, makeSeededRng, seededShuffle } from '../seededRandom'
+import { RESIDENT_FIRST_NAMES, WANDERER_SURNAMES } from '../names'
+import {
+  TOWNSFOLK_BODIES, TOWNSFOLK_HAIR, TOWNSFOLK_HATS,
+  SKIN_TONES, HAIR_COLOURS, OUTFIT_COLOURS, ACCENT_COLOURS, HAT_COLOURS,
+  type TownsfolkLook,
+} from '../../data/townsfolk'
+
+export type AmbientNpcLook =
+  | ({ kind: 'townsfolk' } & TownsfolkLook)
+  | { kind: 'unit'; slug: string }
+
+export interface AmbientNpcIdentity {
+  /** Unique within a roster; also the seed for this NPC's dialogue queue. */
+  id:   string
+  name: string
+  look: AmbientNpcLook
+}
+
+export interface AmbientRoster {
+  /** Mints one wanderer. Never returns a name another live wanderer holds. */
+  mint(): AmbientNpcIdentity
+  /** Hands a wanderer's name back to the pool when they despawn. */
+  release(id: string): void
+  /** Live wanderer count — mostly for tests and debugging. */
+  size(): number
+}
+
+export interface AmbientRosterOptions {
+  /** Anything stable per town visit; hashed, so a string or number both work. */
+  seed: number | string
+  /** Card-sprite slugs this town may dress wanderers in, most-preferred first. */
+  unitSlugs: string[]
+  /** Fraction of wanderers built as composite townsfolk rather than card units. */
+  townsfolkShare?: number
+}
+
+const DEFAULT_TOWNSFOLK_SHARE = 0.6
+
+/** Chance a townsfolk wanderer wears a hat at all (the rest go bare-headed). */
+const HAT_CHANCE = 0.45
+
+function pick<T>(arr: readonly T[], rng: () => number): T {
+  return arr[Math.floor(rng() * arr.length) % arr.length]
+}
+
+function makeTownsfolkLook(rng: () => number): AmbientNpcLook {
+  return {
+    kind:       'townsfolk',
+    body:       pick(TOWNSFOLK_BODIES, rng),
+    hair:       pick(TOWNSFOLK_HAIR, rng),
+    hat:        rng() < HAT_CHANCE ? pick(TOWNSFOLK_HATS, rng) : undefined,
+    skin:       pick(SKIN_TONES, rng),
+    outfit:     pick(OUTFIT_COLOURS, rng),
+    accent:     pick(ACCENT_COLOURS, rng),
+    hairColour: pick(HAIR_COLOURS, rng),
+    hatColour:  pick(HAT_COLOURS, rng),
+  }
+}
+
+/**
+ * Creates the identity generator for one town visit.
+ *
+ * Names come from a seeded shuffle of first x surname pairs, walked in order
+ * and skipping any name a live wanderer already holds — so a town never shows
+ * two Miras at once, and a released name can come back later on somebody new.
+ * (The city builder's residentName() deliberately has no such guarantee: it's a
+ * pure function of grid position and tolerates collisions. Reuse its name pool,
+ * not its uniqueness story.)
+ */
+export function createAmbientRoster(opts: AmbientRosterOptions): AmbientRoster {
+  const seed = typeof opts.seed === 'number' ? opts.seed : hashStr(opts.seed)
+  const rng = makeSeededRng(seed ^ 0x7a11d0)
+  const share = opts.townsfolkShare ?? DEFAULT_TOWNSFOLK_SHARE
+
+  // Full name space, shuffled once. 104 first names x 40 surnames is far more
+  // than a town of a dozen needs, so the walk never realistically runs dry —
+  // but wrap anyway rather than risk an infinite loop if it somehow does.
+  const firstNames = seededShuffle(RESIDENT_FIRST_NAMES, rng)
+  const surnames   = seededShuffle(WANDERER_SURNAMES, rng)
+  const unitSlugs  = opts.unitSlugs.length > 0 ? opts.unitSlugs : []
+
+  const taken = new Map<string, string>()  // id -> name
+  const inUse = new Set<string>()
+  let nameCursor = 0
+  let minted = 0
+
+  function nextName(): string {
+    const total = firstNames.length * surnames.length
+    for (let i = 0; i < total; i++) {
+      const at = (nameCursor + i) % total
+      const name = `${firstNames[at % firstNames.length]} ${surnames[Math.floor(at / firstNames.length) % surnames.length]}`
+      if (!inUse.has(name)) {
+        nameCursor = at + 1
+        return name
+      }
+    }
+    // Every combination is live at once — impossible for a town of a dozen, but
+    // returning something is better than looping forever.
+    return `${firstNames[0]} ${surnames[0]} ${inUse.size}`
+  }
+
+  return {
+    mint(): AmbientNpcIdentity {
+      const id = `wanderer-${seed.toString(36)}-${minted++}`
+      const name = nextName()
+      inUse.add(name)
+      taken.set(id, name)
+      const wantsTownsfolk = unitSlugs.length === 0 || rng() < share
+      const look = wantsTownsfolk
+        ? makeTownsfolkLook(rng)
+        : { kind: 'unit' as const, slug: pick(unitSlugs, rng) }
+      return { id, name, look }
+    },
+    release(id: string): void {
+      const name = taken.get(id)
+      if (name === undefined) return
+      taken.delete(id)
+      inUse.delete(name)
+    },
+    size: () => taken.size,
+  }
+}
+
+/**
+ * Orders a town's wanderer sprite pool: the sprites its config nominates first
+ * (so Millhaven still reads as a fishing town), then the rest of the catalog
+ * seeded-shuffled behind them. Duplicates are dropped, preference order kept.
+ */
+export function buildUnitSlugPool(preferred: string[], catalog: string[], seed: number | string): string[] {
+  const s = typeof seed === 'number' ? seed : hashStr(seed)
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const slug of preferred) {
+    if (slug && !seen.has(slug)) { seen.add(slug); out.push(slug) }
+  }
+  for (const slug of seededShuffle(catalog, makeSeededRng(s ^ 0x5109))) {
+    if (slug && !seen.has(slug)) { seen.add(slug); out.push(slug) }
+  }
+  return out
+}

--- a/web/src/game/names.ts
+++ b/web/src/game/names.ts
@@ -1,0 +1,38 @@
+// ─── Shared character name pools ─────────────────────────────────────────────
+//
+// One source of truth for procedurally-named characters. The first-name pool
+// started life inside the city builder's walkerTypes.ts; the hub town's
+// wandering NPCs need the same pool, and `game/` can't import from
+// `components/`, so it lives here and the city builder imports it back.
+//
+// Nothing here picks a name — callers own their own seeding and uniqueness
+// rules (city-builder residents are a pure function of grid position and
+// tolerate collisions; hub wanderers mint distinct names per town visit, see
+// game/hub/ambientNpcIdentity.ts).
+
+export const RESIDENT_FIRST_NAMES = [
+  'Bob', 'Grak', 'Mira', 'Thorin', 'Zyx', 'Elda', 'Fang', 'Nix', 'Wren', 'Dusk',
+  'Pip', 'Crux', 'Vale', 'Sorn', 'Brix', 'Holt', 'Vera', 'Kurn', 'Dex', 'Ori',
+  'Sable', 'Flint', 'Rook', 'Ivy', 'Bryn', 'Quill', 'Ash', 'Moss', 'Thorn', 'Lark',
+  'Grit', 'Nyx', 'Rune', 'Cora', 'Drake', 'Frey', 'Vex', 'Sage', 'Onyx', 'Luna',
+  'Zara', 'Kade', 'Ember', 'Riven', 'Sylas', 'Jade', 'Dorian', 'Nyssa', 'Orin', 'Soren',
+  'Tess', 'Galen', 'Vira', 'Kira', 'Bram', 'Lena', 'Zane', 'Mara', 'Rhea', 'Dax',
+  'Cyrus', 'Elara', 'Fen', 'Nora', 'Vaughn', 'Sia', 'Kieran', 'Lyra', 'Eira', 'Zev',
+  'Mina', 'Thane', 'Vela', 'Kass', 'Dara', 'Orion', 'Faye', 'Gideon', 'Lira', 'Kara',
+  'Elys', 'Kael', 'Varyn', 'Selene', 'Torik', 'Xara', 'Brakka', 'Zephyr', 'Isolde', 'Malric',
+  'Tavra', 'Voren', 'Calyx', 'Seraph', 'Nymer', 'Talon', 'Velric', 'Auren', 'Morwen', 'Zyra',
+  'Graham', 'Rob', 'Jarv', 'Jason',
+]
+
+// Surnames for townsfolk who need a full name rather than a "<Name> the <Unit>"
+// epithet — trade and place names, so a wanderer reads as somebody who lives
+// and works somewhere rather than as a fantasy hero.
+export const WANDERER_SURNAMES = [
+  'Ashdown', 'Fenwick', 'Millward', 'Thatcher', 'Quarryman', 'Barrowe', 'Coalter',
+  'Dunmere', 'Estwick', 'Fallowes', 'Grindle', 'Hallow', 'Ingles', 'Kettleby',
+  'Lorrimer', 'Marlow', 'Netherby', 'Oakhurst', 'Pennyworth', 'Rushmore',
+  'Saltmarsh', 'Tanner', 'Underhill', 'Vances', 'Wraysbury', 'Yarrow',
+  'Brightwater', 'Cobbleton', 'Duskmoor', 'Elmsley', 'Foxglove', 'Greave',
+  'Harrowgate', 'Larkspur', 'Mossbank', 'Ravensworth', 'Stonecrop', 'Thornbury',
+  'Weatherall', 'Wyndham',
+]


### PR DESCRIPTION
Hub town wanderers ("ambient NPCs") were deliberately anonymous filler, and it showed: 8 shared dialogue lines, no names at all, and sprites drawn only from the player's *deck* — about a dozen bodies, cycled by index, with four towns falling back to `hub-avatar` clones of the player.

Three changes, in three layers.

## Unique names

`RESIDENT_FIRST_NAMES` moves out of the city builder into `game/names.ts` (it can't be imported from `components/` by game-layer code), joined by a new `WANDERER_SURNAMES` pool. `game/hub/ambientNpcIdentity.ts` mints one identity per wanderer from a seeded shuffle of first × surname pairs, skipping any name a live wanderer already holds — so a town never shows two Miras, and a released name comes back later on somebody new. The city builder's `residentName()` deliberately has no such guarantee (pure function of grid position, tolerates collisions); this reuses its name pool, not its uniqueness story.

Names surface as a speech-bubble prefix on tap — `Mira Ashdown: Lovely day for it.` — rather than as another piece of on-screen chrome over a dozen heads.

## Composite sprites with dynamic colours

`data/townsfolk.ts` plus 34 new SVGs, following the pet coat-pattern/accessory approach: neutral white art composited as tinted PIXI siblings. Two authoring rules keep the file count down — every body places the head at identical coordinates, and walk frames move only arms, legs and hems — so the head-attached layers (skin, face, hair, hat) are shared across bodies and need no frames at all. 3 bodies × 4 hairstyles × 3 hats + five palettes gives ~2.3M distinct looks out of 34 small files.

The population is mixed, as asked: roughly 60% composite townsfolk, the rest card-catalog units. Card units stay single-sprite deliberately — their walk frames bob inconsistently across several hundred hand-authored files, so a static overlay would visibly float; their variety comes from the size of the pool instead, which `HubWorld` now widens from the deck to the whole unit catalog (each town's own `ambientNpcSprites` still weighted to the front, so Millhaven keeps its fishermen).

## Dialogue

`game/hub/ambientDialogue.ts` replaces the 8 lines with ~120 generic ones plus pools layered on by context: day/night, rain/snow/fog, ghosts (who speak only their own pool), travellers fresh off the road, wanderers heading through a door, and wanderers tapped indoors. Each NPC walks its own seeded shuffle of the merged pool, reshuffling on wrap and never repeating across the seam, so repeat taps keep finding new lines.

## Also fixed along the way

A wanderer who walked into a shop used to come back out as a different person — `BuildingVisitor` kept only a texture. It now carries the full identity and line cursor, and the interior sprite is composited from the same look, so the person who comes out of the bakery is the person who went in.

## Notes

- The two duplicated spawn sites are collapsed into one `spawnAmbientNpc()`, which now also serves arrivals and building exits.
- The canvas resolves weather itself via the existing `resolveWeather(HUB_WEATHER, HUB_ENV)` call rather than taking a new prop.
- New Storybook story `TownsfolkGallery` renders a grid of minted identities for eyeballing palette clashes and layer alignment without walking a town.

## Verification

`npm run build` clean. `npm run test`: 2795 passed, including 50 new tests across `townsfolk`, `ambientNpcIdentity` and `ambientDialogue` — determinism, name uniqueness, pool layering, and assertions that the art on disk matches the catalog (every referenced sprite exists, animated layers have `-1/-2/-3` frames and head layers don't, tinted layers are pure white, and every body keeps its torso at the same y across all frames).

Sprite compositing was also checked in a browser, since it's a visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaY9e88wmzu8tbC7ugYRV1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaY9e88wmzu8tbC7ugYRV1)_