### PR TITLE
fix(hub): grumpy wake-up OK button was a stale-closure no-op

### DIFF
--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1329,7 +1329,7 @@ function hasOfferableQuest(giverId: string): boolean {
   }
 
 
-  const handleNpcTap = useCallback((line: string, npcId: string) => {
+  const handleNpcTap = useCallback((line: string, npcId: string, skipSleepGate = false) => {
     // Placed animals (HUB_ANIMALS) reuse all NPC quest logic — they share the
     // same id space as quest giverNpcId / receiverNpcId / targetNpcId.
     const namedNpc = locationData.HUB_NPCS.find(n => n.id === npcId)
@@ -1344,12 +1344,15 @@ function hasOfferableQuest(giverId: string): boolean {
     // time (a full game day is 30 real minutes), so nothing is soft-locked.
     // A 1st tap just narrates the sleep; tapping the *same* still-sleeping
     // NPC again wakes them early (grumpily, at a small friendship cost).
-    // Dismissing that grumpy line re-runs this same tap — now that
-    // `wokenNpcIds` covers them, it falls straight through to the normal
-    // cascade below, so waking them also opens up real interaction rather
-    // than requiring a 3rd tap. Every tap after, for the remainder of this
-    // sleep window, treats them as awake too.
-    if (namedNpc?.schedule && isNpcAsleep(namedNpc, getGameHour()) && !wokenNpcIds.has(npcId)) {
+    // Dismissing that grumpy line re-runs this same tap with `skipSleepGate`
+    // so it falls straight through to the normal cascade below — waking
+    // them also opens up real interaction rather than requiring a 3rd tap.
+    // (Can't gate that re-run on `wokenNpcIds` instead: this closure was
+    // captured before the setWokenNpcIds call above takes effect, so it'd
+    // still see the pre-wake state and loop back into this same branch.)
+    // Every tap after, for the remainder of this sleep window, treats them
+    // as awake too, via `wokenNpcIds`.
+    if (!skipSleepGate && namedNpc?.schedule && isNpcAsleep(namedNpc, getGameHour()) && !wokenNpcIds.has(npcId)) {
       if (pendingWakeNpcId === npcId) {
         setPendingWakeNpcId(null)
         setWokenNpcIds(prev => new Set(prev).add(npcId))
@@ -1357,7 +1360,7 @@ function hasOfferableQuest(giverId: string): boolean {
         setDialogueEvent({
           speakerName,
           text: namedNpc.wakeDialogue ?? `😠 You shake ${speakerName} awake. They are NOT pleased about it.`,
-          onClose: () => handleNpcTap(line, npcId),
+          onClose: () => handleNpcTap(line, npcId, true),
         })
         return
       }


### PR DESCRIPTION
## Summary
Follow-up to #2156 (merged): the "you shake {name} awake" dialogue's OK button appeared to do nothing.

- Root cause: the grumpy-wake dialogue's `onClose` recursively called `handleNpcTap(line, npcId)` — but that recursive call referenced the *same* `handleNpcTap` closure that was captured before its own `setWokenNpcIds`/`setPendingWakeNpcId` calls had taken effect (React state updates aren't visible inside a closure already created). So pressing OK just re-entered the same wake branch and re-showed the identical grumpy line — and silently re-applied the -1 friendship penalty each time, invisible to the player since the dialogue looked unchanged.
- Fix: `handleNpcTap` now takes an explicit `skipSleepGate` parameter (defaults to `false`). The recursive `onClose` call passes `skipSleepGate=true`, which bypasses the sleep-gate check directly via a plain argument rather than relying on state timing — so it reliably falls through into the normal chat/trade/quest cascade right after the grumpy line is dismissed.

## Test plan
- [x] `npm run build` (TypeScript check + Vite build) passes
- [x] `npm run test` — 2829 tests pass across 81 test files
- [ ] Manual: tap a sleeping NPC twice, dismiss the grumpy wake line, confirm normal dialogue/trade/quest interaction opens instead of the dialogue silently reappearing

---
_Generated by [Claude Code](https://claude.ai/code/session_019LsYCvLFS7JckrGX6WxYhb)_