### PR TITLE
Wandering NPCs follow-up: vary surnames, add a look gallery story, document the system

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -2725,3 +2725,106 @@ simulation technique above.
    regression sweep and `questPickupPlacement.test.ts`'s pond/floor and
    indoor-item/floor checks already validate any interior generically, no
    test-code changes needed for ordinary content additions.
+
+---
+
+## §21 — Wandering NPCs (ambient townsfolk)
+
+The anonymous crowd that walks a town's streets. Distinct from the named
+`HubNpc`s of §2/§9: wanderers have no entry in `config.json`, no schedule, no
+quests and no dialogue modal. They are minted at spawn, live for one town
+visit, and are never persisted.
+
+**Where the code is**
+
+| Concern | File |
+| --- | --- |
+| Identity: names + looks, per-visit roster | `web/src/game/hub/ambientNpcIdentity.ts` |
+| Flavour lines and the per-NPC line cursor | `web/src/game/hub/ambientDialogue.ts` |
+| Composite sprite catalog and palettes | `web/src/data/townsfolk.ts` |
+| Spawning, walking, compositing, tap bubbles | `web/src/components/hub/HubTownCanvas.tsx` |
+| Sprite pool passed in from React | `web/src/components/hub/HubWorld.tsx` (`unitCards`) |
+| Contact sheet for judging the art | `web/src/components/hub/TownsfolkGallery.stories.tsx` |
+
+### Identity
+
+`createAmbientRoster({ seed, unitSlugs })` mints one `AmbientNpcIdentity` per
+wanderer. Names pair a first name from `game/names.ts`'s `RESIDENT_FIRST_NAMES`
+(shared with the city builder's residents) with a `WANDERER_SURNAMES` surname;
+both halves advance in step, and a name held by a live wanderer is skipped, so a
+town never shows two Miras. `release(id)` hands the name back on despawn.
+
+Everything is seeded off the town's `locationKey`, so the same town produces the
+same crowd — useful when you need to reproduce something you saw.
+
+A look is one of two kinds:
+
+- **`townsfolk`** — a composite of tinted layers (below). Roughly 60% of the
+  crowd, and the whole crowd in a town with no sprite pool at all.
+- **`unit`** — a single card sprite, drawn from `buildUnitSlugPool(preferred,
+  catalog, seed)`: the town's own `ambientNpcSprites` first, then the rest of
+  the unit-card catalog seeded-shuffled behind them. Card units are deliberately
+  *not* given cosmetic overlays — the several hundred hand-authored unit sprites
+  bob inconsistently across their walk frames, so a static overlay would visibly
+  float. Their variety comes from the size of the pool.
+
+### Composite townsfolk sprites
+
+Same technique as the pet coat patterns and accessories (§8): art authored in
+neutral white, composited as PIXI siblings, each tinted independently. Layers,
+back to front — shadow, outfit (the base sprite, which owns the hit area and the
+walk cycle), accent, skin, face, hair, hat.
+
+Art lives at `web/public/sprites/townsfolk-*.svg`. **Two authoring rules make
+the layer sharing work — break either and the layers come apart:**
+
+1. Every body places the head at identical coordinates, so skin, face, hair and
+   hat are shared across all three bodies rather than redrawn per body.
+2. Walk frames animate arms, legs and hems only — the head and shoulders never
+   move. (The older hand-drawn `hub-npc-*.svg` frames bob the whole body by 1px;
+   these deliberately don't.) That's why only `-outfit` and `-accent` ship
+   `-1/-2/-3` frames and the head layers are a single frameless SVG each.
+
+`townsfolk.test.ts` asserts both rules against the art on disk, along with
+"every catalog slug exists" and "tinted layers are pure `#ffffff`".
+
+Adding a colourway needs no new art at all — extend `SKIN_TONES`,
+`HAIR_COLOURS`, `OUTFIT_COLOURS`, `ACCENT_COLOURS` or `HAT_COLOURS`. Adding a
+body needs `townsfolk-<body>-outfit` and `-accent`, each with three frames.
+
+### Dialogue
+
+Tapping a wanderer pops a cosmetic speech bubble reading `<Name>: <line>` — no
+modal, no state change, the same treatment ambient animals get. Lines come from
+`ambientLinePool(ctx)`: ~120 generic lines plus pools layered on by context.
+
+| Context | Pool |
+| --- | --- |
+| Daylight / after dark | `DAY_LINES` / `NIGHT_LINES` |
+| Rain, snow, fog (skipped indoors) | `RAIN_LINES` / `SNOW_LINES` / `FOG_LINES` |
+| Ghost wanderer | `GHOST_LINES` — *replaces* the pool entirely |
+| Just walked in from the road | `ARRIVAL_LINES` |
+| Headed through a building's door | `DOORWAY_LINES` |
+| Tapped inside a building | `INDOOR_LINES` |
+
+Each wanderer holds an `AmbientLineCursor`: a seeded shuffle of the merged pool,
+walked one line per tap, reshuffled on wrap and never repeating across the seam.
+`contextKey(ctx)` changing (night falls, they step indoors) rebuilds the queue.
+
+### Lifecycle
+
+Population is held at `TARGET_NPC_COUNT` (12) by a staggered respawn. A wanderer
+who reaches an open door becomes a `BuildingVisitor` — carrying their identity
+and line cursor, so the person who comes back out of the bakery is the person
+who went in, composited from the same look if you follow them inside. A wanderer
+who reaches an exit tile leaves town and credits the shared cross-town counter
+in `townTravelers.ts`; a town visit can claim one back as an arrival.
+
+### Authoring checklist: giving a town its own crowd
+
+1. Set `ambientNpcSprites` in the town's `config.json` (Town panel in the map
+   editor, §13) to the card/NPC sprites that should be over-represented there —
+   fishermen for a port, soldiers for a keep. It's a preference, not a whitelist:
+   the rest of the catalog still appears behind them.
+2. Leave it empty for a town that should be all composite townsfolk.
+3. Nothing else is per-town. Names, palettes and dialogue are global.

--- a/web/src/components/hub/TownsfolkGallery.stories.tsx
+++ b/web/src/components/hub/TownsfolkGallery.stories.tsx
@@ -1,0 +1,108 @@
+// A contact sheet of wandering-NPC looks, rendered through the same PIXI
+// tinting path the hub town uses. Walking a town to judge the art is slow (you
+// meet a dozen wanderers at a time, and only the ones near the camera), so this
+// puts a whole crowd side by side: palette clashes, layer misalignment and
+// missing art all show up at a glance.
+import { useRef } from 'react'
+import * as PIXI from 'pixi.js'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { usePixiApp } from '../../hooks/usePixiApp'
+import { loadSpriteTexture, loadAnimFrames } from '../../utils/pixiHelpers'
+import { createAmbientRoster } from '../../game/hub/ambientNpcIdentity'
+import type { AmbientNpcLook } from '../../game/hub/ambientNpcIdentity'
+import { townsfolkLayers } from '../../data/townsfolk'
+import type { TownsfolkLayer } from '../../data/townsfolk'
+
+const CELL = 72
+const COLS = 8
+const SPRITE = 56
+
+function lookSpec(look: AmbientNpcLook): { base: TownsfolkLayer; overlays: TownsfolkLayer[] } {
+  if (look.kind === 'townsfolk') return townsfolkLayers(look)
+  return { base: { slug: look.slug, tint: 0xffffff, animated: true, z: 0 }, overlays: [] }
+}
+
+function Gallery({ count, seed, unitSlugs, walking }: {
+  count: number
+  seed: string
+  unitSlugs: string[]
+  walking: boolean
+}) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const rows = Math.ceil(count / COLS)
+
+  usePixiApp(hostRef, COLS * CELL, rows * (CELL + 16), app => {
+    app.renderer.background.color = 0x6a8f5a
+    const roster = createAmbientRoster({ seed, unitSlugs })
+
+    for (let i = 0; i < count; i++) {
+      const npc  = roster.mint()
+      const spec = lookSpec(npc.look)
+      const cx = (i % COLS) * CELL + CELL / 2
+      const cy = Math.floor(i / COLS) * (CELL + 16) + CELL
+
+      const label = new PIXI.Text({
+        text: npc.name,
+        style: { fontSize: 8, fill: '#ffffff', fontFamily: 'monospace' },
+      })
+      label.anchor.set(0.5, 0)
+      label.position.set(cx, cy + 2)
+      app.stage.addChild(label)
+
+      for (const layer of [spec.base, ...spec.overlays].sort((a, b) => a.z - b.z)) {
+        loadSpriteTexture(layer.slug).then(tex => {
+          if (app.renderer == null) return
+          const s = new PIXI.Sprite(tex)
+          s.width = SPRITE; s.height = SPRITE
+          s.anchor.set(0.5, 1)
+          s.position.set(cx, cy)
+          s.tint = layer.tint
+          app.stage.addChild(s)
+          if (!walking || !layer.animated) return
+          // Cycle the walk frames so a mis-registered layer is obvious in motion.
+          loadAnimFrames(layer.slug, 3).then(frames => {
+            let frame = 0
+            let elapsed = 0
+            app.ticker.add(t => {
+              elapsed += t.deltaMS
+              if (elapsed < 200 || s.destroyed) return
+              elapsed = 0
+              frame = (frame + 1) % frames.length
+              s.texture = frames[frame]
+            })
+          }).catch(() => {})
+        }).catch(() => {})
+      }
+    }
+  })
+
+  return <div ref={hostRef} />
+}
+
+const meta = {
+  component: Gallery,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Gallery>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Composite townsfolk only — the case the new art exists for. */
+export const Townsfolk: Story = {
+  args: { count: 32, seed: 'gallery', unitSlugs: [], walking: false },
+}
+
+/** Mid-stride, so a layer that drifts out of register with the body shows up. */
+export const TownsfolkWalking: Story = {
+  args: { count: 32, seed: 'gallery', unitSlugs: [], walking: true },
+}
+
+/** The mix a real town shows: composite townsfolk alongside card-unit sprites. */
+export const MixedCrowd: Story = {
+  args: {
+    count: 32,
+    seed: 'ravenwatch',
+    unitSlugs: ['hub-npc-elder', 'hub-npc-merchant', 'hub-npc-scholar', 'knight', 'archer', 'farmer'],
+    walking: false,
+  },
+}

--- a/web/src/game/hub/ambientNpcIdentity.test.ts
+++ b/web/src/game/hub/ambientNpcIdentity.test.ts
@@ -24,6 +24,13 @@ describe('createAmbientRoster names', () => {
     expect(new Set(npcs.map(n => n.id)).size).toBe(60)
   })
 
+  it('varies the surname too, not just the first name', () => {
+    // A town of a dozen people who all share a surname reads as a bug even
+    // though every full name is technically unique.
+    const surnames = mintMany(12).npcs.map(n => n.name.split(' ')[1])
+    expect(new Set(surnames).size).toBeGreaterThan(6)
+  })
+
   it('draws both halves of the name from the shared pools', () => {
     for (const npc of mintMany(30).npcs) {
       const [first, surname] = npc.name.split(' ')

--- a/web/src/game/hub/ambientNpcIdentity.ts
+++ b/web/src/game/hub/ambientNpcIdentity.ts
@@ -57,6 +57,14 @@ function pick<T>(arr: readonly T[], rng: () => number): T {
   return arr[Math.floor(rng() * arr.length) % arr.length]
 }
 
+function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b)
+}
+
+function lcm(a: number, b: number): number {
+  return (a / gcd(a, b)) * b
+}
+
 function makeTownsfolkLook(rng: () => number): AmbientNpcLook {
   return {
     kind:       'townsfolk',
@@ -86,9 +94,11 @@ export function createAmbientRoster(opts: AmbientRosterOptions): AmbientRoster {
   const rng = makeSeededRng(seed ^ 0x7a11d0)
   const share = opts.townsfolkShare ?? DEFAULT_TOWNSFOLK_SHARE
 
-  // Full name space, shuffled once. 104 first names x 40 surnames is far more
-  // than a town of a dozen needs, so the walk never realistically runs dry —
-  // but wrap anyway rather than risk an infinite loop if it somehow does.
+  // Both halves are shuffled and then advanced in step, so consecutive
+  // wanderers differ in first name *and* surname — walking the surnames only
+  // once the first names ran out would give a town of a dozen people who all
+  // share a surname. Stepping both wraps at lcm(104, 40) = 520 distinct pairs,
+  // far more than the dozen or so alive at any moment.
   const firstNames = seededShuffle(RESIDENT_FIRST_NAMES, rng)
   const surnames   = seededShuffle(WANDERER_SURNAMES, rng)
   const unitSlugs  = opts.unitSlugs.length > 0 ? opts.unitSlugs : []
@@ -99,17 +109,17 @@ export function createAmbientRoster(opts: AmbientRosterOptions): AmbientRoster {
   let minted = 0
 
   function nextName(): string {
-    const total = firstNames.length * surnames.length
+    const total = lcm(firstNames.length, surnames.length)
     for (let i = 0; i < total; i++) {
       const at = (nameCursor + i) % total
-      const name = `${firstNames[at % firstNames.length]} ${surnames[Math.floor(at / firstNames.length) % surnames.length]}`
+      const name = `${firstNames[at % firstNames.length]} ${surnames[at % surnames.length]}`
       if (!inUse.has(name)) {
         nameCursor = at + 1
         return name
       }
     }
-    // Every combination is live at once — impossible for a town of a dozen, but
-    // returning something is better than looping forever.
+    // Every pair in the cycle is live at once — impossible for a town of a
+    // dozen, but returning something is better than looping forever.
     return `${firstNames[0]} ${surnames[0]} ${inUse.size}`
   }
 


### PR DESCRIPTION
Follow-up to #2139, which auto-merged while I was still checking the result in a browser. Three things.

## Surname bug

`nextName()` computed the surname as `surnames[floor(at / firstNames.length)]`, so it only advanced once all 104 first names had been used. In practice every wanderer alive in a town shared one surname — twelve names that were technically unique and read as obviously wrong (a whole town of Oakhursts).

Both halves now advance in step, wrapping at `lcm(104, 40) = 520` distinct pairs — far more than the dozen alive at once. Covered by a test that asserts a town of twelve shows more than six distinct surnames.

## `TownsfolkGallery` stories

A contact sheet of minted looks, rendered through the same PIXI tinting path the town uses — standing still, mid-stride, and as the mixed townsfolk/card-unit crowd a real town shows. Walking a town to judge the art only ever shows the handful of wanderers near the camera; this puts thirty-two side by side, so palette clashes, layer misalignment and missing art show up at a glance. Story-only, so it isn't in the app bundle.

## `docs/hubworld.md` §21

The doc covered named NPCs, animals and the map editor at length but mentioned `ambientNpcSprites` exactly once in passing. New section covers where the code lives, how identities are minted, the composite layer scheme and the two authoring rules it depends on (shared head coordinates; walk frames that move only arms, legs and hems), the dialogue context pools, the building/exit lifecycle, and a per-town authoring checklist.

## Verification

`npm run build` clean. `npm run test`: 2805 passed.

Also driven in a browser via Storybook — Ravenwatch renders composite townsfolk correctly in-world, and tapping four different wanderers gave four different names and four different lines, with the night and weather pools active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaY9e88wmzu8tbC7ugYRV1