### PR TITLE
Wanderer duels: pause on tap, single battle, fix repeat-win reward

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -275,6 +275,7 @@ export default function App() {
   const isDraftModeRef      = useRef(false)                  // true while playing a Card Draft battle
    const quickBattleModeRef = useRef<QuickBattleMode>('easy')                //  Quick Battle Mode
   const worldBattleNodeIdRef = useRef<string | null>(null)
+  const isWandererBattleRef  = useRef(false)                 // true while playing a wandering-NPC duel (#2149)
 
   // ── Current run's act data (lazy-loaded) ────────────────────────────────────
   // Loaded async whenever run.actId changes; actDataFailed distinguishes "still
@@ -693,13 +694,13 @@ export default function App() {
     handlePlay, handleDraftComplete, handleEndless,
     handleDailyChallenge, handleWeeklyChallenge, handleEndlessLeaderboard,
     handleStartDailyChallenge, handleDailyChallengeRetry, handleStartWeeklyChallenge,
-    handleStreakReset, handlePlayAgain, handleStartTraining,
+    handleStreakReset, handlePlayAgain, handleStartTraining, handleStartWandererBattle,
   } = useQuickBattleFlow({
     gameState, handicap, setHandicap, setScreen, dispatch, startBattle, rollRareEvent,
     setWorldMapKey, setStreakBrokenData, setPendingBattleFn, setPendingBattleIsCampaign,
     setQuickPlayRewardClaimed,
     isCampaignRef, isDailyChallengeRef, isWeeklyChallengeRef, isTrainingModeRef,
-    isDraftModeRef, quickBattleModeRef, worldBattleNodeIdRef,
+    isDraftModeRef, quickBattleModeRef, worldBattleNodeIdRef, isWandererBattleRef,
     battleFlawlessRef, battleAllLegendaryRef, battleUsedStructure, battleUsedMobileUnit,
     prevPlayerUnitsRef, prevOpponentUnitsRef,
   })
@@ -725,6 +726,7 @@ export default function App() {
     isDailyChallengeRef.current = false
     isWeeklyChallengeRef.current = false
     isDraftModeRef.current = false
+    isWandererBattleRef.current = false
     const currentRun = run
 
     const isLoss = gameState?.phase.type === 'gameOver' && gameState.phase.winner !== 'player'
@@ -1164,7 +1166,7 @@ export default function App() {
     newsUnreadCount, feedbackOpen, showTitleLoginModal,
     handleDailyChallenge, handleWeeklyChallenge, handleEndlessLeaderboard,
     handlePlay, handleDraftComplete, handleStartDailyChallenge,
-    handleStartWeeklyChallenge, handleStartTraining, handleResetGame, checkForUpdates,
+    handleStartWeeklyChallenge, handleStartTraining, handleStartWandererBattle, handleResetGame, checkForUpdates,
     hubData, currentLocationKey, worldMapKey, restrictedTownNodeIds,
     miniGamesEntry, setMiniGamesEntry, hubMiniGameEntry, setHubMiniGameEntry,
     setShopBuildingId, setShopTappedNpc, setShowTitleLoginModal, setFeedbackOpen,
@@ -1206,7 +1208,7 @@ export default function App() {
     handleCampaign, handleCampaign2, handleEndless, setCommander,
     newsUnreadCount, feedbackOpen, showTitleLoginModal, handleDailyChallenge,
     handleWeeklyChallenge, handleEndlessLeaderboard, handlePlay, handleDraftComplete,
-    handleStartDailyChallenge, handleStartWeeklyChallenge, handleStartTraining,
+    handleStartDailyChallenge, handleStartWeeklyChallenge, handleStartTraining, handleStartWandererBattle,
     handleResetGame, checkForUpdates,
     handleUseConsumable, handleMainMenu, rewardChoices, rewardCrystals, summaryStats,
     handleRewardPick, handleRewardSkip, handleActComplete, hasNextAct,
@@ -1223,7 +1225,7 @@ export default function App() {
     battle, gameState, dispatch,
     showBossSplash, actTheme, isCampaign, quickPlayRewardClaimed,
     activeRareEvent, handleRareEventDone,
-    isCampaignRef, worldBattleNodeIdRef, isDailyChallengeRef, isWeeklyChallengeRef,
+    isCampaignRef, worldBattleNodeIdRef, isDailyChallengeRef, isWeeklyChallengeRef, isWandererBattleRef,
     gameStateRef, summaryDoneRef,
     handlePlayCard, handlePlayAoeCard, handleGiveUp, setIsUserPaused,
     handleSetStance, handleCycleSpeed, handleWaveRewardPick, handleWaveRewardSkip,

--- a/web/src/app/AppContext.tsx
+++ b/web/src/app/AppContext.tsx
@@ -132,6 +132,8 @@ export interface AppContextValue {
   handleStartDailyChallenge: () => void
   handleStartWeeklyChallenge: () => void
   handleStartTraining:       (enemyUnitName: string, playerCards: Card[]) => void
+  /** Launch a single-battle duel offered by a wandering hub-town NPC (#2149). */
+  handleStartWandererBattle: () => void
   handleResetGame:           () => void
   checkForUpdates:           () => Promise<void>
 

--- a/web/src/app/BattleContext.tsx
+++ b/web/src/app/BattleContext.tsx
@@ -31,6 +31,8 @@ export interface BattleContextValue {
   worldBattleNodeIdRef:  MutableRefObject<string | null>
   isDailyChallengeRef:   MutableRefObject<boolean>
   isWeeklyChallengeRef:  MutableRefObject<boolean>
+  /** True while playing a single-battle duel offered by a wandering hub-town NPC (#2149). */
+  isWandererBattleRef:   MutableRefObject<boolean>
   gameStateRef:          MutableRefObject<GameState | null>
   summaryDoneRef:        MutableRefObject<() => void>
 

--- a/web/src/app/routes/BattleRoutes.tsx
+++ b/web/src/app/routes/BattleRoutes.tsx
@@ -19,7 +19,7 @@ export function BattleRoutes() {
   const {
     battle, gameState, dispatch, showBossSplash, actTheme, isCampaign,
     quickPlayRewardClaimed, activeRareEvent, handleRareEventDone,
-    isCampaignRef, worldBattleNodeIdRef, isDailyChallengeRef, isWeeklyChallengeRef,
+    isCampaignRef, worldBattleNodeIdRef, isDailyChallengeRef, isWeeklyChallengeRef, isWandererBattleRef,
     gameStateRef, summaryDoneRef,
     handlePlayCard, handlePlayAoeCard, handleGiveUp, setIsUserPaused,
     handleSetStance, handleCycleSpeed, handleWaveRewardPick, handleWaveRewardSkip,
@@ -128,6 +128,7 @@ export function BattleRoutes() {
             showStreak={!isCampaignRef.current && worldBattleNodeIdRef.current === null && !isDailyChallengeRef.current && !isWeeklyChallengeRef.current}
             dailyChallengeState={isDailyChallengeRef.current ? dcGameOverState : undefined}
             worldBattle={worldBattleNodeIdRef.current !== null}
+            singleBattle={isWandererBattleRef.current}
           />
         ) : (
           <>

--- a/web/src/app/routes/HubRoutes.tsx
+++ b/web/src/app/routes/HubRoutes.tsx
@@ -23,7 +23,7 @@ export function HubRoutes() {
     setShopBuildingId, setShopTappedNpc, setShowTitleLoginModal, setFeedbackOpen,
     setActiveNarratorLog,
     handleCampaign, handleCampaign2, handleEndless, handleBuyCrystalPack,
-    goToWorldLocation, handleWorldBattle, handlePlay,
+    goToWorldLocation, handleWorldBattle, handleStartWandererBattle,
   } = useApp()
 
   return (
@@ -46,7 +46,7 @@ export function HubRoutes() {
           onCampaign={() => { setReturnScreen('hubworld'); handleCampaign() }}
           onCampaign2={() => { setReturnScreen('hubworld'); handleCampaign2() }}
           onEndless={() => { setReturnScreen('hubworld'); handleEndless() }}
-          onWandererBattle={() => { setReturnScreen('hubworld'); handlePlay('normal') }}
+          onWandererBattle={() => { setReturnScreen('hubworld'); handleStartWandererBattle() }}
           onWorldMap={() => setScreen('worldmap')}
           onNavigateTown={goToWorldLocation}
           onNarratorLog={(characterId) => { setReturnScreen('hubworld'); setActiveNarratorLog(characterId); setScreen('narratorJournal') }}

--- a/web/src/app/useQuickBattleFlow.ts
+++ b/web/src/app/useQuickBattleFlow.ts
@@ -40,6 +40,8 @@ interface UseQuickBattleFlowArgs {
   isDraftModeRef:       MutableRefObject<boolean>
   quickBattleModeRef:   MutableRefObject<QuickBattleMode>
   worldBattleNodeIdRef: MutableRefObject<string | null>
+  /** True while playing a single-battle duel offered by a wandering hub-town NPC (#2149). */
+  isWandererBattleRef:   MutableRefObject<boolean>
   battleFlawlessRef:     MutableRefObject<boolean>
   battleAllLegendaryRef: MutableRefObject<boolean>
   battleUsedStructure:   MutableRefObject<boolean>
@@ -61,6 +63,7 @@ interface UseQuickBattleFlowResult {
   handleStreakReset:   () => void
   handlePlayAgain:     () => void
   handleStartTraining: (enemyUnitName: string, playerCards: Card[]) => void
+  handleStartWandererBattle: () => void
 }
 
 /**
@@ -72,7 +75,7 @@ export function useQuickBattleFlow({
   setWorldMapKey, setStreakBrokenData, setPendingBattleFn, setPendingBattleIsCampaign,
   setQuickPlayRewardClaimed,
   isCampaignRef, isDailyChallengeRef, isWeeklyChallengeRef, isTrainingModeRef,
-  isDraftModeRef, quickBattleModeRef, worldBattleNodeIdRef,
+  isDraftModeRef, quickBattleModeRef, worldBattleNodeIdRef, isWandererBattleRef,
   battleFlawlessRef, battleAllLegendaryRef, battleUsedStructure, battleUsedMobileUnit,
   prevPlayerUnitsRef, prevOpponentUnitsRef,
 }: UseQuickBattleFlowArgs): UseQuickBattleFlowResult {
@@ -86,6 +89,7 @@ export function useQuickBattleFlow({
     battleUsedMobileUnit.current = false
     prevOpponentUnitsRef.current = new Map()
     prevPlayerUnitsRef.current = new Map()
+    setQuickPlayRewardClaimed(false)
     const { opts, playerCards } = buildQuickBattleOpts(mode, handicap)
     battleAllLegendaryRef.current = playerCards.length > 0 && playerCards.every(c => c.rarity === 'legendary')
     startBattle(newGame(opts))
@@ -99,6 +103,20 @@ export function useQuickBattleFlow({
       setPendingBattleFn(() => () => launchQuickBattle(mode))
     } else {
       launchQuickBattle(mode)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [launchQuickBattle])
+
+  // A single-battle duel offered by a wandering hub-town NPC (#2149) — same
+  // deck-slot warning gate as handlePlay, but flags isWandererBattleRef so
+  // GameOver can suppress the "Play Again" loop.
+  const handleStartWandererBattle = useCallback(() => {
+    if (loadDeckSlot('b').length > 0) {
+      setPendingBattleIsCampaign(false)
+      setPendingBattleFn(() => () => { isWandererBattleRef.current = true; launchQuickBattle('normal') })
+    } else {
+      isWandererBattleRef.current = true
+      launchQuickBattle('normal')
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [launchQuickBattle])
@@ -329,6 +347,6 @@ export function useQuickBattleFlow({
     handlePlay, handleDraftComplete, handleEndless,
     handleDailyChallenge, handleWeeklyChallenge, handleEndlessLeaderboard,
     handleStartDailyChallenge, handleDailyChallengeRetry, handleStartWeeklyChallenge,
-    handleStreakReset, handlePlayAgain, handleStartTraining,
+    handleStreakReset, handlePlayAgain, handleStartTraining, handleStartWandererBattle,
   }
 }

--- a/web/src/components/battle/GameOver.stories.tsx
+++ b/web/src/components/battle/GameOver.stories.tsx
@@ -38,6 +38,19 @@ export const VictoryRewardClaimed: Story = {
   },
 };
 
+export const SingleBattleVictoryClaimed: Story = {
+  args: {
+    state: exampleGameState,
+    winner: 'player',
+    handicap: 1,
+    onOpenPack: fn(),
+    rewardClaimed: true,
+    onPlayAgain: fn(),
+    onMainMenu: fn(),
+    singleBattle: true,
+  },
+};
+
 export const Defeat: Story = {
   args: {
     state: {

--- a/web/src/components/battle/GameOver.tsx
+++ b/web/src/components/battle/GameOver.tsx
@@ -32,6 +32,9 @@ interface Props {
   dailyChallengeState?: DailyChallengeState
   /** World-map battle: show a single "Return to Map" action instead of the play-again flow. */
   worldBattle?: boolean
+  /** A one-shot duel (e.g. a wandering hub-town NPC challenge, #2149): hide the
+   *  "Play Again" replay loop and label the remaining action to head back to town. */
+  singleBattle?: boolean
 }
 
 const VICTORY_ART = `   \\o/
@@ -55,7 +58,7 @@ const DRAW_ART = `  =====
   =====
   DRAW!`
 
-export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, onPlayAgain, onMainMenu, campaignAbandon, quickPlayHint, showStreak, dailyChallengeState, worldBattle }: Props) {
+export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, onPlayAgain, onMainMenu, campaignAbandon, quickPlayHint, showStreak, dailyChallengeState, worldBattle, singleBattle }: Props) {
   const won  = winner === 'player'
   const draw = winner === 'draw'
   const isEndlessDefeat = !!state.endlessMode && !won && !draw
@@ -205,8 +208,8 @@ export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, o
         ) : won && onOpenPack ? (
           rewardClaimed ? (
             <>
-              <button className="action-btn" onClick={onPlayAgain}>[ Play Again ]</button>
-              <button className="action-btn" onClick={onMainMenu}>[ I'm Done ]</button>
+              {!singleBattle && <button className="action-btn" onClick={onPlayAgain}>[ Play Again ]</button>}
+              <button className="action-btn" onClick={onMainMenu}>{singleBattle ? '[ Back to Town ]' : "[ I'm Done ]"}</button>
             </>
           ) : (
             <button className="action-btn action-btn--large action-btn--gold" onClick={onOpenPack}>
@@ -215,16 +218,18 @@ export function GameOver({ state, winner, handicap, onOpenPack, rewardClaimed, o
           )
         ) : (
           <>
-            <button className="action-btn" onClick={onPlayAgain}>
-              {campaignAbandon ? (won ? '[ Claim Reward ]' : '[ Retry Node ]') : '[ Play Again ]'}
-            </button>
+            {!singleBattle && (
+              <button className="action-btn" onClick={onPlayAgain}>
+                {campaignAbandon ? (won ? '[ Claim Reward ]' : '[ Retry Node ]') : '[ Play Again ]'}
+              </button>
+            )}
             {campaignAbandon && (
               <button className="action-btn action-btn--danger gameover-abandon-btn u-text-sm" onClick={() => setConfirmAbandon(true)}>
                 [ Abandon Run ]
               </button>
             )}
             <button className="action-btn" onClick={onMainMenu}>
-              [ Main Menu ]
+              {singleBattle ? '[ Back to Town ]' : '[ Main Menu ]'}
             </button>
           </>
         )}

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -58,6 +58,9 @@ const NPC_BLOCK_WAIT_MAX_MS  = 900   // give up waiting and try to reroute after
 // Chance a spawning (non-ghost) wanderer offers a card-battle challenge (#2149).
 const CHALLENGER_CHANCE = 0.2
 
+// How long a wanderer pauses their wandering after being tapped.
+const NPC_TAP_STUN_MS = 5000
+
 const NIGHT_LIGHT_INNER  = 4 * T   // fully lit within this radius of avatar
 const NIGHT_LIGHT_OUTER  = 7 * T   // fully dark beyond this radius
 const NIGHT_NPC_LIGHT_R  = 2 * T   // small glow radius around each NPC
@@ -2184,6 +2187,8 @@ export function HubTownCanvas({
         built.sprite.cursor    = 'pointer'
         built.sprite.on('pointerdown', (e) => {
           e.stopPropagation()
+          state.walkQueue   = []
+          state.wanderTimer = NPC_TAP_STUN_MS
           if (state.isChallenger) onAmbientNpcChallengeRef.current?.(state.identity.id, state.identity.name)
           else showAmbientNpcTapBubble(state)
         })


### PR DESCRIPTION
## Summary

- Tapping any wandering ("ambient") NPC in the hub town now pauses their wandering for 5 seconds, whether the tap shows the usual flavour bubble or (for a battle challenger, #2149) the duel-offer dialogue.
- A wanderer duel is now a single battle: `GameOver` no longer offers `[ Play Again ]` for it, just one `[ Back to Town ]` action — so accepting a challenge, winning or losing, sends you straight back to the hub instead of chaining into another random quick battle. Since the hub's wanderer roster is fully rebuilt on every visit, the NPC who issued the challenge is simply gone when you return.
- Fixed a pre-existing bug (not specific to wanderers): `quickPlayRewardClaimed` was only ever reset in `handleDraftComplete`/`handlePlayAgain`, never in `launchQuickBattle` — so winning a second consecutive quick battle (any mode, including a second wanderer duel) silently withheld the `[ CLAIM REWARD ]` button because the flag was still `true` from the previous battle.

## Test plan

- [x] `npm run build` — typechecks and builds cleanly
- [x] `npm run test` — all 264 test files / 2805 tests pass (the Playwright browser-cleanup error at the end is pre-existing, documented noise unrelated to this change)
- [x] Traced both scenarios through the code: win a wanderer duel → only `[ CLAIM REWARD ]` then `[ Back to Town ]`, no Play Again; win a *second* wanderer duel → `quickPlayRewardClaimed` is reset by `launchQuickBattle`, so `[ CLAIM REWARD ]` shows again.