### PR TITLE
Animate hub town doors on avatar/NPC walk-through

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -24,6 +24,9 @@ import { emitSound, startInteriorAudio, stopInteriorAudio, setNightAmbiance } fr
 import { WALL_TILES } from '../../data/tiles/buildingMaterials'
 import type { WallMaterial, RoofMaterial } from '../../data/tiles/buildingMaterials'
 import { placeBuildingTiles, resolveBuildingVisual } from '../../data/tiles/buildingRender'
+import { getDoorRoleTiles, DOOR_STYLE_BY_MATERIAL } from '../../data/tiles/doorTiles'
+import type { DoorRole } from '../../data/tiles/doorTiles'
+import { DoorAnimationController, DOOR_STEP_MS } from '../../game/hub/doorAnimation'
 import { loadPlayerAvatar, ALL_CONSUMABLES } from '../../game/questline'
 import { getAugmentCard, AUGMENT_SPRITE } from '../../game/augments'
 import { createChunkCuller } from '../../utils/chunkCull'
@@ -530,6 +533,13 @@ export function HubTownCanvas({
     // would be adopted while empty and then culled. Multi-variant buildings instead
     // toggle each sprite's `visible` per frame (see the variant toggle in the ticker).
     const buildingVariantSprites: { buildingId: string; minLevel: number; nextLevel: number; sprite: PIXI.Sprite }[] = []
+    // Trigger-driven door open/close animation (see game/hub/doorAnimation.ts).
+    // Only single-leaf doors are animated — double-leaf materials (e.g.
+    // ironholdKeep's portcullis) keep their existing static art, since the
+    // animated double-leaf tiles are two tiles wide and the live door's
+    // walk-in trigger is a single tile.
+    const doorAnimation = new DoorAnimationController()
+    const doorAnimSprites: { doorKey: string; role: DoorRole; material: WallMaterial; sprite: PIXI.Sprite }[] = []
     {
       const fallbackPromises: Promise<void>[] = []
 
@@ -541,7 +551,8 @@ export function HubTownCanvas({
         track: { buildingId: string; minLevel: number; nextLevel: number } | null,
         initiallyVisible: boolean,
       ) => {
-        const placements = placeBuildingTiles(rect, wall, roof, doors)
+        const doubleLeaf = DOOR_STYLE_BY_MATERIAL[wall].doubleLeaf
+        const placements = placeBuildingTiles(rect, wall, roof, doors, { skipDoorLeaf: !doubleLeaf })
         for (const [tileId, positions] of placements) {
           loadTileRef(tileId).then(tex => {
             if (app.renderer == null) return
@@ -554,6 +565,33 @@ export function HubTownCanvas({
               if (track) buildingVariantSprites.push({ ...track, sprite: s })
             }
           }).catch(() => {})
+        }
+
+        if (!doubleLeaf) {
+          const [rx1, , rx2] = rect
+          for (const door of doors) {
+            if (door.hideSprite || door.tx < rx1 || door.tx > rx2) continue
+            const doorKey = `${door.tx},${door.ty}`
+            for (const role of ['Top', 'Bottom'] as const) {
+              const ty = role === 'Top' ? door.ty - 2 : door.ty - 1
+              const [tileId] = getDoorRoleTiles(wall, role, 0)
+              loadTileRef(tileId).then(tex => {
+                if (app.renderer == null) return
+                const s = new PIXI.Sprite(tex)
+                s.position.set(door.tx * T, ty * T)
+                s.width = T; s.height = T
+                s.visible = initiallyVisible
+                // nodeLayer paints after avatarLayer/spriteLayer, so the door
+                // leaf naturally draws in front of anyone walking into it —
+                // and its draw order relative to the static arch tile
+                // (buildingLayer) is fixed by container order, not by which
+                // texture promise resolves first.
+                nodeLayer.addChild(s)
+                doorAnimSprites.push({ doorKey, role, material: wall, sprite: s })
+                if (track) buildingVariantSprites.push({ ...track, sprite: s })
+              }).catch(() => {})
+            }
+          }
         }
       }
 
@@ -1897,6 +1935,7 @@ export function HubTownCanvas({
             wanderNpc(npc)
             return
           }
+          doorAnimation.openDoor(`${tx},${ty}`, performance.now())
           // Record them as a visitor inside this building before despawning
           // the exterior sprite, so they can be seen if the player follows
           // them in, and so they eventually let themselves back out (#2111
@@ -2259,6 +2298,9 @@ export function HubTownCanvas({
             avatar.x = door.tx * T + T / 2
             avatar.y = door.ty * T + T
             currentTile = [door.tx, door.ty]
+            // Door swings open as the player steps back out; the animation
+            // controller auto-closes it a moment later.
+            doorAnimation.openDoor(`${door.tx},${door.ty}`, performance.now())
           }
           onAvatarMoveRef.current(avatar.x, avatar.y)
         }
@@ -3208,7 +3250,14 @@ export function HubTownCanvas({
             onDoorLockedRef.current?.(door.buildingId, `quest:${door.requiredQuest}`)
             return
           }
-          onNodeInteractRef.current(`interior:${door.buildingId}`)
+          // Swing the door open and give the player a beat to see it before
+          // cutting to the interior view.
+          doorAnimation.openDoor(`${door.tx},${door.ty}`, performance.now())
+          const enteredBuildingId = door.buildingId
+          setTimeout(() => {
+            if (app.renderer == null) return
+            onNodeInteractRef.current(`interior:${enteredBuildingId}`)
+          }, DOOR_STEP_MS * 2)
           return
         }
 
@@ -3662,6 +3711,20 @@ export function HubTownCanvas({
           }
         }
 
+        // Animated door leaves — advance the trigger-driven open/close state
+        // machine and swap textures for any door whose frame changed.
+        if (doorAnimSprites.length > 0) {
+          const changedDoors = doorAnimation.advance(performance.now())
+          for (const doorKey of changedDoors) {
+            const frame = doorAnimation.frameFor(doorKey)
+            for (const d of doorAnimSprites) {
+              if (d.doorKey !== doorKey) continue
+              const [tileId] = getDoorRoleTiles(d.material, d.role, frame)
+              loadTileRef(tileId).then(tex => { d.sprite.texture = tex }).catch(() => {})
+            }
+          }
+        }
+
         // Level-gated exterior NPCs — hide until their building reaches the level
         // (and again once hideAtLevel passes). When visible the normal schedule /
         // walk logic governs the container, so only force-hide here.
@@ -4035,6 +4098,7 @@ export function HubTownCanvas({
             }
             const door = HUB_DOORS.find(d => d.buildingId === visitBuildingId)
             if (door && isDoorOpen(door.tx, door.ty)) {
+              doorAnimation.openDoor(`${door.tx},${door.ty}`, performance.now())
               // The same person walks back out — name, look and all.
               spawnAmbientNpc({
                 origin: [door.tx, door.ty], identity: record.identity,

--- a/web/src/data/tiles/buildingRender.ts
+++ b/web/src/data/tiles/buildingRender.ts
@@ -29,6 +29,7 @@ export function placeBuildingTiles(
   wall: WallMaterial,
   roof: RoofMaterial,
   doors: BuildingDoorTile[] = [],
+  opts: { skipDoorLeaf?: boolean } = {},
 ): Map<number, [number, number][]> {
   const placements = new Map<number, [number, number][]>()
   const place = (tileId: number, tx: number, ty: number) => {
@@ -71,10 +72,17 @@ export function placeBuildingTiles(
   // door can sit anywhere relative to the building (e.g. above a flight of
   // steps) and still render — matching tx to this rect only picks which
   // wall's door art to use.
+  //
+  // `skipDoorLeaf` omits the doorTop/doorBottom leaf tiles — the live hub
+  // canvas draws those itself as animated sprites (see doorAnimation.ts) and
+  // only wants the static arch decoration from this pass. Callers that don't
+  // animate doors (e.g. the map editor preview) leave it unset and get the
+  // full static door as before.
   const wallTiles = WALL_TILES[wall]
   for (const door of doors) {
     if (door.hideSprite || door.tx < x1 || door.tx > x2) continue
     place(wallTiles.doorArchTop, door.tx, door.ty - 2)
+    if (opts.skipDoorLeaf) continue
     place(wallTiles.doorTop,     door.tx, door.ty - 2)
     place(wallTiles.doorBottom,  door.tx, door.ty - 1)
   }

--- a/web/src/game/hub/doorAnimation.test.ts
+++ b/web/src/game/hub/doorAnimation.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { DoorAnimationController, DOOR_STEP_MS } from './doorAnimation'
+
+describe('DoorAnimationController', () => {
+  it('starts closed for a door that has never been triggered', () => {
+    const ctrl = new DoorAnimationController()
+    expect(ctrl.frameFor('1,1')).toBe(0)
+  })
+
+  it('steps closed -> opening -> open as time advances after openDoor', () => {
+    const ctrl = new DoorAnimationController()
+    let now = 0
+    ctrl.openDoor('1,1', now)
+    expect(ctrl.frameFor('1,1')).toBe(0)
+
+    now += DOOR_STEP_MS
+    ctrl.advance(now)
+    expect(ctrl.frameFor('1,1')).toBe(1)
+
+    now += DOOR_STEP_MS
+    ctrl.advance(now)
+    expect(ctrl.frameFor('1,1')).toBe(2)
+  })
+
+  it('auto-closes after the hold window once nothing keeps it open', () => {
+    const ctrl = new DoorAnimationController()
+    let now = 0
+    ctrl.openDoor('1,1', now)
+    now += DOOR_STEP_MS; ctrl.advance(now)
+    now += DOOR_STEP_MS; ctrl.advance(now)
+    expect(ctrl.frameFor('1,1')).toBe(2)
+
+    // Well past the hold window with nobody re-triggering the door.
+    now += 5000
+    ctrl.advance(now)
+    expect(ctrl.frameFor('1,1')).toBe(1)
+    now += DOOR_STEP_MS
+    ctrl.advance(now)
+    expect(ctrl.frameFor('1,1')).toBe(0)
+  })
+
+  it('re-triggering openDoor while open extends the hold instead of closing', () => {
+    const ctrl = new DoorAnimationController()
+    let now = 0
+    ctrl.openDoor('1,1', now)
+    now += DOOR_STEP_MS; ctrl.advance(now)
+    now += DOOR_STEP_MS; ctrl.advance(now)
+    expect(ctrl.frameFor('1,1')).toBe(2)
+
+    now += 400
+    ctrl.openDoor('1,1', now) // second entity arrives before the door would close
+    now += 400
+    ctrl.advance(now)
+    // Still open — the hold was extended, not reset to closed.
+    expect(ctrl.frameFor('1,1')).toBe(2)
+  })
+
+  it('tracks multiple doors independently', () => {
+    const ctrl = new DoorAnimationController()
+    const now = 0
+    ctrl.openDoor('1,1', now)
+    expect(ctrl.frameFor('2,2')).toBe(0)
+  })
+
+  it('advance() reports which door keys changed frame', () => {
+    const ctrl = new DoorAnimationController()
+    let now = 0
+    ctrl.openDoor('1,1', now)
+    now += DOOR_STEP_MS
+    const changed = ctrl.advance(now)
+    expect(changed).toEqual(['1,1'])
+  })
+})

--- a/web/src/game/hub/doorAnimation.ts
+++ b/web/src/game/hub/doorAnimation.ts
@@ -1,0 +1,63 @@
+import type { DoorFrame } from '../../data/tiles/doorTiles'
+
+// Trigger-driven door open/close animation, keyed by a door's tile position
+// ("tx,ty"). Mirrors the timing of the Storybook demo (DoorAnimationDemo.tsx:
+// STEP_MS = 260) but only steps forward when something actually walks
+// through — it doesn't free-run a loop.
+export const DOOR_STEP_MS = 260
+// How long a door stays open (no queued steps) before it auto-closes. Long
+// enough that a second entity arriving shortly after the first doesn't see
+// the door slam shut in front of them.
+const HOLD_MS = 600
+
+interface DoorAnimState {
+  frame: DoorFrame
+  queue: DoorFrame[]
+  nextStepAt: number
+  openUntil: number
+}
+
+export class DoorAnimationController {
+  private doors = new Map<string, DoorAnimState>()
+
+  private stateFor(doorKey: string): DoorAnimState {
+    let state = this.doors.get(doorKey)
+    if (!state) {
+      state = { frame: 0, queue: [], nextStepAt: 0, openUntil: 0 }
+      this.doors.set(doorKey, state)
+    }
+    return state
+  }
+
+  /** Current frame for a door, or closed (0) if it's never been triggered. */
+  frameFor(doorKey: string): DoorFrame {
+    return this.doors.get(doorKey)?.frame ?? 0
+  }
+
+  /** Opens a door (queues opening→open if not already open/opening), and
+   *  extends how long it stays open before auto-closing. Safe to call
+   *  repeatedly while multiple entities pass through the same door. */
+  openDoor(doorKey: string, now: number): void {
+    const state = this.stateFor(doorKey)
+    state.openUntil = now + HOLD_MS
+    if (state.frame === 2 || state.queue.includes(2)) return
+    state.queue = [1, 2]
+    if (state.nextStepAt === 0 || state.nextStepAt < now) state.nextStepAt = now + DOOR_STEP_MS
+  }
+
+  /** Advances every door's animation. Returns the keys whose frame changed
+   *  this call, so the caller knows which sprites need a texture swap. */
+  advance(now: number): string[] {
+    const changed: string[] = []
+    for (const [doorKey, state] of this.doors) {
+      if (state.frame === 2 && state.queue.length === 0 && state.openUntil <= now) {
+        state.queue = [1, 0]
+      }
+      if (state.queue.length === 0 || now < state.nextStepAt) continue
+      state.frame = state.queue.shift()!
+      state.nextStepAt = now + DOOR_STEP_MS
+      changed.push(doorKey)
+    }
+    return changed
+  }
+}


### PR DESCRIPTION
## Summary
- Wires the Storybook animated-door tile data (`data/tiles/doorTiles.ts`) into the live hub town canvas (`HubTownCanvas.tsx`), which previously only drew a single static closed-door tile per building.
- Doors now swing open (closed → opening → open) when the avatar or an NPC reaches a door tile, and swing shut again a moment later — driven by a new trigger-based state machine, `web/src/game/hub/doorAnimation.ts` (`DoorAnimationController`), rather than the Storybook demo's free-running loop.
- Hooked into the four places that already detect "something reached a door tile": avatar entering a building, avatar exiting back to the exterior, an NPC walking into an open building, and a visiting NPC walking back out.
- Only the door's Top/Bottom rows are animated, matching the door's existing on-screen footprint exactly — no door-sign repositioning needed. Double-leaf materials (`ironholdKeep`'s portcullis) keep their existing static art, since the animated double-leaf tiles are two tiles wide and the door's walk-in trigger is a single tile.
- `buildingRender.ts`'s `placeBuildingTiles()` gets an opt-in `skipDoorLeaf` flag so the live canvas can render the door leaf itself as animated sprites; the map editor's static door preview is unaffected (flag defaults off).

## Test plan
- [x] `npm run build` — typecheck + Vite build passes clean
- [x] `npm run test` — 2811 tests pass across 81 files (including new `doorAnimation.test.ts`)
- [ ] Manual: walk the avatar into and out of a building through a visible door and confirm it swings open then shut; watch an ambient NPC walk into an open building and confirm the same
- [ ] Manual: `Storybook → World/Door Animation` story still renders unaffected; map editor's building/door preview is visually unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01Coby8TFQjLMv2KrxFiSEX4)_