### PR TITLE
[UI 1.2] Rebuild the button system and migrate raw &lt;button&gt; elements (part 1: ui/ + screens/)

### DIFF
--- a/web/src/components/screens/AchievementsScreen.tsx
+++ b/web/src/components/screens/AchievementsScreen.tsx
@@ -4,6 +4,7 @@ import {
   loadAchievementSave, claimAchievementReward, claimAllAchievementRewards,
 } from '../../game/achievements'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { Button } from '../ui/Button'
 import { addCardsToCollection, loadCrystals, saveCrystals } from '../../game/collection'
 import { addToInventory, ALL_ITEMS } from '../../game/dailyLogin'
 import { addUnlockedAvatar } from '../../game/questline'
@@ -162,9 +163,9 @@ export function AchievementsScreen({ onBack, onCrystalsChanged, embedded }: Prop
       <div className="ach-claim-all-bar u-flex u-items-c u-just-sb">
         <div className="ach-category-label">{CATEGORY_LABELS[activeCategory]}</div>
         {totalClaimable > 0 && (
-          <button className="action-btn ach-claim-all-btn" onClick={handleClaimAll}>
+          <Button className="ach-claim-all-btn" onClick={handleClaimAll}>
             CLAIM ALL ({totalClaimable})
-          </button>
+          </Button>
         )}
       </div>
 
@@ -195,12 +196,12 @@ export function AchievementsScreen({ onBack, onCrystalsChanged, embedded }: Prop
                 {isClaimed ? (
                   <span className="ach-status-claimed">CLAIMED</span>
                 ) : unlocked ? (
-                  <button
-                    className={`action-btn ach-claim-btn${justDone ? ' ach-claim-btn--done' : ''}`}
+                  <Button
+                    className={`ach-claim-btn${justDone ? ' ach-claim-btn--done' : ''}`}
                     onClick={() => handleClaim(def)}
                   >
                     {justDone ? '✓ DONE' : 'CLAIM'}
-                  </button>
+                  </Button>
                 ) : (
                   <span className="ach-status-locked">🔒</span>
                 )}

--- a/web/src/components/screens/AugmentCollectionScreen.tsx
+++ b/web/src/components/screens/AugmentCollectionScreen.tsx
@@ -403,13 +403,12 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
           <span className="aug-stack-drill-title">
             {activeStack.setName} Set
           </span>
-          <button
-            className="action-btn"
+          <Button
             onClick={() => setEquipTarget(activeStack)}
             style={{ fontSize: 11, padding: '2px 8px' }}
           >
             Equip to Unit
-          </button>
+          </Button>
         </div>
       ) : (
         /* Filter bar — only shown when not in drill-down */
@@ -513,13 +512,14 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
               <span style={{ fontSize: 12, opacity: 0.8 }}>
                 Stack: {stackLevelSummary(activeStack)}
               </span>
-              <button
-                className={`action-btn action-btn--gold${souls >= stackUpgradeCost(activeStack) ? '' : ' action-btn--disabled'}`}
+              <Button
+                variant="gold"
+                className={souls >= stackUpgradeCost(activeStack) ? '' : 'action-btn--disabled'}
                 onClick={() => handleUpgradeStack(activeStack)}
                 style={{ fontSize: 11, padding: '2px 8px' }}
               >
                 ↑ Upgrade Stack · {stackUpgradeCost(activeStack).toLocaleString()} souls
-              </button>
+              </Button>
             </div>
           )}
 
@@ -550,18 +550,18 @@ export function AugmentCollectionScreen({ onBack, embedded }: Props) {
                               onClick={e => { e.stopPropagation(); setDetailCardName(inst.equippedToCardName!) }}
                             >↗</span>
                           )}
-                          <button
-                            className={`action-btn action-btn--gold${souls < AUGMENT_UPGRADE_COST ? ' action-btn--disabled' : ''}`}
+                          <Button
+                            variant="gold"
+                            className={souls < AUGMENT_UPGRADE_COST ? 'action-btn--disabled' : ''}
                             onClick={e => { e.stopPropagation(); handleUpgrade(inst) }}
                             title={`Upgrade · ${AUGMENT_UPGRADE_COST} souls`}
                             style={{ padding: '1px 6px', fontSize: 11 }}
-                          >↑</button>
-                          <button
-                            className="action-btn"
+                          >↑</Button>
+                          <Button
                             onClick={e => { e.stopPropagation(); handleBreakdown(inst) }}
                             title={`Break down · +${AUGMENT_DISENCHANT_VALUE[displayCard.rarity]} souls`}
                             style={{ padding: '1px 6px', fontSize: 11 }}
-                          >💀</button>
+                          >💀</Button>
                         </div>
                       </LazyCell>
                     ))}

--- a/web/src/components/screens/CardDraftScreen.tsx
+++ b/web/src/components/screens/CardDraftScreen.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { CardTile } from '../cards/CardTile'
 import { getCardCatalog } from '../../game/cards'
 import { SECRET_RARITIES } from '../../game/types'
+import { Button } from '../ui/Button'
 
 const ROUNDS = 8
 const CHOICES_PER_ROUND = 3
@@ -48,7 +49,7 @@ export function CardDraftScreen({ onComplete, onBack }: Props) {
       </div>
 
       {round === 0 && (
-        <button className="action-btn action-btn--danger" onClick={onBack}>← BACK</button>
+        <Button variant="danger" onClick={onBack}>← BACK</Button>
       )}
     </div>
   )

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -641,7 +641,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
             <div className="daily-modal-desc" style={{ textAlign: 'center' }}>
               Total: +{disenchantModal.reduce((s, i) => s + i.crystals, 0)} 💎
             </div>
-            <button className="action-btn" onClick={() => setDisenchantModal(null)}>OK</button>
+            <Button onClick={() => setDisenchantModal(null)}>OK</Button>
           </div>
         </ModalBackdrop>
       )}
@@ -664,7 +664,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
             <div className="daily-modal-desc" style={{ textAlign: 'center' }}>
               Total: +{upgradeModal.reduce((s, i) => s + i.xpGained, 0)} mastery XP
             </div>
-            <button className="action-btn" onClick={() => setUpgradeModal(null)}>OK</button>
+            <Button onClick={() => setUpgradeModal(null)}>OK</Button>
           </div>
         </ModalBackdrop>
       )}
@@ -676,9 +676,9 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
     <OverlayScreen title="COLLECTION" onBack={onBack} right={
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         {onViewAugments && (
-          <button className="action-btn" style={{ fontSize: 12, padding: '3px 10px' }} onClick={onViewAugments}>
+          <Button style={{ fontSize: 12, padding: '3px 10px' }} onClick={onViewAugments}>
             Augments 👻
-          </button>
+          </Button>
         )}
         <span className="crystal-count">💎 {crystals.toLocaleString()}</span>
       </div>

--- a/web/src/components/screens/CommanderScreen.tsx
+++ b/web/src/components/screens/CommanderScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { getMasteryXp, masteryProgress, loadCollection } from '../../game/collection'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { Button } from '../ui/Button'
 
 interface Props {
   commander: CommanderState
@@ -327,9 +328,8 @@ export function CommanderScreen({
         {(['feed', 'play', 'pet'] as PetAction[]).map(action => {
           const ready = cooldowns[action] === 0
           return (
-            <button
+            <Button
               key={action}
-              className={`action-btn${ready ? '' : ' action-btn--disabled'}`}
               onClick={() => handleAction(action)}
               disabled={!ready}
               title={ready ? undefined : `Ready in ${formatCooldown(cooldowns[action])}`}
@@ -338,7 +338,7 @@ export function CommanderScreen({
               {!ready && (
                 <span className="commander-cd"> {formatCooldown(cooldowns[action])}</span>
               )}
-            </button>
+            </Button>
           )
         })}
       </div>
@@ -351,14 +351,14 @@ export function CommanderScreen({
       {/* Dismiss section */}
       <div className="commander-dismiss-wrap u-flex u-just-c">
         {!confirmDismiss ? (
-          <button className="action-btn action-btn--danger" onClick={() => setConfirmDismiss(true)}>
+          <Button variant="danger" onClick={() => setConfirmDismiss(true)}>
             Dismiss Commander
-          </button>
+          </Button>
         ) : (
           <div className="commander-confirm u-flex u-items-c u-gap-4 u-wrap u-just-c">
             <span>Dismiss {state.cardName}? ({promosLeft} promotion{promosLeft !== 1 ? 's' : ''} left today)</span>
-            <button className="action-btn action-btn--danger" onClick={handleDismiss}>Confirm</button>
-            <button className="action-btn" onClick={() => setConfirmDismiss(false)}>Cancel</button>
+            <Button variant="danger" onClick={handleDismiss}>Confirm</Button>
+            <Button onClick={() => setConfirmDismiss(false)}>Cancel</Button>
           </div>
         )}
       </div>

--- a/web/src/components/screens/DailyChallengeScreen.tsx
+++ b/web/src/components/screens/DailyChallengeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { getDailyChallengeState, getDailyPlayerDeck, fetchDailyLeaderboard, LeaderboardEntry } from '../../game/dailyChallenge'
+import { Button } from '../ui/Button'
 
 interface Props {
   onStart: () => void
@@ -39,7 +40,7 @@ export function DailyChallengeScreen({ onStart, onBack }: Props) {
   return (
     <div className="dc-screen">
       <div className="overlay-header u-flex u-items-c u-gap-6">
-        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <Button onClick={onBack}>← BACK</Button>
         <span className="overlay-title">DAILY CHALLENGE</span>
       </div>
       <div className="u-text-c">
@@ -101,9 +102,9 @@ export function DailyChallengeScreen({ onStart, onBack }: Props) {
       </div>
 
       <div className="dc-actions u-col u-gap-4">
-        <button className="action-btn action-btn--large" onClick={onStart}>
+        <Button size="lg" onClick={onStart}>
           {state.attempts === 0 ? '▶ START CHALLENGE' : '▶ TRY AGAIN'}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/web/src/components/screens/DailyLoginModal.tsx
+++ b/web/src/components/screens/DailyLoginModal.tsx
@@ -3,6 +3,7 @@ import { RewardDef } from '../../game/dailyLogin'
 import { CardTile } from '../cards/CardTile'
 import { getCardCatalog } from '../../game/cards'
 import { loadPlayerName } from '../../game/questline'
+import { Button } from '../ui/Button'
 import rollbar from '../../rollbar'
 
 interface Props {
@@ -111,9 +112,9 @@ export function DailyLoginModal({ reward, onClose }: Props) {
           )}
         </div>
 
-        <button className="action-btn" onClick={onClose}>
+        <Button onClick={onClose}>
           CLAIM ✓
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/web/src/components/screens/EndlessLeaderboardScreen.tsx
+++ b/web/src/components/screens/EndlessLeaderboardScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { fetchEndlessLeaderboard, fetchTodaysEndlessLeaderboard, getEndlessPersonalBest, EndlessLeaderboardEntry, fetchDailyLeaderboard, LeaderboardEntry } from '../../game/dailyChallenge'
+import { Button } from '../ui/Button'
 
 interface Props {
   onBack: () => void
@@ -63,7 +64,7 @@ export function EndlessLeaderboardScreen({ onBack }: Props) {
   return (
     <div className="el-screen">
       <div className="overlay-header u-flex u-items-c u-gap-6">
-        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <Button onClick={onBack}>← BACK</Button>
         <span className="overlay-title">🏆 LEADERBOARDS</span>
       </div>
 

--- a/web/src/components/screens/InventoryScreen.tsx
+++ b/web/src/components/screens/InventoryScreen.tsx
@@ -6,6 +6,7 @@ import { loadConsumableStash, loadRunConsumables, ALL_CONSUMABLES, ConsumableDef
 import { loadItemStore } from '../../game/itemStore'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Section } from '../ui/Section'
+import { Button } from '../ui/Button'
 
 interface Props {
   onBack: () => void
@@ -101,9 +102,9 @@ export function InventoryScreen({ onBack, onCrystalsChanged, embedded }: Props) 
             <div className="inventory-secret-icon">🌌</div>
             <div className="inventory-secret-title">DEEP THOUGHT SPEAKS</div>
             <div className="inventory-secret-msg">"{secretMsg}"</div>
-            <button className="action-btn action-btn--gold" onClick={claimSecret}>
+            <Button variant="gold" onClick={claimSecret}>
               CLAIM REWARD
-            </button>
+            </Button>
           </div>
         )}
 
@@ -195,7 +196,7 @@ export function InventoryScreen({ onBack, onCrystalsChanged, embedded }: Props) 
                 Acquired: {detail.item.acquiredDate}
               </div>
             )}
-            <button className="action-btn" onClick={() => setDetail(null)}>CLOSE</button>
+            <Button onClick={() => setDetail(null)}>CLOSE</Button>
           </div>
         </div>
       )}

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -32,6 +32,7 @@ import { TowerDefence, TowerPool } from '../minigames/TowerDefence'
 import { HarbourRegatta } from '../minigames/HarbourRegatta'
 import { PageHeader } from '../ui/PageHeader'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { Button } from '../ui/Button'
 
 export type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing' | 'towerDefence'
 
@@ -304,9 +305,9 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
                 <div className="city-builder-hub-name">CITY BUILDER</div>
                 <div className="city-builder-hub-desc">Place units &amp; buildings to earn gold. Level up your cards permanently.</div>
               </div>
-              <button className="action-btn action-btn--gold" onClick={() => setSubScreen('citybuilder')}>
+              <Button variant="gold" onClick={() => setSubScreen('citybuilder')}>
                 ENTER
-              </button>
+              </Button>
             </div>
 
             {/* Game grid */}
@@ -330,14 +331,14 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
                         ? '✅ Today\'s challenge complete!'
                         : `🎯 Beat ${getDailyChallengeTarget(id)} for +${DAILY_CHALLENGE_BONUS_TICKETS} 🎫`}
                     </div>
-                    <button
-                      className={`action-btn${locked ? '' : ' action-btn--gold'}`}
+                    <Button
+                      variant={locked ? 'default' : 'gold'}
                       onClick={() => startGame(id)}
                       disabled={locked}
                       title={locked ? `Need ${cost} crystals to play` : undefined}
                     >
                       {locked ? `NEED ${cost} 💎` : 'PLAY'}
-                    </button>
+                    </Button>
                   </div>
                 )
               })}
@@ -347,12 +348,12 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
 
             <div className="minigame-hub-actions u-flex u-gap-6 u-wrap u-just-c">
-              <button className="action-btn" onClick={() => setSubScreen('prizes')}>
+              <Button onClick={() => setSubScreen('prizes')}>
                 🎁 PRIZE SHOP ({tickets} 🎫)
-              </button>
-              <button className="action-btn" onClick={() => setSubScreen('leaderboard')}>
+              </Button>
+              <Button onClick={() => setSubScreen('leaderboard')}>
                 🏆 LEADERBOARDS
-              </button>
+              </Button>
             </div>
           </>
         )}
@@ -360,7 +361,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
         {subScreen === 'prizes' && (
           <div className="prize-screen u-col">
             <div className="overlay-header u-flex u-items-c u-gap-6">
-              <button className="action-btn" onClick={() => initialSubScreen === 'prizes' ? onBack() : setSubScreen('menu')}>← BACK</button>
+              <Button onClick={() => initialSubScreen === 'prizes' ? onBack() : setSubScreen('menu')}>← BACK</Button>
               <span className="overlay-title">🎁 PRIZE SHOP</span>
               <div className="ticket-balance">🎫 {tickets}</div>
             </div>
@@ -378,13 +379,13 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
                     </div>
                     <div className="prize-row-right u-col u-items-end u-gap-2">
                       <div className="prize-row-cost">🎫 {prize.cost.toLocaleString()}</div>
-                      <button
-                        className={`action-btn${canAfford ? ' action-btn--gold' : ''}`}
+                      <Button
+                        variant={canAfford ? 'gold' : 'default'}
                         onClick={() => redeemPrize(prize)}
                         disabled={!canAfford}
                       >
                         REDEEM
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 )
@@ -396,7 +397,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
         {subScreen === 'leaderboard' && (
           <div className="lb-screen u-col">
             <div className="overlay-header u-flex u-items-c u-gap-6">
-              <button className="action-btn" onClick={() => initialSubScreen === 'leaderboard' ? onBack() : setSubScreen('menu')}>← BACK</button>
+              <Button onClick={() => initialSubScreen === 'leaderboard' ? onBack() : setSubScreen('menu')}>← BACK</Button>
               <span className="overlay-title">🏆 LEADERBOARDS</span>
             </div>
 

--- a/web/src/components/screens/NewsScreen.tsx
+++ b/web/src/components/screens/NewsScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { LedScroller, LedScrollerMessage } from '../ui/LedScroller/LedScroller'
+import { Button } from '../ui/Button'
 import { getChronicleStatus } from '../../game/chronicle'
 import { getAllNews, markNewsRead, dismissNewsItem, loadDismissedNewsIds, NewsItem } from '../../game/news'
 
@@ -87,17 +88,15 @@ export function NewsScreen({ onBack }: Props) {
         ))}
         {!loading && pageCount > 1 && (
           <div className="news-pagination">
-            <button
-              className="action-btn"
+            <Button
               disabled={safePage === 0}
               onClick={() => setPage(p => Math.max(0, p - 1))}
-            >← Prev</button>
+            >← Prev</Button>
             <span className="news-pagination__label">{safePage + 1} / {pageCount}</span>
-            <button
-              className="action-btn"
+            <Button
               disabled={safePage === pageCount - 1}
               onClick={() => setPage(p => Math.min(pageCount - 1, p + 1))}
-            >Next →</button>
+            >Next →</Button>
           </div>
         )}
       </div>

--- a/web/src/components/screens/QuickBattleScreen.tsx
+++ b/web/src/components/screens/QuickBattleScreen.tsx
@@ -61,7 +61,7 @@ export function QuickBattleScreen({ onStartBattle, onBack }: Props) {
         </div>
       </div>
 
-      <button className="action-btn action-btn--danger" onClick={onBack}>← BACK</button>
+      <Button variant="danger" onClick={onBack}>← BACK</Button>
     </div>
   )
 }

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -5,6 +5,7 @@ import {
 import { isSoundEnabled, setSoundEnabled, getSoundVolume, setSoundVolume, getMusicVolume, setMusicVolume } from '../../game/sound'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Section } from '../ui/Section'
+import { Button } from '../ui/Button'
 import { LoginModal } from '../modals/LoginModal'
 import rollbar from '../../rollbar'
 import { auth } from '../../firebase'
@@ -437,12 +438,12 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   </div>
                 </div>
                 <div style={{ display: 'flex', gap: '8px' }}>
-                  <button className="action-btn" onClick={handleSync} disabled={syncing}>
+                  <Button onClick={handleSync} disabled={syncing}>
                     {syncing ? 'SYNCING...' : 'SYNC NOW'}
-                  </button>
-                  <button className="action-btn" onClick={handleSignOut} style={{ fontSize: '11px', padding: '6px 12px' }}>
+                  </Button>
+                  <Button onClick={handleSignOut} style={{ fontSize: '11px', padding: '6px 12px' }}>
                     SIGN OUT
-                  </button>
+                  </Button>
                 </div>
               </div>
               {pendingCloudSave && (
@@ -452,8 +453,8 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   </div>
                   <div className="settings-sublabel">Load it? Your local progress will be replaced.</div>
                   <div style={{ display: 'flex', gap: '8px' }}>
-                    <button className="action-btn" onClick={handleLoadCloudSave}>LOAD CLOUD SAVE</button>
-                    <button className="action-btn" onClick={handleKeepLocal} style={{ fontSize: '11px', padding: '6px 12px' }}>KEEP LOCAL</button>
+                    <Button onClick={handleLoadCloudSave}>LOAD CLOUD SAVE</Button>
+                    <Button onClick={handleKeepLocal} style={{ fontSize: '11px', padding: '6px 12px' }}>KEEP LOCAL</Button>
                   </div>
                 </div>
               )}
@@ -465,9 +466,9 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">Sync save across devices</div>
                 <div className="settings-sublabel">Sign in to back up and restore your progress</div>
               </div>
-              <button className="action-btn" onClick={() => setShowLoginModal(true)} disabled={authLoading}>
+              <Button onClick={() => setShowLoginModal(true)} disabled={authLoading}>
                 SIGN IN
-              </button>
+              </Button>
             </div>
           )}
           {syncMsg && (
@@ -581,13 +582,13 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
             {confirmReset ? (
               <div className="settings-confirm-row u-flex u-gap-4 u-items-c u-just-end">
                 <span className="settings-confirm-msg">Are you sure? This cannot be undone.</span>
-                <button className="action-btn action-btn--danger settings-danger-btn" onClick={handleReset}>CONFIRM RESET</button>
-                <button className="action-btn" onClick={() => setConfirmReset(false)} style={{ fontSize: '11px', padding: '6px 12px' }}>CANCEL</button>
+                <Button variant="danger" className="settings-danger-btn" onClick={handleReset}>CONFIRM RESET</Button>
+                <Button onClick={() => setConfirmReset(false)} style={{ fontSize: '11px', padding: '6px 12px' }}>CANCEL</Button>
               </div>
             ) : (
-              <button className="action-btn action-btn--danger settings-danger-btn" onClick={handleReset}>
+              <Button variant="danger" className="settings-danger-btn" onClick={handleReset}>
                 RESET GAME
-              </button>
+              </Button>
             )}
           </div>
         </Section>
@@ -600,18 +601,18 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-sublabel">Which screen opens when the game launches</div>
               </div>
               <div style={{ display: 'flex', gap: '8px' }}>
-                <button
-                  className={`action-btn${hubDefault === 'hub' ? ' action-btn--gold' : ''}`}
+                <Button
+                  variant={hubDefault === 'hub' ? 'gold' : 'default'}
                   onClick={() => { saveHubDefault('hub'); setHubDefault('hub') }}
                 >
                   HUB WORLD
-                </button>
-                <button
-                  className={`action-btn${hubDefault === 'title' ? ' action-btn--gold' : ''}`}
+                </Button>
+                <Button
+                  variant={hubDefault === 'title' ? 'gold' : 'default'}
                   onClick={() => { saveHubDefault('title'); setHubDefault('title') }}
                 >
                   TITLE SCREEN
-                </button>
+                </Button>
               </div>
             </div>
           </Section>
@@ -625,7 +626,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-label">Hub World</div>
                   <div className="settings-sublabel">Prototype terrain canvas</div>
                 </div>
-                <button className="action-btn" onClick={onHubWorld}>OPEN</button>
+                <Button onClick={onHubWorld}>OPEN</Button>
               </div>
             )}
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
@@ -633,7 +634,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">Unlock Hub World</div>
                 <div className="settings-sublabel">Dev cheat — sets the hub world unlock flag</div>
               </div>
-              <button className="action-btn" onClick={() => { unlockHubWorld(); window.location.reload() }}>UNLOCK</button>
+              <Button onClick={() => { unlockHubWorld(); window.location.reload() }}>UNLOCK</Button>
             </div>
           </Section>
         )}
@@ -645,14 +646,14 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">Export save data</div>
                 <div className="settings-sublabel">Download all localStorage as a JSON file</div>
               </div>
-              <button className="action-btn" onClick={exportLocalStorage}>EXPORT</button>
+              <Button onClick={exportLocalStorage}>EXPORT</Button>
             </div>
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
               <div>
                 <div className="settings-label">Import save data</div>
                 <div className="settings-sublabel">Load a previously exported JSON save file</div>
               </div>
-              <button className="action-btn" onClick={() => importRef.current?.click()}>IMPORT</button>
+              <Button onClick={() => importRef.current?.click()}>IMPORT</Button>
               <input ref={importRef} type="file" accept=".json" style={{ display: 'none' }} onChange={handleImport} />
             </div>
             {importMsg && (
@@ -667,14 +668,14 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">Rollbar: send info</div>
                 <div className="settings-sublabel">Send a test info event to Rollbar</div>
               </div>
-              <button className="action-btn" onClick={handleRollbarTest}>SEND INFO</button>
+              <Button onClick={handleRollbarTest}>SEND INFO</Button>
             </div>
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
               <div>
                 <div className="settings-label">Rollbar: trigger error</div>
                 <div className="settings-sublabel">Throw an intentional error for Rollbar to capture</div>
               </div>
-              <button className="action-btn action-btn--danger" onClick={handleRollbarError}>TRIGGER ERROR</button>
+              <Button variant="danger" onClick={handleRollbarError}>TRIGGER ERROR</Button>
             </div>
             {rollbarMsg && (
               <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
@@ -694,7 +695,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-label">Gift management</div>
                   <div className="settings-sublabel">Create and delete one-off player gifts</div>
                 </div>
-                <button className="action-btn action-btn--gold" onClick={onGiftAdmin}>OPEN</button>
+                <Button variant="gold" onClick={onGiftAdmin}>OPEN</Button>
               </div>
             )}
             {onNewsAdmin && (
@@ -703,7 +704,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-label">News / What's New</div>
                   <div className="settings-sublabel">Post new feature announcements and patch notes</div>
                 </div>
-                <button className="action-btn action-btn--gold" onClick={onNewsAdmin}>OPEN</button>
+                <Button variant="gold" onClick={onNewsAdmin}>OPEN</Button>
               </div>
             )}
             {onCampaignAdmin && (
@@ -712,7 +713,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-label">Campaign editor</div>
                   <div className="settings-sublabel">Edit act nodes, enemy decks, and environments</div>
                 </div>
-                <button className="action-btn action-btn--gold" onClick={onCampaignAdmin}>OPEN</button>
+                <Button variant="gold" onClick={onCampaignAdmin}>OPEN</Button>
               </div>
             )}
             {onFeedbackAdmin && (
@@ -721,7 +722,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-label">Feedback inbox</div>
                   <div className="settings-sublabel">View and delete player-submitted feedback</div>
                 </div>
-                <button className="action-btn action-btn--gold" onClick={onFeedbackAdmin}>OPEN</button>
+                <Button variant="gold" onClick={onFeedbackAdmin}>OPEN</Button>
               </div>
             )}
             {onTownAccessAdmin && (
@@ -730,7 +731,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   <div className="settings-label">Town access</div>
                   <div className="settings-sublabel">Choose which hub-world towns players can enter</div>
                 </div>
-                <button className="action-btn action-btn--gold" onClick={onTownAccessAdmin}>OPEN</button>
+                <Button variant="gold" onClick={onTownAccessAdmin}>OPEN</Button>
               </div>
             )}
             <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
@@ -738,7 +739,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">Reset hub quests &amp; pickups</div>
                 <div className="settings-sublabel">Clears all quest progress and collected pickup state</div>
               </div>
-              <button className="action-btn action-btn--danger" onClick={handleResetHubData}>RESET</button>
+              <Button variant="danger" onClick={handleResetHubData}>RESET</Button>
             </div>
           </Section>
         )}
@@ -809,13 +810,12 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                   {updateStatus === 'done'     && 'Done. If a new version was found the game will reload automatically.'}
                 </div>
               </div>
-              <button
-                className="action-btn"
+              <Button
                 onClick={handleCheckForUpdates}
                 disabled={updateStatus === 'checking'}
               >
                 {updateStatus === 'checking' ? 'CHECKING...' : 'CHECK FOR UPDATES'}
-              </button>
+              </Button>
             </div>
           )}
         </Section>

--- a/web/src/components/screens/ShopScreen.tsx
+++ b/web/src/components/screens/ShopScreen.tsx
@@ -29,6 +29,7 @@ import { saveCrystals } from '../../game/collection'
 import { emitSound } from '../../game/sound'
 import { SpriteImg } from '../ui/SpriteImg'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { Button } from '../ui/Button'
 import { getCardCatalog } from '../../game/cards'
 import { CardTile } from '../cards/CardTile'
 
@@ -301,14 +302,15 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
                   {bought ? (
                     <div className="shop-purchased">PURCHASED ✓</div>
                   ) : (
-                    <button
-                      className={`action-btn action-btn--gold shop-card-buy-btn${!canAfford ? ' shop-card-buy-btn--poor' : ''}`}
+                    <Button
+                      variant="gold"
+                      className={`shop-card-buy-btn${!canAfford ? ' shop-card-buy-btn--poor' : ''}`}
                       onClick={() => handleBuyCard(deal)}
                       disabled={!canAfford}
                     >
                       {discounted && <span className="shop-discount-badge">-10%</span>}
                       {price} 💎
-                    </button>
+                    </Button>
                   )}
                 </div>
               )
@@ -336,13 +338,14 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
                 {bought ? (
                   <div className="shop-purchased">PURCHASED ✓</div>
                 ) : (
-                  <button
-                    className={`action-btn action-btn--gold shop-card-buy-btn${!canAfford ? ' shop-card-buy-btn--poor' : ''}`}
+                  <Button
+                    variant="gold"
+                    className={`shop-card-buy-btn${!canAfford ? ' shop-card-buy-btn--poor' : ''}`}
                     onClick={handleBuyAugment}
                     disabled={!canAfford}
                   >
                     {dailyAugment.price} 💎
-                  </button>
+                  </Button>
                 )}
               </div>
             </div>
@@ -362,14 +365,15 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
                   <div className="shop-consumable-icon">{c.icon}</div>
                   <div className="shop-consumable-name">{c.name}</div>
                   <div className="shop-consumable-desc">{c.desc}</div>
-                  <button
-                    className={`action-btn action-btn--gold shop-consumable-buy-btn${canAfford ? '' : ' shop-card-buy-btn--poor'}`}
+                  <Button
+                    variant="gold"
+                    className={`shop-consumable-buy-btn${canAfford ? '' : ' shop-card-buy-btn--poor'}`}
                     onClick={() => handleBuyConsumable(c.id, c.price)}
                     disabled={!canAfford}
                   >
                     {discounted && <span className="shop-discount-badge">-10%</span>}
                     {effectivePrice} 💎
-                  </button>
+                  </Button>
                 </div>
               )
             })}
@@ -402,15 +406,15 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
               MAX{maxPackQty > 0 ? ` ×${maxPackQty}` : ''}
             </button>
           </div>
-          <button
-            className="action-btn action-btn--gold"
+          <Button
+            variant="gold"
             onClick={handleBuyPackClick}
             disabled={false}
           >
             {canBuyPack
               ? `Buy ${packQty > 1 ? `${packQty}× ` : ''}— ${CRYSTAL_PACK_COST * packQty} 💎`
               : `Need ${CRYSTAL_PACK_COST * packQty - crystals} more 💎`}
-          </button>
+          </Button>
 
           {/* Max buy confirmation modal */}
           {pendingPackBuy && (
@@ -421,8 +425,8 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
                   This will buy <strong>{packQty} card pack{packQty !== 1 ? 's' : ''}</strong> for <strong>{CRYSTAL_PACK_COST * packQty} 💎</strong>
                 </div>
                 <div className="shop-confirm-actions">
-                  <button className="action-btn" onClick={() => setPendingPackBuy(false)}>Oh no</button>
-                  <button className="action-btn action-btn--gold" onClick={handleConfirmPackBuy}>Oh yes!</button>
+                  <Button onClick={() => setPendingPackBuy(false)}>Oh no</Button>
+                  <Button variant="gold" onClick={handleConfirmPackBuy}>Oh yes!</Button>
                 </div>
               </div>
             </div>
@@ -462,13 +466,13 @@ export function ShopScreen({ crystals, onBuyCrystalPack, onCrystalsChange, onBac
                         : "You don't have this item."}
                   </div>
                 )}
-                <button
-                  className={`action-btn${!hasItem ? ' action-btn--dim' : ''}`}
+                <Button
+                  className={!hasItem ? 'action-btn--dim' : ''}
                   onClick={() => handleSellClick(slotId, hasItem)}
                   disabled={!hasItem || alreadySold}
                 >
                   Sell {slot.icon} {slot.name}
-                </button>
+                </Button>
               </div>
             )
           })}

--- a/web/src/components/screens/TrainingScreen.tsx
+++ b/web/src/components/screens/TrainingScreen.tsx
@@ -4,6 +4,7 @@ import { loadCollection, loadDeck, buildDeckCards, deckTotalCards, STARTER_DECK 
 import { Card } from '../../game/types'
 import { SpriteImg } from '../ui/SpriteImg'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { Button } from '../ui/Button'
 interface Props {
   onBack: () => void
   onStart: (enemyUnitName: string, playerCards: Card[]) => void
@@ -67,12 +68,12 @@ export function TrainingScreen({ onBack, onStart }: Props) {
           <p className="training-hint">
             Your current saved deck will be used. Edit it in the Deck Builder before training.
           </p>
-          <button
-            className="action-btn action-btn--large"
+          <Button
+            size="lg"
             onClick={handleStartWithSavedDeck}
           >
             ▶ Start Training
-          </button>
+          </Button>
         </div>
 
         <div className="training-rules">

--- a/web/src/components/screens/WeeklyChallengeScreen.tsx
+++ b/web/src/components/screens/WeeklyChallengeScreen.tsx
@@ -4,6 +4,7 @@ import {
   fetchWeeklyLeaderboard, WeeklyLeaderboardEntry,
 } from '../../game/weeklyChallenge'
 import { getChronicleFragments, getExoticShards } from '../../game/itemStore'
+import { Button } from '../ui/Button'
 
 interface Props {
   onStart: () => void
@@ -38,7 +39,7 @@ export function WeeklyChallengeScreen({ onStart, onBack }: Props) {
   return (
     <div className="dc-screen">
       <div className="overlay-header u-flex u-items-c u-gap-6">
-        <button className="action-btn" onClick={onBack}>← BACK</button>
+        <Button onClick={onBack}>← BACK</Button>
         <span className="overlay-title">WEEKLY CHALLENGE</span>
       </div>
       <div className="u-text-c">
@@ -107,9 +108,9 @@ export function WeeklyChallengeScreen({ onStart, onBack }: Props) {
       </div>
 
       <div className="dc-actions u-col u-gap-4">
-        <button className="action-btn action-btn--large" onClick={onStart}>
+        <Button size="lg" onClick={onStart}>
           {state.attempts === 0 ? '▶ START CHALLENGE' : '▶ TRY AGAIN'}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export type ButtonSize    = 'xs' | 'sm' | 'md' | 'lg'
-export type ButtonVariant = 'default' | 'gold' | 'danger'
+export type ButtonVariant = 'default' | 'gold' | 'danger' | 'ghost'
 
 const SIZE_CLASS: Record<ButtonSize, string> = {
   xs: 'action-btn--xs',
@@ -14,29 +14,36 @@ const VARIANT_CLASS: Record<ButtonVariant, string> = {
   default: '',
   gold:    'action-btn--gold',
   danger:  'action-btn--danger',
+  ghost:   'action-btn--ghost',
 }
 
 interface Props {
-  size?:      ButtonSize
-  variant?:   ButtonVariant
-  onClick?:   () => void
-  disabled?:  boolean
-  title?:     string
-  className?: string
-  style?:     React.CSSProperties
-  children:   React.ReactNode
+  size?:           ButtonSize
+  variant?:        ButtonVariant
+  type?:           'button' | 'submit' | 'reset'
+  onClick?:        (e: React.MouseEvent<HTMLButtonElement>) => void
+  onPointerDown?:  (e: React.PointerEvent<HTMLButtonElement>) => void
+  disabled?:       boolean
+  title?:          string
+  'aria-label'?:   string
+  className?:      string
+  style?:          React.CSSProperties
+  children:        React.ReactNode
 }
 
-export function Button({
+export const Button = React.forwardRef<HTMLButtonElement, Props>(function Button({
   size    = 'md',
   variant = 'default',
+  type    = 'button',
   onClick,
+  onPointerDown,
   disabled,
   title,
+  'aria-label': ariaLabel,
   className,
   style,
   children,
-}: Props) {
+}, ref) {
   const classes = [
     'action-btn',
     SIZE_CLASS[size],
@@ -46,13 +53,17 @@ export function Button({
 
   return (
     <button
+      ref={ref}
+      type={type}
       className={classes}
       onClick={onClick}
+      onPointerDown={onPointerDown}
       disabled={disabled}
       title={title}
+      aria-label={ariaLabel}
       style={style}
     >
       {children}
     </button>
   )
-}
+})

--- a/web/src/components/ui/NodeMap/NodePeekModal.tsx
+++ b/web/src/components/ui/NodeMap/NodePeekModal.tsx
@@ -2,6 +2,7 @@
 
 import { QuestNode, ReplayModifier } from "../../../game/questline";
 import { StatRow } from "../StatRow";
+import { Button } from "../Button";
 import { NODE_ICON, NODE_LABEL } from "./constants";
 
 // ── Reward / difficulty helpers ───────────────────────────────────────────────
@@ -95,11 +96,11 @@ export function NodePeekModal({
             )}
             <div className="nm-peek-actions u-flex u-gap-4">
               {isAvailable && (
-                <button className="action-btn nm-peek-enter-btn u-grow" onClick={onEnter}>
+                <Button className="nm-peek-enter-btn u-grow" onClick={onEnter}>
                   {node.type === 'battle' && !isCleared ? 'ENTER BATTLE ⚔' : 'TRAVEL ➤'}
-                </button>
+                </Button>
               )}
-              <button className="action-btn nm-peek-back-btn" onClick={onClose}>BACK</button>
+              <Button className="nm-peek-back-btn" onClick={onClose}>BACK</Button>
             </div>
           </>
         ) : (
@@ -129,15 +130,15 @@ export function NodePeekModal({
             )}
             <div className="nm-peek-actions u-flex u-gap-4">
               {(isBattle || node.type === 'event' || node.type === 'merchant') ? (
-                <button className="action-btn nm-peek-enter-btn u-grow" onClick={onEnter}>
+                <Button className="nm-peek-enter-btn u-grow" onClick={onEnter}>
                   {node.type === 'merchant' ? 'ENTER SHOP' : node.type === 'event' ? 'APPROACH' : 'ENTER BATTLE'}
-                </button>
+                </Button>
               ) : (
-                <button className="action-btn nm-peek-enter-btn u-grow" onClick={onEnter}>
+                <Button className="nm-peek-enter-btn u-grow" onClick={onEnter}>
                   {node.type === 'rest' ? 'REST HERE' : 'PROCEED'}
-                </button>
+                </Button>
               )}
-              <button className="action-btn nm-peek-back-btn" onClick={onClose}>BACK</button>
+              <Button className="nm-peek-back-btn" onClick={onClose}>BACK</Button>
             </div>
           </>
         )}

--- a/web/src/components/ui/PageHeader.tsx
+++ b/web/src/components/ui/PageHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Button } from './Button'
 export interface Props {
     title: React.ReactNode | string
       subtitle?: string
@@ -9,7 +10,7 @@ export interface Props {
 export function PageHeader({ title, subtitle, onBack, right }: Props) {
     return (
         <div className="overlay-header u-flex u-items-c u-gap-6">
-            {onBack && <button className="action-btn" onClick={onBack}>← BACK</button>}
+            {onBack && <Button onClick={onBack}>← BACK</Button>}
                     <div className="nm-act-label u-col u-grow">
             <span className="overlay-title">{title}</span>
             {subtitle && <span className="nm-act-sub">{subtitle}</span>}

--- a/web/src/styles/buttons.css
+++ b/web/src/styles/buttons.css
@@ -1,21 +1,26 @@
 /* buttons.css — split from styles.css (#2169). .action-btn and variants, plus the shared ProgressBar/StatRow/Section primitives. */
 
-/* ─── Buttons ────────────────────────────────────────── */
+/* ─── Buttons (#2171) ─────────────────────────────────── */
 
 .action-btn {
-  background: none;
+  position: relative;
+  background: var(--game-bg-raised);
   border: 2px solid var(--game-text-color);
   color: var(--game-text-color);
   font-family: inherit;
   font-size: 1rem;
   padding: 8px 20px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: transform 0.1s ease-out, box-shadow 0.15s, background 0.15s, border-color 0.15s;
   border-radius: 3px;
   line-height: 1.4;
   min-height: 36px;
   box-sizing: border-box;
   text-wrap-style: none;
+  /* Struck-metal bevel, same pair used by Panel (#2170) */
+  box-shadow:
+    inset 0 1px 0 var(--panel-edge-light),
+    inset 0 -1px 0 var(--panel-edge-dark);
 }
 
 /* ─── Button size modifiers ──────────────────────────── */
@@ -32,6 +37,19 @@
   min-height: 22px;
 }
 
+/* iOS/Android guidance is a 44px minimum touch target. Mouse pointers keep
+   the compact sizes above; coarse (touch) pointers get bumped up here so a
+   thumb can reliably hit every size without changing the visual density on
+   desktop. */
+@media (pointer: coarse) {
+  .action-btn,
+  .action-btn--sm,
+  .action-btn--xs,
+  .action-btn--large {
+    min-height: 44px;
+  }
+}
+
 .action-btn--dim {
   border-color: color-mix(in srgb, var(--game-text-color) 40%, transparent);
   color: var(--game-text-color-dim);
@@ -39,8 +57,27 @@
 
 .action-btn:hover {
   background: color-mix(in srgb, var(--game-text-color) 15%, transparent);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--game-text-color) 40%, transparent);
+  box-shadow:
+    0 0 12px color-mix(in srgb, var(--game-text-color) 40%, transparent),
+    inset 0 1px 0 var(--panel-edge-light),
+    inset 0 -1px 0 var(--panel-edge-dark);
   text-shadow: 0 0 6px color-mix(in srgb, var(--game-text-color) 60%, transparent);
+}
+
+/* The button visibly depresses on press — translate down plus the bevel
+   direction swapping (light now reads from the bottom) — so touch devices,
+   where :hover never fires, still get feedback. */
+.action-btn:active {
+  transform: translateY(1px);
+  box-shadow:
+    inset 0 1px 3px var(--panel-edge-dark),
+    inset 0 -1px 0 var(--panel-edge-light);
+  transition-duration: 0.05s;
+}
+
+.action-btn:focus-visible {
+  outline: 2px solid var(--accent-gold);
+  outline-offset: 2px;
 }
 
 @keyframes nodeTargetPulse {
@@ -55,7 +92,7 @@
   animation: nodeTargetPulse 1s ease-in-out infinite;
 }
 
-/* ─── Gold button variant (pack open) ───────────────── */
+/* ─── Gold button variant (pack open, rewards) ───────── */
 
 .action-btn--gold {
   border-color: var(--color-gold-alt);
@@ -63,7 +100,10 @@
 }
 .action-btn--gold:hover {
   background: color-mix(in srgb, var(--accent-gold) 15%, transparent);
-  box-shadow: 0 0 14px color-mix(in srgb, var(--accent-gold) 50%, transparent);
+  box-shadow:
+    0 0 14px color-mix(in srgb, var(--accent-gold) 50%, transparent),
+    inset 0 1px 0 var(--panel-edge-light),
+    inset 0 -1px 0 var(--panel-edge-dark);
   text-shadow: 0 0 6px color-mix(in srgb, var(--accent-gold) 70%, transparent);
 }
 
@@ -74,33 +114,75 @@
 .action-btn--danger:hover {
   background: color-mix(in srgb, var(--accent-ember) 10%, transparent);
   border-color: var(--accent-ember);
-  box-shadow: 0 0 10px color-mix(in srgb, var(--accent-ember) 20%, transparent);
+  box-shadow:
+    0 0 10px color-mix(in srgb, var(--accent-ember) 20%, transparent),
+    inset 0 1px 0 var(--panel-edge-light),
+    inset 0 -1px 0 var(--panel-edge-dark);
 }
 
+/* Low-emphasis: no fill, no border, just text — for tertiary actions that
+   shouldn't compete with a screen's primary/secondary buttons. */
+.action-btn--ghost {
+  background: none;
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--game-text-color-dim);
+}
+.action-btn--ghost:hover {
+  background: color-mix(in srgb, var(--game-text-color) 8%, transparent);
+  box-shadow: none;
+  text-shadow: none;
+  color: var(--game-text-color);
+}
+.action-btn--ghost:active {
+  box-shadow: none;
+}
+
+/* Real :disabled, driven by the HTML attribute — not just the manual
+   --disabled class below, which several call sites still apply directly
+   without also setting the disabled attribute. */
+.action-btn:disabled,
 .action-btn--disabled {
   border-color: color-mix(in srgb, var(--text-inverse) 20%, transparent);
   color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
   cursor: not-allowed;
+  background: var(--game-bg-raised);
+  transform: none;
 }
 
-.action-btn--disabled:hover {
-  background: none;
-  box-shadow: none;
+.action-btn:disabled:hover,
+.action-btn:disabled:active,
+.action-btn--disabled:hover,
+.action-btn--disabled:active {
+  background: var(--game-bg-raised);
+  box-shadow:
+    inset 0 1px 0 var(--panel-edge-light),
+    inset 0 -1px 0 var(--panel-edge-dark);
+  text-shadow: none;
+  transform: none;
   border-color: color-mix(in srgb, var(--text-inverse) 20%, transparent);
   color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
 }
 
 .action-btn--noborder {
   border: none;
+  background: none;
+  box-shadow: none;
   color: var(--color-gold-alt);
 }
 .action-btn--noborder:hover {
   background: none;
   box-shadow: none;
 }
+.action-btn--noborder:active {
+  transform: none;
+  box-shadow: none;
+}
 
 .action-btn--noborder-disabled {
   border: none;
+  background: none;
+  box-shadow: none;
   color: color-mix(in srgb, var(--text-inverse) 30%, transparent);
   cursor: not-allowed;
 }


### PR DESCRIPTION
Partial progress on #2171 — Phase 1 of the #2165 UI overhaul epic (stacked after #2190/#2170, #2189/#2169, #2188/#2168, #2187/#2167, #2186/#2166).

## Summary

`.action-btn` was a hollow outline with a `:hover` glow and nothing else — no `:active` feedback (meaning zero response on touch devices, where `:hover` never fires), disabled styling driven by a manually-toggled class rather than the `disabled` attribute, and touch targets below the 44px guidance. Meanwhile `ui/Button.tsx` existed with a proper API but was used by only 8 files against 701 raw `<button>` elements.

This PR does the full CSS/component rebuild (applies everywhere immediately) plus migrates the two directories the issue names first (`components/ui/` and `components/screens/`). The issue itself calls for by-directory batching ("do this in batches... editor and admin surfaces can go last"), so the remaining directories (`battle/`, `cards/`, `hub/`, `campaign/`, `minigames/`, plus `modals/`/`rare-events/`) are left for follow-up PRs.

## `.action-btn` rebuild (benefits every button immediately, migrated or not)

- Struck-metal fill with the same bevel pair `Panel` (#2170) uses, replacing the flat transparent background
- Real `:active` state: `translateY(1px)` + the bevel direction swapping, so the button visibly depresses on press
- Real `:disabled`, driven by the HTML attribute (a `.action-btn:disabled` rule alongside the existing manual `.action-btn--disabled` class, kept for call sites that toggle it without also setting the attribute)
- `:focus-visible` ring (2px solid `--accent-gold`, 2px offset)
- New `--ghost` variant for low-emphasis/tertiary actions
- `@media (pointer: coarse)` bumps every size to ≥44px min-height on touch, keeping the existing compact sizes for mouse

`ui/Button.tsx` gained `type`, `aria-label`, `onPointerDown` props and `forwardRef` — several raw `<button>`s existed only because the component couldn't take a ref or needed a prop it didn't expose.

## Migration: 701 → 632 raw `<button>`s

| Directory | Migrated | Notes |
|---|---|---|
| `components/ui/` | 6 | `PageHeader`, `NodeMap/NodePeekModal` |
| `components/screens/` | 63 | 16 files — `SettingsScreen` (23), `CollectionScreen`, `MiniGamesMenu`, `AugmentCollectionScreen`, `ShopScreen`, `TrainingScreen`, `InventoryScreen`, `CommanderScreen`, `NewsScreen`, `AchievementsScreen`, `WeeklyChallengeScreen`, `DailyChallengeScreen`, `QuickBattleScreen`, `EndlessLeaderboardScreen`, `DailyLoginModal`, `CardDraftScreen` |

Only actual `.action-btn` call sites were converted. Left as raw `<button>` **deliberately**, not because Button lacked a prop:
- The `filter-btn` family — a separate, already-tokenized component (e.g. Collection's filter/sort/group bar)
- `Toolbar/*` (`ToolbarButton` etc.) — its own reusable primitive for the map/battlefield editor canvas toolbar, not a duplicate of `Button`
- One-off custom styles that were never `action-btn`: `title-auth-btn`, `player-tab`, `chr-chapter`, `character-*`

## Remaining count (stated per the acceptance criteria)

`701 → 632` raw `<button>`s in `components/` (excluding stories). Remaining by directory: `battle` 23, `campaign` 25, `cards` 57, `hub` 73, `minigames` 111, `modals` 13, `rare-events` 20, `screens` 47 (mostly `filter-btn`), `ui` 8 (`Toolbar`/`title-auth`, listed above as deliberate). `mapEditor` (188), `battlefieldEditor` (18) and `admin` (43) — 249 total — are the dev-only surfaces the issue explicitly allows deferring/skipping.

## Verified in a real browser, not just build/test

Screenshot of the fully-migrated Settings screen (17 buttons across 8 sections) confirms every button renders the new fill/bevel correctly against the new Panel-styled Section headers, with zero console errors. Also verified `:active` (visibly darker/pressed), and `:focus-visible` (`getComputedStyle` confirms the gold outline) in isolated checks during the CSS rebuild.

## Test plan

- [x] `.action-btn` has `:hover`, `:active`, `:disabled` and `:focus-visible` states — verified via screenshots + computed style
- [x] Touch targets ≥44px under `@media (pointer: coarse)` for all sizes
- [x] `npm run build`, `npx tsc --noEmit`, `npm run test` (2861/2861) all pass clean
- [x] Real-device touch verification not performed in this sandboxed environment — verified via Playwright's pointer-down simulation instead, which exercises the same `:active` CSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_