### PR TITLE
[UI 1.3] Icon system to replace emoji glyphs across the UI (part 1: title screen)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo, useReducer, Suspense } from 'react'
 import { ScreenLoadingFallback } from './components/ScreenLoadingFallback'
+import { IconSprite } from './components/ui/icons/IconSprite'
 import { resolvedNodeOpts, loadHandicap } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
@@ -1244,6 +1245,7 @@ export default function App() {
     <AppProvider value={appContextValue}>
     <BattleProvider value={battleContextValue}>
     <div className="game-container">
+      <IconSprite />
       <div className="game-title">JARV'S AMAZING WEB GAME</div>
 
       <Suspense fallback={<ScreenLoadingFallback />}>

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -19,6 +19,7 @@ import { generatePack, addCardsToCollection } from '../../game/collection'
 import { WinStreak } from './WinStreak'
 import { LoginButton } from '../ui/LoginButton'
 import { Button } from '../ui/Button'
+import { Icon } from '../ui/icons/Icon'
 
 const CAMPAIGN_UNLOCK_CARDS = 30
 const EIGHTBIT_CLICKS = 8
@@ -212,7 +213,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
             undefined
           }
         >
-          {savedRun ? '⚔  CONTINUE RUN' : '⚔  CAMPAIGN'}
+          <Icon name="sword" size={16} /> {savedRun ? 'CONTINUE RUN' : 'CAMPAIGN'}
         </TitleButton>
 
         <TitleButton
@@ -228,7 +229,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
           extraClass="title-primary-btn"
           title={valid ? undefined : `Deck needs ${10 - count} more cards`}
         >
-          ∞  ENDLESS MODE
+          <Icon name="infinity" size={16} /> ENDLESS MODE
         </TitleButton>
 
         <TitleButton onClick={onDailyChallenge} extraClass="title-daily-btn">
@@ -240,31 +241,31 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         </TitleButton>
 
         <TitleButton onClick={onEndlessLeaderboard} extraClass="title-endless-lb-btn">
-          🏆  LEADERBOARDS
+          <Icon name="trophy" size={16} /> LEADERBOARDS
         </TitleButton>
 
         <TitleButton onClick={onTraining} extraClass="title-training-btn">
-          ⚔  TRAINING MODE
+          <Icon name="sword" size={16} /> TRAINING MODE
         </TitleButton>
 
         <TitleButton onClick={onMiniGames} extraClass={`title-minigames-btn`}>
-          🎮  MINI GAMES
+          <Icon name="minigames" size={16} /> MINI GAMES
         </TitleButton>
         {cityAttackAlert && (
           <TitleButton variant="large" onClick={onCityBuilder} extraClass="title-campaign-btn title-minigames-btn title-btn--alert title-alert-badge">
-            ⚔ CITY ALERT
+            <Icon name="sword" size={16} /> CITY ALERT
           </TitleButton>
         )}
         {hubUnlocked && onHub && (
           <TitleButton variant="large" onClick={onHub} extraClass="title-campaign-btn">
-            🌆  HUB WORLD
+            <Icon name="hub" size={16} /> HUB WORLD
           </TitleButton>
         )}
       </div>
 
       {!campaignUnlocked && (
         <div className="title-campaign-locked-hint">
-          🔒 Campaign unlocks at {CAMPAIGN_UNLOCK_CARDS} cards ({totalOwned}/{CAMPAIGN_UNLOCK_CARDS}) — play Quick Battle to earn more!
+          <Icon name="lock" size={14} /> Campaign unlocks at {CAMPAIGN_UNLOCK_CARDS} cards ({totalOwned}/{CAMPAIGN_UNLOCK_CARDS}) — play Quick Battle to earn more!
         </div>
       )}
 
@@ -272,14 +273,14 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
       <div className="title-nav-section">
         <div className="title-nav-label">[ MANAGE ]</div>
         <div className="title-nav-grid">
-          <TitleButton onClick={onPlayer} badge={achievementAlert}>👤 PLAYER</TitleButton>
-          <TitleButton onClick={onDeckBuilder}>🃏 DECK</TitleButton>
-          <TitleButton onClick={onCollection} badge={collectionAlert}>📦 COLLECTION</TitleButton>
-          <TitleButton onClick={onShop} badge={shopAlert}>🛒 SHOP</TitleButton>
-          <TitleButton onClick={onCodex}>📖 CODEX</TitleButton>
-          <TitleButton onClick={onChronicle} badge={chronicleAlert}>📜 CHRONICLE</TitleButton>
-          <TitleButton onClick={onNews} badge={hasUnreadNews}>📰 WHAT'S NEW</TitleButton>
-          <TitleButton onClick={onSettings} extraClass="title-settings-btn">⚙ SETTINGS</TitleButton>
+          <TitleButton onClick={onPlayer} badge={achievementAlert}><Icon name="player" size={16} /> PLAYER</TitleButton>
+          <TitleButton onClick={onDeckBuilder}><Icon name="deck" size={16} /> DECK</TitleButton>
+          <TitleButton onClick={onCollection} badge={collectionAlert}><Icon name="collection" size={16} /> COLLECTION</TitleButton>
+          <TitleButton onClick={onShop} badge={shopAlert}><Icon name="shop" size={16} /> SHOP</TitleButton>
+          <TitleButton onClick={onCodex}><Icon name="codex" size={16} /> CODEX</TitleButton>
+          <TitleButton onClick={onChronicle} badge={chronicleAlert}><Icon name="chronicle" size={16} /> CHRONICLE</TitleButton>
+          <TitleButton onClick={onNews} badge={hasUnreadNews}><Icon name="news" size={16} /> WHAT'S NEW</TitleButton>
+          <TitleButton onClick={onSettings} extraClass="title-settings-btn"><Icon name="settings" size={16} /> SETTINGS</TitleButton>
           {commanderName && onCommander && (
             <TitleButton onClick={onCommander} extraClass="title-commander-btn">
               <SpriteImg name={commanderName} className="commander-btn-sprite" />
@@ -293,8 +294,8 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
       <div className="title-footer u-col u-items-c u-gap-2 u-relative">
         <div className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>
           {wrongSave
-            ? <>{wrongSave.cards}/{catalogTotal} cards &nbsp;·&nbsp; 💎 {wrongSave.crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {wrongSave.deck}</>
-            : <>{distinctUnlocked}/{catalogTotal} cards &nbsp;·&nbsp; 💎 {crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {count}</>
+            ? <>{wrongSave.cards}/{catalogTotal} cards &nbsp;·&nbsp; <Icon name="crystal" size={12} /> {wrongSave.crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {wrongSave.deck}</>
+            : <>{distinctUnlocked}/{catalogTotal} cards &nbsp;·&nbsp; <Icon name="crystal" size={12} /> {crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {count}</>
           }
         </div>
         <div className="title-auth-bar u-flex u-items-c u-gap-5">

--- a/web/src/components/ui/icons/Icon.stories.tsx
+++ b/web/src/components/ui/icons/Icon.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Icon } from './Icon';
+import { IconSprite, ICON_NAMES } from './IconSprite';
+
+const meta = {
+  title: 'UI/Icon',
+  component: Icon,
+  parameters: { layout: 'centered' },
+  decorators: [(Story) => (<><IconSprite /><Story /></>)],
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: 'player' },
+};
+
+export const AllIcons: Story = {
+  args: { name: 'player' },
+  render: () => (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(6, auto)',
+      gap: 20,
+      background: 'var(--game-bg)',
+      color: 'var(--game-text-color)',
+      padding: 20,
+    }}>
+      {ICON_NAMES.map((name) => (
+        <div key={name} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, fontSize: 10 }}>
+          <Icon name={name} size={28} />
+          <span>{name}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  args: { name: 'trophy' },
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, background: 'var(--game-bg)', color: 'var(--color-gold-alt)', padding: 20 }}>
+      <Icon name="trophy" size={16} />
+      <Icon name="trophy" size={20} />
+      <Icon name="trophy" size={24} />
+      <Icon name="trophy" size={32} />
+      <Icon name="trophy" size={48} />
+    </div>
+  ),
+};
+
+export const ThemedByColor: Story = {
+  args: { name: 'crystal' },
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, background: 'var(--game-bg)', padding: 20 }}>
+      <Icon name="crystal" size={32} style={{ color: 'var(--game-text-color)' }} />
+      <Icon name="crystal" size={32} style={{ color: 'var(--accent-gold)' }} />
+      <Icon name="crystal" size={32} style={{ color: 'var(--accent-ember)' }} />
+      <Icon name="crystal" size={32} style={{ color: 'var(--accent-arcane)' }} />
+    </div>
+  ),
+};

--- a/web/src/components/ui/icons/Icon.tsx
+++ b/web/src/components/ui/icons/Icon.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { IconName } from './IconSprite'
+
+interface Props {
+  name: IconName
+  size?: number
+  className?: string
+  style?: React.CSSProperties
+  /** Set when the icon is the only content of an interactive control — feeds a11y (#2182). */
+  'aria-label'?: string
+}
+
+/**
+ * Renders one icon from the sprite sheet mounted by <IconSprite /> (see
+ * IconSprite.tsx). Uses currentColor by default, so it themes with
+ * whatever CSS `color` the surrounding text has — no colour prop needed.
+ */
+export function Icon({ name, size = 20, className, style, 'aria-label': ariaLabel }: Props) {
+  const classes = ['icon', className].filter(Boolean).join(' ')
+  return (
+    <svg
+      className={classes}
+      width={size}
+      height={size}
+      style={{ display: 'inline-block', flexShrink: 0, fill: 'currentColor', ...style }}
+      role={ariaLabel ? 'img' : undefined}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+    >
+      <use href={`#icon-${name}`} />
+    </svg>
+  )
+}

--- a/web/src/components/ui/icons/IconSprite.tsx
+++ b/web/src/components/ui/icons/IconSprite.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+
+/**
+ * The game's icon set (#2172), replacing OS-rendered emoji so iconography
+ * looks the same on iOS/Android/desktop and doesn't clash with the 2,535
+ * hand-made sprite SVGs. Simple geometric shapes at 24x24, matching the
+ * sprite set's blocky, flat-shaded language but drawn in a single
+ * `currentColor` so each icon themes with whatever text colour surrounds it.
+ *
+ * Mount <IconSprite /> once near the app root; every <Icon name="..." />
+ * instance references a <symbol> here via <use>, so the markup for all 23
+ * icons is only ever parsed once regardless of how many places render them.
+ */
+export const ICON_NAMES = [
+  'player', 'deck', 'collection', 'shop', 'codex', 'chronicle', 'news',
+  'settings', 'trophy', 'minigames', 'sword', 'infinity', 'hub', 'crystal',
+  'lock', 'coin', 'heart', 'mana', 'back-arrow', 'close', 'info', 'filter',
+  'search',
+] as const
+
+export type IconName = typeof ICON_NAMES[number]
+
+export function IconSprite() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }} aria-hidden="true">
+      <defs>
+        <symbol id="icon-player" viewBox="0 0 24 24">
+          <circle cx="12" cy="7" r="4" />
+          <path d="M4 21v-1c0-4.4 3.6-8 8-8s8 3.6 8 8v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z" />
+        </symbol>
+
+        <symbol id="icon-deck" viewBox="0 0 24 24">
+          <rect x="4" y="8" width="12" height="15" rx="1.5" transform="rotate(-10 10 15.5)" opacity="0.55" />
+          <rect x="7" y="3" width="13" height="17" rx="1.5" />
+        </symbol>
+
+        <symbol id="icon-collection" viewBox="0 0 24 24">
+          <path d="M3 8.5 5 4h14l2 4.5V20a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 20z" />
+          <rect x="3" y="8" width="18" height="2" opacity="0.5" />
+        </symbol>
+
+        <symbol id="icon-shop" viewBox="0 0 24 24">
+          <path d="M8 8Q12 1 16 8" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+          <path d="M5 8h14l-1.4 11.5a1.5 1.5 0 0 1-1.5 1.5H7.9a1.5 1.5 0 0 1-1.5-1.5z" />
+        </symbol>
+
+        <symbol id="icon-codex" viewBox="0 0 24 24">
+          <path d="M4 4.5A1.5 1.5 0 0 1 5.5 3H19a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H5.5A1.5 1.5 0 0 1 4 19.5z" />
+          <rect x="4" y="3" width="2.6" height="18" opacity="0.55" />
+        </symbol>
+
+        <symbol id="icon-chronicle" viewBox="0 0 24 24">
+          <rect x="5" y="5" width="14" height="14" rx="1" />
+          <ellipse cx="12" cy="5" rx="7" ry="2" />
+          <ellipse cx="12" cy="19" rx="7" ry="2" />
+        </symbol>
+
+        <symbol id="icon-news" viewBox="0 0 24 24">
+          <path d="M4 4h13a1 1 0 0 1 1 1v13.5A1.5 1.5 0 0 0 19.5 20H5a1 1 0 0 1-1-1z" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <rect x="7" y="7.5" width="7" height="4.5" opacity="0.6" />
+          <rect x="7" y="14" width="10" height="1.6" opacity="0.6" />
+          <rect x="16" y="7.5" width="1.6" height="4.5" opacity="0.6" />
+        </symbol>
+
+        <symbol id="icon-settings" viewBox="0 0 24 24">
+          <path fillRule="evenodd" d="M12 2.5a1.4 1.4 0 0 1 1.37 1.12l.24 1.16a7.6 7.6 0 0 1 1.87.78l1-.63a1.4 1.4 0 0 1 1.75.19l.98.98a1.4 1.4 0 0 1 .19 1.75l-.63 1a7.6 7.6 0 0 1 .78 1.87l1.16.24a1.4 1.4 0 0 1 1.12 1.37v1.4a1.4 1.4 0 0 1-1.12 1.37l-1.16.24a7.6 7.6 0 0 1-.78 1.87l.63 1a1.4 1.4 0 0 1-.19 1.75l-.98.98a1.4 1.4 0 0 1-1.75.19l-1-.63a7.6 7.6 0 0 1-1.87.78l-.24 1.16A1.4 1.4 0 0 1 12 21.5a1.4 1.4 0 0 1-1.37-1.12l-.24-1.16a7.6 7.6 0 0 1-1.87-.78l-1 .63a1.4 1.4 0 0 1-1.75-.19l-.98-.98a1.4 1.4 0 0 1-.19-1.75l.63-1a7.6 7.6 0 0 1-.78-1.87l-1.16-.24A1.4 1.4 0 0 1 2.5 12v-1.4a1.4 1.4 0 0 1 1.12-1.37l1.16-.24a7.6 7.6 0 0 1 .78-1.87l-.63-1a1.4 1.4 0 0 1 .19-1.75l.98-.98a1.4 1.4 0 0 1 1.75-.19l1 .63a7.6 7.6 0 0 1 1.87-.78l.24-1.16A1.4 1.4 0 0 1 12 2.5zm0 6a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7z" />
+        </symbol>
+
+        <symbol id="icon-trophy" viewBox="0 0 24 24">
+          <path d="M7 4h10v6a5 5 0 0 1-10 0z" />
+          <path d="M7 5H4a1 1 0 0 0-1 1v1a4 4 0 0 0 4 4M17 5h3a1 1 0 0 1 1 1v1a4 4 0 0 1-4 4" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <rect x="10.5" y="15" width="3" height="4" />
+          <rect x="7" y="19" width="10" height="2" rx="1" />
+        </symbol>
+
+        <symbol id="icon-minigames" viewBox="0 0 24 24">
+          <rect x="4" y="4" width="16" height="16" rx="3" />
+          <circle cx="9" cy="9" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="15" cy="9" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="9" cy="15" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="15" cy="15" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="12" cy="12" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+        </symbol>
+
+        <symbol id="icon-sword" viewBox="0 0 24 24">
+          <rect x="10.8" y="2" width="2.4" height="12" rx="1" />
+          <rect x="7.5" y="13" width="9" height="2.2" rx="1" />
+          <rect x="10.4" y="15" width="3.2" height="5" rx="1.2" />
+          <circle cx="12" cy="21" r="1.4" />
+        </symbol>
+
+        <symbol id="icon-infinity" viewBox="0 0 24 24">
+          <path fillRule="evenodd" d="M7 8a4.5 4.5 0 0 0 0 9c1.9 0 3.1-1.1 4-2.3l1-1.4 1 1.4c.9 1.2 2.1 2.3 4 2.3a4.5 4.5 0 0 0 0-9c-1.9 0-3.1 1.1-4 2.3l-1 1.4-1-1.4C10.1 9.1 8.9 8 7 8zm0 2.6c.83 0 1.5.5 2.2 1.5l.5.7-.5.7c-.7 1-1.37 1.5-2.2 1.5a2.1 2.1 0 0 1 0-4.4zm10 0a2.1 2.1 0 0 1 0 4.4c-.83 0-1.5-.5-2.2-1.5l-.5-.7.5-.7c.7-1 1.37-1.5 2.2-1.5z" />
+        </symbol>
+
+        <symbol id="icon-hub" viewBox="0 0 24 24">
+          <path d="M12 3 3 10.5V21h6v-6h6v6h6V10.5z" />
+        </symbol>
+
+        <symbol id="icon-crystal" viewBox="0 0 24 24">
+          <path d="M12 2 5 8l7 14 7-14z" />
+          <path d="M5 8h14L12 2z" opacity="0.6" />
+        </symbol>
+
+        <symbol id="icon-lock" viewBox="0 0 24 24">
+          <path d="M7 10V7.5a5 5 0 0 1 10 0V10" fill="none" stroke="currentColor" strokeWidth="2.2" />
+          <rect x="4.5" y="10" width="15" height="11" rx="2" />
+          <rect x="11" y="14" width="2" height="4" rx="1" fill="var(--game-bg, #0a0a0a)" />
+        </symbol>
+
+        <symbol id="icon-coin" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" />
+          <circle cx="12" cy="12" r="6.2" fill="none" stroke="var(--game-bg, #0a0a0a)" strokeWidth="1.4" />
+        </symbol>
+
+        <symbol id="icon-heart" viewBox="0 0 24 24">
+          <path d="M12 20.5S3 14.8 3 8.8A4.8 4.8 0 0 1 12 6a4.8 4.8 0 0 1 9 2.8c0 6-9 11.7-9 11.7z" />
+        </symbol>
+
+        <symbol id="icon-mana" viewBox="0 0 24 24">
+          <path d="M12 2S5 12 5 16a7 7 0 0 0 14 0c0-4-7-14-7-14z" />
+        </symbol>
+
+        <symbol id="icon-back-arrow" viewBox="0 0 24 24">
+          <path d="M11 4 4 12l7 8" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M4 12h16" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+        </symbol>
+
+        <symbol id="icon-close" viewBox="0 0 24 24">
+          <rect x="11" y="2" width="2" height="20" rx="1" transform="rotate(45 12 12)" />
+          <rect x="11" y="2" width="2" height="20" rx="1" transform="rotate(-45 12 12)" />
+        </symbol>
+
+        <symbol id="icon-info" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9.5" />
+          <rect x="10.8" y="10.5" width="2.4" height="7" rx="1" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="12" cy="7.2" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+        </symbol>
+
+        <symbol id="icon-filter" viewBox="0 0 24 24">
+          <path d="M3 4h18l-6.5 8v6l-5 3v-9z" />
+        </symbol>
+
+        <symbol id="icon-search" viewBox="0 0 24 24">
+          <circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" strokeWidth="2.4" />
+          <rect x="17.5" y="15.5" width="2.6" height="7" rx="1.3" transform="rotate(-45 18.8 19)" />
+        </symbol>
+      </defs>
+    </svg>
+  )
+}


### PR DESCRIPTION
Partial progress on #2172 — Phase 1 of the #2165 UI overhaul epic (stacked after #2191/#2171, #2190/#2170, #2189/#2169, #2188/#2168, #2187/#2167, #2186/#2166).

## Summary

The game used OS-rendered emoji as its icon set — Apple's glyphs on iOS, Google's on Android, Microsoft's on Windows, three completely different visual styles, none of them the game's, and clashing with the 2,535 hand-made sprite SVGs already in the repo.

## The icon set

23 icons for the first pass (exactly the list the issue names): player, deck, collection, shop, codex, chronicle, news, settings, trophy, minigames, sword, infinity, hub, crystal, lock, coin, heart, mana, back-arrow, close, info, filter, search.

- **`ui/icons/IconSprite.tsx`** — a hidden `<svg><symbol>` sheet, mounted once at the app root (`App.tsx`) so all 23 icons' markup is parsed once regardless of how many places render them
- **`ui/icons/Icon.tsx`** — `<svg><use href="#icon-{name}"/></svg>`, sized via a `size` prop, `currentColor` by default so it themes with whatever colour surrounds it
- Simple geometric shapes at 24×24, matching the sprite set's blocky flat-shaded language but monochrome so they can inherit `currentColor` the way the detailed multi-colour unit sprites don't
- `Icon.stories.tsx` shows the full 23-icon set, a size comparison, and a themed-by-color comparison (verified the same icon renders correctly in green/gold/ember/arcane just by changing CSS `color`)

## Call sites: title screen (the issue's named starting point)

Replaced emoji at the title screen — the highest-traffic screen in the game: main nav (Campaign/Endless/Leaderboards/Training/Mini Games/Hub World), the secondary MANAGE grid (Player/Deck/Collection/Shop/Codex/Chronicle/News/Settings), the campaign-locked hint, and the footer crystal count.

Hub modals, shop, quests and toolbars are the issue's other named targets and follow in later PRs, per the same by-priority approach used for #2171.

## Verified in a real browser, not just build/test

Screenshots of the full icon set caught and fixed two icons that didn't read correctly in isolation:
- **shop**: the handle drawn as an arc stroke wasn't visible — fixed with a quadratic curve for a clearer bag handle
- **sword**: the crossguard was as wide as the blade was tall, making it read as a plus sign — fixed with a narrower guard, now clearly reads as a sword

Then verified the title screen itself with all emoji replaced: every icon (sword, infinity, trophy, dice, lock, person, cards, box, bag, book, scroll, newspaper, gear, crystal) renders correctly in the game's green terminal palette, zero console errors.

## Test plan

- [x] Icon sprite sheet committed, drawn to match the existing sprite style
- [x] `ui/Icon.tsx` plus `Icon.stories.tsx` showing the full set at each size
- [x] Icons inherit `currentColor` and respond to the token palette — verified via a themed-by-color story
- [x] Emoji removed from the title nav (hub modals/shop/quests/toolbars follow in later PRs)
- [x] `npm run build` and `npm run test` (2861/2861) pass clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_