### PR TITLE
Fix hub doors rendering with the wrong wall material

### DIFF
--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -607,10 +607,17 @@ export function HubTownCanvas({
           continue
         }
 
-        // Pass every door; placeBuildingTiles matches them to a footprint by
-        // position (south edge), mirroring the original renderer — door buildingId
-        // does not always equal the building's id, so we must not filter by id.
-        const doors = HUB_DOORS.map(d => ({ tx: d.tx, ty: d.ty, hideSprite: d.hideSprite }))
+        // Only this building's own doors — door.buildingId (the door's *target*
+        // interior) doesn't always equal the owning structure's id, so match on
+        // ownerBuildingId (the structure the door was authored under) instead.
+        // Matching by tx-in-rect alone is ambiguous: in a dense town many
+        // buildings' rects share a column range (e.g. a gatehouse spanning most
+        // of the map's width), so every building sharing that range would
+        // otherwise race to draw its own wall material's door art onto the
+        // same tile.
+        const doors = HUB_DOORS
+          .filter(d => d.ownerBuildingId === building.id)
+          .map(d => ({ tx: d.tx, ty: d.ty, hideSprite: d.hideSprite }))
 
         // Distinct visual thresholds: base (0) plus each levelVisuals minLevel.
         const thresholds = [0, ...((building.levelVisuals ?? []).map(v => v.minLevel))]

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -114,6 +114,15 @@ export interface HubDoor {
   /** Entry is blocked until this quest id has status 'completed'. Mirrors
    *  HubInteriorExit.requiredQuest for the exterior-door case. */
   requiredQuest?: string
+  /** The structural building (`Building.id`) this door's sprite/wall art was
+   *  authored against — NOT necessarily the same as `buildingId` (the door's
+   *  *target* interior, which can point elsewhere). Used to pick which
+   *  building's wall material renders this door's art, since matching by tx
+   *  alone is ambiguous in dense towns where many buildings' rects share a
+   *  column range (e.g. a gatehouse spanning most of the map's width).
+   *  Undefined for the rare door authored directly in config.json's top-level
+   *  `doors` array, outside any building. */
+  ownerBuildingId?: string
 }
 
 export interface DecorGlow {
@@ -641,6 +650,7 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
     _nestedWindows.push(...expandBundleWindows(b.bundleID, ox, oy))
     _nestedDecor.push(...expandBundleDecor(b.bundleID, ox, oy))
     const bundleDoors = expandBundleDoors(b.bundleID, b.id ?? '', ox, oy)
+      .map(d => ({ ...d, ownerBuildingId: b.id }))
     _nestedDoors.push(...bundleDoors)
     for (const d of bundleDoors) recordInteriorOwner(d.buildingId, b.id, b.upgradeKind)
     continue
@@ -650,7 +660,11 @@ for (const b of rawConfig.buildings as RawBuilding[]) {
     // the door sprite always renders one tile north of it (see
     // buildingRender.ts) unless hideSprite keeps it a fully invisible trigger.
     const targetId = d.buildingId ?? b.id ?? ''
-    _nestedDoors.push({ buildingId: targetId, tx: ox + d.tx, ty: oy + d.ty, hideSign: d.hideSign, hideSprite: d.hideSprite, hideLabel: d.hideLabel })
+    _nestedDoors.push({
+      buildingId: targetId, tx: ox + d.tx, ty: oy + d.ty,
+      hideSign: d.hideSign, hideSprite: d.hideSprite, hideLabel: d.hideLabel,
+      ownerBuildingId: b.id,
+    })
     recordInteriorOwner(targetId, b.id, b.upgradeKind)
   }
   for (const w of b.windows ?? [])


### PR DESCRIPTION
## Summary
Follow-up fix for #2141 (animated hub town doors), which shipped a visible bug: many doors rendered with the wrong wall material's art — e.g. a grey castle-stone door on a brick-walled shop.

**Root cause:** buildings were matched to `HUB_DOORS` entries by checking only whether a door's `tx` fell within the building's rect x-span — with no check on which building actually authored the door. In a dense town layout, most doors' `tx` overlaps several unrelated buildings' rects (a gatehouse alone spans nearly the full map width), so every matching building raced to draw its own wall material's door art onto the same tile; whichever async texture load resolved last won. This was a latent bug in the pre-existing static door rendering too, but the animated door leaves made it far more visible (a large, saturated 2-tile block instead of a thin, mostly-transparent arch decoration).

**Fix:**
- `web/src/data/hub/loader.ts`: `HubDoor` gets a new `ownerBuildingId` field — the structural building (`Building.id`) a door was actually authored under, which can differ from `buildingId` (the door's *target* interior). Populated for both the plain nested-door path and the bundle-door path.
- `web/src/components/hub/HubTownCanvas.tsx`: the building-rendering loop now filters `HUB_DOORS` to a building's own doors via `ownerBuildingId` before passing them to `placeBuildingTiles`/the animated door sprites, instead of handing every building the full door list.

Verified with Playwright screenshots against the `World/Door Animation` Storybook story (unaffected — confirms tile art itself was always correct) and the `HubTownCanvas → Ravenwatch` story before/after the fix: every shop now shows its own wall-matched door instead of a random unrelated material.

## Test plan
- [x] `npm run build` — typecheck + Vite build passes clean
- [x] `npm run test` — 2811 tests pass across 81 files
- [x] Playwright screenshot of `components-hub-hubtowncanvas--ravenwatch` in Storybook, before/after: confirmed every door now renders its own building's wall material instead of a mismatched one
- [ ] Manual: walk the avatar into/out of a building and confirm the door still swings open/closed correctly with the right art

---
_Generated by [Claude Code](https://claude.ai/code/session_01Coby8TFQjLMv2KrxFiSEX4)_