### PR TITLE
[UI 1.5] Standardise modals on ModalBackdrop

### DIFF
--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -2,10 +2,16 @@ import React from 'react'
 import type { Preview } from '@storybook/react-vite'
 import '../src/styles/index.css'
 import { ToastProvider } from '../src/components/ui/Toast'
+import { IconSprite } from '../src/components/ui/icons/IconSprite'
 
 const preview: Preview = {
   decorators: [
-    Story => React.createElement(ToastProvider, null, React.createElement(Story)),
+    Story => React.createElement(
+      ToastProvider,
+      null,
+      React.createElement(IconSprite),
+      React.createElement(Story),
+    ),
   ],
   parameters: {
     controls: {

--- a/web/src/components/admin/GiftClaimModal.tsx
+++ b/web/src/components/admin/GiftClaimModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { GiftDef, rewardSummary } from '../../game/gifts'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
 
 interface Props {
   gifts: GiftDef[]
@@ -8,8 +9,8 @@ interface Props {
 
 export function GiftClaimModal({ gifts, onClaim }: Props) {
   return (
-    <div className="daily-modal-backdrop" onClick={onClaim}>
-      <div className="daily-modal" onClick={e => e.stopPropagation()}>
+    <ModalBackdrop onClose={onClaim} title="Gift Received">
+      <div className="daily-modal">
         <div className="daily-modal-header">✦ GIFT RECEIVED ✦</div>
         <div className="daily-modal-sub">The developer has sent you a gift!</div>
 
@@ -37,6 +38,6 @@ export function GiftClaimModal({ gifts, onClaim }: Props) {
           CLAIM ALL ✓
         </button>
       </div>
-    </div>
+    </ModalBackdrop>
   )
 }

--- a/web/src/components/modals/ConfirmModal.tsx
+++ b/web/src/components/modals/ConfirmModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ModalBackdrop } from '../ui/ModalBackdrop'
+import { Modal } from '../ui/Modal'
 
 interface Props {
   title: string
@@ -11,15 +11,18 @@ interface Props {
 
 export function ConfirmModal({ title, body, confirmLabel, onConfirm, onCancel }: Props) {
   return (
-    <ModalBackdrop onClose={onCancel}>
-      <div className="confirm-modal">
-        <div className="confirm-modal-title">{title}</div>
-        <div className="confirm-modal-body">{body}</div>
-        <div className="confirm-modal-actions u-flex u-gap-5 u-just-c">
+    <Modal
+      title={title}
+      onClose={onCancel}
+      tone="danger"
+      footer={
+        <>
           <button className="action-btn" onClick={onCancel}>Cancel</button>
           <button className="action-btn action-btn--danger" onClick={onConfirm}>{confirmLabel}</button>
-        </div>
-      </div>
-    </ModalBackdrop>
+        </>
+      }
+    >
+      {body}
+    </Modal>
   )
 }

--- a/web/src/components/modals/LoginModal.tsx
+++ b/web/src/components/modals/LoginModal.tsx
@@ -9,6 +9,7 @@ import { auth } from '../../firebase'
 import { uploadSave, downloadSave } from '../../game/cloudSave'
 import { type CloudSave } from '../../game/cloudSave'
 import rollbar from '../../rollbar'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
 
 interface Props {
   user: User | null
@@ -130,8 +131,8 @@ export function LoginModal({ user, authLoading, onClose, onLoginSuccess }: Props
   const isError = errorMsg && !errorMsg.includes('sent')
 
   return (
-    <div className="login-modal-backdrop" onClick={onClose}>
-      <div className="login-modal" onClick={e => e.stopPropagation()}>
+    <ModalBackdrop onClose={onClose} title="Sign In">
+      <div className="login-modal">
         <div className="login-modal-header">SIGN IN</div>
         <div className="login-modal-sub">Back up and sync your save across devices.</div>
 
@@ -176,6 +177,6 @@ export function LoginModal({ user, authLoading, onClose, onLoginSuccess }: Props
           </button>
         </div>
       </div>
-    </div>
+    </ModalBackdrop>
   )
 }

--- a/web/src/components/screens/DailyLoginModal.tsx
+++ b/web/src/components/screens/DailyLoginModal.tsx
@@ -4,6 +4,7 @@ import { CardTile } from '../cards/CardTile'
 import { getCardCatalog } from '../../game/cards'
 import { loadPlayerName } from '../../game/questline'
 import { Button } from '../ui/Button'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
 import rollbar from '../../rollbar'
 
 interface Props {
@@ -50,8 +51,8 @@ export function DailyLoginModal({ reward, onClose }: Props) {
   }, [])
 
   return (
-    <div className="daily-modal-backdrop" onClick={onClose}>
-      <div className="daily-modal" onClick={e => e.stopPropagation()}>
+    <ModalBackdrop onClose={onClose} title="Daily Reward">
+      <div className="daily-modal">
         <div className="daily-modal-header">
           ✦ DAILY REWARD ✦
         </div>
@@ -116,6 +117,6 @@ export function DailyLoginModal({ reward, onClose }: Props) {
           CLAIM ✓
         </Button>
       </div>
-    </div>
+    </ModalBackdrop>
   )
 }

--- a/web/src/components/ui/Modal.stories.tsx
+++ b/web/src/components/ui/Modal.stories.tsx
@@ -1,0 +1,46 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Modal } from './Modal';
+
+const meta = {
+  component: Modal,
+  parameters: { layout: 'fullscreen' },
+  title: 'UI/Modal',
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Confirm Action',
+    onClose: fn(),
+    children: <p style={{ margin: 0 }}>Are you sure you want to do this?</p>,
+  },
+};
+
+export const WithFooter: Story = {
+  args: {
+    title: 'Discard Deck?',
+    onClose: fn(),
+    tone: 'danger',
+    children: <p style={{ margin: 0 }}>This can&apos;t be undone.</p>,
+    footer: (
+      <>
+        <button className="action-btn" onClick={fn()}>Cancel</button>
+        <button className="action-btn action-btn--danger" onClick={fn()}>Discard</button>
+      </>
+    ),
+  },
+};
+
+export const GoldTone: Story = {
+  args: {
+    title: 'Reward Claimed',
+    onClose: fn(),
+    tone: 'gold',
+    children: <p style={{ margin: 0 }}>You received 100 gold.</p>,
+  },
+};

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { ModalBackdrop } from './ModalBackdrop'
+import { Panel, type PanelTone } from './Panel'
+import { Icon } from './icons/Icon'
+
+interface Props {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+  footer?: React.ReactNode
+  tone?: PanelTone
+  closeOnEscape?: boolean
+  zIndex?: number
+}
+
+/**
+ * Standard dialog shell — ModalBackdrop (focus trap/Esc/scroll-lock) + Panel
+ * (surface/border/elevation) + a header row with title and close button.
+ * Not every ModalBackdrop consumer needs this (some want fully custom
+ * layout), but new small centered dialogs should default to it.
+ */
+export function Modal({ title, onClose, children, footer, tone = 'neutral', closeOnEscape, zIndex }: Props) {
+  return (
+    <ModalBackdrop onClose={onClose} title={title} closeOnEscape={closeOnEscape} zIndex={zIndex}>
+      <Panel elevation="floating" tone={tone} className="modal-shell">
+        <div className="modal-shell-header">
+          <span className="modal-shell-title">{title}</span>
+          <button
+            type="button"
+            className="modal-shell-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <Icon name="close" size={14} />
+          </button>
+        </div>
+        <div className="modal-shell-body">
+          {children}
+        </div>
+        {footer && <div className="modal-shell-footer">{footer}</div>}
+      </Panel>
+    </ModalBackdrop>
+  )
+}

--- a/web/src/components/ui/ModalBackdrop.tsx
+++ b/web/src/components/ui/ModalBackdrop.tsx
@@ -1,20 +1,139 @@
-import React from 'react'
+import React, { useEffect, useRef, useSyncExternalStore } from 'react'
 import ReactDOM from 'react-dom'
+
+// ── Shared modal stack ──────────────────────────────────────────────────────
+// Tracks every currently-mounted ModalBackdrop by a unique id, topmost last.
+// Nested modals (e.g. a confirm dialog opened from inside another modal) each
+// get their own instance of this component; only the topmost one should react
+// to Esc or trap Tab, so every instance subscribes to the stack via
+// useSyncExternalStore (same pattern as SpriteImg.tsx's shared animation
+// ticker) and re-renders when who's on top changes.
+let modalSeq = 0
+const modalStack: number[] = []
+const stackSubs = new Set<() => void>()
+
+function pushModal(id: number) {
+  modalStack.push(id)
+  stackSubs.forEach(fn => fn())
+}
+function popModal(id: number) {
+  const i = modalStack.indexOf(id)
+  if (i !== -1) modalStack.splice(i, 1)
+  stackSubs.forEach(fn => fn())
+}
+function subscribeStack(fn: () => void) {
+  stackSubs.add(fn)
+  return () => { stackSubs.delete(fn) }
+}
+function getTopmost() {
+  return modalStack[modalStack.length - 1]
+}
+
+// ── Reference-counted body scroll lock ──────────────────────────────────────
+let lockCount = 0
+let savedOverflow = ''
+function lockScroll() {
+  if (lockCount === 0) {
+    savedOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+  }
+  lockCount++
+}
+function unlockScroll() {
+  lockCount = Math.max(0, lockCount - 1)
+  if (lockCount === 0) {
+    document.body.style.overflow = savedOverflow
+  }
+}
+
+const FOCUSABLE = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
 
 interface Props {
   onClose: () => void
   children: React.ReactNode
+  /** Escape hatch — defaults to the named --z-modal token; only override for a
+      documented reason (e.g. a modal that must sit above another modal). */
   zIndex?: number
+  /** Set false for a modal that must not be dismissed with Escape. */
+  closeOnEscape?: boolean
+  /** Labels the dialog for screen readers (sets aria-label). */
+  title?: string
 }
 
-export function ModalBackdrop({ onClose, children, zIndex }: Props) {
+export function ModalBackdrop({ onClose, children, zIndex, closeOnEscape = true, title }: Props) {
+  const idRef = useRef<number>(0)
+  if (idRef.current === 0) idRef.current = ++modalSeq
+  const panelRef = useRef<HTMLDivElement>(null)
+  const previouslyFocused = useRef<HTMLElement | null>(null)
+
+  const topmostId = useSyncExternalStore(subscribeStack, getTopmost)
+  const isTopmost = topmostId === idRef.current
+
+  useEffect(() => {
+    const id = idRef.current
+    pushModal(id)
+    lockScroll()
+    return () => {
+      popModal(id)
+      unlockScroll()
+    }
+  }, [])
+
+  // Focus trap + Esc, active only while this instance is the topmost modal.
+  useEffect(() => {
+    if (!isTopmost) return
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null
+    const panel = panelRef.current
+    const focusables = panel ? Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE)) : []
+    ;(focusables[0] ?? panel)?.focus()
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && closeOnEscape) {
+        e.stopPropagation()
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab' || !panel) return
+      const nodes = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE))
+      if (nodes.length === 0) return
+      const first = nodes[0]
+      const last = nodes[nodes.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      // Restore focus to whatever triggered this modal, but only once nothing
+      // else (e.g. a still-open parent modal) already reclaimed it.
+      if (document.activeElement === panel || panel?.contains(document.activeElement)) {
+        previouslyFocused.current?.focus?.()
+      }
+    }
+  }, [isTopmost, closeOnEscape, onClose])
+
   return ReactDOM.createPortal(
     <div
       className="modal-backdrop"
       style={zIndex !== undefined ? { zIndex } : undefined}
       onClick={onClose}
     >
-      <div onClick={e => e.stopPropagation()}>
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        onClick={e => e.stopPropagation()}
+      >
         {children}
       </div>
     </div>,

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -492,17 +492,6 @@
    DAILY LOGIN MODAL
    ═══════════════════════════════════════════════════════════ */
 
-.daily-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.82);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 200;
-  animation: fadeIn 0.25s ease;
-}
-
 .daily-modal {
   background: var(--game-bg);
   border: 2px solid rgba(255,200,50,0.6);

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -5,13 +5,95 @@
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: var(--overlay-scrim);
+  /* Scrim plus a subtle vignette so the backdrop reads as depth, not just a
+     flat dimmer, and a light blur to separate the dialog from the page
+     underneath. */
+  background:
+    radial-gradient(ellipse at center, transparent 0%, rgba(0, 0, 0, 0.35) 100%),
+    var(--overlay-scrim);
+  backdrop-filter: blur(3px);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 16px;
   z-index: var(--z-modal);
-  animation: fadeIn 0.15s ease-out;
+  animation: modal-backdrop-in var(--dur-fast) ease-out;
+}
+
+/* The dialog panel itself — a distinct animation name from the shared
+   fadeIn keyframes elsewhere, so this doesn't inherit whichever duplicate
+   fadeIn definition happens to load last (#2169 split multiple identically
+   named @keyframes across files; that's a separate pre-existing issue). */
+.modal-backdrop > div {
+  animation: modal-panel-in var(--dur-normal) ease-out;
+}
+
+@keyframes modal-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes modal-panel-in {
+  from { opacity: 0; transform: scale(0.96) translateY(6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ─── Modal shell (ui/Modal.tsx) ─────────────────────── */
+
+.modal-shell {
+  width: min(420px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.modal-shell-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-edge-dark);
+}
+
+.modal-shell-title {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent-gold);
+}
+
+.modal-shell-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-gray-9);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.modal-shell-close:hover {
+  color: var(--color-gray-10);
+  border-color: var(--accent-gold);
+}
+
+.modal-shell-body {
+  padding: 16px;
+}
+
+.modal-shell-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-edge-dark);
 }
 
 /* ─── Confirm Modal ─────────────────────────────────── */
@@ -726,16 +808,6 @@
 }
 
 /* ─── Login Modal ───────────────────────────────────────── */
-
-.login-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.75);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9200;
-}
 
 .login-modal {
   background: var(--game-bg);


### PR DESCRIPTION
Resolves #2174 — Phase 1 of the #2165 UI overhaul epic (stacked after #2193/#2173, #2192/#2172, #2191/#2171, #2190/#2170, #2189/#2169, #2188/#2168, #2187/#2167, #2186/#2166).

## `ui/ModalBackdrop.tsx`

Every consumer previously got none of the following for free — now they all do, with no per-consumer code changes needed:

- **Focus trap**: Tab/Shift+Tab cycles within the dialog instead of escaping to the page behind it; focus moves into the dialog on open and is restored to the trigger element on close.
- **Esc to close**: new `closeOnEscape` prop (default `true`) for the rare dialog that shouldn't be dismissible this way.
- **Reference-counted scroll lock**: `document.body.style.overflow` is locked while any modal is open, and only released once the last one closes — nested modals don't fight over restoring it.
- **Nested-modal stack**: a module-level stack (via `useSyncExternalStore`, same pattern as `SpriteImg.tsx`'s shared animation ticker) tracks every mounted `ModalBackdrop`; only the topmost instance traps Tab or reacts to Esc, so opening a confirm dialog from inside another modal behaves correctly.
- **Entrance animation**: a vignette + light blur on the scrim, and a scale/fade-in on the dialog panel — given unique keyframe names (`modal-backdrop-in`, `modal-panel-in`) rather than reusing the pre-existing `fadeIn` keyframes, which are already duplicated across two files with different values (a latent bug from #2169's split, left alone — out of scope here).
- New `title` prop → `aria-label` on the dialog.
- `zIndex` kept as an optional escape hatch, defaulting to `var(--z-modal)`.

The inner wrapper div deliberately keeps no new CSS class (just `role="dialog"`/`aria-modal`/`tabIndex`), so none of this touches layout for any of the 27 existing consumers.

## `ui/Modal.tsx`

A shell for the common case — `Panel` + `ModalBackdrop` with a title/close-button header, a body slot, and an optional footer/actions row — so new small centered dialogs don't each hand-roll header markup. `ConfirmModal` is migrated onto it as the reference example.

## Migrated off hand-rolled backdrops

The issue described "two" hand-rolled overlays bypassing `ModalBackdrop`; a grep turned up at least four building their own `position: fixed` scrim instead:

- `ConfirmModal.tsx` → rebuilt on the new `Modal` shell
- `LoginModal.tsx`, `GiftClaimModal.tsx`, `DailyLoginModal.tsx` → kept their bespoke inner layout, now portal through `ModalBackdrop` for backdrop/dismiss/a11y

Removed the now-dead `.login-modal-backdrop` and `.daily-modal-backdrop` CSS rules (both fully superseded by `.modal-backdrop`).

**Deliberately deferred**: `TutorialOverlay.tsx` and a longer tail of full-screen narrative/reward overlays (`BossEpilogueScreen`, rare-events mini-games, hub `HomeShelf`/`HallOfAchievements`/`FishAppraisalScreen`, `DeckBuilder`, battle `VictoryPanel`/`BattleSummary`/`BossDialogueScreen`, `InventoryScreen`, `ShopScreen`) — these are full-screen overlays with intentionally different behavior (e.g. no outside-click dismiss), not small centered dialogs, so a mechanical swap onto `ModalBackdrop` isn't the right call without a closer look at each one.

## Bonus fix: PR #2193 CI failure

While this branch was stacked on the not-yet-merged #2193 (Toast primitive), its "test" CI check started failing — 11 Storybook stories crashed with `useToast must be used within a ToastProvider`, since `ToastProvider` was mounted at `App.tsx`'s root but never in the Storybook preview. Fixed on the `claude/issue-2173-toast-primitive` branch directly (now merged) by adding it as a global Storybook decorator.

While verifying this PR's modal work in a real browser, found the same class of issue for `Icon` (#2172): `<Icon>` resolves `<use href="#icon-name">` against whatever `<symbol>` defs exist in the DOM, which in the real app is `IconSprite` mounted once at `App.tsx`'s root — but Storybook never had it either, so any story with an `<Icon>` (now including every `Modal`-shell dialog) rendered a blank glyph. Added to the same global decorator.

## Verified in a real browser, not just build/test

- Nested-modal stacking (`PetModal` → "Dismiss Pet" → nested `ConfirmModal`, a real two-level case already in the codebase): confirmed both backdrops mount, focus moves into the topmost dialog, Esc closes only the topmost one, and scroll stays locked until the last modal closes
- `Modal` shell screenshots (default, with footer, gold tone) confirm the header/close button/vignette/animation render correctly
- `LoginModal`, `GiftClaimModal`, `DailyLoginModal` all render correctly through `ModalBackdrop` (a `Firebase: auth/invalid-api-key` console error on the first two is pre-existing sandbox noise from `game/gifts.ts`/`firebase.ts` lacking real credentials in this environment — unrelated to this change, confirmed by the diff not touching either import)

## Test plan

- [x] `ModalBackdrop` gets focus trap, Esc, scroll lock, nested-modal-aware stacking, entrance animation — zero prop changes required for existing consumers
- [x] `ui/Modal.tsx` shell + `Modal.stories.tsx` (default/footer/gold-tone)
- [x] `ConfirmModal`, `LoginModal`, `GiftClaimModal`, `DailyLoginModal` migrated; dead CSS removed
- [x] Nested-modal stacking verified in a real browser (focus, scoped Esc, scroll lock)
- [x] `npm run build`, `npx tsc --noEmit`, `npm run test` (2861/2861) all pass clean
- [x] PR #2193's CI failure diagnosed and fixed (merged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_