### PR TITLE
Add lake and cave fish buyers to both fishmongers

### DIFF
--- a/web/src/components/minigames/Fishing.test.ts
+++ b/web/src/components/minigames/Fishing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { FISH_TIERS, CAVE_FISH_TIERS, TIER_HUB_ITEM, CAVE_TIER_HUB_ITEM, computeFishStars } from './Fishing'
+import { FISH_TIERS, CAVE_FISH_TIERS, LAKE_FISH_TIERS, OCEAN_FISH_TIERS, TIER_HUB_ITEM, CAVE_TIER_HUB_ITEM, LAKE_TIER_HUB_ITEM, OCEAN_TIER_HUB_ITEM, computeFishStars } from './Fishing'
 import HUB_ITEMS from '../../data/hubItems.json'
 
 const hubItemIds = new Set(HUB_ITEMS.map(i => i.id))
@@ -7,6 +7,8 @@ const hubItemIds = new Set(HUB_ITEMS.map(i => i.id))
 describe.each([
   ['river', FISH_TIERS, TIER_HUB_ITEM],
   ['cave', CAVE_FISH_TIERS, CAVE_TIER_HUB_ITEM],
+  ['lake', LAKE_FISH_TIERS, LAKE_TIER_HUB_ITEM],
+  ['ocean', OCEAN_FISH_TIERS, OCEAN_TIER_HUB_ITEM],
 ] as const)('%s fish tiers', (_variant, tiers, tierHubItem) => {
   it('chances sum to exactly 100', () => {
     expect(tiers.reduce((sum, t) => sum + t.chance, 0)).toBe(100)

--- a/web/src/data/hub/fishSellability.test.ts
+++ b/web/src/data/hub/fishSellability.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { getHubWorldData } from './hubWorldFactory'
+import { TIER_HUB_ITEM, CAVE_TIER_HUB_ITEM, LAKE_TIER_HUB_ITEM, OCEAN_TIER_HUB_ITEM } from '../../components/minigames/Fishing'
+
+// Regression guard: lake and cave fish tiers were catchable (Ravenwatch has
+// hub-fishing-lake/-cave spots) but had no buyer anywhere in the game — every
+// fishmonger's tradeHubItem sell menu only covered river + ocean tiers, so a
+// player fishing those locales ended up holding fish nobody would ever buy,
+// with every sell choice permanently greyed out no matter how much they held.
+const { allQuests } = await getHubWorldData()
+
+const ALL_FISH_ITEM_IDS = [
+  ...Object.values(TIER_HUB_ITEM),
+  ...Object.values(CAVE_TIER_HUB_ITEM),
+  ...Object.values(LAKE_TIER_HUB_ITEM),
+  ...Object.values(OCEAN_TIER_HUB_ITEM),
+]
+
+function allTradeHubItemWantIds(): Set<string> {
+  const ids = new Set<string>()
+  for (const tree of Object.values(allQuests.HUB_DIALOGUES)) {
+    for (const node of Object.values(tree.nodes)) {
+      for (const choice of node.choices ?? []) {
+        for (const eff of choice.effects ?? []) {
+          if (eff.type !== 'tradeHubItem') continue
+          if (eff.wantItemId) ids.add(eff.wantItemId)
+          for (const w of eff.wantItems ?? []) ids.add(w.itemId)
+        }
+      }
+    }
+  }
+  return ids
+}
+
+describe('every catchable fish tier has at least one buyer somewhere', () => {
+  const wanted = allTradeHubItemWantIds()
+  it.each(ALL_FISH_ITEM_IDS)('%s is buyable by some NPC', (id) => {
+    expect(wanted.has(id)).toBe(true)
+  })
+})

--- a/web/src/data/hub/millhaven/questDefs.json
+++ b/web/src/data/hub/millhaven/questDefs.json
@@ -1171,6 +1171,162 @@
               ]
             },
             {
+              "label": "Shallows — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-shallows",
+                  "giveCrystals": 3,
+                  "missingText": "You've no shallows fish on you.",
+                  "successText": "Barely a mouthful, but the cats love them. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Weedbed Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-weedbed",
+                  "giveCrystals": 6,
+                  "missingText": "You've no weedbed fish on you.",
+                  "successText": "Good pan-sized fish, that. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Water Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-deepwater",
+                  "giveCrystals": 12,
+                  "missingText": "You've no deep water fish on you.",
+                  "successText": "Now that's a proper catch. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Old Water Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-oldwater",
+                  "giveCrystals": 25,
+                  "missingText": "You've no old water fish on you.",
+                  "successText": "Heavens, look at the size of it! 25 crystals, and worth every one."
+                }
+              ]
+            },
+            {
+              "label": "Prize Water Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-prizewater",
+                  "giveCrystals": 45,
+                  "missingText": "A prize water catch? I'll believe it when I see it.",
+                  "successText": "I'll have this in the window within the hour. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Still Legend Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-stilllegend",
+                  "giveCrystals": 90,
+                  "missingText": "A Still Legend catch? Sailor Finn tells taller tales sober.",
+                  "successText": "By the tides... I've only heard songs about these. 90 crystals — don't tell my husband."
+                }
+              ]
+            },
+            {
+              "label": "Blindling — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-blindling",
+                  "giveCrystals": 3,
+                  "missingText": "You've no blindling fish on you.",
+                  "successText": "Barely a mouthful, but the cats love them. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Cave-dweller Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-dweller",
+                  "giveCrystals": 6,
+                  "missingText": "You've no cave-dweller fish on you.",
+                  "successText": "Good pan-sized fish, that. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Lurker Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-lurker",
+                  "giveCrystals": 12,
+                  "missingText": "You've no deep lurker fish on you.",
+                  "successText": "Now that's a proper catch. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Ancient Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-ancient",
+                  "giveCrystals": 25,
+                  "missingText": "You've no ancient fish on you.",
+                  "successText": "Heavens, look at the size of it! 25 crystals, and worth every one."
+                }
+              ]
+            },
+            {
+              "label": "Abyssal Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-abyssal",
+                  "giveCrystals": 45,
+                  "missingText": "An abyssal catch? I'll believe it when I see it.",
+                  "successText": "I'll have this in the window within the hour. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Sunless Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-sunless",
+                  "giveCrystals": 90,
+                  "missingText": "A Sunless catch? Sailor Finn tells taller tales sober.",
+                  "successText": "By the tides... I've only heard songs about these. 90 crystals — don't tell my husband."
+                }
+              ]
+            },
+            {
               "label": "That's all for now.",
               "effects": [
                 {

--- a/web/src/data/hub/saltmereport/questDefs.json
+++ b/web/src/data/hub/saltmereport/questDefs.json
@@ -245,6 +245,240 @@
               ]
             },
             {
+              "label": "Shoal — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-shoal",
+                  "giveCrystals": 3,
+                  "missingText": "Not a shoal fish on you.",
+                  "successText": "Bait-box size, but coin's coin. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Reef Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-reef",
+                  "giveCrystals": 6,
+                  "missingText": "No reef fish in that pack.",
+                  "successText": "Decent pan fish. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Shelf Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-deepshelf",
+                  "giveCrystals": 12,
+                  "missingText": "You've no deep shelf fish on you.",
+                  "successText": "Good weight to it. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Open Water Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-openwater",
+                  "giveCrystals": 25,
+                  "missingText": "You've no open water fish on you.",
+                  "successText": "Now that's a fish! 25 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Sea Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-deepsea",
+                  "giveCrystals": 45,
+                  "missingText": "A deep sea catch? Show me first.",
+                  "successText": "The whole dock will hear about this one. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Abyss Tide Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "ocean-fish-abysstide",
+                  "giveCrystals": 90,
+                  "missingText": "An Abyss Tide catch? I'll believe fins when I see them.",
+                  "successText": "By the deep… I'll retire on the story alone. 90 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Shallows — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-shallows",
+                  "giveCrystals": 3,
+                  "missingText": "Not a shallows fish on you.",
+                  "successText": "Bait-box size, but coin's coin. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Weedbed Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-weedbed",
+                  "giveCrystals": 6,
+                  "missingText": "No weedbed fish in that pack.",
+                  "successText": "Decent pan fish. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Water Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-deepwater",
+                  "giveCrystals": 12,
+                  "missingText": "You've no deep water fish on you.",
+                  "successText": "Good weight to it. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Old Water Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-oldwater",
+                  "giveCrystals": 25,
+                  "missingText": "You've no old water fish on you.",
+                  "successText": "Now that's a fish! 25 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Prize Water Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-prizewater",
+                  "giveCrystals": 45,
+                  "missingText": "A prize water catch? Show me first.",
+                  "successText": "The whole dock will hear about this one. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Still Legend Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "lake-fish-stilllegend",
+                  "giveCrystals": 90,
+                  "missingText": "A Still Legend catch? I'll believe fins when I see them.",
+                  "successText": "By the deep… I'll retire on the story alone. 90 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Blindling — 3 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-blindling",
+                  "giveCrystals": 3,
+                  "missingText": "Not a blindling fish on you.",
+                  "successText": "Bait-box size, but coin's coin. 3 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Cave-dweller Fish — 6 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-dweller",
+                  "giveCrystals": 6,
+                  "missingText": "No cave-dweller fish in that pack.",
+                  "successText": "Decent pan fish. 6 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Deep Lurker Fish — 12 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-lurker",
+                  "giveCrystals": 12,
+                  "missingText": "You've no deep lurker fish on you.",
+                  "successText": "Good weight to it. 12 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Ancient Fish — 25 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-ancient",
+                  "giveCrystals": 25,
+                  "missingText": "You've no ancient fish on you.",
+                  "successText": "Now that's a fish! 25 crystals."
+                }
+              ]
+            },
+            {
+              "label": "Abyssal Fish — 45 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-abyssal",
+                  "giveCrystals": 45,
+                  "missingText": "An abyssal catch? Show me first.",
+                  "successText": "The whole dock will hear about this one. 45 crystals!"
+                }
+              ]
+            },
+            {
+              "label": "Sunless Fish — 90 💎",
+              "next": "sell",
+              "effects": [
+                {
+                  "type": "tradeHubItem",
+                  "wantItemId": "cave-fish-sunless",
+                  "giveCrystals": 90,
+                  "missingText": "A Sunless catch? I'll believe fins when I see them.",
+                  "successText": "By the deep… I'll retire on the story alone. 90 crystals."
+                }
+              ]
+            },
+            {
               "label": "That's the lot.",
               "effects": [
                 {


### PR DESCRIPTION
## Summary

- Root cause of a reported bug: a player fishing Ravenwatch's lake/cave spots ended up holding fish (Blindling, Deep Lurker, Abyssal, Ancient, Cave-dweller, Shallows, Deep Water, ...) that **no NPC in the entire game would buy**. Marta's (Millhaven) and Pearl's (Saltmere) sell menus only covered river + ocean tiers — Pearl was missing ocean too, despite being a coastal fishmonger. Every sell choice correctly read as "unavailable" (via the recent grey-out fix), which made it look like a staleness bug rather than what it actually was: genuinely nothing to sell.
- Extended both `tradeHubItem` trees with the missing 12 entries each (6 lake + 6 cave tiers, same price ladder — 3/6/12/25/45/90 — and voice as their existing river/ocean entries), so all 24 fish-tier hub items across every locale now have a buyer.
- Added `fishSellability.test.ts`: scans every town's dialogue trees for `tradeHubItem` effects and fails if any catchable fish tier has no buyer anywhere — the regression guard that should have caught this.
- Extended `Fishing.test.ts`'s tier→hub-item mapping checks to the `lake`/`ocean` variants (previously only `river`/`cave` were covered, so a mapping gap in those wouldn't have been caught either).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 2861 tests pass (24/24 fish tiers now confirmed buyable)
- [x] `npm run build` — clean
- [x] Verified programmatically that Marta's and Pearl's want-lists now cover all 24 fish-tier hub-item ids with zero gaps

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVcoEc6J939CD2Qe9mNvMb)_