### PR TITLE
Grey out tradeHubItem dialogue choices the player can't afford

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -2092,6 +2092,15 @@ a one-line barter (Thornwood Camp's `ranger-sable-trade` — sturdy boots for
 90💎). Trades are repeatable by design; use a `flag` effect + `hideIfFlag` on
 the choice if a specific trade should be once-only.
 
+A choice whose sole effect is `tradeHubItem` automatically greys itself out
+(`DialogueChoice.disabled`, `HubDialogue.tsx`) when the player doesn't hold
+enough of the wanted item(s) — computed by `tradeChoiceUnavailable` in
+`HubWorld.tsx`'s `runDialogueNode`, no authoring needed. It stays tappable
+(dimmed, not hidden) so `missingText` still explains why, rather than the
+player only finding out after tapping. A sell menu with a dozen tiers (like
+Marta's) now visually distinguishes what's actually in the pack from what
+isn't.
+
 The live trade network (buyer NPC → wants → gives): Weeping Widow (Gravemoor)
 ← poetry book, 50💎 · Widow Tamsin (Millhaven) ← lost locket, 60💎 ·
 Harbourmaster Vane (Saltmere) ← fancy hat, 75💎 · Baker Otto (capital) ← 3

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -933,6 +933,29 @@ function formatTradeReward(eff: Extract<DialogueEffect, { type: 'tradeHubItem' }
   return parts.join('  ·  ')
 }
 
+// Normalizes a tradeHubItem effect's want-list — either the single wantItemId
+// or the multi-item wantItems recipe — into one shape. Shared by applyChoice
+// (which needs the same list to check/consume) and the choice-disabled check
+// below (which needs it read-only, before the choice is even tapped).
+function tradeWantList(eff: Extract<DialogueEffect, { type: 'tradeHubItem' }>): Array<{ itemId: string; count: number }> {
+  return eff.wantItems
+    ? eff.wantItems.map(w => ({ itemId: w.itemId, count: w.count ?? 1 }))
+    : eff.wantItemId
+      ? [{ itemId: eff.wantItemId, count: eff.wantCount ?? 1 }]
+      : []
+}
+
+// A choice greys itself out (DialogueChoice.disabled) when its sole effect is
+// a tradeHubItem barter the player can't currently afford — e.g. Fishwife
+// Marta's per-tier sell list, so an empty-handed tier reads as unavailable
+// instead of only failing after the tap.
+function tradeChoiceUnavailable(c: DialogueChoiceDef): boolean {
+  const eff = c.effects?.[0]
+  if (!eff || eff.type !== 'tradeHubItem') return false
+  const wanted = tradeWantList(eff)
+  return wanted.length === 0 || wanted.some(w => getHubItemCount(w.itemId) < w.count)
+}
+
 // Grants friendship XP and — since it's a nonzero delta — floats a ❤️/💔
 // above that NPC's head via showFriendshipReactionRef, if they're currently a
 // visible exterior sprite (a no-op otherwise, e.g. an off-screen NPC named by
@@ -1217,10 +1240,11 @@ function hasOfferableQuest(giverId: string): boolean {
       const nonExitDefs = visible.filter(c => !isExitDef(c))
       const exitDefs    = visible.filter(isExitDef)
       const toChoice = (c: DialogueChoiceDef, primary: boolean, isExit?: boolean) => ({
-        label:   c.label,
+        label:    c.label,
         primary,
         isExit,
-        onClick: () => applyChoice(tree, c, npcId, speakerName, npcDef),
+        disabled: tradeChoiceUnavailable(c),
+        onClick:  () => applyChoice(tree, c, npcId, speakerName, npcDef),
       })
       const nonExitChoices = nonExitDefs.map((c, i) => toChoice(c, i === 0))
       finalChoices = exitDefs.length > 0
@@ -1228,9 +1252,10 @@ function hasOfferableQuest(giverId: string): boolean {
         : [...nonExitChoices, ...buildTalkGiveChoices(npcId, npcDef, speaker)]
     } else {
       finalChoices = visible.map((c, i) => ({
-        label:   c.label,
-        primary: i === 0,
-        onClick: () => applyChoice(tree, c, npcId, speakerName, npcDef),
+        label:    c.label,
+        primary:  i === 0,
+        disabled: tradeChoiceUnavailable(c),
+        onClick:  () => applyChoice(tree, c, npcId, speakerName, npcDef),
       }))
     }
 
@@ -1277,11 +1302,7 @@ function hasOfferableQuest(giverId: string): boolean {
           }
           // Multi-item recipes (wantItems) are all-or-nothing: verify every
           // count before removing anything.
-          const wanted: Array<{ itemId: string; count: number }> = eff.wantItems
-            ? eff.wantItems.map(w => ({ itemId: w.itemId, count: w.count ?? 1 }))
-            : eff.wantItemId
-              ? [{ itemId: eff.wantItemId, count: eff.wantCount ?? 1 }]
-              : []
+          const wanted = tradeWantList(eff)
           if (wanted.length === 0 || wanted.some(w => getHubItemCount(w.itemId) < w.count)) {
             setDialogueEvent({ speakerName, text: eff.missingText })
             return


### PR DESCRIPTION
## Summary

- Fishwife Marta's fish-sell menu (12 tiers) — and every other `tradeHubItem`-based sell/barter dialogue choice in the game — always rendered every option identically, whether or not the player actually held that item. Tapping a tier you didn't have just failed with a `missingText` line; there was no visual signal beforehand.
- `DialogueChoice` (`HubDialogue.tsx`) already had a `disabled` flag built for exactly this ("dims without blocking the tap"), but nothing set it.
- Wired it up **generically** in `runDialogueNode` (`HubWorld.tsx`): any choice whose sole effect is `tradeHubItem` now greys itself out via a new `tradeChoiceUnavailable` check whenever the wanted item(s) aren't held — the same check `applyChoice` already runs before consuming them, extracted into a shared `tradeWantList` helper so both paths stay in sync. This covers every `tradeHubItem` sell menu across every town, not just Marta's.
- Choices stay tappable while dimmed, so `missingText` still explains why — just visually distinguished up front instead of only failing after the tap.
- Documented the auto-disable behavior in `docs/hubworld.md` §16 (the `tradeHubItem` section) so future dialogue authors don't need to do anything extra for it.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2829 tests pass (no behavior change to existing tested flows — `applyChoice`'s trade logic is untouched aside from reusing the extracted helper)
- [x] `npm run build` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVcoEc6J939CD2Qe9mNvMb)_