### PR TITLE
Track caught fish species in the Town Journal

### DIFF
--- a/web/src/components/hub/TownJournal.tsx
+++ b/web/src/components/hub/TownJournal.tsx
@@ -8,7 +8,9 @@ import {
   hasMetNpc, getMetNpcIds,
   hasSeenAnimal, getSeenAnimalVariants, getSeenAnimalTypes,
   hasSeenArea,
+  hasCaughtFish,
 } from '../../game/hub/journal'
+import { FISH_TIERS, CAVE_FISH_TIERS, LAKE_FISH_TIERS, OCEAN_FISH_TIERS, type FishTier } from '../minigames/Fishing'
 
 const TRACK_ICON: Record<string, string> = { ally: '🤝', rival: '⚔️', romance: '💗' }
 
@@ -29,7 +31,33 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
-type Tab = 'animals' | 'people' | 'places'
+interface FishLocale {
+  id: string
+  label: string
+  tiers: FishTier[]
+}
+
+const FISH_LOCALES: FishLocale[] = [
+  { id: 'river', label: 'River', tiers: FISH_TIERS },
+  { id: 'lake',  label: 'Lake',  tiers: LAKE_FISH_TIERS },
+  { id: 'ocean', label: 'Ocean', tiers: OCEAN_FISH_TIERS },
+  { id: 'cave',  label: 'Cave Lake', tiers: CAVE_FISH_TIERS },
+]
+
+interface FishSpecies {
+  locale: string
+  tierName: string
+  tierIcon: string
+  name: string
+}
+
+const ALL_FISH_SPECIES: FishSpecies[] = FISH_LOCALES.flatMap(({ id, tiers }) =>
+  tiers.flatMap(tier => tier.names.map(name => ({
+    locale: id, tierName: tier.tier, tierIcon: tier.icon, name,
+  }))),
+)
+
+type Tab = 'animals' | 'fish' | 'people' | 'places'
 
 interface Props {
   onClose: () => void
@@ -38,10 +66,14 @@ interface Props {
 
 export function TownJournalContent({ onClose, locationData }: Props) {
   const [tab, setTab] = useState<Tab>('animals')
+  const [fishLocale, setFishLocale] = useState<string>(FISH_LOCALES[0].id)
 
   const seenAnimalTypes = getSeenAnimalTypes()
   const animalsTotal = ANIMAL_TYPES.length
   const animalsSeen = seenAnimalTypes.size
+
+  const fishTotal = ALL_FISH_SPECIES.length
+  const fishSeen = ALL_FISH_SPECIES.filter(s => hasCaughtFish(s.locale, s.name)).length
 
   const seen = new Set<string>()
   const namedNpcs = locationData.HUB_NPCS.filter(n => {
@@ -59,12 +91,13 @@ export function TownJournalContent({ onClose, locationData }: Props) {
 
   const TABS: { id: Tab; label: string; discovered: number; total: number }[] = [
     { id: 'animals', label: 'Animals', discovered: animalsSeen, total: animalsTotal },
+    { id: 'fish',    label: 'Fish',    discovered: fishSeen,    total: fishTotal },
     { id: 'people',  label: 'People',  discovered: peopleMet,   total: peopleTotal },
     { id: 'places',  label: 'Places',  discovered: placesSeen,  total: placesTotal },
   ]
 
-  const overallDiscovered = animalsSeen + peopleMet + placesSeen
-  const overallTotal = animalsTotal + peopleTotal + placesTotal
+  const overallDiscovered = animalsSeen + fishSeen + peopleMet + placesSeen
+  const overallTotal = animalsTotal + fishTotal + peopleTotal + placesTotal
   const overallPct = overallTotal > 0 ? Math.round((overallDiscovered / overallTotal) * 100) : 0
 
   return (
@@ -111,6 +144,45 @@ export function TownJournalContent({ onClose, locationData }: Props) {
               )
             })}
           </div>
+        )}
+
+        {tab === 'fish' && (
+          <>
+            <div className="hoa-tabs">
+              {FISH_LOCALES.map(loc => {
+                const localeSpecies = ALL_FISH_SPECIES.filter(s => s.locale === loc.id)
+                const localeSeen = localeSpecies.filter(s => hasCaughtFish(s.locale, s.name)).length
+                return (
+                  <button
+                    key={loc.id}
+                    className={`hoa-tab${loc.id === fishLocale ? ' hoa-tab--active' : ''}`}
+                    onClick={() => setFishLocale(loc.id)}
+                  >
+                    {loc.label} ({localeSeen}/{localeSpecies.length})
+                  </button>
+                )
+              })}
+            </div>
+            <div className="town-directory__list town-journal__list">
+              {ALL_FISH_SPECIES.filter(s => s.locale === fishLocale).map(species => {
+                const known = hasCaughtFish(species.locale, species.name)
+                return (
+                  <div key={`${species.locale}:${species.name}`} className="town-directory__row">
+                    <div className="town-directory__info">
+                      <span className="town-directory__name">
+                        {known ? species.name : '???'}
+                      </span>
+                      <span className="town-directory__place">
+                        {known
+                          ? `${species.tierIcon} ${species.tierName} tier`
+                          : 'Not yet caught.'}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </>
         )}
 
         {tab === 'people' && (

--- a/web/src/components/hub/TownJournal.tsx
+++ b/web/src/components/hub/TownJournal.tsx
@@ -164,20 +164,28 @@ export function TownJournalContent({ onClose, locationData }: Props) {
               })}
             </div>
             <div className="town-directory__list town-journal__list">
-              {ALL_FISH_SPECIES.filter(s => s.locale === fishLocale).map(species => {
-                const known = hasCaughtFish(species.locale, species.name)
+              {(FISH_LOCALES.find(l => l.id === fishLocale)?.tiers ?? []).map(tier => {
+                const tierSeen = tier.names.filter(name => hasCaughtFish(fishLocale, name)).length
                 return (
-                  <div key={`${species.locale}:${species.name}`} className="town-directory__row">
-                    <div className="town-directory__info">
-                      <span className="town-directory__name">
-                        {known ? species.name : '???'}
-                      </span>
-                      <span className="town-directory__place">
-                        {known
-                          ? `${species.tierIcon} ${species.tierName} tier`
-                          : 'Not yet caught.'}
-                      </span>
+                  <div key={tier.tier} className="town-journal__tier-group">
+                    <div className="town-journal__tier-header">
+                      {tier.icon} {tier.tier} ({tierSeen}/{tier.names.length})
                     </div>
+                    {tier.names.map(name => {
+                      const known = hasCaughtFish(fishLocale, name)
+                      return (
+                        <div key={name} className="town-directory__row">
+                          <div className="town-directory__info">
+                            <span className="town-directory__name">
+                              {known ? name : '???'}
+                            </span>
+                            <span className="town-directory__place">
+                              {known ? 'Caught' : 'Not yet caught.'}
+                            </span>
+                          </div>
+                        </div>
+                      )
+                    })}
                   </div>
                 )
               })}

--- a/web/src/components/minigames/Fishing.tsx
+++ b/web/src/components/minigames/Fishing.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { addCollectible, addHubItem, getHubItemCount, removeHubItem } from '../../game/itemStore'
 import { addCardsToCollection } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
+import { recordFishCaught } from '../../game/hub/journal'
 import ITEMS_DATA from '../../data/items.json'
 import { logError } from '../../logger'
 
@@ -13,7 +14,7 @@ const BITE_WINDOW_MS = 1500
 
 // ── Fish data ─────────────────────────────────────────────────────────────────
 
-interface FishTier {
+export interface FishTier {
   tier: string
   icon: string
   names: string[]
@@ -348,11 +349,14 @@ export function Fishing({ onDone, rewardMode = 'tickets', variant = 'river' }: P
       catch (e) { logError('Fishing: addCollectible failed', { error: String(e) }) }
     } else if (c.kind === 'card') {
       addCardsToCollection([{ cardName: c.name, count: 1 }])
-    } else if (rewardMode === 'catch') {
-      const hubItemId = tierHubItem[c.tier]
-      if (hubItemId) {
-        try { addHubItem(hubItemId, 1) }
-        catch (e) { logError('Fishing: addHubItem failed', { error: String(e) }) }
+    } else {
+      recordFishCaught(variant, c.name)
+      if (rewardMode === 'catch') {
+        const hubItemId = tierHubItem[c.tier]
+        if (hubItemId) {
+          try { addHubItem(hubItemId, 1) }
+          catch (e) { logError('Fishing: addHubItem failed', { error: String(e) }) }
+        }
       }
     }
   }

--- a/web/src/game/hub/journal.test.ts
+++ b/web/src/game/hub/journal.test.ts
@@ -3,6 +3,7 @@ import {
   recordNpcMet, hasMetNpc, getMetNpcIds,
   recordAnimalSeen, hasSeenAnimal, getSeenAnimalVariants, getSeenAnimalTypes,
   recordAreaSeen, hasSeenArea, getSeenAreaKeys,
+  recordFishCaught, hasCaughtFish, getCaughtFishKeys,
 } from './journal'
 
 function installLocalStorageStub(): void {
@@ -58,6 +59,16 @@ describe('journal', () => {
     // Same area id in a different town is a distinct key.
     expect(hasSeenArea('millhaven', 'market')).toBe(false)
     expect(getSeenAreaKeys()).toEqual(new Set(['ravenwatch:market']))
+  })
+
+  it('records caught fish species scoped per-locale, deduplicating', () => {
+    expect(hasCaughtFish('river', 'Minnow')).toBe(false)
+    expect(recordFishCaught('river', 'Minnow')).toBe(true)
+    expect(recordFishCaught('river', 'Minnow')).toBe(false)
+    expect(hasCaughtFish('river', 'Minnow')).toBe(true)
+    // Same species name in a different locale is a distinct key.
+    expect(hasCaughtFish('ocean', 'Minnow')).toBe(false)
+    expect(getCaughtFishKeys()).toEqual(new Set(['river:Minnow']))
   })
 
   it('returns empty + false when localStorage throws', () => {

--- a/web/src/game/hub/journal.ts
+++ b/web/src/game/hub/journal.ts
@@ -9,10 +9,11 @@ interface JournalData {
   animalTypes: string[]
   animalVariants: Record<string, string[]>
   areas: string[]
+  fish: string[]
 }
 
 function emptyData(): JournalData {
-  return { npcs: [], animalTypes: [], animalVariants: {}, areas: [] }
+  return { npcs: [], animalTypes: [], animalVariants: {}, areas: [], fish: [] }
 }
 
 function load(): JournalData {
@@ -25,6 +26,7 @@ function load(): JournalData {
       animalTypes: parsed.animalTypes ?? [],
       animalVariants: parsed.animalVariants ?? {},
       areas: parsed.areas ?? [],
+      fish: parsed.fish ?? [],
     }
   } catch {
     return emptyData()
@@ -112,4 +114,28 @@ export function hasSeenArea(town: string, areaId: string): boolean {
 
 export function getSeenAreaKeys(): Set<string> {
   return new Set(load().areas)
+}
+
+// ── Fish caught ──────────────────────────────────────────────────────────────
+// Keyed by "<locale>:<species name>" — locale ('river'/'cave'/'lake'/'ocean')
+// disambiguates species names that recur across locales' tier tables (e.g.
+// "Sea Bass" appears in both the river and ocean tiers as distinct catches).
+
+/** Record that a named fish species has been caught at the given fishing
+ *  locale. Returns true if newly recorded. */
+export function recordFishCaught(locale: string, name: string): boolean {
+  const data = load()
+  const key = `${locale}:${name}`
+  if (data.fish.includes(key)) return false
+  data.fish.push(key)
+  save(data)
+  return true
+}
+
+export function hasCaughtFish(locale: string, name: string): boolean {
+  return load().fish.includes(`${locale}:${name}`)
+}
+
+export function getCaughtFishKeys(): Set<string> {
+  return new Set(load().fish)
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15677,6 +15677,14 @@ html.light-mode .action-btn {
 
 /* ── Town Journal panel (reuses .town-directory layout + .hoa-tabs) ────────── */
 .town-journal__list { margin-top: 12px; }
+.town-journal__tier-group + .town-journal__tier-group { margin-top: 14px; }
+.town-journal__tier-header {
+  font-size: 11px;
+  font-weight: bold;
+  color: #9ac89a;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
 
 /* ── Town Upgrades panel (reuses .town-directory layout) ───────────────────── */
 .town-upgrades__rep {


### PR DESCRIPTION
## Summary

- The Town Journal (📖) tracked Animals/People/Places but had no record of fishing progress, even though every fishing spot (river, cave, lake, ocean) rolls one of 6 tiers × ~5 named species each (~112 species total).
- Added `recordFishCaught` / `hasCaughtFish` / `getCaughtFishKeys` to `journal.ts`, keyed by `<locale>:<species name>` so the same species name recurring across locales (e.g. "Sea Bass" in both river and ocean tiers) is tracked separately.
- `Fishing.tsx` now calls `recordFishCaught(variant, name)` whenever a fish is landed — unconditional on `rewardMode`, so both the arcade minigame and hub-world catch mode count toward discovery.
- `TownJournal.tsx` gets a new **Fish** tab with a locale sub-nav (River/Lake/Ocean/Cave Lake), listing every species per locale — `???` until caught, tier name/icon once discovered — folded into the journal's overall completion percentage.
- Exported `FishTier` from `Fishing.tsx` so the journal component can type the shared tier tables it now imports.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/game/hub/journal.test.ts src/components/minigames/Fishing.test.ts src/components/hub` — 24 tests pass
- [x] `npm run build` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVcoEc6J939CD2Qe9mNvMb)_