### PR TITLE
[UI 0.1] Design token layer for the dark-fantasy direction

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -67,6 +67,49 @@
   --dur-normal: 0.3s;
   --dur-slow:   0.5s;
   --dur-xslow:  0.8s;
+
+  /* ─── Dark-fantasy token layer (#2166) ─────────────────
+     Additive: existing tokens above are untouched, since hundreds of
+     per-screen rules still depend on them directly. These are for the
+     shared/global rules only (buttons, overlays, modals, sections,
+     utilities) — per-screen literal migration happens in the Phase 2
+     screen issues (#2175-#2181). Every token below is referenced by at
+     least one real rule; none are speculative/dead. */
+
+  /* Accents — gold reserved for rewards/rarity/economy, ember for
+     danger/damage, arcane for magic/upgrades, blood for enemy. */
+  --accent-gold:   var(--color-gold-alt);
+  --accent-ember:  var(--color-red);
+  --accent-arcane: #e040fb;
+  --accent-blood:  #6a2288;
+
+  /* Text */
+  --text-inverse: #fff;
+
+  /* Borders / edging */
+  --border-edge:      var(--color-gray-5);
+  --border-edge-dark: #1e1e1e;
+
+  /* Elevation — a neutral depth shadow, not a colour glow */
+  --elevation-overlay: 0 4px 16px rgba(0, 0, 0, 0.6);
+
+  /* Overlay scrim (modal backdrop) */
+  --overlay-scrim: rgba(0, 0, 0, 0.75);
+
+  /* Radius — 3-step scale */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+
+  /* Z-index — named scale for shared/global chrome. --z-dropdown and
+     --z-modal currently coincide (both 200); later issues can split
+     them once dropdown/modal stacking needs to diverge. --z-base and
+     --z-hud are reserved for #2169+ once genuinely global (non-
+     per-screen) chrome exists to anchor them to. */
+  --z-dropdown: 200;
+  --z-modal:    200;
+  --z-toast:    9000;
+  --z-debug:    9999;
 }
 
 html.light-mode {
@@ -1232,7 +1275,7 @@ body {
 
 .action-btn {
   background: none;
-  border: 2px solid #33ff33;
+  border: 2px solid var(--game-text-color);
   color: var(--game-text-color);
   font-family: inherit;
   font-size: 1rem;
@@ -1261,19 +1304,19 @@ body {
 }
 
 .action-btn--dim {
-  border-color: rgba(51, 255, 51, 0.4);
+  border-color: color-mix(in srgb, var(--game-text-color) 40%, transparent);
   color: var(--game-text-color-dim);
 }
 
 .action-btn:hover {
-  background: rgba(51, 255, 51, 0.15);
-  box-shadow: 0 0 12px rgba(51, 255, 51, 0.4);
-  text-shadow: 0 0 6px rgba(51, 255, 51, 0.6);
+  background: color-mix(in srgb, var(--game-text-color) 15%, transparent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--game-text-color) 40%, transparent);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--game-text-color) 60%, transparent);
 }
 
 @keyframes nodeTargetPulse {
-  0%, 100% { box-shadow: 0 0 8px rgba(51, 255, 51, 0.4); }
-  50%       { box-shadow: 0 0 14px rgba(51, 255, 51, 0.7); }
+  0%, 100% { box-shadow: 0 0 8px color-mix(in srgb, var(--game-text-color) 40%, transparent); }
+  50%       { box-shadow: 0 0 14px color-mix(in srgb, var(--game-text-color) 70%, transparent); }
 }
 
 .action-btn--large {
@@ -1387,32 +1430,32 @@ body {
   color: var(--color-gold-alt);
 }
 .action-btn--gold:hover {
-  background: rgba(255, 204, 0, 0.15);
-  box-shadow: 0 0 14px rgba(255, 204, 0, 0.5);
-  text-shadow: 0 0 6px rgba(255, 204, 0, 0.7);
+  background: color-mix(in srgb, var(--accent-gold) 15%, transparent);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--accent-gold) 50%, transparent);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--accent-gold) 70%, transparent);
 }
 
 .action-btn--danger {
-  border-color: rgba(255, 68, 68, 0.4);
+  border-color: color-mix(in srgb, var(--accent-ember) 40%, transparent);
   color: #ff6666;
 }
 .action-btn--danger:hover {
-  background: rgba(255, 68, 68, 0.1);
-  border-color: var(--color-red);
-  box-shadow: 0 0 10px rgba(255, 68, 68, 0.2);
+  background: color-mix(in srgb, var(--accent-ember) 10%, transparent);
+  border-color: var(--accent-ember);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--accent-ember) 20%, transparent);
 }
 
 .action-btn--disabled {
-  border-color: rgba(255, 255, 255, 0.2);
-  color: rgba(255, 255, 255, 0.3);
+  border-color: color-mix(in srgb, var(--text-inverse) 20%, transparent);
+  color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
   cursor: not-allowed;
 }
 
 .action-btn--disabled:hover {
   background: none;
   box-shadow: none;
-  border-color: rgba(255, 255, 255, 0.2);
-  color: rgba(255, 255, 255, 0.3);
+  border-color: color-mix(in srgb, var(--text-inverse) 20%, transparent);
+  color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
 }
 
 .action-btn--noborder {
@@ -1426,14 +1469,14 @@ body {
 
 .action-btn--noborder-disabled {
   border: none;
-  color: rgba(255, 255, 255, 0.3);
+  color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
   cursor: not-allowed;
 }
 .action-btn--noborder-disabled:hover {
   background: none;
   box-shadow: none;
-  border-color: rgba(255, 255, 255, 0.2);
-  color: rgba(255, 255, 255, 0.3);
+  border-color: color-mix(in srgb, var(--text-inverse) 20%, transparent);
+  color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
 }
 
 /* ─── Game Over: action row ──────────────────────────── */
@@ -2075,7 +2118,7 @@ body {
 
 .filter-btn {
   background: none;
-  border: 1px solid #444;
+  border: 1px solid var(--border-edge);
   color: var(--game-text-color-dim);
   font-family: inherit;
   font-size: var(--font-xs);
@@ -2093,7 +2136,7 @@ body {
 .filter-btn--active {
   border-color: var(--game-text-color);
   color: var(--game-text-color);
-  background: rgba(51, 255, 51, 0.08);
+  background: color-mix(in srgb, var(--game-text-color) 8%, transparent);
 }
 
 .filter-btn--disabled {
@@ -2138,7 +2181,7 @@ body {
 .filter-btn--fit    { flex: 1; }
 
 .filter-btn--gold {
-  border-color: rgba(255, 215, 0, 0.4);
+  border-color: color-mix(in srgb, var(--color-gold) 40%, transparent);
   color: var(--color-gold);
 }
 .filter-btn--gold:disabled {
@@ -2148,7 +2191,7 @@ body {
 .filter-btn--gold.filter-btn--active {
   border-color: var(--color-gold);
   color: var(--color-gold);
-  background: rgba(255, 215, 0, 0.08);
+  background: color-mix(in srgb, var(--color-gold) 8%, transparent);
 }
 
 /* ─── Filter popup panel ─────────────────────────────── */
@@ -2162,9 +2205,9 @@ body {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  z-index: 200;
+  z-index: var(--z-dropdown);
   background: var(--game-bg);
-  border: 1px solid #444;
+  border: 1px solid var(--border-edge);
   border-radius: 3px;
   padding: 10px;
   display: flex;
@@ -2172,7 +2215,7 @@ body {
   gap: 10px;
   min-width: 260px;
   max-width: 340px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--elevation-overlay);
   overflow-y: auto;
   max-height: 60vh;
 }
@@ -2189,7 +2232,7 @@ body {
 }
 
 .filter-popup-footer {
-  border-top: 1px solid #222;
+  border-top: 1px solid var(--color-gray-3);
   padding-top: 6px;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -190,10 +190,10 @@ html.light-mode {
 .u-no-select { user-select: none; }
 
 /* Borders */
-.u-rounded-sm { border-radius: 2px; }
-.u-rounded    { border-radius: 4px; }
-.u-rounded-lg { border-radius: 6px; }
-.u-rounded-xl { border-radius: 8px; }
+.u-rounded-sm { border-radius: var(--radius-sm); }
+.u-rounded    { border-radius: var(--radius-md); }
+.u-rounded-lg { border-radius: var(--radius-lg); }
+.u-rounded-xl { border-radius: 8px; } /* one step past the 3-step scale; intentionally left as a literal */
 .u-circle     { border-radius: 50%; }
 .u-border     { border: 1px solid var(--game-border); }
 
@@ -901,7 +901,7 @@ body {
   background: linear-gradient(160deg, rgba(40,0,60,0.55) 0%, rgba(10,0,20,0.55) 100%);
   animation: mythic-pulse 2s ease-in-out infinite;
 }
-.card-tile--mythic .card-rarity { color: #e040fb; text-shadow: 0 0 10px rgba(224,64,251,1); }
+.card-tile--mythic .card-rarity { color: var(--accent-arcane); text-shadow: 0 0 10px rgba(224,64,251,1); }
 .card-tile--mythic .card-title  { color: #e8b0ff; }
 .card-tile--mythic .card-cost   { color: #e040fb; text-shadow: 0 0 10px rgba(224,64,251,0.9); }
 
@@ -1375,7 +1375,7 @@ body {
   position: fixed;
   inset: 0;
   background: #000;
-  z-index: 9999;
+  z-index: var(--z-debug);
 }
 
 .intro-content {
@@ -3241,16 +3241,16 @@ body {
 }
 
 .section--bordered {
-  border: 1px solid #1e1e1e;
-  border-radius: 4px;
+  border: 1px solid var(--border-edge-dark);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .section--bordered .section-title {
   color: var(--color-gold-alt);
   padding: 8px 14px 6px;
-  background: rgba(255, 204, 0, 0.04);
-  border-bottom: 1px solid #1e1e1e;
+  background: color-mix(in srgb, var(--accent-gold) 4%, transparent);
+  border-bottom: 1px solid var(--border-edge-dark);
 }
 
 /* ─── Shared Modal Backdrop ──────────────────────────── */
@@ -3258,12 +3258,12 @@ body {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.75);
+  background: var(--overlay-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 16px;
-  z-index: 200;
+  z-index: var(--z-modal);
   animation: fadeIn 0.15s ease-out;
 }
 
@@ -6625,7 +6625,7 @@ body {
   outline-color: #2a1a0a;
 }
 .battlefield--act3 .top-bar { border-color: #2a1a0a; }
-.battlefield--act3 .base-bar--opponent { border-color: #6a2288; }
+.battlefield--act3 .base-bar--opponent { border-color: var(--accent-blood); }
 
 /* Act 4 — Crystal Spire (arcane blue glow) */
 .battlefield--act4 .lane {
@@ -7512,7 +7512,7 @@ body {
   position: fixed;
   bottom: 80px;
   right: 12px;
-  z-index: 9000;
+  z-index: var(--z-toast);
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -7550,7 +7550,7 @@ body {
   position: fixed;
   bottom: 80px;
   left: 12px;
-  z-index: 9000;
+  z-index: var(--z-toast);
   max-width: 280px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Resolves #2166 (Phase 0 of the #2165 UI overhaul epic).

## Summary

- Adds a new dark-fantasy design token layer to `web/src/styles.css`'s `:root` block, additive alongside the existing 46 tokens: accents (`--accent-gold/-ember/-arcane/-blood`), `--text-inverse`, border/edge tokens, an `--elevation-overlay` shadow, an `--overlay-scrim`, a 3-step radius scale (`--radius-sm/-md/-lg`), and a named z-index scale (`--z-dropdown/-modal/-toast/-debug`).
- Migrates the truly shared/global CSS off hardcoded hex/rgba literals onto the new tokens: `.action-btn` and `.filter-btn` (the two shared button families AGENTS.md calls out by name), `.modal-backdrop`, `.section--bordered`, and the `.u-rounded-*` utilities.
- Every new token is wired into at least one real, value-preserving consumer — no dead tokens. Where an issue-listed selector had no natural shared-scope home for a token (e.g. `--accent-arcane`/`--accent-blood`, the z-index tiers beyond dropdown/modal), it's anchored to one clearly global, non-per-screen rule (mythic card rarity colour, the act-3 opponent border, the achievement/service-worker toast chrome, the intro splash screen) as a single-line, same-value swap.

## Out of scope (by design, per the issue)

- The ~654 hex / 380 rgba literals in per-screen rules — deferred to the Phase 2 screen issues (#2175–#2181).
- The 15 undefined CSS custom properties (`--game-accent`, `--game-text`, `--font-mono`, etc.) — that's #2167.
- `--z-base` / `--z-hud` are reserved names, not yet wired — no genuinely global (non-screen-specific) consumer exists for them yet; forcing one in would mean reaching into per-screen z-index literals, which is exactly the scope this issue avoids for colour. A later issue can claim them once a real global consumer exists.
- `ui/Button.tsx`, `ui/Section.tsx`, `ui/OverlayScreen.tsx`, `ui/ModalBackdrop.tsx` — untouched; they only consume CSS classes.

This is a mechanical detokenization pass, not a redesign — every substitution reproduces the previous rendered value exactly (verified by diffing each literal's RGB/alpha against its replacement token during editing).

## Test plan

- [x] `npm run build` (tsc + vite build) passes clean
- [x] `npm run test` (vitest) — 2861/2861 tests pass (the `chrome-headless-shell` unhandled error at the end is known Storybook/Playwright cleanup noise, documented in AGENTS.md)
- [x] `npm run build-storybook` completes successfully (static check that the new `color-mix()`/token CSS parses cleanly across the whole component tree)
- [x] Every new token confirmed to have ≥1 real `var(--token)` consumer via grep

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_