### PR TITLE
feat(hub): wake sleeping NPCs with a 2nd tap, grumpily

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -276,6 +276,14 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   const [pinnedNpcId,         setPinnedNpcId]         = useState<string | null>(null)
   const [openTreasure,        setOpenTreasure]        = useState<HubTreasure | null>(null)
   const [collectedTreasureIds] = useState<Set<string>>(() => getCollectedTreasureIds())
+  // Sleeping-NPC wake-up: first tap while asleep just narrates it (existing
+  // behaviour); a 2nd tap on the *same* NPC while `pendingWakeNpcId` still
+  // matches wakes them up grumpy. `wokenNpcIds` remembers who's been woken so
+  // later taps in the same sleep window skip straight to normal interaction
+  // instead of re-narrating sleep or re-waking them. Both are pruned below
+  // once each NPC's schedule moves them past `sleep` for real.
+  const [pendingWakeNpcId, setPendingWakeNpcId] = useState<string | null>(null)
+  const [wokenNpcIds,      setWokenNpcIds]      = useState<Set<string>>(new Set())
   // Refresh friendship/quest state after interactions (lightweight — just reads localStorage)
   const [_tick, setTick] = useState(0)
   const refreshState = useCallback(() => setTick(t => t + 1), [])
@@ -344,6 +352,20 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   }, [town, onCrystalsChange, refreshState])
 
   const { gameHour, isNight: isGameNight } = useHubClock()
+
+  // Once an NPC's schedule moves them past `sleep` for real, forget any
+  // wake-up state from that sleep window so the next one starts fresh.
+  useEffect(() => {
+    const stillAsleep = (npcId: string) => {
+      const npc = locationData.HUB_NPCS.find(n => n.id === npcId)
+      return !!npc && isNpcAsleep(npc, gameHour)
+    }
+    if (pendingWakeNpcId && !stillAsleep(pendingWakeNpcId)) setPendingWakeNpcId(null)
+    setWokenNpcIds(prev => {
+      const next = new Set([...prev].filter(stillAsleep))
+      return next.size === prev.size ? prev : next
+    })
+  }, [gameHour, locationData, pendingWakeNpcId])
 
   function getNpcDisplayName(npcId: string): string {
     return locationData.HUB_NPCS.find(n => n.id === npcId)?.name
@@ -1319,7 +1341,22 @@ function hasOfferableQuest(giverId: string): boolean {
     // Sleeping NPCs don't chat, trade, or take quest hand-ins — the whole
     // cascade below assumes an awake NPC. Sleep windows are short in real
     // time (a full game day is 30 real minutes), so nothing is soft-locked.
-    if (namedNpc?.schedule && isNpcAsleep(namedNpc, getGameHour())) {
+    // A 1st tap just narrates the sleep; tapping the *same* still-sleeping
+    // NPC again wakes them early (grumpily, at a small friendship cost) and
+    // lets the rest of this tap's cascade — and every tap after, for the
+    // remainder of this sleep window — treat them as awake.
+    if (namedNpc?.schedule && isNpcAsleep(namedNpc, getGameHour()) && !wokenNpcIds.has(npcId)) {
+      if (pendingWakeNpcId === npcId) {
+        setPendingWakeNpcId(null)
+        setWokenNpcIds(prev => new Set(prev).add(npcId))
+        grantFriendship(npcId, -1)
+        setDialogueEvent({
+          speakerName,
+          text: namedNpc.wakeDialogue ?? `😠 You shake ${speakerName} awake. They are NOT pleased about it.`,
+        })
+        return
+      }
+      setPendingWakeNpcId(npcId)
       setDialogueEvent({
         speakerName,
         text: namedNpc.sleepDialogue ?? `💤 ${speakerName} is fast asleep.`,
@@ -1505,7 +1542,7 @@ function hasOfferableQuest(giverId: string): boolean {
 
     // ── Default dialogue (animals / unnamed) ─────────────────────────────────
     setDialogueEvent({ speakerName, text: line })
-  }, [refreshState, handleNodeInteract])
+  }, [refreshState, handleNodeInteract, pendingWakeNpcId, wokenNpcIds])
 
   // Gifting a held material to an NPC — the generic counterpart to the
   // curated `tradeHubItem` dialogue-tree effect (docs/hubworld.md §16), but

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1342,9 +1342,12 @@ function hasOfferableQuest(giverId: string): boolean {
     // cascade below assumes an awake NPC. Sleep windows are short in real
     // time (a full game day is 30 real minutes), so nothing is soft-locked.
     // A 1st tap just narrates the sleep; tapping the *same* still-sleeping
-    // NPC again wakes them early (grumpily, at a small friendship cost) and
-    // lets the rest of this tap's cascade — and every tap after, for the
-    // remainder of this sleep window — treat them as awake.
+    // NPC again wakes them early (grumpily, at a small friendship cost).
+    // Dismissing that grumpy line re-runs this same tap — now that
+    // `wokenNpcIds` covers them, it falls straight through to the normal
+    // cascade below, so waking them also opens up real interaction rather
+    // than requiring a 3rd tap. Every tap after, for the remainder of this
+    // sleep window, treats them as awake too.
     if (namedNpc?.schedule && isNpcAsleep(namedNpc, getGameHour()) && !wokenNpcIds.has(npcId)) {
       if (pendingWakeNpcId === npcId) {
         setPendingWakeNpcId(null)
@@ -1353,6 +1356,7 @@ function hasOfferableQuest(giverId: string): boolean {
         setDialogueEvent({
           speakerName,
           text: namedNpc.wakeDialogue ?? `😠 You shake ${speakerName} awake. They are NOT pleased about it.`,
+          onClose: () => handleNpcTap(line, npcId),
         })
         return
       }

--- a/web/src/data/hub/loader.ts
+++ b/web/src/data/hub/loader.ts
@@ -223,6 +223,9 @@ export interface HubNpc {
   /** Line shown when tapped while the schedule has this NPC sleeping.
    *  Defaults to a generic "fast asleep" narration. */
   sleepDialogue?: string
+  /** Line shown when a 2nd tap wakes this NPC up early — see `isNpcAsleep`.
+   *  Defaults to a generic grumpy-about-being-woken narration. */
+  wakeDialogue?: string
   /** Lines cycled INSTEAD of `dialogue` once campaign 1 is complete
    *  (isCampaignComplete('c1')) — how the world acknowledges the sealed
    *  Fracture. Activity pools (dialogueByActivity) still take precedence. */


### PR DESCRIPTION
## Summary
- Tapping a sleeping NPC once still just narrates the sleep (unchanged "💤 fast asleep" behavior).
- Tapping the **same** still-sleeping NPC a **2nd time** now wakes them up early: shows a grumpy `wakeDialogue` line (falls back to a generic "you shake them awake, they are NOT pleased" default), and applies a small friendship penalty (-1) for disturbing their sleep.
- Once woken, the NPC is treated as awake for the rest of that sleep window — normal chat/trade/quest hand-ins resume instead of being blocked by the sleep gate.
- Wake-up state (`pendingWakeNpcId` / `wokenNpcIds`) is pruned automatically once the NPC's schedule actually moves them past `sleep`, so the next sleep window starts fresh.
- New optional `HubNpc.wakeDialogue` field lets individual NPCs author a custom grumpy line; it's optional (mirrors the existing generic fallback pattern used by `sleepDialogue`), so no data files needed updating.

## Test plan
- [x] `npm run build` (TypeScript check + Vite build) passes
- [x] `npm run test` — 2818 tests pass across 80 test files (unrelated Playwright browser-cleanup error is pre-existing noise per `AGENTS.md`)
- [ ] Manual: tap a sleeping NPC twice in the hub world and confirm the grumpy wake line + subsequent normal interaction

---
_Generated by [Claude Code](https://claude.ai/code/session_019LsYCvLFS7JckrGX6WxYhb)_