### PR TITLE
Fix unreachable fish appraisal dialogue on Sailor Finn

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -2185,7 +2185,9 @@ Tapping a pond tile directly (rather than the fishing NPC) also opens this
 flow — see "Tap-to-fish" below.
 
 **Sailor Finn's fish appraisal (Millhaven):** a screen-less NPC
-(`sailor-finn`) with a `dialogueTree` (`finn-appraise`,
+(`sailor-finn-appraiser`, a separate dockside placement from the quest-giving
+`sailor-finn` — same character, distinct id so tap lookups don't collide)
+with a `dialogueTree` (`finn-appraise`,
 `millhaven/questDefs.json`) offering one choice per ocean-tier hub-item, each
 gated with `requireHubItem` (§7b) so only tiers the player is actually
 holding appear. Picking one shows a flavored appraisal line (roughly the

--- a/web/src/data/hub/millhaven/config.json
+++ b/web/src/data/hub/millhaven/config.json
@@ -2350,7 +2350,7 @@
       ]
     },
     {
-      "id": "sailor-finn",
+      "id": "sailor-finn-appraiser",
       "name": "Sailor Finn",
       "sprite": "hub-npc-fisherman",
       "tx": 44,

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -1184,7 +1184,7 @@
     },
     {
       "id": "finn-appraise",
-      "npcId": "sailor-finn",
+      "npcId": "sailor-finn-appraiser",
       "start": "greet",
       "nodes": {
         "greet": {

--- a/web/src/data/hub/npcTravelIntegrity.test.ts
+++ b/web/src/data/hub/npcTravelIntegrity.test.ts
@@ -55,3 +55,23 @@ describe('NPC travel entries target a real town with a matching present record',
     }
   }
 })
+
+// Guard: within a single town, HUB_NPCS.find(n => n.id === npcId) (used by
+// every tap/quest/dialogue lookup in HubWorld.tsx) always resolves to the
+// FIRST matching record. Two NPCs sharing an id in the same config.json
+// silently shadow one another — the second one's dialogueTree/quest wiring
+// becomes unreachable even though its sprite still renders and shows its own
+// flavour dialogue. (Cross-town id reuse is fine and expected — that's how
+// 'travel' schedule entries above work.)
+describe('NPC ids are unique within a single town', () => {
+  for (const [townKey, { locationData }] of Object.entries(locationRegistry)) {
+    it(`${townKey}: no duplicate npc ids`, () => {
+      const seen = new Map<string, number>()
+      for (const npc of locationData.HUB_NPCS) {
+        seen.set(npc.id, (seen.get(npc.id) ?? 0) + 1)
+      }
+      const dupes = [...seen.entries()].filter(([, count]) => count > 1).map(([id]) => id)
+      expect(dupes, `duplicate npc id(s) in ${townKey}'s config.json: ${dupes.join(', ')}`).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Millhaven's `config.json` defined **two** `HUB_NPCS` entries with the same id `sailor-finn`: the west-dock quest-giver (missing-catch / lost-at-sea storyline) and a separate dockside NPC wired to the `finn-appraise` dialogue tree.
- Every tap/quest/dialogue lookup in `HubWorld.tsx` resolves an NPC by id via `Array.find`, which always returns the **first** matching entry. So tapping the appraiser sprite showed its own correct greeting line ("Got something worth a look?...") but then fell through to the *other* Finn's record — which has no `dialogueTree` — so the appraisal choices never rendered.
- Gave the appraiser its own id (`sailor-finn-appraiser`) and updated the `finn-appraise` tree's `npcId` metadata + docs to match.
- Added a regression test (`npcTravelIntegrity.test.ts`) asserting no town's NPC list contains duplicate ids, since nothing previously caught this.

## Test plan

- [x] `npx vitest run src/data/hub src/game/hub` — 40 files / 2335 tests pass
- [x] `npx tsc --noEmit` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVcoEc6J939CD2Qe9mNvMb)_