### PR TITLE
[UI 1.4] Shared toast / notification primitive

### DIFF
--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -1,7 +1,12 @@
+import React from 'react'
 import type { Preview } from '@storybook/react-vite'
 import '../src/styles/index.css'
+import { ToastProvider } from '../src/components/ui/Toast'
 
 const preview: Preview = {
+  decorators: [
+    Story => React.createElement(ToastProvider, null, React.createElement(Story)),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo, useReducer, Suspense } from 'react'
 import { ScreenLoadingFallback } from './components/ScreenLoadingFallback'
 import { IconSprite } from './components/ui/icons/IconSprite'
+import { ToastProvider } from './components/ui/Toast'
 import { resolvedNodeOpts, loadHandicap } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
@@ -1242,6 +1243,7 @@ export default function App() {
   ])
 
   return (
+    <ToastProvider>
     <AppProvider value={appContextValue}>
     <BattleProvider value={battleContextValue}>
     <div className="game-container">
@@ -1261,5 +1263,6 @@ export default function App() {
     </div>
     </BattleProvider>
     </AppProvider>
+    </ToastProvider>
   )
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo, useReducer, Suspense } from 'react'
 import { ScreenLoadingFallback } from './components/ScreenLoadingFallback'
+import { IconSprite } from './components/ui/icons/IconSprite'
 import { resolvedNodeOpts, loadHandicap } from './game/campaignHelpers'
 import { usePlaytime } from './hooks/usePlaytime'
 import { recordScreen } from './utils/crashSentinel'
@@ -1244,6 +1245,7 @@ export default function App() {
     <AppProvider value={appContextValue}>
     <BattleProvider value={battleContextValue}>
     <div className="game-container">
+      <IconSprite />
       <div className="game-title">JARV'S AMAZING WEB GAME</div>
 
       <Suspense fallback={<ScreenLoadingFallback />}>

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -61,6 +61,7 @@ import { StatsScreen } from './citybuilder/StatsScreen'
 import { ZoneEditor } from './citybuilder/ZoneEditor'
 import { DisasterModal } from './citybuilder/DisasterModal'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { useToast } from '../ui/Toast'
 import { Toolbar } from '../ui/Toolbar/Toolbar'
 import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
 import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
@@ -651,7 +652,7 @@ export function CityBuilder({ onBack }: Props) {
   const [showDisaster, setShowDisaster] = useState(false)
   const [pickerIndex, setPickerIndex] = useState<number>(0)
   const [levelCard, setLevelCard] = useState<string | null>(null)
-  const [toast, setToast] = useState<string | null>(null)
+  const { showToast } = useToast()
   const [walkers, setWalkers] = useState<Walker[]>([])
   const [builderWalkers, setBuilderWalkers] = useState<BuilderWalker[]>([])
   const [visualCarriers, setVisualCarriers] = useState<VisualCarrier[]>([])
@@ -686,11 +687,6 @@ export function CityBuilder({ onBack }: Props) {
   const walkersRef = useRef(walkers)
   const builderWalkersRef = useRef(builderWalkers)
   const screenRef = useRef(screen)
-
-  function showToast(msg: string) {
-    setToast(msg)
-    setTimeout(() => setToast(null), 3000)
-  }
 
   function save(next: CityState) {
     const { state: checked, newlyCompleted } = checkMilestones(next)
@@ -1604,8 +1600,7 @@ export function CityBuilder({ onBack }: Props) {
       if (gold > 0) {
         setCity(prev => ({ ...prev, gold: prev.gold + gold }))
         saveCityState({ ...city, gold: city.gold + gold })
-        setToast(`Your defenders earned ${gold.toLocaleString()} 🪙 gold!`)
-        setTimeout(() => setToast(null), 4000)
+        showToast(`Your defenders earned ${gold.toLocaleString()} 🪙 gold!`, { variant: 'reward', duration: 4000 })
       }
       setScreen('city')
     }
@@ -1786,8 +1781,6 @@ export function CityBuilder({ onBack }: Props) {
     >
 
       <div className="city-screen u-relative u-col u-gap-2">
-        {toast && <div className="city-toast" role="alert">{toast}</div>}
-
         {pendingMilestone && (
           <MilestoneBanner
             milestone={pendingMilestone}

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -30,6 +30,7 @@ import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { getCardCatalog } from '../../game/cards'
 import { loadCollection, getOwnedCount, saveCollection, getMasteryXp, masteryLevel, masteryXpForLevel } from '../../game/collection'
 import { OverlayScreen } from '../ui/OverlayScreen'
+import { useToast } from '../ui/Toast'
 import { Walker, WalkerTask, TaskType, PersonalityTrait } from './citybuilder/walkerTypes'
 import { VisualCarrier, computeRoadWaypoints } from './CityBuilder'
 import { FarmGrid } from './citybuilder/farming/FarmGrid'
@@ -146,7 +147,7 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
   const [walkers, setWalkers]       = useState<Walker[]>([])
   const [pickerIndex, setPickerIndex] = useState<number>(0)
   const [bulldozer, setBulldozer]   = useState(false)
-  const [toast, setToast]           = useState<string | null>(null)
+  const { showToast } = useToast()
   const [raidReport, setRaidReport] = useState<FarmRaidEvent | null>(null)
   const [currentTime, setCurrentTime] = useState(Date.now())
   const [showExpandModal, setShowExpandModal] = useState(false)
@@ -170,11 +171,6 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
 
   const farmRows2 = farm.rows ?? FARM_ROWS
   const farmCols2 = farm.cols ?? FARM_COLS
-
-  function showToast(msg: string) {
-    setToast(msg)
-    setTimeout(() => setToast(null), 3000)
-  }
 
   function saveFarm(next: FarmState) {
     setFarm(next)
@@ -589,8 +585,6 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
       right={<div className="city-level-badge" title={`Farm level ${farmLevel} — ${farmRows2}×${farmCols2} grid`}>LVL {farmLevel}</div>}
     >
       <div className="farm-screen u-col u-gap-2">
-        {toast && <div className="city-toast" role="alert">{toast}</div>}
-
         {raidReport && (
           <FarmRaidModal
             raid={raidReport}

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -26,6 +26,7 @@ import { OverlayScreen } from '../ui/OverlayScreen'
 import { MasteryBar } from '../ui/MasteryBar'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { Button } from '../ui/Button'
+import { useToast } from '../ui/Toast'
 
 interface Props {
   crystals: number
@@ -72,6 +73,7 @@ const LazyCell = memo(function LazyCell({ children, className }: { children: Rea
 })
 
 export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commanderName, onPromoteCommander, onViewAugments, embedded }: Props) {
+  const { showToast } = useToast()
   const catalog = getCardCatalog()
   const questTargetCards = getQuestTargetCards()
   const allAffinityLabels = Array.from(
@@ -98,13 +100,11 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const [filterMenuOpen, setFilterMenuOpen] = useState(false)
   const [sortMenuOpen,   setSortMenuOpen]   = useState(false)
   const [groupMenuOpen,  setGroupMenuOpen]  = useState(false)
-  const [flash, setFlash]       = useState<string | null>(null)
   const [upgradeModal, setUpgradeModal] = useState<Array<{cardName: string, xpGained: number}> | null>(null)
   const [disenchantModal, setDisenchantModal] = useState<Array<{cardName: string, crystals: number}> | null>(null)
   const [detailCard, setDetailCard] = useState<import('../../game/types').Card | null>(null)
   const [augmentCard, setAugmentCard] = useState<import('../../game/types').Card | null>(null)
   const [levelUpCard, setLevelUpCard] = useState<string | null>(null)
-  const [secretToast, setSecretToast] = useState<string | null>(null)
   const legendaryViewCount = useRef(0)
   const filterMenuRef = useRef<HTMLDivElement>(null)
   const sortMenuRef   = useRef<HTMLDivElement>(null)
@@ -244,8 +244,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   }
 
   function notify(msg: string) {
-    setFlash(msg)
-    setTimeout(() => setFlash(null), 2000)
+    showToast(msg, { variant: 'reward', duration: 2000 })
   }
 
   function handleDisenchantAll() {
@@ -340,8 +339,6 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
         >
           ★ Upgrade all ({totalUpgradeable})
         </Button>
-        {flash && <span className="collection-flash">{flash}</span>}
-        {secretToast && <div className="collection-secret-toast">{secretToast}</div>}
       </div>
 
       {/* Filter / Sort / Group bar */}
@@ -572,8 +569,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
                         legendaryViewCount.current += 1
                         if (legendaryViewCount.current === 10) {
                           incrementAchievementProgress('misc:legend_stare')
-                          setSecretToast('✦ The legendaries have noticed your gaze.')
-                          setTimeout(() => setSecretToast(null), 3500)
+                          showToast('✦ The legendaries have noticed your gaze.', { variant: 'reward', duration: 3500 })
                         }
                       }
                     }}

--- a/web/src/components/screens/CommanderScreen.tsx
+++ b/web/src/components/screens/CommanderScreen.tsx
@@ -15,6 +15,7 @@ import { getMasteryXp, masteryProgress, loadCollection } from '../../game/collec
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Button } from '../ui/Button'
+import { useToast } from '../ui/Toast'
 
 interface Props {
   commander: CommanderState
@@ -24,11 +25,6 @@ interface Props {
   onRewardCard: () => void
   onRewardPack: () => void
   onCommanderChanged: (state: CommanderState | null) => void
-}
-
-interface Toast {
-  id: number
-  text: string
 }
 
 interface Sparkle {
@@ -92,7 +88,6 @@ function CommanderXpBar({ xp }: { xp: number }) {
   )
 }
 
-let toastSeq = 0
 let sparkleSeq = 0
 
 export function CommanderScreen({
@@ -104,8 +99,8 @@ export function CommanderScreen({
   onRewardPack,
   onCommanderChanged,
 }: Props) {
+  const { showToast } = useToast()
   const [state, setState] = useState<CommanderState>(commander)
-  const [toasts, setToasts] = useState<Toast[]>([])
   const [cooldowns, setCooldowns] = useState<Record<PetAction, number>>(() => ({
     feed: cooldownRemaining(commander, 'feed'),
     play: cooldownRemaining(commander, 'play'),
@@ -216,12 +211,6 @@ export function CommanderScreen({
 
   // ── Toast ─────────────────────────────────────────────────────────────────
 
-  function addToast(text: string) {
-    const id = ++toastSeq
-    setToasts(prev => [...prev, { id, text }])
-    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 3000)
-  }
-
   // ── Action buttons ────────────────────────────────────────────────────────
 
   const handleAction = useCallback((action: PetAction) => {
@@ -233,7 +222,7 @@ export function CommanderScreen({
     saveCommander(next)
 
     const flavors = ACTION_FLAVOR[action]
-    addToast(flavors[Math.floor(Math.random() * flavors.length)])
+    showToast(flavors[Math.floor(Math.random() * flavors.length)], { variant: 'info' })
 
     if (reward.type === 'xp') {
       onRewardXp(state.cardName, reward.amount)
@@ -249,18 +238,18 @@ export function CommanderScreen({
         }
         return newXp
       })
-      addToast(`+${reward.amount} mastery XP for ${state.cardName}!`)
+      showToast(`+${reward.amount} mastery XP for ${state.cardName}!`, { variant: 'reward' })
     } else if (reward.type === 'crystals') {
       onRewardCrystals(reward.amount)
-      addToast(`+${reward.amount} 💎 found!`)
+      showToast(`+${reward.amount} 💎 found!`, { variant: 'reward' })
     } else if (reward.type === 'card') {
       onRewardCard()
-      addToast('They found a card on patrol!')
+      showToast('They found a card on patrol!', { variant: 'reward' })
     } else if (reward.type === 'pack') {
       onRewardPack()
-      addToast('They returned with a card pack!')
+      showToast('They returned with a card pack!', { variant: 'reward' })
     }
-  }, [state, onRewardXp, onRewardCrystals, onRewardCard, onRewardPack])
+  }, [state, showToast, onRewardXp, onRewardCrystals, onRewardCard, onRewardPack])
 
   function handleDismiss() {
     clearCommander()
@@ -314,13 +303,6 @@ export function CommanderScreen({
         <div className="commander-name">{state.cardName}</div>
         <div className="commander-subtitle">Army Commander</div>
         <CommanderXpBar xp={masteryXp} />
-      </div>
-
-      {/* Toast messages */}
-      <div className="commander-toasts u-col u-gap-2 u-text-c" aria-live="polite">
-        {toasts.map(t => (
-          <div key={t.id} className="commander-toast">{t.text}</div>
-        ))}
       </div>
 
       {/* Actions */}

--- a/web/src/components/screens/MiniGamesMenu.tsx
+++ b/web/src/components/screens/MiniGamesMenu.tsx
@@ -33,6 +33,7 @@ import { HarbourRegatta } from '../minigames/HarbourRegatta'
 import { PageHeader } from '../ui/PageHeader'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Button } from '../ui/Button'
+import { useToast } from '../ui/Toast'
 
 export type SubScreen = 'menu' | MiniGameId | 'prizes' | 'leaderboard' | 'citybuilder' | 'fishing' | 'towerDefence'
 
@@ -75,19 +76,13 @@ function pickRandomCards(count: number, rarity?: 'uncommon' | 'rare' | 'legendar
 }
 
 export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName, onBack, onGameDone, initialSubScreen }: Props) {
+  const { showToast } = useToast()
   const [subScreen, setSubScreen] = useState<SubScreen>(initialSubScreen ?? 'menu')
   const [tickets, setTickets] = useState(() => loadTickets())
-  const [toast, setToast] = useState<string | null>(null)
   const [lbEntries, setLbEntries] = useState<MiniGameLeaderboardEntry[]>([])
   const [lbGame, setLbGame] = useState<MiniGameId>('marble')
   const [lbMode, setLbMode] = useState<'today' | 'allTime'>('allTime')
   const [lbLoading, setLbLoading] = useState(false)
-  const [prizeToast, setPrizeToast] = useState<string | null>(null)
-
-  function showToast(msg: string, duration = 3000) {
-    setToast(msg)
-    setTimeout(() => setToast(null), duration)
-  }
 
   function refreshTickets() {
     setTickets(loadTickets())
@@ -99,7 +94,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
     const cost = MINI_GAME_COSTS[id]
     const currentCrystals = loadCrystals()
     if (currentCrystals < cost) {
-      showToast(`Not enough crystals! Need ${cost} 💎`)
+      showToast(`Not enough crystals! Need ${cost} 💎`, { variant: 'warning' })
       return
     }
     const newCrystals = currentCrystals - cost
@@ -119,7 +114,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
     if (claimDailyChallengeIfEligible(gameId, ticketsEarned)) {
       refreshTickets()
       incrementAchievementProgress('miniGame:dailyChallengesCompleted')
-      showToast(`🎯 Daily Challenge complete! +${DAILY_CHALLENGE_BONUS_TICKETS} bonus tickets!`)
+      showToast(`🎯 Daily Challenge complete! +${DAILY_CHALLENGE_BONUS_TICKETS} bonus tickets!`, { variant: 'reward' })
     }
 
     // Track achievements
@@ -175,8 +170,7 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
 
   function redeemPrize(prize: TicketPrize) {
     if (!spendTickets(prize.cost)) {
-      setPrizeToast(`Not enough tickets! Need ${prize.cost} 🎫`)
-      setTimeout(() => setPrizeToast(null), 3000)
+      showToast(`Not enough tickets! Need ${prize.cost} 🎫`, { variant: 'warning' })
       return
     }
 
@@ -189,17 +183,17 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       const next = current + reward.amount
       saveCrystals(next)
       onCrystalsChange(next)
-      setPrizeToast(`+${reward.amount} 💎 Crystals added!`)
+      showToast(`+${reward.amount} 💎 Crystals added!`, { variant: 'reward', duration: 4000 })
     } else if (reward.type === 'card') {
       const names = pickRandomCards(1, reward.rarity)
       if (names.length > 0) {
         addCardsToCollection([{ cardName: names[0], count: 1 }])
-        setPrizeToast(`🃏 ${names[0]} added to your collection!`)
+        showToast(`🃏 ${names[0]} added to your collection!`, { variant: 'reward', duration: 4000 })
       }
     } else if (reward.type === 'cards') {
       const names = pickRandomCards(reward.count, reward.rarity)
       addCardsToCollection(names.map(n => ({ cardName: n, count: 1 })))
-      setPrizeToast(`🃏 ${reward.count} cards added to your collection!`)
+      showToast(`🃏 ${reward.count} cards added to your collection!`, { variant: 'reward', duration: 4000 })
     } else if (reward.type === 'bundle') {
       const current = loadCrystals()
       const next = current + 500
@@ -207,10 +201,8 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
       onCrystalsChange(next)
       const names = pickRandomCards(5)
       addCardsToCollection(names.map(n => ({ cardName: n, count: 1 })))
-      setPrizeToast('Bundle redeemed! +500 💎 + 5 cards!')
+      showToast('Bundle redeemed! +500 💎 + 5 cards!', { variant: 'reward', duration: 4000 })
     }
-
-    setTimeout(() => setPrizeToast(null), 4000)
   }
 
   // ── Leaderboard loading ───────────────────────────────────────────────────────
@@ -290,8 +282,6 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
     } >
 
       <div className="minigame-hub">
-        {/* Toast */}
-        {toast && <div className="minigame-toast" role="alert">{toast}</div>}
 
 
         <div className="minigame-hub-currency">💎 {currentCrystals.toLocaleString()} crystals</div>
@@ -365,8 +355,6 @@ export function MiniGamesMenu({ crystals, onCrystalsChange, user, characterName,
               <span className="overlay-title">🎁 PRIZE SHOP</span>
               <div className="ticket-balance">🎫 {tickets}</div>
             </div>
-
-            {prizeToast && <div className="minigame-toast minigame-toast--prize" role="alert">{prizeToast}</div>}
 
             <div className="prize-list u-col u-gap-3">
               {TICKET_PRIZES.map(prize => {

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -20,6 +20,7 @@ import { WinStreak } from './WinStreak'
 import { LoginButton } from '../ui/LoginButton'
 import { Button } from '../ui/Button'
 import { Icon } from '../ui/icons/Icon'
+import { useToast } from '../ui/Toast'
 
 const CAMPAIGN_UNLOCK_CARDS = 30
 const EIGHTBIT_CLICKS = 8
@@ -100,7 +101,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
 
   // Secret #1 — Konami Code
   const konamiProgress = useRef(0)
-  const [konamiToast, setKonamiToast] = useState<string | null>(null)
+  const { showToast } = useToast()
   const handleKonami = useCallback((e: KeyboardEvent) => {
     if (e.key === KONAMI[konamiProgress.current]) {
       konamiProgress.current++
@@ -111,17 +112,15 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
           const pack = generatePack()
           addCardsToCollection(pack.map(name => ({ cardName: name, count: 1 })))
           incrementAchievementProgress('misc:konami_code')
-          setKonamiToast('↑↑↓↓←→←→  •  CHEAT ACCEPTED  •  Pack granted!')
-          setTimeout(() => setKonamiToast(null), 4000)
+          showToast('↑↑↓↓←→←→  •  CHEAT ACCEPTED  •  Pack granted!', { variant: 'reward', duration: 4000 })
         } else {
-          setKonamiToast('You already claimed this secret. Nice try.')
-          setTimeout(() => setKonamiToast(null), 3000)
+          showToast('You already claimed this secret. Nice try.', { variant: 'info', duration: 3000 })
         }
       }
     } else {
       konamiProgress.current = 0
     }
-  }, [])
+  }, [showToast])
   useEffect(() => {
     window.addEventListener('keydown', handleKonami)
     return () => window.removeEventListener('keydown', handleKonami)
@@ -179,11 +178,6 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
     <div className="title-screen u-relative u-col u-items-c u-just-c u-grow">
       {/* Animated background scan line */}
       <div className="title-bg-scan" aria-hidden="true" />
-
-      {/* Secret #1 — Konami code toast */}
-      {konamiToast && (
-        <div className="konami-toast" role="alert">{konamiToast}</div>
-      )}
 
       <WinStreak winStreak={winStreak} bestStreak={bestStreak} />
 

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -19,6 +19,7 @@ import { generatePack, addCardsToCollection } from '../../game/collection'
 import { WinStreak } from './WinStreak'
 import { LoginButton } from '../ui/LoginButton'
 import { Button } from '../ui/Button'
+import { Icon } from '../ui/icons/Icon'
 
 const CAMPAIGN_UNLOCK_CARDS = 30
 const EIGHTBIT_CLICKS = 8
@@ -212,7 +213,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
             undefined
           }
         >
-          {savedRun ? '⚔  CONTINUE RUN' : '⚔  CAMPAIGN'}
+          <Icon name="sword" size={16} /> {savedRun ? 'CONTINUE RUN' : 'CAMPAIGN'}
         </TitleButton>
 
         <TitleButton
@@ -228,7 +229,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
           extraClass="title-primary-btn"
           title={valid ? undefined : `Deck needs ${10 - count} more cards`}
         >
-          ∞  ENDLESS MODE
+          <Icon name="infinity" size={16} /> ENDLESS MODE
         </TitleButton>
 
         <TitleButton onClick={onDailyChallenge} extraClass="title-daily-btn">
@@ -240,31 +241,31 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
         </TitleButton>
 
         <TitleButton onClick={onEndlessLeaderboard} extraClass="title-endless-lb-btn">
-          🏆  LEADERBOARDS
+          <Icon name="trophy" size={16} /> LEADERBOARDS
         </TitleButton>
 
         <TitleButton onClick={onTraining} extraClass="title-training-btn">
-          ⚔  TRAINING MODE
+          <Icon name="sword" size={16} /> TRAINING MODE
         </TitleButton>
 
         <TitleButton onClick={onMiniGames} extraClass={`title-minigames-btn`}>
-          🎮  MINI GAMES
+          <Icon name="minigames" size={16} /> MINI GAMES
         </TitleButton>
         {cityAttackAlert && (
           <TitleButton variant="large" onClick={onCityBuilder} extraClass="title-campaign-btn title-minigames-btn title-btn--alert title-alert-badge">
-            ⚔ CITY ALERT
+            <Icon name="sword" size={16} /> CITY ALERT
           </TitleButton>
         )}
         {hubUnlocked && onHub && (
           <TitleButton variant="large" onClick={onHub} extraClass="title-campaign-btn">
-            🌆  HUB WORLD
+            <Icon name="hub" size={16} /> HUB WORLD
           </TitleButton>
         )}
       </div>
 
       {!campaignUnlocked && (
         <div className="title-campaign-locked-hint">
-          🔒 Campaign unlocks at {CAMPAIGN_UNLOCK_CARDS} cards ({totalOwned}/{CAMPAIGN_UNLOCK_CARDS}) — play Quick Battle to earn more!
+          <Icon name="lock" size={14} /> Campaign unlocks at {CAMPAIGN_UNLOCK_CARDS} cards ({totalOwned}/{CAMPAIGN_UNLOCK_CARDS}) — play Quick Battle to earn more!
         </div>
       )}
 
@@ -272,14 +273,14 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
       <div className="title-nav-section">
         <div className="title-nav-label">[ MANAGE ]</div>
         <div className="title-nav-grid">
-          <TitleButton onClick={onPlayer} badge={achievementAlert}>👤 PLAYER</TitleButton>
-          <TitleButton onClick={onDeckBuilder}>🃏 DECK</TitleButton>
-          <TitleButton onClick={onCollection} badge={collectionAlert}>📦 COLLECTION</TitleButton>
-          <TitleButton onClick={onShop} badge={shopAlert}>🛒 SHOP</TitleButton>
-          <TitleButton onClick={onCodex}>📖 CODEX</TitleButton>
-          <TitleButton onClick={onChronicle} badge={chronicleAlert}>📜 CHRONICLE</TitleButton>
-          <TitleButton onClick={onNews} badge={hasUnreadNews}>📰 WHAT'S NEW</TitleButton>
-          <TitleButton onClick={onSettings} extraClass="title-settings-btn">⚙ SETTINGS</TitleButton>
+          <TitleButton onClick={onPlayer} badge={achievementAlert}><Icon name="player" size={16} /> PLAYER</TitleButton>
+          <TitleButton onClick={onDeckBuilder}><Icon name="deck" size={16} /> DECK</TitleButton>
+          <TitleButton onClick={onCollection} badge={collectionAlert}><Icon name="collection" size={16} /> COLLECTION</TitleButton>
+          <TitleButton onClick={onShop} badge={shopAlert}><Icon name="shop" size={16} /> SHOP</TitleButton>
+          <TitleButton onClick={onCodex}><Icon name="codex" size={16} /> CODEX</TitleButton>
+          <TitleButton onClick={onChronicle} badge={chronicleAlert}><Icon name="chronicle" size={16} /> CHRONICLE</TitleButton>
+          <TitleButton onClick={onNews} badge={hasUnreadNews}><Icon name="news" size={16} /> WHAT'S NEW</TitleButton>
+          <TitleButton onClick={onSettings} extraClass="title-settings-btn"><Icon name="settings" size={16} /> SETTINGS</TitleButton>
           {commanderName && onCommander && (
             <TitleButton onClick={onCommander} extraClass="title-commander-btn">
               <SpriteImg name={commanderName} className="commander-btn-sprite" />
@@ -293,8 +294,8 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
       <div className="title-footer u-col u-items-c u-gap-2 u-relative">
         <div className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>
           {wrongSave
-            ? <>{wrongSave.cards}/{catalogTotal} cards &nbsp;·&nbsp; 💎 {wrongSave.crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {wrongSave.deck}</>
-            : <>{distinctUnlocked}/{catalogTotal} cards &nbsp;·&nbsp; 💎 {crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {count}</>
+            ? <>{wrongSave.cards}/{catalogTotal} cards &nbsp;·&nbsp; <Icon name="crystal" size={12} /> {wrongSave.crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {wrongSave.deck}</>
+            : <>{distinctUnlocked}/{catalogTotal} cards &nbsp;·&nbsp; <Icon name="crystal" size={12} /> {crystals.toLocaleString()} &nbsp;·&nbsp; Deck: {count}</>
           }
         </div>
         <div className="title-auth-bar u-flex u-items-c u-gap-5">

--- a/web/src/components/ui/Toast.stories.tsx
+++ b/web/src/components/ui/Toast.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+
+import { ToastProvider, useToast, type ToastVariant } from './Toast';
+import { IconSprite } from './icons/IconSprite';
+
+const meta = {
+  title: 'UI/Toast',
+  parameters: { layout: 'centered' },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function FireOnMount({ variant, message }: { variant: ToastVariant; message: string }) {
+  const { showToast } = useToast();
+  useEffect(() => {
+    showToast(message, { variant, duration: 999999 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div style={{ color: 'var(--game-text-color)', padding: 40 }}>Toast fired on mount — see the stack.</div>;
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ position: 'relative', width: 360, height: 200, background: 'var(--game-bg)' }}>
+      <IconSprite />
+      <ToastProvider>{children}</ToastProvider>
+    </div>
+  );
+}
+
+export const Info: Story = {
+  render: () => <Wrapper><FireOnMount variant="info" message="Auto-saved." /></Wrapper>,
+};
+
+export const Success: Story = {
+  render: () => <Wrapper><FireOnMount variant="success" message="Card mastered!" /></Wrapper>,
+};
+
+export const Reward: Story = {
+  render: () => <Wrapper><FireOnMount variant="reward" message="+250 crystals!" /></Wrapper>,
+};
+
+export const Warning: Story = {
+  render: () => <Wrapper><FireOnMount variant="warning" message="Not enough gold!" /></Wrapper>,
+};
+
+export const ErrorVariant: Story = {
+  name: 'Error',
+  render: () => <Wrapper><FireOnMount variant="error" message="Sync failed. Check your connection." /></Wrapper>,
+};
+
+function FireThree() {
+  const { showToast } = useToast();
+  useEffect(() => {
+    showToast('First message queued.', { variant: 'info', duration: 999999 });
+    showToast('Second message queued.', { variant: 'success', duration: 999999 });
+    showToast('Third message queued — stacked, not overlapping.', { variant: 'reward', duration: 999999 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div style={{ color: 'var(--game-text-color)', padding: 40 }}>Fired three toasts simultaneously.</div>;
+}
+
+export const StackedQueue: Story = {
+  render: () => (
+    <div style={{ position: 'relative', width: 420, height: 260, background: 'var(--game-bg)' }}>
+      <IconSprite />
+      <ToastProvider><FireThree /></ToastProvider>
+    </div>
+  ),
+};

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,0 +1,137 @@
+import React, { createContext, useCallback, useContext, useState } from 'react'
+import { Icon } from './icons/Icon'
+import type { IconName } from './icons/IconSprite'
+
+export type ToastVariant = 'info' | 'success' | 'reward' | 'warning' | 'error'
+
+interface ToastOptions {
+  variant?: ToastVariant
+  /** Overrides the variant's default auto-dismiss time, in ms. */
+  duration?: number
+  icon?: IconName
+}
+
+interface ToastItem {
+  id: number
+  message: string
+  variant: ToastVariant
+  duration: number
+  icon?: IconName
+  remaining: number
+  startedAt: number
+  timeoutId: ReturnType<typeof setTimeout> | null
+  removing: boolean
+}
+
+const DEFAULT_DURATION: Record<ToastVariant, number> = {
+  info: 3000,
+  success: 3000,
+  reward: 4000,
+  warning: 4000,
+  error: 5000,
+}
+
+// Oldest-out eviction once a screen fires more than this many at once.
+const MAX_TOASTS = 4
+// How long the exit animation runs before the item actually leaves the array.
+const EXIT_MS = 200
+
+interface ToastContextValue {
+  showToast: (message: string, options?: ToastOptions) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+/** Throws outside a <ToastProvider> — mirrors the existing AppContext pattern. */
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within a ToastProvider')
+  return ctx
+}
+
+let toastSeq = 0
+
+/**
+ * Mounted once near the app root (App.tsx) so every screen can call
+ * useToast() regardless of which route group it lives in. Renders its own
+ * fixed-position stack — nothing else needs to render a host component.
+ */
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+
+  const startExit = useCallback((id: number) => {
+    setToasts(prev => prev.map(t => (t.id === id ? { ...t, removing: true } : t)))
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id))
+    }, EXIT_MS)
+  }, [])
+
+  const showToast = useCallback((message: string, options: ToastOptions = {}) => {
+    const variant = options.variant ?? 'info'
+    const duration = options.duration ?? DEFAULT_DURATION[variant]
+    const id = ++toastSeq
+    const timeoutId = setTimeout(() => startExit(id), duration)
+    const item: ToastItem = {
+      id, message, variant, duration, icon: options.icon,
+      remaining: duration, startedAt: Date.now(), timeoutId, removing: false,
+    }
+    setToasts(prev => {
+      const next = [...prev, item]
+      if (next.length > MAX_TOASTS) {
+        const evicted = next.shift()
+        if (evicted?.timeoutId) clearTimeout(evicted.timeoutId)
+      }
+      return next
+    })
+  }, [startExit])
+
+  const pause = useCallback((id: number) => {
+    setToasts(prev => prev.map(t => {
+      if (t.id !== id || !t.timeoutId || t.removing) return t
+      clearTimeout(t.timeoutId)
+      const elapsed = Date.now() - t.startedAt
+      return { ...t, timeoutId: null, remaining: Math.max(t.remaining - elapsed, 0) }
+    }))
+  }, [])
+
+  const resume = useCallback((id: number) => {
+    setToasts(prev => prev.map(t => {
+      if (t.id !== id || t.timeoutId || t.removing) return t
+      const timeoutId = setTimeout(() => startExit(id), t.remaining)
+      return { ...t, timeoutId, startedAt: Date.now() }
+    }))
+  }, [startExit])
+
+  const dismiss = useCallback((id: number) => {
+    setToasts(prev => {
+      const t = prev.find(x => x.id === id)
+      if (t?.timeoutId) clearTimeout(t.timeoutId)
+      return prev
+    })
+    startExit(id)
+  }, [startExit])
+
+  const hasError = toasts.some(t => t.variant === 'error' && !t.removing)
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="toast-stack" aria-live={hasError ? 'assertive' : 'polite'} aria-atomic="false">
+        {toasts.map(t => (
+          <div
+            key={t.id}
+            className={`toast toast--${t.variant}${t.removing ? ' toast--exiting' : ''}`}
+            role="alert"
+            onClick={() => dismiss(t.id)}
+            onMouseEnter={() => pause(t.id)}
+            onMouseLeave={() => resume(t.id)}
+            onTouchStart={() => pause(t.id)}
+          >
+            {t.icon && <Icon name={t.icon} size={16} className="toast-icon" />}
+            <span className="toast-message">{t.message}</span>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/web/src/components/ui/icons/Icon.stories.tsx
+++ b/web/src/components/ui/icons/Icon.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Icon } from './Icon';
+import { IconSprite, ICON_NAMES } from './IconSprite';
+
+const meta = {
+  title: 'UI/Icon',
+  component: Icon,
+  parameters: { layout: 'centered' },
+  decorators: [(Story) => (<><IconSprite /><Story /></>)],
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: 'player' },
+};
+
+export const AllIcons: Story = {
+  args: { name: 'player' },
+  render: () => (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(6, auto)',
+      gap: 20,
+      background: 'var(--game-bg)',
+      color: 'var(--game-text-color)',
+      padding: 20,
+    }}>
+      {ICON_NAMES.map((name) => (
+        <div key={name} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, fontSize: 10 }}>
+          <Icon name={name} size={28} />
+          <span>{name}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  args: { name: 'trophy' },
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, background: 'var(--game-bg)', color: 'var(--color-gold-alt)', padding: 20 }}>
+      <Icon name="trophy" size={16} />
+      <Icon name="trophy" size={20} />
+      <Icon name="trophy" size={24} />
+      <Icon name="trophy" size={32} />
+      <Icon name="trophy" size={48} />
+    </div>
+  ),
+};
+
+export const ThemedByColor: Story = {
+  args: { name: 'crystal' },
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, background: 'var(--game-bg)', padding: 20 }}>
+      <Icon name="crystal" size={32} style={{ color: 'var(--game-text-color)' }} />
+      <Icon name="crystal" size={32} style={{ color: 'var(--accent-gold)' }} />
+      <Icon name="crystal" size={32} style={{ color: 'var(--accent-ember)' }} />
+      <Icon name="crystal" size={32} style={{ color: 'var(--accent-arcane)' }} />
+    </div>
+  ),
+};

--- a/web/src/components/ui/icons/Icon.tsx
+++ b/web/src/components/ui/icons/Icon.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { IconName } from './IconSprite'
+
+interface Props {
+  name: IconName
+  size?: number
+  className?: string
+  style?: React.CSSProperties
+  /** Set when the icon is the only content of an interactive control — feeds a11y (#2182). */
+  'aria-label'?: string
+}
+
+/**
+ * Renders one icon from the sprite sheet mounted by <IconSprite /> (see
+ * IconSprite.tsx). Uses currentColor by default, so it themes with
+ * whatever CSS `color` the surrounding text has — no colour prop needed.
+ */
+export function Icon({ name, size = 20, className, style, 'aria-label': ariaLabel }: Props) {
+  const classes = ['icon', className].filter(Boolean).join(' ')
+  return (
+    <svg
+      className={classes}
+      width={size}
+      height={size}
+      style={{ display: 'inline-block', flexShrink: 0, fill: 'currentColor', ...style }}
+      role={ariaLabel ? 'img' : undefined}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+    >
+      <use href={`#icon-${name}`} />
+    </svg>
+  )
+}

--- a/web/src/components/ui/icons/IconSprite.tsx
+++ b/web/src/components/ui/icons/IconSprite.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+
+/**
+ * The game's icon set (#2172), replacing OS-rendered emoji so iconography
+ * looks the same on iOS/Android/desktop and doesn't clash with the 2,535
+ * hand-made sprite SVGs. Simple geometric shapes at 24x24, matching the
+ * sprite set's blocky, flat-shaded language but drawn in a single
+ * `currentColor` so each icon themes with whatever text colour surrounds it.
+ *
+ * Mount <IconSprite /> once near the app root; every <Icon name="..." />
+ * instance references a <symbol> here via <use>, so the markup for all 23
+ * icons is only ever parsed once regardless of how many places render them.
+ */
+export const ICON_NAMES = [
+  'player', 'deck', 'collection', 'shop', 'codex', 'chronicle', 'news',
+  'settings', 'trophy', 'minigames', 'sword', 'infinity', 'hub', 'crystal',
+  'lock', 'coin', 'heart', 'mana', 'back-arrow', 'close', 'info', 'filter',
+  'search',
+] as const
+
+export type IconName = typeof ICON_NAMES[number]
+
+export function IconSprite() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" style={{ display: 'none' }} aria-hidden="true">
+      <defs>
+        <symbol id="icon-player" viewBox="0 0 24 24">
+          <circle cx="12" cy="7" r="4" />
+          <path d="M4 21v-1c0-4.4 3.6-8 8-8s8 3.6 8 8v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z" />
+        </symbol>
+
+        <symbol id="icon-deck" viewBox="0 0 24 24">
+          <rect x="4" y="8" width="12" height="15" rx="1.5" transform="rotate(-10 10 15.5)" opacity="0.55" />
+          <rect x="7" y="3" width="13" height="17" rx="1.5" />
+        </symbol>
+
+        <symbol id="icon-collection" viewBox="0 0 24 24">
+          <path d="M3 8.5 5 4h14l2 4.5V20a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 20z" />
+          <rect x="3" y="8" width="18" height="2" opacity="0.5" />
+        </symbol>
+
+        <symbol id="icon-shop" viewBox="0 0 24 24">
+          <path d="M8 8Q12 1 16 8" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+          <path d="M5 8h14l-1.4 11.5a1.5 1.5 0 0 1-1.5 1.5H7.9a1.5 1.5 0 0 1-1.5-1.5z" />
+        </symbol>
+
+        <symbol id="icon-codex" viewBox="0 0 24 24">
+          <path d="M4 4.5A1.5 1.5 0 0 1 5.5 3H19a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H5.5A1.5 1.5 0 0 1 4 19.5z" />
+          <rect x="4" y="3" width="2.6" height="18" opacity="0.55" />
+        </symbol>
+
+        <symbol id="icon-chronicle" viewBox="0 0 24 24">
+          <rect x="5" y="5" width="14" height="14" rx="1" />
+          <ellipse cx="12" cy="5" rx="7" ry="2" />
+          <ellipse cx="12" cy="19" rx="7" ry="2" />
+        </symbol>
+
+        <symbol id="icon-news" viewBox="0 0 24 24">
+          <path d="M4 4h13a1 1 0 0 1 1 1v13.5A1.5 1.5 0 0 0 19.5 20H5a1 1 0 0 1-1-1z" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <rect x="7" y="7.5" width="7" height="4.5" opacity="0.6" />
+          <rect x="7" y="14" width="10" height="1.6" opacity="0.6" />
+          <rect x="16" y="7.5" width="1.6" height="4.5" opacity="0.6" />
+        </symbol>
+
+        <symbol id="icon-settings" viewBox="0 0 24 24">
+          <path fillRule="evenodd" d="M12 2.5a1.4 1.4 0 0 1 1.37 1.12l.24 1.16a7.6 7.6 0 0 1 1.87.78l1-.63a1.4 1.4 0 0 1 1.75.19l.98.98a1.4 1.4 0 0 1 .19 1.75l-.63 1a7.6 7.6 0 0 1 .78 1.87l1.16.24a1.4 1.4 0 0 1 1.12 1.37v1.4a1.4 1.4 0 0 1-1.12 1.37l-1.16.24a7.6 7.6 0 0 1-.78 1.87l.63 1a1.4 1.4 0 0 1-.19 1.75l-.98.98a1.4 1.4 0 0 1-1.75.19l-1-.63a7.6 7.6 0 0 1-1.87.78l-.24 1.16A1.4 1.4 0 0 1 12 21.5a1.4 1.4 0 0 1-1.37-1.12l-.24-1.16a7.6 7.6 0 0 1-1.87-.78l-1 .63a1.4 1.4 0 0 1-1.75-.19l-.98-.98a1.4 1.4 0 0 1-.19-1.75l.63-1a7.6 7.6 0 0 1-.78-1.87l-1.16-.24A1.4 1.4 0 0 1 2.5 12v-1.4a1.4 1.4 0 0 1 1.12-1.37l1.16-.24a7.6 7.6 0 0 1 .78-1.87l-.63-1a1.4 1.4 0 0 1 .19-1.75l.98-.98a1.4 1.4 0 0 1 1.75-.19l1 .63a7.6 7.6 0 0 1 1.87-.78l.24-1.16A1.4 1.4 0 0 1 12 2.5zm0 6a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7z" />
+        </symbol>
+
+        <symbol id="icon-trophy" viewBox="0 0 24 24">
+          <path d="M7 4h10v6a5 5 0 0 1-10 0z" />
+          <path d="M7 5H4a1 1 0 0 0-1 1v1a4 4 0 0 0 4 4M17 5h3a1 1 0 0 1 1 1v1a4 4 0 0 1-4 4" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <rect x="10.5" y="15" width="3" height="4" />
+          <rect x="7" y="19" width="10" height="2" rx="1" />
+        </symbol>
+
+        <symbol id="icon-minigames" viewBox="0 0 24 24">
+          <rect x="4" y="4" width="16" height="16" rx="3" />
+          <circle cx="9" cy="9" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="15" cy="9" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="9" cy="15" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="15" cy="15" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="12" cy="12" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+        </symbol>
+
+        <symbol id="icon-sword" viewBox="0 0 24 24">
+          <rect x="10.8" y="2" width="2.4" height="12" rx="1" />
+          <rect x="7.5" y="13" width="9" height="2.2" rx="1" />
+          <rect x="10.4" y="15" width="3.2" height="5" rx="1.2" />
+          <circle cx="12" cy="21" r="1.4" />
+        </symbol>
+
+        <symbol id="icon-infinity" viewBox="0 0 24 24">
+          <path fillRule="evenodd" d="M7 8a4.5 4.5 0 0 0 0 9c1.9 0 3.1-1.1 4-2.3l1-1.4 1 1.4c.9 1.2 2.1 2.3 4 2.3a4.5 4.5 0 0 0 0-9c-1.9 0-3.1 1.1-4 2.3l-1 1.4-1-1.4C10.1 9.1 8.9 8 7 8zm0 2.6c.83 0 1.5.5 2.2 1.5l.5.7-.5.7c-.7 1-1.37 1.5-2.2 1.5a2.1 2.1 0 0 1 0-4.4zm10 0a2.1 2.1 0 0 1 0 4.4c-.83 0-1.5-.5-2.2-1.5l-.5-.7.5-.7c.7-1 1.37-1.5 2.2-1.5z" />
+        </symbol>
+
+        <symbol id="icon-hub" viewBox="0 0 24 24">
+          <path d="M12 3 3 10.5V21h6v-6h6v6h6V10.5z" />
+        </symbol>
+
+        <symbol id="icon-crystal" viewBox="0 0 24 24">
+          <path d="M12 2 5 8l7 14 7-14z" />
+          <path d="M5 8h14L12 2z" opacity="0.6" />
+        </symbol>
+
+        <symbol id="icon-lock" viewBox="0 0 24 24">
+          <path d="M7 10V7.5a5 5 0 0 1 10 0V10" fill="none" stroke="currentColor" strokeWidth="2.2" />
+          <rect x="4.5" y="10" width="15" height="11" rx="2" />
+          <rect x="11" y="14" width="2" height="4" rx="1" fill="var(--game-bg, #0a0a0a)" />
+        </symbol>
+
+        <symbol id="icon-coin" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" />
+          <circle cx="12" cy="12" r="6.2" fill="none" stroke="var(--game-bg, #0a0a0a)" strokeWidth="1.4" />
+        </symbol>
+
+        <symbol id="icon-heart" viewBox="0 0 24 24">
+          <path d="M12 20.5S3 14.8 3 8.8A4.8 4.8 0 0 1 12 6a4.8 4.8 0 0 1 9 2.8c0 6-9 11.7-9 11.7z" />
+        </symbol>
+
+        <symbol id="icon-mana" viewBox="0 0 24 24">
+          <path d="M12 2S5 12 5 16a7 7 0 0 0 14 0c0-4-7-14-7-14z" />
+        </symbol>
+
+        <symbol id="icon-back-arrow" viewBox="0 0 24 24">
+          <path d="M11 4 4 12l7 8" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M4 12h16" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+        </symbol>
+
+        <symbol id="icon-close" viewBox="0 0 24 24">
+          <rect x="11" y="2" width="2" height="20" rx="1" transform="rotate(45 12 12)" />
+          <rect x="11" y="2" width="2" height="20" rx="1" transform="rotate(-45 12 12)" />
+        </symbol>
+
+        <symbol id="icon-info" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9.5" />
+          <rect x="10.8" y="10.5" width="2.4" height="7" rx="1" fill="var(--game-bg, #0a0a0a)" />
+          <circle cx="12" cy="7.2" r="1.5" fill="var(--game-bg, #0a0a0a)" />
+        </symbol>
+
+        <symbol id="icon-filter" viewBox="0 0 24 24">
+          <path d="M3 4h18l-6.5 8v6l-5 3v-9z" />
+        </symbol>
+
+        <symbol id="icon-search" viewBox="0 0 24 24">
+          <circle cx="10.5" cy="10.5" r="6.5" fill="none" stroke="currentColor" strokeWidth="2.4" />
+          <rect x="17.5" y="15.5" width="2.6" height="7" rx="1.3" transform="rotate(-45 18.8 19)" />
+        </symbol>
+      </defs>
+    </svg>
+  )
+}

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -906,34 +906,9 @@
   background: rgba(255, 215, 0, 0.12);
   box-shadow: 0 0 10px rgba(255, 215, 0, 0.3);
 }
-.collection-pack-btn--disabled,
-
-.collection-flash {
-  font-size: var(--font-md);
-  color: var(--game-text-color);
-  animation: fadeFlash 2s ease-out forwards;
-  white-space: nowrap;
-}
-
-.collection-secret-toast {
-  position: fixed;
-  bottom: 60px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #0a0a1a;
-  border: 1px solid #aa88ff;
-  color: #cc99ff;
-  font-size: var(--font-base);
-  padding: 8px 18px;
-  border-radius: 4px;
-  pointer-events: none;
-  z-index: 500;
-  animation: fadeFlash 3.5s ease-out forwards;
-  white-space: nowrap;
-}
-@keyframes fadeFlash {
-  0%, 60% { opacity: 1; }
-  100%     { opacity: 0; }
+.collection-pack-btn--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 /* ─── Collection Cell extras ─────────────────────────── */

--- a/web/src/styles/hub.css
+++ b/web/src/styles/hub.css
@@ -483,20 +483,6 @@
   letter-spacing: 2px;
 }
 
-.commander-toasts {
-  min-height: 40px;
-  margin: 4px 0;
-}
-.commander-toast {
-  font-size: var(--font-sm);
-  color: #aaffaa;
-  animation: commander-fadein 0.2s ease;
-}
-@keyframes commander-fadein {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
 .commander-actions {
   margin: 8px 0;
 }

--- a/web/src/styles/minigames-2.css
+++ b/web/src/styles/minigames-2.css
@@ -263,21 +263,6 @@
 
 .city-hint { font-size: 10px; color: #4a7a4a; }
 
-.city-toast {
-  position: fixed;
-  top: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #0a1a0a;
-  border: 1px solid #207020;
-  color: #90e090;
-  padding: 8px 16px;
-  border-radius: 4px;
-  font-size: 12px;
-  z-index: 9999;
-  pointer-events: none;
-}
-
 .city-gold { color: var(--color-gold-dim); font-weight: bold; }
 
 /* ── Card Picker ──────────────────────────────────────────────────────────── */
@@ -1059,29 +1044,6 @@
   font-weight: bold;
   letter-spacing: 1px;
   animation: title-alert-pulse 1.2s ease-in-out infinite alternate;
-}
-
-/* ── Toast ───────────────────────────────────────────────────────────────── */
-
-.minigame-toast {
-  position: fixed;
-  top: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #1a1a3a;
-  border: 1px solid #5050a0;
-  color: #d0d0ff;
-  padding: 8px 20px;
-  font-size: var(--font-base);
-  z-index: 9999;
-  pointer-events: none;
-  max-width: 90vw;
-  text-align: center;
-}
-
-.minigame-toast--prize {
-  border-color: #a08040;
-  color: #ffd060;
 }
 
 /* ── Individual mini-game screen wrapper ─────────────────────────────────── */

--- a/web/src/styles/panels.css
+++ b/web/src/styles/panels.css
@@ -145,3 +145,63 @@
     inset 0 1px 0 var(--panel-edge-light),
     inset 0 -1px 0 var(--panel-edge-dark);
 }
+
+/* ─── Toast (#2173) ──────────────────────────────────────
+   Shared notification stack, replacing six hand-rolled implementations
+   (title screen, collection, commander, minigames menu, city builder,
+   farming sim). Mounted once by ui/Toast.tsx's <ToastProvider>. */
+
+.toast-stack {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--gap-3);
+  pointer-events: none;
+  max-width: 90vw;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--gap-3);
+  background: var(--surface-2);
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-md);
+  box-shadow:
+    var(--elevation-overlay),
+    inset 0 1px 0 var(--panel-edge-light),
+    inset 0 -1px 0 var(--panel-edge-dark);
+  color: var(--game-text-color);
+  padding: var(--gap-4) var(--gap-6);
+  font-size: var(--font-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  animation: toast-in var(--dur-normal) ease-out;
+}
+
+.toast--exiting {
+  animation: toast-out var(--dur-fast) ease-in forwards;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes toast-out {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-8px); }
+}
+
+.toast-icon { flex-shrink: 0; }
+
+.toast--success { border-color: var(--color-green-bright); color: var(--color-green-bright); }
+.toast--reward  { border-color: var(--accent-gold); color: var(--accent-gold); }
+.toast--warning { border-color: var(--color-orange); color: var(--color-orange); }
+.toast--error   { border-color: var(--accent-ember); color: #ff8888; }

--- a/web/src/styles/rare-events.css
+++ b/web/src/styles/rare-events.css
@@ -170,28 +170,6 @@
 .inventory-secret-title { font-size: var(--font-base); color: #c060ff; font-weight: bold; letter-spacing: 2px; }
 .inventory-secret-msg   { font-size: var(--font-md); color: #e0b0ff; font-style: italic; max-width: 280px; }
 
-/* ── Secret #1 — Konami Code toast ──────────────────────────────────────── */
-.konami-toast {
-  position: fixed;
-  top: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #1a2a1a;
-  border: 1px solid #4a9a4a;
-  color: #7ddd7d;
-  padding: 0.6rem 1.25rem;
-  font-size: 0.85rem;
-  letter-spacing: 0.06em;
-  border-radius: 4px;
-  z-index: 9999;
-  pointer-events: none;
-  animation: konami-toast-in 0.3s ease;
-}
-@keyframes konami-toast-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(-0.5rem); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
 /* ── Secret #2 — DevBuild rare event ──────────────────────────────────── */
 .dev-build-overlay {
   inset: 0;


### PR DESCRIPTION
Resolves #2173 — Phase 1 of the #2165 UI overhaul epic (stacked after #2192/#2172, #2191/#2171, #2190/#2170, #2189/#2169, #2188/#2168, #2187/#2167, #2186/#2166).

## Summary

Six screens each hand-rolled their own transient-message state, timer and markup: `TitleScreen`'s Konami toast, `CollectionScreen`'s flash + secret toast, `CommanderScreen`'s toast array, `MiniGamesMenu`'s toast + prize toast, `CityBuilder`'s toast, `FarmingSim`'s toast. Inconsistent feedback for the same class of event (a reward, a save, an error) depending on which screen you're standing in, and every new screen re-writing the timer logic from scratch.

## `ui/Toast.tsx`

`ToastProvider` + `useToast()`, mounted once at the app root (`App.tsx`, wrapping the whole tree) rather than nested inside `AppOverlays.tsx` as the issue suggested — `AppOverlays` is a **sibling** of the route groups (`EntryRoutes`, `CampaignRoutes`, etc.), not their ancestor, so nesting the provider there would leave `TitleScreen`/`CollectionScreen`/etc. outside its context and `useToast()` would throw. Wrapping the whole app tree is the only place that actually works for every consumer.

- **Variants**: `info`/`success`/`reward`/`warning`/`error`, styled off the #2170 panel tokens (surface, border-edge, elevation, panel-edge bevel) — no new colour literals beyond the existing `--accent-gold/-ember`, `--color-orange`, `--color-green-bright` tokens
- **True queueing**: each toast has its own id and independent timer, so concurrent messages stack in a flex column instead of clobbering each other — `CommanderScreen`'s old array-based queue is now just repeated `showToast()` calls, no local array needed
- **Cap + eviction**: `MAX_TOASTS = 4`, oldest-out (clears the evicted item's timer too)
- **Pause on hover/touch**: clears the dismiss timer and remembers the remaining time so a toast doesn't vanish mid-read; resumes with the remaining time on mouseleave
- **Manual dismiss** on click
- **Enter/exit animation**: two-phase removal (mark `removing`, wait out a short exit animation, then splice) — respects `prefers-reduced-motion` for free, since the existing global rule in `base.css` already zeroes all animation/transition durations app-wide
- **`aria-live`**: `"assertive"` while any current toast is an error, else `"polite"` — a shared-container approximation of per-message assertiveness that keeps the stack as one true arrival-order queue rather than splitting errors into a second DOM region
- **z-index** from `--z-toast` (the named scale from #2166)

## Migration

All 6 call sites migrated, local state/timer code deleted, and the now-dead CSS removed (`.konami-toast`, `.collection-flash`/`-secret-toast`, `.commander-toast(s)`, `.minigame-toast(--prize)`, `.city-toast` — the last shared between `CityBuilder` and `FarmingSim`, confirmed unused elsewhere before removal).

**Bonus fix found along the way**: while removing `.collection-flash`, found it was accidentally comma-coupled to `.collection-pack-btn--disabled` (`.collection-pack-btn--disabled,\n\n.collection-flash { ... }`) — the disabled button state was inheriting an unrelated `fadeFlash` animation instead of having its own styling. Split it into its own rule with a normal opacity/cursor treatment matching the codebase's other `--disabled` patterns.

## Verified in a real browser, not just build/test

- A Storybook story firing three toasts simultaneously confirms they **stack vertically without overlapping**
- Each variant screenshot confirms the right tone/colour (info=green, success=green, reward=gold, warning=orange, error=red)
- The migrated Collection screen still renders correctly with zero console errors

## Test plan

- [x] `ui/Toast.tsx` and provider, with `Toast.stories.tsx` covering every variant and a stacked-queue story
- [x] All six hand-rolled toasts migrated and their local timer/state code deleted
- [x] Stacking verified — fired three at once, confirmed queueing not overlapping
- [x] `aria-live` set; reduced-motion respected (via the existing global rule)
- [x] Toast z-index comes from `--z-toast`, above modals
- [x] `npm run build`, `npx tsc --noEmit`, `npm run test` (2861/2861) all pass clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_