### PR TITLE
Fishing: tap-to-fish on pond tiles + ocean/lake locales + Sailor Finn

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -465,6 +465,7 @@ Then on the NPC (in `config.json`): `"dialogueTree": "scholar-chat"` (keep a
 | `requireWeather` | string? | Choice only shown while the town's resolved weather (§12) matches (`"clear"`/`"rain"`/`"snow"`/`"fog"`). Weather is date/season-driven — for QA, force `"weather": {"type": "snow"}` in the town config, or use Millhaven (rains year-round). |
 | `requireTimeOfDay` | `"day"` \| `"night"` \| `"dawn"`? | Choice only shown while `hubClock.getTimeOfDay(gameHour)` matches: night 20:00–05:59, dawn 06:00–07:59, day otherwise (§9). |
 | `requireActivity` | `NpcActivity`? | Choice only shown while the speaking NPC's own schedule (§9) currently has this activity (`getNpcActivity`). No effect on NPCs without a `schedule`. |
+| `requireHubItem` | string? | Choice only shown while the player holds at least 1 of this hub-item id (`hasHubItem`). Read-only — doesn't consume it, unlike `tradeHubItem`. Used by Sailor Finn's fish appraisal (§16). |
 
 #### `DialogueEffect` types
 | `type` | Fields | Behaviour |
@@ -2154,21 +2155,91 @@ the default flavour bubble:
 
 Placed (named) animals keep their normal §8 quest/dialogue routing.
 
-### Hub fishing (item-gated)
+### Hub fishing (item-gated) & pond locales (#2148)
 
-Hub fishing NPCs use `"screen": "hub-fishing"` (Millhaven harbour, Capital
-City riverside, Ravenwatch pond). `handleNodeInteract` (HubWorld.tsx) blocks
-entry without a `fishing-rod` or without holding at least one `fish-bait`;
-both are global, so one rod works in every town. Entry does **not** consume
+Hub fishing NPCs use a `"screen"` starting with `"hub-fishing"` —
+`hub-fishing` (Capital City riverside — the default/generic "river" catch
+table), `hub-fishing-ocean` (Millhaven harbour), `hub-fishing-lake`
+(Ravenwatch's open-air pond, x2 NPCs), `hub-fishing-cave` (Ravenwatch's
+Sunless Depths, an underground/subterranean lake). `handleNodeInteract`
+(HubWorld.tsx) gates entry on `screen.startsWith('hub-fishing')`, blocking it
+without a `fishing-rod` or without holding at least one `fish-bait`; both are
+global, so one rod works in every town/locale. Entry does **not** consume
 bait — each cast inside the minigame does. The screen renders
-`<Fishing rewardMode="catch">` (App.tsx), which shows the live bait count in
-its header and deducts one `fish-bait` (via `removeHubItem`) on every cast
-("CAST!" / "TRY AGAIN" / "FISH AGAIN"); once bait hits 0, casting is disabled
-and only "GIVE UP"/"DONE" remain to exit. The caught fish is added to the
-inventory as a tier-keyed hub-item (`fish-tiddler` … `fish-legendary`) and
-**no tickets are awarded**. The arcade fishing tile (MiniGamesMenu,
-`"screen": "fishing"` nowhere in hub configs anymore) is unchanged, has no
-bait cost, and still pays tickets.
+`<Fishing rewardMode="catch" variant="…">` (HubRoutes.tsx — `variant` matches
+the locale: `river` default/omitted, `ocean`, `lake`, `cave`), which shows the
+live bait count in its header and deducts one `fish-bait` (via
+`removeHubItem`) on every cast ("CAST!" / "TRY AGAIN" / "FISH AGAIN"); once
+bait hits 0, casting is disabled and only "GIVE UP"/"DONE" remain to exit.
+Each variant has its own six-tier catch table (`Fishing.tsx` —
+`FISH_TIERS`/`OCEAN_FISH_TIERS`/`LAKE_FISH_TIERS`/`CAVE_FISH_TIERS`) and its
+own exclusive tier-keyed hub-items (e.g. `fish-tiddler` … `fish-legendary`
+for river, `ocean-fish-shoal` … `ocean-fish-abysstide` for ocean — see
+`hubItems.json`), so different towns genuinely fish up different sets of
+fish. **No tickets are awarded** in hub mode. The arcade fishing tile
+(MiniGamesMenu, `"screen": "fishing"` nowhere in hub configs anymore) is
+unchanged, has no bait cost, still uses the plain `river` table, and still
+pays tickets.
+
+Tapping a pond tile directly (rather than the fishing NPC) also opens this
+flow — see "Tap-to-fish" below.
+
+**Sailor Finn's fish appraisal (Millhaven):** a screen-less NPC
+(`sailor-finn`) with a `dialogueTree` (`finn-appraise`,
+`millhaven/questDefs.json`) offering one choice per ocean-tier hub-item, each
+gated with `requireHubItem` (§7b) so only tiers the player is actually
+holding appear. Picking one shows a flavored appraisal line (roughly the
+same crystal value Fishwife Marta's `marta-fish-trade` tree pays for that
+tier) — **read-only**, the fish is not consumed, unlike Marta's `tradeHubItem`
+sale. Marta's tree also has matching `ocean-fish-*` sell choices alongside
+the original generic `fish-*` ones (kept for fish caught elsewhere and
+brought to Millhaven).
+
+### Authoring checklist: new pond-locale fishing spot
+
+1. Pick a `variant` (`river` default, or add a new one to `Fishing.tsx`'s
+   `VARIANT_TIERS`/`VARIANT_TIER_HUB_ITEM` maps with its own six `FishTier`
+   entries and a `<Locale>_TIER_HUB_ITEM` map of tier label → hub-item id).
+2. Register each new tier hub-item in `hubItems.json` (`category:
+   'material'`).
+3. Add a `screen: 'hub-fishing-<locale>'` case to `HubRoutes.tsx` rendering
+   `<Fishing rewardMode="catch" variant="<locale>">`, and a
+   `screenEnterLabel` entry in `HubWorld.tsx`. The rod/bait gate
+   (`screen.startsWith('hub-fishing')`) and `NPC_SCREEN_KEYWORDS`
+   (`NpcEditor.tsx`) need the new screen id too.
+4. Place a fishing NPC with that `screen` in the town's `config.json` (or
+   reuse an existing one — the closest such NPC to a tapped pond tile decides
+   which locale a §"Tap-to-fish" prompt offers, so towns can only have as
+   many distinct locales as they have fishing NPCs).
+5. Optionally give the new tier's top item a buyer (`tradeHubItem`, §16) so
+   it isn't a dead end.
+6. Run `npm run test` and `npm run build`; verify in-game: the NPC's own tap
+   and a pond-tile tap both open the right variant, casting awards the new
+   locale's items, and (if wired) the buyer accepts them.
+
+### Tap-to-fish (pond tile taps, #2148/#2152)
+
+Tapping a pond tile directly (rather than the fisherman NPC) also opens the
+"cast a line?" flow, in `HubTownCanvas.tsx`'s exterior tap handler:
+
+1. If the tapped tile is in the town's pond-tile set (minus bridge tiles —
+   walkable spans over water aren't fishable), `nearestFishingScreen(tx, ty)`
+   finds the closest exterior NPC whose `screen` starts with `hub-fishing`
+   and returns its screen id (or `null` if the town has no fishing NPC at
+   all, in which case the tap falls through to an ordinary walk-there tap).
+2. The avatar is routed via the normal BFS pathfinder (`nearestWalkable`) to
+   the closest walkable tile to the pond tile, carrying a `pendingPondFish`
+   target (mirrors `pendingScreen`, and is likewise reset by any subsequent
+   tap so a new tap cancels a stale one).
+3. On arrival, if the avatar ends up within `POND_FISH_TAP_RADIUS` (3,
+   Chebyshev distance) of the tapped pond tile, `onPondFishTap(screen)` fires
+   into `HubWorld.tsx`'s `handlePondFishTap`, which shows a "Cast a line?"
+   confirm dialogue (reusing `screenEnterLabel`/`handleNodeInteract` — so
+   rod/bait gating is identical to tapping the NPC).
+
+Scoped to towns/ponds with an existing fishing NPC — expanding fishing to
+every pond tile in every town (most towns have decorative ponds with no
+fishing NPC at all) is tracked separately.
 
 ### Authoring checklist: new shop good + trade chain
 

--- a/web/src/app/routes/HubRoutes.tsx
+++ b/web/src/app/routes/HubRoutes.tsx
@@ -137,12 +137,25 @@ export function HubRoutes() {
         </OverlayScreen>
       )}
 
-      {/* The underground lake's fishing spot — same rod/bait gate as
-          hub-fishing (checked in HubWorld's handleNodeInteract), but a
-          cave-exclusive catch table (Fishing.tsx's variant prop). */}
+      {/* Pond-locale fishing spots (#2148/#2153) — same rod/bait gate as
+          hub-fishing (checked in HubWorld's handleNodeInteract via a
+          startsWith('hub-fishing') check), but each a locale-exclusive
+          catch table (Fishing.tsx's variant prop). 'cave' = the underground
+          lake, 'lake' = a town's open still-water pond, 'ocean' = a
+          harbour/coastal spot. */}
       {screen === 'hub-fishing-cave' && (
         <OverlayScreen title="🎣 FISHING" onBack={() => setScreen('hubworld')}>
           <Fishing rewardMode="catch" variant="cave" onDone={() => setScreen('hubworld')} />
+        </OverlayScreen>
+      )}
+      {screen === 'hub-fishing-lake' && (
+        <OverlayScreen title="🎣 FISHING" onBack={() => setScreen('hubworld')}>
+          <Fishing rewardMode="catch" variant="lake" onDone={() => setScreen('hubworld')} />
+        </OverlayScreen>
+      )}
+      {screen === 'hub-fishing-ocean' && (
+        <OverlayScreen title="🎣 FISHING" onBack={() => setScreen('hubworld')}>
+          <Fishing rewardMode="catch" variant="ocean" onDone={() => setScreen('hubworld')} />
         </OverlayScreen>
       )}
 

--- a/web/src/app/screens.ts
+++ b/web/src/app/screens.ts
@@ -69,6 +69,8 @@ export type Screen =
   | 'hub-minigame'
   | 'hub-fishing'
   | 'hub-fishing-cave'
+  | 'hub-fishing-lake'
+  | 'hub-fishing-ocean'
   | 'casino'
   | 'theatre'
   | 'worldmap'

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -55,6 +55,11 @@ const NPC_WALK_PX_PER_S = 80
 const NPC_BLOCK_WAIT_POLL_MS = 150   // how often to re-check a blocked tile
 const NPC_BLOCK_WAIT_MAX_MS  = 900   // give up waiting and try to reroute after this long
 
+// Tapping a pond tile routes the avatar to the nearest walkable tile; the
+// "cast line?" prompt only fires if that spot ends up within this many tiles
+// (Chebyshev distance) of the tapped water (#2148).
+const POND_FISH_TAP_RADIUS = 3
+
 // Chance a spawning (non-ghost) wanderer offers a card-battle challenge (#2149).
 const CHALLENGER_CHANCE = 0.2
 
@@ -160,6 +165,10 @@ interface Props {
   onEnterInterior?:  (buildingId: string) => void
   onExitInterior?:   () => void
   onTileTap?:        (tx: number, ty: number) => void
+  /** Fires when a tap on a pond tile routes the avatar within fishing range
+   *  of a town's fishing spot — passes the screen id to offer (e.g.
+   *  'hub-fishing'). Not fired for ponds with no nearby fishing NPC. */
+  onPondFishTap?:    (screen: string) => void
   pickedUpIds?:      Set<string>
   onItemPickup?:     (id: string, questId?: string) => void
   doorKeys?:         Set<string>
@@ -201,7 +210,7 @@ export function HubTownCanvas({
   onAreaEnter, onNodeInteract, onAvatarMove, onAvatarStep,
   returnRef, unitCards, commander, onNpcTap, onAnimalTap, onAnimalSeen, onAmbientAnimalTap,
   onAmbientNpcChallenge,
-  interiorEnterRef, interiorExitRef, petActionRef, onEnterInterior, onExitInterior, onTileTap,
+  interiorEnterRef, interiorExitRef, petActionRef, onEnterInterior, onExitInterior, onTileTap, onPondFishTap,
   pickedUpIds, onItemPickup, doorKeys, onDoorLocked, questNpcState, activeQuestIdsRef,
   completedQuestIdsRef, collectedTreasureIds, onTreasureStep,
   gameHour, isNight, npcProximityDialogue,
@@ -257,6 +266,8 @@ export function HubTownCanvas({
   onExitInteriorRef.current = onExitInterior
   const onTileTapRef        = useRef(onTileTap)
   onTileTapRef.current      = onTileTap
+  const onPondFishTapRef    = useRef(onPondFishTap)
+  onPondFishTapRef.current  = onPondFishTap
   const onItemPickupRef     = useRef(onItemPickup)
   onItemPickupRef.current   = onItemPickup
   const onDoorLockedRef     = useRef(onDoorLocked)
@@ -532,6 +543,25 @@ export function HubTownCanvas({
         for (let tx = x1; tx <= x2; tx++)
           for (let ty = y1; ty <= y2; ty++)
             buildingSet.add(`${tx},${ty}`)
+
+    // Pond tiles tap-routable for fishing (#2148) — bridge tiles are walkable
+    // spans over water, not water itself, so they're excluded.
+    const pondBridgeSet = new Set(HUB_BRIDGE_TILES.map(([tx, ty]) => `${tx},${ty}`))
+    const pondTapSet = new Set(
+      HUB_POND_TILES.filter(([tx, ty]) => !pondBridgeSet.has(`${tx},${ty}`)).map(([tx, ty]) => `${tx},${ty}`)
+    )
+    // The nearest exterior NPC offering a fishing screen to a tapped pond
+    // tile, or null if this town has no exterior fishing spot at all.
+    function nearestFishingScreen(tx: number, ty: number): string | null {
+      let best: string | null = null
+      let bestD = Infinity
+      for (const n of EXTERIOR_NPCS) {
+        if (!n.screen?.startsWith('hub-fishing')) continue
+        const d = Math.hypot(n.tx - tx, n.ty - ty)
+        if (d < bestD) { bestD = d; best = n.screen }
+      }
+      return best
+    }
 
     // ── Buildings ──────────────────────────────────────────────────────────────
     // Each building is drawn as one or more *visual variants* (a base variant plus
@@ -2205,6 +2235,7 @@ export function HubTownCanvas({
     let walkTarget:  [number, number] | null = null
     let isWalking    = false
     let pendingScreen: string | null = null
+    let pendingPondFish: { tile: [number, number]; screen: string } | null = null
 
     // ── Interior state ─────────────────────────────────────────────────────────
     let interiorActive      = false
@@ -3134,6 +3165,12 @@ export function HubTownCanvas({
       try {
         if (walkQueue.length === 0) {
           isWalking = false
+          if (pendingPondFish) {
+            const { tile, screen } = pendingPondFish
+            pendingPondFish = null
+            const dist = Math.max(Math.abs(currentTile[0] - tile[0]), Math.abs(currentTile[1] - tile[1]))
+            if (dist <= POND_FISH_TAP_RADIUS) onPondFishTapRef.current?.(screen)
+          }
           if (pendingScreen) {
             const s = pendingScreen
             pendingScreen = null
@@ -3265,7 +3302,7 @@ export function HubTownCanvas({
       }
     }
 
-    function startWalk(target: [number, number], nodeScreen?: string) {
+    function startWalk(target: [number, number], nodeScreen?: string, pondFish?: { tile: [number, number]; screen: string }) {
       for (const s of activeBubbles) bubbleLayer.removeChild(s.container)
       activeBubbles.length = 0
       for (const r of activeReactions) bubbleLayer.removeChild(r.text)
@@ -3279,6 +3316,7 @@ export function HubTownCanvas({
       walkQueue = path.slice(1)
       walkTarget = target
       pendingScreen = nodeScreen ?? null
+      pendingPondFish = pondFish ?? null
       if (!isWalking) processWalkQueue()
     }
 
@@ -3353,6 +3391,21 @@ export function HubTownCanvas({
         if (tappedDoor) {
           startWalk([tappedDoor.tx, tappedDoor.ty])
           return
+        }
+
+        // Pond tile tap (#2148) — route to the closest walkable tile and, if
+        // this town has a fishing spot, offer to cast a line once arrived.
+        if (pondTapSet.has(`${tapTx},${tapTy}`)) {
+          const screen = nearestFishingScreen(tapTx, tapTy)
+          if (screen) {
+            const pondWalkable = exteriorWalkable()
+            for (const k of npcOccupiedTiles()) pondWalkable.delete(k)
+            const pondPxX = tapTx * T + T / 2
+            const pondPxY = tapTy * T + T / 2
+            const target  = nearestWalkable(pondPxX, pondPxY, pondWalkable, T)
+            startWalk(target, undefined, { tile: [tapTx, tapTy], screen })
+            return
+          }
         }
 
         const node = EXTERIOR_NPCS.find(n => n.tx === tapTx && n.ty === tapTy && n.screen)

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -154,6 +154,8 @@ const SCREEN_ENTER_LABEL: Record<string, string> = {
   fishing:           'Cast a line?',
   'hub-fishing':     'Cast a line?',
   'hub-fishing-cave': 'Cast a line into the dark water?',
+  'hub-fishing-lake': 'Cast a line into the lake?',
+  'hub-fishing-ocean': 'Cast a line into the sea?',
   marble:            'Play marbles?',
   marblerace:        'Watch a marble race?',
   regatta:           'Race a skiff in the regatta?',
@@ -674,11 +676,11 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     }
     // Hub fishing is gated on owning a rod and holding at least 1 bait.
     // Both are global hub-items, so a rod bought in Millhaven works at any
-    // town's fishing spot — including the underground lake's cave variant
-    // (hub-fishing-cave), which uses the same rod/bait but a different catch
-    // table (Fishing.tsx's variant prop). Bait is consumed per cast inside
-    // Fishing.tsx, not on entry.
-    if (screen === 'hub-fishing' || screen === 'hub-fishing-cave') {
+    // town's fishing spot — including every pond-locale variant
+    // (hub-fishing-cave/-lake/-ocean), which all share the same rod/bait but
+    // each have their own catch table (Fishing.tsx's variant prop). Bait is
+    // consumed per cast inside Fishing.tsx, not on entry.
+    if (screen.startsWith('hub-fishing')) {
       if (!hasHubItem('fishing-rod')) {
         setDialogueEvent({ speakerName: '', text: "You can't fish without a rod. Millhaven's harbour stall sells them." })
         return
@@ -1176,7 +1178,8 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireWeather || c.requireWeather === currentWeather) &&
       (!c.requireTimeOfDay || c.requireTimeOfDay === getTimeOfDay(gameHour)) &&
       (!c.requireActivity  || (!!npcDef && 'schedule' in npcDef &&
-          getNpcActivity(npcDef as HubNpc, gameHour) === c.requireActivity))
+          getNpcActivity(npcDef as HubNpc, gameHour) === c.requireActivity)) &&
+      (!c.requireHubItem || hasHubItem(c.requireHubItem))
     ))
     const speaker = node.speakerName ?? speakerName
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -691,6 +691,20 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
     onNavigate?.(screen, buildingId, npc)
   }, [onNavigate, onCampaign, onCampaign2, onWorldMap, onNavigateTown, onNarratorLog, commander])
 
+  // Tapping a pond tile within range of a town's fishing spot (#2148) prompts
+  // to cast a line, mirroring the confirm dialogue a fishing NPC's own tap
+  // shows — rod/bait gating is still handled by handleNodeInteract.
+  const handlePondFishTap = useCallback((screen: string) => {
+    setDialogueEvent({
+      speakerName: '',
+      text: screenEnterLabel(screen),
+      choices: [
+        { label: 'Cast a line', primary: true, onClick: () => handleNodeInteract(screen) },
+        { label: 'Not now', isExit: true, onClick: () => setDialogueEvent(null) },
+      ],
+    })
+  }, [handleNodeInteract])
+
   const handleReturn = useCallback(() => {
     returnRef.current?.()
   }, [])
@@ -2263,6 +2277,7 @@ function hasOfferableQuest(giverId: string): boolean {
             onEnterInterior={(buildingId) => { setInteriorActive(true); setActiveBuildingId(buildingId) }}
             onExitInterior={() => { setInteriorActive(false); setActiveBuildingId(null) }}
             onTileTap={onTileTap}
+            onPondFishTap={handlePondFishTap}
             pickedUpIds={pickedUpIds}
             onItemPickup={handleItemPickup}
             doorKeys={doorKeys}

--- a/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
+++ b/web/src/components/mapEditor/npcQuestDrawer/NpcEditor.tsx
@@ -12,7 +12,7 @@ import { SCREEN_IDS } from '../EntityInspector'
 // Screens reachable from an NPC's dialogue: the standard SCREEN_IDS list, plus
 // special dispatcher keywords handled directly in HubWorld.tsx's
 // handleNodeInteract (not full-blown screens, e.g. modals / one-off flows).
-const NPC_SCREEN_KEYWORDS = ['adopt-pet', 'town-upgrades', 'bounty-board', 'worldmap', 'campaign', 'endless', 'hub-fishing', 'hub-fishing-cave', 'commander']
+const NPC_SCREEN_KEYWORDS = ['adopt-pet', 'town-upgrades', 'bounty-board', 'worldmap', 'campaign', 'endless', 'hub-fishing', 'hub-fishing-cave', 'hub-fishing-lake', 'hub-fishing-ocean', 'commander']
 const NPC_SCREEN_OPTIONS = Array.from(new Set([...SCREEN_IDS, ...NPC_SCREEN_KEYWORDS])).sort()
 
 export type { PickKind } from '../mapEditorTypes'

--- a/web/src/components/minigames/Fishing.tsx
+++ b/web/src/components/minigames/Fishing.tsx
@@ -93,6 +93,78 @@ export const CAVE_FISH_TIERS: FishTier[] = [
   },
 ]
 
+// Lake variant — open, still-water species for a town's ordinary pond/lake
+// spot (as opposed to a flowing river). Same weights/ranges/chances as
+// FISH_TIERS; distinct tier labels double as the key into LAKE_TIER_HUB_ITEM.
+export const LAKE_FISH_TIERS: FishTier[] = [
+  {
+    tier: 'Shallows', icon: '🐟',
+    names: ['Lake Minnow', 'Reed Bleak', 'Shoreling', 'Pond Skimmer', 'Duckweed Dace'],
+    minG: 100,   maxG: 500,   minCm: 8,   maxCm: 25,  minT: 2,   maxT: 6,   chance: 40,
+  },
+  {
+    tier: 'Weedbed', icon: '🐠',
+    names: ['Lake Roach', 'Lily Perch', 'Weedy Rudd', 'Still-water Bream', 'Reed Chub'],
+    minG: 500,   maxG: 2000,  minCm: 25,  maxCm: 45,  minT: 8,   maxT: 18,  chance: 30,
+  },
+  {
+    tier: 'Deep Water', icon: '🐡',
+    names: ['Lake Carp', 'Tench', 'Still Barbel', 'Lake Zander', 'Pond Catfish'],
+    minG: 2000,  maxG: 5000,  minCm: 45,  maxCm: 70,  minT: 22,  maxT: 40,  chance: 15,
+  },
+  {
+    tier: 'Old Water', icon: '🦈',
+    names: ['Lake Pike', 'Landlocked Salmon', 'Basin Trout', 'Old Catfish', 'Lake Sturgeon'],
+    minG: 5000,  maxG: 12000, minCm: 70,  maxCm: 110, minT: 42,  maxT: 75,  chance: 9,
+  },
+  {
+    tier: 'Prize Water', icon: '🏆',
+    names: ['Giant Lake Carp', 'Monster of the Mere', 'Lake Titan', 'Champion Trout', 'Great Basin Pike'],
+    minG: 12000, maxG: 25000, minCm: 110, maxCm: 150, minT: 80,  maxT: 130, chance: 5,
+  },
+  {
+    tier: 'Still Legend', icon: '✨',
+    names: ['The Lake Watcher', 'Ancient Basin Carp', 'Mere Serpent'],
+    minG: 25000, maxG: 50000, minCm: 150, maxCm: 200, minT: 150, maxT: 250, chance: 1,
+  },
+]
+
+// Ocean variant — saltwater species for a harbour/coastal fishing spot.
+// Same weights/ranges/chances as FISH_TIERS; distinct tier labels double as
+// the key into OCEAN_TIER_HUB_ITEM.
+export const OCEAN_FISH_TIERS: FishTier[] = [
+  {
+    tier: 'Shoal', icon: '🐟',
+    names: ['Silverside', 'Sand Smelt', 'Anchovy', 'Sprat', 'Tide Minnow'],
+    minG: 100,   maxG: 500,   minCm: 8,   maxCm: 25,  minT: 2,   maxT: 6,   chance: 40,
+  },
+  {
+    tier: 'Reef', icon: '🐠',
+    names: ['Mackerel', 'Sea Bream', 'Herring', 'Grey Mullet', 'Wrasse'],
+    minG: 500,   maxG: 2000,  minCm: 25,  maxCm: 45,  minT: 8,   maxT: 18,  chance: 30,
+  },
+  {
+    tier: 'Deep Shelf', icon: '🐡',
+    names: ['Cod', 'Sea Bass', 'Pollock', 'Haddock', 'Conger Eel'],
+    minG: 2000,  maxG: 5000,  minCm: 45,  maxCm: 70,  minT: 22,  maxT: 40,  chance: 15,
+  },
+  {
+    tier: 'Open Water', icon: '🦈',
+    names: ['Bluefin', 'Halibut', 'Barracuda', 'Bull Shark', 'Marlin'],
+    minG: 5000,  maxG: 12000, minCm: 70,  maxCm: 110, minT: 42,  maxT: 75,  chance: 9,
+  },
+  {
+    tier: 'Deep Sea', icon: '🏆',
+    names: ['Giant Tuna', 'Broadbill Swordfish', 'Deep-sea Grouper', 'Ocean Titan', 'Great Marlin'],
+    minG: 12000, maxG: 25000, minCm: 110, maxCm: 150, minT: 80,  maxT: 130, chance: 5,
+  },
+  {
+    tier: 'Abyss Tide', icon: '✨',
+    names: ['The Tideborn Leviathan', 'Kraken Spawn', 'Deepwater Wyrmfish'],
+    minG: 25000, maxG: 50000, minCm: 150, maxCm: 200, minT: 150, maxT: 250, chance: 1,
+  },
+]
+
 // ── Catch types ───────────────────────────────────────────────────────────────
 
 interface FishCatch {
@@ -161,6 +233,14 @@ export const CAVE_TIER_HUB_ITEM: Record<string, string> = {
   Blindling: 'cave-fish-blindling', 'Cave-dweller': 'cave-fish-dweller', 'Deep Lurker': 'cave-fish-lurker',
   Ancient: 'cave-fish-ancient', Abyssal: 'cave-fish-abyssal', Sunless: 'cave-fish-sunless',
 }
+export const LAKE_TIER_HUB_ITEM: Record<string, string> = {
+  Shallows: 'lake-fish-shallows', Weedbed: 'lake-fish-weedbed', 'Deep Water': 'lake-fish-deepwater',
+  'Old Water': 'lake-fish-oldwater', 'Prize Water': 'lake-fish-prizewater', 'Still Legend': 'lake-fish-stilllegend',
+}
+export const OCEAN_TIER_HUB_ITEM: Record<string, string> = {
+  Shoal: 'ocean-fish-shoal', Reef: 'ocean-fish-reef', 'Deep Shelf': 'ocean-fish-deepshelf',
+  'Open Water': 'ocean-fish-openwater', 'Deep Sea': 'ocean-fish-deepsea', 'Abyss Tide': 'ocean-fish-abysstide',
+}
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -171,16 +251,25 @@ interface Props {
    *  inventory instead, and no tickets are ever awarded. */
   rewardMode?: 'tickets' | 'catch'
   /** 'river' (default): the standard Tiddler→Legendary tiers used at every
-   *  ordinary fishing spot. 'cave': the pale, blind cave-lake species —
-   *  same weights/ranges, exclusive hub-items — used only at the
-   *  underground lake's fishing spot. */
-  variant?: 'river' | 'cave'
+   *  ordinary fishing spot. 'cave': the pale, blind cave-lake species, used
+   *  only at the underground lake's fishing spot. 'lake': still-water
+   *  species for a town's open pond/lake. 'ocean': saltwater species for a
+   *  harbour/coastal spot. Each variant has its own exclusive hub-items
+   *  (#2148/#2153 — pond locales). */
+  variant?: 'river' | 'cave' | 'lake' | 'ocean'
+}
+
+const VARIANT_TIERS: Record<NonNullable<Props['variant']>, FishTier[]> = {
+  river: FISH_TIERS, cave: CAVE_FISH_TIERS, lake: LAKE_FISH_TIERS, ocean: OCEAN_FISH_TIERS,
+}
+const VARIANT_TIER_HUB_ITEM: Record<NonNullable<Props['variant']>, Record<string, string>> = {
+  river: TIER_HUB_ITEM, cave: CAVE_TIER_HUB_ITEM, lake: LAKE_TIER_HUB_ITEM, ocean: OCEAN_TIER_HUB_ITEM,
 }
 
 export function Fishing({ onDone, rewardMode = 'tickets', variant = 'river' }: Props) {
   const usesBait = rewardMode === 'catch'
-  const tiers = variant === 'cave' ? CAVE_FISH_TIERS : FISH_TIERS
-  const tierHubItem = variant === 'cave' ? CAVE_TIER_HUB_ITEM : TIER_HUB_ITEM
+  const tiers = VARIANT_TIERS[variant]
+  const tierHubItem = VARIANT_TIER_HUB_ITEM[variant]
 
   const [phase, setPhase]   = useState<Phase>('idle')
   const [result, setResult] = useState<Catch | null>(null)

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2342,7 +2342,23 @@
         "millhaven-harbour-angler-topic-auto-2",
         "millhaven-harbour-angler-topic-auto-3"
       ],
-      "screen": "hub-fishing",
+      "screen": "hub-fishing-ocean",
+      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftTrack": "ally",
+      "dislikedGiftItemIds": [
+        "silk-ribbon"
+      ]
+    },
+    {
+      "id": "sailor-finn",
+      "name": "Sailor Finn",
+      "sprite": "hub-npc-fisherman",
+      "tx": 44,
+      "ty": 16,
+      "dialogueTree": "finn-appraise",
+      "dialogue": [
+        "Got something worth a look? I've appraised catches from here to the Ashen Wastes."
+      ],
       "favoriteGiftItemId": "fish-trophy",
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -1093,6 +1093,84 @@
               ]
             },
             {
+              "label": "Shoal — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-shoal",
+                  "giveCrystals": 3,
+                  "missingText": "No shoal fish in that pack of yours. The harbour dock's the place for those.",
+                  "successText": "Barely a mouthful, but the cats love them. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Reef Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-reef",
+                  "giveCrystals": 6,
+                  "missingText": "You've no reef fish on you.",
+                  "successText": "Good pan-sized fish, that. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Shelf Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-deepshelf",
+                  "giveCrystals": 12,
+                  "missingText": "You've no deep shelf fish on you.",
+                  "successText": "Now that's a proper catch. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Open Water Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-openwater",
+                  "giveCrystals": 25,
+                  "missingText": "You've no open water fish on you.",
+                  "successText": "Heavens, look at the size of it! 25 crystals, and worth every one."
+                }
+              ]
+            },
+            {
+              "label": "Deep Sea Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-deepsea",
+                  "giveCrystals": 45,
+                  "missingText": "A deep sea catch? I'll believe it when I see it.",
+                  "successText": "I'll have this in the window within the hour. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Abyss Tide Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-abysstide",
+                  "giveCrystals": 90,
+                  "missingText": "An Abyss Tide catch? Sailor Finn tells taller tales sober.",
+                  "successText": "By the tides... I've only heard songs about these. 90 crystals — don't tell my husband."
+                }
+              ]
+            },
+            {
               "label": "That's all for now.",
               "effects": [
                 {
@@ -1101,6 +1179,73 @@
               ]
             }
           ]
+        }
+      }
+    },
+    {
+      "id": "finn-appraise",
+      "npcId": "sailor-finn",
+      "start": "greet",
+      "nodes": {
+        "greet": {
+          "text": "Let's have a look at your catch, then. What've you got?",
+          "choices": [
+            {
+              "label": "A Shoal fish.",
+              "requireHubItem": "ocean-fish-shoal",
+              "next": "tier-shoal"
+            },
+            {
+              "label": "A Reef fish.",
+              "requireHubItem": "ocean-fish-reef",
+              "next": "tier-reef"
+            },
+            {
+              "label": "A Deep Shelf fish.",
+              "requireHubItem": "ocean-fish-deepshelf",
+              "next": "tier-deepshelf"
+            },
+            {
+              "label": "An Open Water fish.",
+              "requireHubItem": "ocean-fish-openwater",
+              "next": "tier-openwater"
+            },
+            {
+              "label": "A Deep Sea fish.",
+              "requireHubItem": "ocean-fish-deepsea",
+              "next": "tier-deepsea"
+            },
+            {
+              "label": "An Abyss Tide fish.",
+              "requireHubItem": "ocean-fish-abysstide",
+              "next": "tier-abysstide"
+            },
+            {
+              "label": "Nothing yet.",
+              "next": "nothing-yet"
+            }
+          ]
+        },
+        "tier-shoal": {
+          "text": "\"Shoal fish — bait-sized, but every angler starts somewhere. Fishwife Marta pays a few coppers for these, maybe 3 crystals.\""
+        },
+        "tier-reef": {
+          "text": "\"A reef fish, good and firm. Marta'll give you a fair 6 crystals for that one.\""
+        },
+        "tier-deepshelf": {
+          "text": "\"Pulled up from the shelf, by the weight of it. That's a solid 12-crystal catch.\""
+        },
+        "tier-openwater": {
+          "text": "\"Now that's real open-ocean iron. Marta would pay 25 crystals and count herself lucky.\""
+        },
+        "tier-deepsea": {
+          "text": "\"A deep-sea beauty. I've only landed a handful like it myself — worth a good 45 crystals.\""
+        },
+        "tier-abysstide": {
+          "text": "\"...By the depths. An Abyss Tide catch. Thirty years at sea and I've never landed one myself. Marta would pay a small fortune for that — 90 crystals, easy.\""
+        },
+        "nothing-yet": {
+          "text": "\"Come back once you've hauled something in off the harbour dock — I'll tell you true what it's worth.\""
         }
       }
     },

--- a/web/src/data/hub/questDefs.ts
+++ b/web/src/data/hub/questDefs.ts
@@ -249,6 +249,7 @@ export interface DialogueChoiceDef {
   hideIfQuest?: string     // hide this choice once that quest is completed
   requireTimeOfDay?: 'day' | 'night' | 'dawn' // only show this choice during that time bucket (hubClock getTimeOfDay)
   requireActivity?: NpcActivity               // only show this choice while the speaking NPC's schedule has this activity
+  requireHubItem?: string  // only show this choice while the player holds at least 1 of this hub-item id (read-only check — doesn't consume it, unlike tradeHubItem)
 }
 
 export interface DialogueNode {

--- a/web/src/data/hub/ravenwatch/config.json
+++ b/web/src/data/hub/ravenwatch/config.json
@@ -11855,7 +11855,7 @@
       "sprite": "hub-npc-fisherman",
       "tx": 45,
       "ty": 49,
-      "screen": "hub-fishing",
+      "screen": "hub-fishing-lake",
       "dialogue": [
         "Nothings biting today. Maybe try again later?",
         "The fish are shy around here. Patience is key."
@@ -11864,7 +11864,7 @@
         "ravenwatch-fishing-hole-topic-auto-1",
         "ravenwatch-fishing-hole-topic-auto-2"
       ],
-      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftItemId": "lake-fish-prizewater",
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
         "silk-ribbon"
@@ -11876,14 +11876,14 @@
       "sprite": "hub-npc-fisherman",
       "tx": 44,
       "ty": 51,
-      "screen": "hub-fishing",
+      "screen": "hub-fishing-lake",
       "dialogue": [
         "The pond is calm today. Care to fish?"
       ],
       "conversationTopics": [
         "ravenwatch-fishing-hole-2-topic-auto-1"
       ],
-      "favoriteGiftItemId": "fish-trophy",
+      "favoriteGiftItemId": "lake-fish-prizewater",
       "favoriteGiftTrack": "ally",
       "dislikedGiftItemIds": [
         "silk-ribbon"

--- a/web/src/data/hubItems.json
+++ b/web/src/data/hubItems.json
@@ -120,6 +120,90 @@
     "category": "material"
   },
   {
+    "id": "lake-fish-shallows",
+    "name": "Shallows",
+    "icon": "🐟",
+    "desc": "A tiny still-water fish, quick and darting through the reeds.",
+    "category": "material"
+  },
+  {
+    "id": "lake-fish-weedbed",
+    "name": "Weedbed",
+    "icon": "🐠",
+    "desc": "Pulled up from the lily pads. Good eating, or good trading.",
+    "category": "material"
+  },
+  {
+    "id": "lake-fish-deepwater",
+    "name": "Deep Water",
+    "icon": "🐡",
+    "desc": "A sturdy fish from the lake's colder, deeper reaches.",
+    "category": "material"
+  },
+  {
+    "id": "lake-fish-oldwater",
+    "name": "Old Water",
+    "icon": "🦈",
+    "desc": "Heavy enough to make your arms ache. It's seen a few seasons.",
+    "category": "material"
+  },
+  {
+    "id": "lake-fish-prizewater",
+    "name": "Prize Water",
+    "icon": "🏆",
+    "desc": "A magnificent lake specimen. Anglers would trade stories for this one.",
+    "category": "material"
+  },
+  {
+    "id": "lake-fish-stilllegend",
+    "name": "Still Legend",
+    "icon": "✨",
+    "desc": "A fish out of lakeside legend. Nobody believes you caught it.",
+    "category": "material"
+  },
+  {
+    "id": "ocean-fish-shoal",
+    "name": "Shoal",
+    "icon": "🐟",
+    "desc": "A tiny saltwater fish, silvery and quick. Barely a mouthful.",
+    "category": "material"
+  },
+  {
+    "id": "ocean-fish-reef",
+    "name": "Reef",
+    "icon": "🐠",
+    "desc": "A modest coastal catch. The harbour fishmongers pay fairly for these.",
+    "category": "material"
+  },
+  {
+    "id": "ocean-fish-deepshelf",
+    "name": "Deep Shelf",
+    "icon": "🐡",
+    "desc": "Hauled up from the continental shelf. A respectable catch.",
+    "category": "material"
+  },
+  {
+    "id": "ocean-fish-openwater",
+    "name": "Open Water",
+    "icon": "🦈",
+    "desc": "A serious open-ocean catch. It fought the whole way in.",
+    "category": "material"
+  },
+  {
+    "id": "ocean-fish-deepsea",
+    "name": "Deep Sea",
+    "icon": "🏆",
+    "desc": "A magnificent deep-sea specimen. Sailors' eyes light up at the sight.",
+    "category": "material"
+  },
+  {
+    "id": "ocean-fish-abysstide",
+    "name": "Abyss Tide",
+    "icon": "✨",
+    "desc": "A fish out of sailors' legend. Even Sailor Finn will struggle to believe this one.",
+    "category": "material"
+  },
+  {
     "id": "fancy-hat",
     "name": "Fancy Hat",
     "icon": "🎩",


### PR DESCRIPTION
Closes #2152, closes #2153. Part of #2148 (left open — tracked via those two sub-issues).

## Summary

**Tap-to-fish (#2152):** Tapping a pond tile now routes the avatar to the nearest walkable tile (reusing the existing BFS pathfinder). If the avatar ends up within 3 tiles of the tapped water and the town has a fishing spot nearby, a "Cast a line?" modal offers to fish — same rod/bait gating as tapping the fisherman NPC directly. Scoped to towns/ponds that already have a fishing NPC (Millhaven harbour, Capital City riverside, Ravenwatch pond + Sunless Depths cave).

**Pond locales + Sailor Finn (#2153):**
- Fishing now has 4 locale variants instead of 2: `river` (Capital City, unchanged default), `cave` (Ravenwatch's Sunless Depths, unchanged), plus two new ones — `ocean` (Millhaven harbour) and `lake` (Ravenwatch's open-air pond). Each variant has its own six-tier catch table and exclusive hub-items, so different towns genuinely fish up a different set of fish.
- **Sailor Finn** (new NPC, Millhaven harbour) appraises a held ocean-tier fish — a read-only companion to Fishwife Marta's existing sell-for-crystals trade, not a duplicate of it. Added a small, reusable `requireHubItem` dialogue-choice gate to support this (mirrors the existing `requireFlag`/`requireWeather`/etc. gates).
- Fishwife Marta's trade tree gained matching `ocean-fish-*` sell choices alongside the original generic `fish-*` ones (kept so fish caught elsewhere and brought to Millhaven are still sellable — no economy breakage for existing saves).

## Test plan
- [x] `npm run build` (typecheck + Vite build) — clean
- [x] `npm run test` — 2805/2805 passing (the Playwright browser-cleanup error is pre-existing/documented noise, not a regression)
- [x] `python3 -c "import json; json.load(...)"` sanity-checked the edited `config.json`/`questDefs.json` files
- [ ] Manual in-game verification (tap a pond tile in Millhaven/Ravenwatch/Capital City, confirm routing + modal; talk to Sailor Finn holding an ocean-tier fish)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvbhdLmFmKjt9T2fJfbaPr)_