### PR TITLE
Stop reshuffling shop menus and let long choice lists scroll

### DIFF
--- a/docs/hubworld.md
+++ b/docs/hubworld.md
@@ -2101,6 +2101,21 @@ player only finding out after tapping. A sell menu with a dozen tiers (like
 Marta's) now visually distinguishes what's actually in the pack from what
 isn't.
 
+Two more auto-behaviors specific to shop-style nodes (`runDialogueNode`
+detects one via `isShopNode` — the node contains at least one `tradeHubItem`
+choice, which per every town's questDefs.json never happens alongside
+narrative/branching choices, only alongside an optional `end` exit choice):
+- **Stable order.** Ordinary dialogue nodes shuffle their choices (so a
+  good/neutral/bad outcome isn't always in the same slot) — shop nodes skip
+  that and keep their authored JSON order, since a sell menu that reorders
+  itself on every visit is hard to scan, especially selling several items
+  back-to-back through the same repeat-`next` loop.
+- **Scrolling choice list.** `HubDialogue.tsx`'s choice column caps at
+  `38vh` with `overflow-y: auto` once there's more than one choice — without
+  it, a long list (Marta's 12 tiers + exit) can grow taller than the game
+  container, which clips overflow (`overflow: hidden`), stranding the top
+  rows off-screen with no way to reach them on a short viewport.
+
 The live trade network (buyer NPC → wants → gives): Weeping Widow (Gravemoor)
 ← poetry book, 50💎 · Widow Tamsin (Millhaven) ← lost locket, 60💎 ·
 Harbourmaster Vane (Saltmere) ← fancy hat, 75💎 · Baker Otto (capital) ← 3

--- a/web/src/components/hub/HubDialogue.stories.tsx
+++ b/web/src/components/hub/HubDialogue.stories.tsx
@@ -103,3 +103,28 @@ function buyStory(speakerName: string, itemName: string, price: number): Story {
 
 export const GildwynShopGreeting: Story = buyStory('Gildwyn', 'Frost Wyrm', 600)
 export const VornShopGreeting: Story = buyStory('Vorn', 'Ashen Sovereign', 1200)
+
+// A tradeHubItem-style sell menu (Fishwife Marta's fish tiers): long enough
+// to exceed the game container's height, so the choice list scrolls inside
+// its own max-height instead of clipping off-screen. Also mixes in disabled
+// (greyed-out) entries, as the choices the player doesn't currently hold.
+const FISH_TIER_LABELS = [
+  'Tiddler — 3 💎', 'Small Fish — 6 💎', 'Medium Fish — 12 💎', 'Large Fish — 25 💎',
+  'Trophy Fish — 45 💎', 'Legendary Fish — 90 💎', 'Shoal — 3 💎', 'Reef Fish — 6 💎',
+  'Deep Shelf Fish — 12 💎', 'Open Water Fish — 25 💎', 'Deep Sea Fish — 45 💎', 'Abyss Tide Fish — 90 💎',
+]
+
+export const LongSellMenu: Story = {
+  args: { line: "Let's see the catch, then. What are you selling?", speakerName: 'Fishwife Marta', onClose: fn() },
+  render: () => (
+    <HubDialogue
+      line="Let's see the catch, then. What are you selling?"
+      speakerName="Fishwife Marta"
+      onClose={fn()}
+      choices={[
+        ...FISH_TIER_LABELS.map((label, i) => ({ label, disabled: i % 3 === 0, onClick: fn() })),
+        { label: "That's all for now.", isExit: true, onClick: fn() },
+      ]}
+    />
+  ),
+}

--- a/web/src/components/hub/HubDialogue.tsx
+++ b/web/src/components/hub/HubDialogue.tsx
@@ -63,9 +63,13 @@ export function HubDialogue({ line, onClose, speakerName, choices }: Props) {
         <div
           style={
             // Single action stays inline/right-aligned; multiple branch options
-            // stack vertically full-width so 3–4 choices read clearly.
+            // stack vertically full-width so 3–4 choices read clearly. A long
+            // list (a sell menu with a dozen tiers) scrolls internally instead
+            // of growing past the top of the screen — the game container clips
+            // overflow, so an uncapped list would otherwise strand its top rows
+            // off-screen with no way to reach them.
             choices && choices.length > 1
-              ? { display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6 }
+              ? { display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6, maxHeight: '38vh', overflowY: 'auto' }
               : { display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 6 }
           }
         >

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1211,10 +1211,7 @@ function hasOfferableQuest(giverId: string): boolean {
     const node = tree.nodes[nodeId]
     if (!node) { setDialogueEvent(null); return }
     markNodeSeen(tree.id, nodeId)
-    // Shuffled so a good/neutral/bad outcome isn't always in the same list
-    // position (see `shuffled` above) — order among exit-style choices (e.g.
-    // an authored "leave" choice) is separated back out below regardless.
-    const visible = shuffled((node.choices ?? []).filter(c =>
+    const filtered = (node.choices ?? []).filter(c =>
       (!c.requireFlag  || hasDialogueFlag(c.requireFlag)) &&
       (!c.hideIfFlag   || !hasDialogueFlag(c.hideIfFlag)) &&
       (!c.requireCampaignComplete || isCampaignComplete(c.requireCampaignComplete)) &&
@@ -1226,7 +1223,16 @@ function hasOfferableQuest(giverId: string): boolean {
       (!c.requireActivity  || (!!npcDef && 'schedule' in npcDef &&
           getNpcActivity(npcDef as HubNpc, gameHour) === c.requireActivity)) &&
       (!c.requireHubItem || hasHubItem(c.requireHubItem))
-    ))
+    )
+    // Shuffled so a good/neutral/bad outcome isn't always in the same list
+    // position (see `shuffled` above) — order among exit-style choices (e.g.
+    // an authored "leave" choice) is separated back out below regardless.
+    // Shop-style nodes (any tradeHubItem choice — always a flat sell/barter
+    // list, never mixed with narrative branches, per every town's questDefs)
+    // keep their authored order instead: a sell menu that reorders itself on
+    // every visit is hard to scan, especially selling several items in a row.
+    const isShopNode = filtered.some(c => c.effects?.some(e => e.type === 'tradeHubItem'))
+    const visible = isShopNode ? filtered : shuffled(filtered)
     const speaker = node.speakerName ?? speakerName
 
     let finalChoices: DialogueChoice[]


### PR DESCRIPTION
## Summary

Two related sell-menu gaps, both hit hardest by Fishwife Marta's 12-tier fish list:

- **Order changed on every visit.** `runDialogueNode` (`HubWorld.tsx`) shuffles every node's choices so a narrative good/neutral/bad outcome doesn't always land in the same slot — but that applied indiscriminately to shop-style nodes too, so a sell menu reordered itself every time you opened it (worse when selling several items back-to-back through the same repeat-`next` loop). A node is now detected as shop-style (`isShopNode`) if it contains at least one `tradeHubItem` choice — per every town's `questDefs.json`, that never mixes with narrative branching, only an optional `end` exit choice — and such nodes now keep their authored JSON order instead of being shuffled.
- **No scroll on long lists.** `HubDialogue.tsx`'s choice column had no height cap, so a long list (Marta's 12 tiers + exit) could grow taller than `.game-container`, which clips overflow (`overflow: hidden`) — stranding the top rows off-screen with no way to reach them on a short viewport. Capped the choice column at `38vh` with `overflow-y: auto` so it scrolls in place; short lists are unaffected.
- Added a `LongSellMenu` story to `HubDialogue.stories.tsx` (13 choices, some disabled) to visually cover both.
- Documented both auto-behaviors in `docs/hubworld.md` §16.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2829 tests pass
- [x] `npm run build` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVcoEc6J939CD2Qe9mNvMb)_