### PR TITLE
[UI 2.2] Battlefield HUD and card hand visual pass

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -20,6 +20,11 @@ import { hasSeen, markSeen } from '../../game/tutorial'
 import { useLetterboxSize } from '../../hooks/useLetterboxSize'
 import { loadDevConfig, patchDevConfig } from '../../game/devStore'
 import { isDevMode } from '../../game/debug'
+import { BaseBar } from './battlefield/BaseBar'
+import { ManaBar } from './battlefield/ManaBar'
+import { StanceBar } from './battlefield/StanceBar'
+import { TopBar } from './battlefield/TopBar'
+import { CombatLogPanel } from './battlefield/CombatLogPanel'
 
 const modalAutoDismissTime = 2000
 const BATTLE_TUTORIAL_ID = 'gameplay'
@@ -62,35 +67,6 @@ interface Props {
   isAdmin?: boolean
 }
 
-function ManaBar({ mana, maxMana, manaAccum }: { mana: number; maxMana: number; manaAccum: number }) {
-  const pips = Array.from({ length: maxMana }, (_, i) => {
-    if (i < mana) return 'full'
-    if (i === mana) return 'partial'
-    return 'empty'
-  })
-  return (
-    <div className="mana-bar u-flex u-items-c">
-      {pips.map((pipState, i) => (
-        <span key={i} className={`mana-pip mana-pip--${pipState}`}>
-          {pipState === 'partial'
-            ? <span className="mana-pip-fill" style={{ width: `${manaAccum * 100}%` }} />
-            : null}
-        </span>
-      ))}
-    </div>
-  )
-}
-
-function HpBar({ current, max, color }: { current: number; max: number; color: string }) {
-  const pct = Math.max(0, (current / max) * 100)
-  return (
-    <div className="hp-bar-track">
-      <div className="hp-bar-fill" style={{ width: `${pct}%`, background: color }} />
-      <span className="hp-bar-text">{current}/{max}</span>
-    </div>
-  )
-}
-
 const STRATEGY_LABELS: Record<string, string> = {
   swarm:  'SWARM',
   turtle: 'TURTLE',
@@ -131,6 +107,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   // it. BattlefieldCanvas reads this every frame, so it takes effect at once.
   const [debugOverlay, setDebugOverlay] = useState(() => loadDevConfig().battlefieldDebugOverlay)
   const [showDeckViewer, setShowDeckViewer] = useState(false)
+  const [logOpen, setLogOpen] = useState(false)
   const [confirmGiveUp, setConfirmGiveUp] = useState(false)
   const [showBattleTutorial, setShowBattleTutorial] = useState(
     () => !isCampaign && !hasSeen(BATTLE_TUTORIAL_ID)
@@ -230,6 +207,8 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   const timeStr = (isCampaign && !state.suddenDeath) ? countdownStr : elapsedStr
   const sdSec = Math.ceil(state.suddenDeathTimer / 1000)
   const event = state.activeBattleEvent
+  const activeRelicDef = activeRelic ? getRelicDef(activeRelic) : null
+  const activeRelicChip = activeRelicDef ? { icon: activeRelicDef.icon, name: activeRelicDef.name, desc: activeRelicDef.desc } : null
 
   // The battlefield always renders at a fixed aspect ratio (BATTLEFIELD_ASPECT_RATIO),
   // letterboxed within the stage rather than stretched — see useLetterboxSize. Falls
@@ -288,41 +267,22 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
       {/* Top cluster: floats above the lane in the reserved top band */}
       <div className="bf-top-cluster">
-      {/* Top bar: clock, scores */}
-      <div className={`top-bar${state.suddenDeath ? ' top-bar--sudden-death' : ''}`}>
-        <button className="bf-pause-btn" onClick={() => doPause(true)} title="Menu">MENU</button>
-        <span className="game-clock">{timeStr}</span>
-        {state.endlessMode && (
-          <span className="endless-wave-chip">WAVE {state.endlessWave ?? 1}</span>
-        )}
-        {state.endlessMode && (state.endlessWaveTruceMs ?? 0) > 0 && (
-          <span className="endless-truce-chip">TRUCE {Math.ceil((state.endlessWaveTruceMs ?? 0) / 1000)}s</span>
-        )}
-        <span className="score-display">
-          <span className="score-player">{state.playerScore}</span>
-          <span className="score-sep"> – </span>
-          <span className="score-opponent">{state.opponentScore}</span>
-        </span>
-        {event && (
-          <span className={`event-status-chip event-status-chip--${event.type}`}>
-            {event.type === 'bloodMoon' ? '🌑 BLOOD MOON'
-            : event.type === 'fogOfWar' ? '🌫 FOG OF WAR'
-            : event.type === 'supplyDrop' ? '📦 SUPPLY DROP'
-            : '🌋 QUAKE'}
-          </span>
-        )}
-        {activeRelic && (() => {
-          const def = getRelicDef(activeRelic)
-          return def ? (
-            <span className="relic-chip" title={def.desc}>
-              {def.icon} {def.name}
-            </span>
-          ) : null
-        })()}
-        {isNoDamageMode() && (
-          <span className="dev-badge">DEV MODE</span>
-        )}
-      </div>
+      <TopBar
+        timeStr={timeStr}
+        suddenDeath={state.suddenDeath}
+        endlessMode={state.endlessMode}
+        endlessWave={state.endlessWave}
+        endlessTruceSecs={Math.ceil((state.endlessWaveTruceMs ?? 0) / 1000)}
+        playerScore={state.playerScore}
+        opponentScore={state.opponentScore}
+        eventType={event?.type ?? null}
+        activeRelic={activeRelicChip}
+        devMode={isNoDamageMode()}
+        logAvailable
+        logOpen={logOpen}
+        onToggleLog={() => setLogOpen(o => !o)}
+        onPause={() => doPause(true)}
+      />
 
       {/* Replay modifier strip — only shown in pause menu */}
       {paused && activeModifiers && activeModifiers.length > 0 && (
@@ -334,20 +294,20 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       )}
 
       {/* Opponent base */}
-      <div className="base-bar base-bar--opponent">
-        <img
-          className="base-bar-portrait base-bar-portrait--opponent"
-          src={`${BASE_SPRITE_PATH}${opponentCommanderSlug}.svg`}
-          alt="opponent"
-        />
-        <HpBar current={state.opponentBase.hp} max={state.opponentBase.maxHp} color="#ff4444" />
-        <span className="base-bar-info u-flex u-items-c u-gap-3">
-          {STRATEGY_LABELS[state.opponentStrategy] && (
-            <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
-          )}
-        </span>
+      <BaseBar
+        owner="opponent"
+        portraitSrc={`${BASE_SPRITE_PATH}${opponentCommanderSlug}.svg`}
+        portraitAlt="opponent"
+        hp={state.opponentBase.hp}
+        maxHp={state.opponentBase.maxHp}
+        color="#ff4444"
+        rightSlot={STRATEGY_LABELS[state.opponentStrategy] && (
+          <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
+        )}
+      />
       </div>
-      </div>
+
+      <CombatLogPanel entries={state.log} open={logOpen} onClose={() => setLogOpen(false)} />
 
       {/* The Lane — letterboxed to LANE_ASPECT_RATIO inside the slot the HUD
           bands leave, so its shape (and therefore its tile grid) is the same on
@@ -422,18 +382,15 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       {/* Bottom cluster: floats below the lane in the reserved bottom band */}
       <div className="bf-bottom-cluster">
       {/* Player base */}
-      <div className="base-bar base-bar--player">
-        <img
-          className="base-bar-portrait base-bar-portrait--player"
-          src={`${BASE_SPRITE_PATH}${playerAvatar}.svg`}
-          alt={playerName}
-        />
-        <HpBar current={state.playerBase.hp} max={state.playerBase.maxHp} color="#33ff33" />
-        <span className="base-bar-info u-flex u-items-c u-gap-3">
-          MANA {state.mana}/{state.maxMana}
-          <ManaBar mana={state.mana} maxMana={state.maxMana} manaAccum={state.manaAccum} />
-        </span>
-      </div>
+      <BaseBar
+        owner="player"
+        portraitSrc={`${BASE_SPRITE_PATH}${playerAvatar}.svg`}
+        portraitAlt={playerName}
+        hp={state.playerBase.hp}
+        maxHp={state.playerBase.maxHp}
+        color="#33ff33"
+        rightSlot={<>MANA {state.mana}/{state.maxMana} <ManaBar mana={state.mana} maxMana={state.maxMana} manaAccum={state.manaAccum} /></>}
+      />
 
       {/* Stance + speed controls */}
       {(() => {
@@ -449,33 +406,17 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           : 0
 
         return (
-          <div className="stance-bar">
-            {(['attack', 'hold', 'defend', 'auto'] as const).map(s => {
-              const isAllowed = !rules || rules.allowed.includes(s)
-              if (!isAllowed) return null
-              const label = s === 'attack' ? 'CHARGE' : s === 'hold' ? 'HOLD' : s === 'defend' ? 'DEFEND' : 'ATTACK'
-              const isActive = stance === s
-              const isCoolingDown = onCooldown && s !== 'auto' && !isActive
-              const showCountdown = isActive && s !== 'auto' && durationSecsLeft > 0
-              const showCooldown  = isCoolingDown && cooldownSecsLeft > 0
-              return (
-                <button
-                  key={s}
-                  className={`filter-btn${isActive ? ' filter-btn--active' : ''}${isCoolingDown ? ' filter-btn--cooldown' : ''}`}
-                  onClick={() => onSetStance?.(s)}
-                  disabled={(state.suddenDeath && s !== 'attack') || isCoolingDown}
-                  title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
-                >
-                  {label}
-                  {showCountdown && <span className="stance-timer"> {durationSecsLeft}s</span>}
-                  {showCooldown  && <span className="stance-timer stance-timer--cd"> {cooldownSecsLeft}s</span>}
-                </button>
-              )
-            })}
-            <button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
-              x{speedMultiplier}
-            </button>
-          </div>
+          <StanceBar
+            stance={stance}
+            allowedStances={rules?.allowed ?? null}
+            suddenDeath={state.suddenDeath}
+            onCooldown={onCooldown}
+            cooldownSecsLeft={cooldownSecsLeft}
+            durationSecsLeft={durationSecsLeft}
+            speedMultiplier={speedMultiplier}
+            onSetStance={onSetStance}
+            onCycleSpeed={onCycleSpeed}
+          />
         )
       })()}
 

--- a/web/src/components/battle/battlefield/BaseBar.stories.tsx
+++ b/web/src/components/battle/battlefield/BaseBar.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { BaseBar } from './BaseBar';
+import { ManaBar } from './ManaBar';
+
+const meta = {
+  component: BaseBar,
+  parameters: { layout: 'centered' },
+  title: 'Battle/BaseBar',
+  decorators: [(Story) => <div style={{ width: 320, background: '#0a0a0a', padding: 12 }}><Story /></div>],
+} satisfies Meta<typeof BaseBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Opponent: Story = {
+  args: {
+    owner: 'opponent',
+    portraitSrc: '/sprites/goblin.svg',
+    portraitAlt: 'opponent',
+    hp: 850,
+    maxHp: 1000,
+    color: '#ff4444',
+    rightSlot: <span className="strategy-label">RUSH</span>,
+  },
+};
+
+export const Player: Story = {
+  args: {
+    owner: 'player',
+    portraitSrc: '/sprites/knight.svg',
+    portraitAlt: 'player',
+    hp: 1000,
+    maxHp: 1000,
+    color: '#33ff33',
+    rightSlot: <>MANA 4/6 <ManaBar mana={4} maxMana={6} manaAccum={0.4} /></>,
+  },
+};
+
+export const PlayerLowHp: Story = {
+  args: {
+    owner: 'player',
+    portraitSrc: '/sprites/knight.svg',
+    portraitAlt: 'player',
+    hp: 120,
+    maxHp: 1000,
+    color: '#33ff33',
+    rightSlot: <>MANA 2/6 <ManaBar mana={2} maxMana={6} manaAccum={0.1} /></>,
+  },
+};

--- a/web/src/components/battle/battlefield/BaseBar.tsx
+++ b/web/src/components/battle/battlefield/BaseBar.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { HpBar } from './HpBar'
+
+interface Props {
+  owner: 'player' | 'opponent'
+  portraitSrc: string
+  portraitAlt: string
+  hp: number
+  maxHp: number
+  color: string
+  rightSlot?: React.ReactNode
+}
+
+/** One base's HUD row — portrait, HP bar, and an owner-specific slot for
+ *  whatever goes on the right (opponent: strategy label; player: mana). */
+export function BaseBar({ owner, portraitSrc, portraitAlt, hp, maxHp, color, rightSlot }: Props) {
+  return (
+    <div className={`base-bar base-bar--${owner}`}>
+      <img className={`base-bar-portrait base-bar-portrait--${owner}`} src={portraitSrc} alt={portraitAlt} />
+      <HpBar current={hp} max={maxHp} color={color} />
+      {rightSlot && (
+        <span className="base-bar-info u-flex u-items-c u-gap-3">
+          {rightSlot}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/battle/battlefield/CombatLogPanel.stories.tsx
+++ b/web/src/components/battle/battlefield/CombatLogPanel.stories.tsx
@@ -1,0 +1,38 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { CombatLogPanel } from './CombatLogPanel';
+
+const meta = {
+  component: CombatLogPanel,
+  parameters: { layout: 'centered' },
+  title: 'Battle/CombatLogPanel',
+  decorators: [(Story) => <div style={{ width: 340, height: 300, position: 'relative', background: '#0a0a0a' }}><Story /></div>],
+} satisfies Meta<typeof CombatLogPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const sampleEntries = [
+  'Player deployed Goblin.',
+  'Opponent deployed Archer.',
+  '!!★ HERO Valeria unleashed by Player!',
+  'Valeria destroyed Archer!',
+  'Your AOE! 3 enemies hit for 42 damage.',
+  'Player units healed 20 HP.',
+  'Opponent upgraded Watchtower! (Lvl 2)',
+  '💎 Crystal Golem cracked — half HP, double damage!',
+];
+
+export const Empty: Story = {
+  args: { entries: [], open: true, onClose: fn() },
+};
+
+export const WithEntries: Story = {
+  args: { entries: sampleEntries, open: true, onClose: fn() },
+};
+
+export const Closed: Story = {
+  args: { entries: sampleEntries, open: false, onClose: fn() },
+};

--- a/web/src/components/battle/battlefield/CombatLogPanel.tsx
+++ b/web/src/components/battle/battlefield/CombatLogPanel.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Button } from '../../ui/Button'
+
+type LogTone = 'important' | 'kill' | 'damage' | 'buff' | 'routine'
+
+const MAX_ENTRIES = 40
+
+/** Entries are free-form text from the engine (no structured event type),
+ *  so this is a best-effort keyword classifier for colour-coding — not a
+ *  source of truth about what actually happened in a tick. */
+function classify(entry: string): { tone: LogTone; text: string } {
+  if (entry.startsWith('!!')) return { tone: 'important', text: entry.slice(2) }
+  const lower = entry.toLowerCase()
+  if (lower.includes('destroyed') || lower.includes('crumbles') || lower.includes('collapses')) {
+    return { tone: 'kill', text: entry }
+  }
+  if (lower.includes('damage') || lower.includes('hit for') || lower.includes('blast') || lower.includes('explodes') || lower.includes('erupts')) {
+    return { tone: 'damage', text: entry }
+  }
+  if (lower.includes('heal') || lower.includes('gain') || lower.includes('surge') || lower.includes('upgraded')) {
+    return { tone: 'buff', text: entry }
+  }
+  return { tone: 'routine', text: entry }
+}
+
+interface Props {
+  entries: string[]
+  open: boolean
+  onClose: () => void
+}
+
+/** Scrollable battle log — colour-codes kills/damage/buffs so the feed is
+ *  scannable at a glance, and de-emphasises routine deploy/idle ticks.
+ *  Only ever shows the most recent MAX_ENTRIES; state.log itself is
+ *  unbounded (used elsewhere for full battle history) but rendering all of
+ *  it here would be needless DOM growth over a long match. */
+export function CombatLogPanel({ entries, open, onClose }: Props) {
+  if (!open) return null
+  const recent = entries.slice(-MAX_ENTRIES).reverse()
+  return (
+    <div className="bf-log-panel">
+      <div className="bf-log-panel-header">
+        <span>BATTLE LOG</span>
+        <Button size="xs" onClick={onClose} aria-label="Close battle log">✕</Button>
+      </div>
+      <div className="bf-log-panel-list">
+        {recent.length === 0
+          ? <div className="bf-log-entry bf-log-entry--routine">Nothing has happened yet.</div>
+          : recent.map((raw, i) => {
+            const { tone, text } = classify(raw)
+            return (
+              <div key={i} className={`bf-log-entry bf-log-entry--${tone}`}>{text}</div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/battle/battlefield/HpBar.stories.tsx
+++ b/web/src/components/battle/battlefield/HpBar.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { HpBar } from './HpBar';
+
+const meta = {
+  component: HpBar,
+  parameters: { layout: 'centered' },
+  title: 'Battle/HpBar',
+  decorators: [(Story) => <div style={{ width: 220, background: '#0a0a0a', padding: 12 }}><Story /></div>],
+} satisfies Meta<typeof HpBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Full: Story = {
+  args: { current: 1000, max: 1000, color: '#33ff33' },
+};
+
+export const Half: Story = {
+  args: { current: 480, max: 1000, color: '#33ff33' },
+};
+
+export const Low: Story = {
+  args: { current: 90, max: 1000, color: '#ff4444' },
+};
+
+export const Critical: Story = {
+  args: { current: 12, max: 1000, color: '#ff4444' },
+};

--- a/web/src/components/battle/battlefield/HpBar.tsx
+++ b/web/src/components/battle/battlefield/HpBar.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+const LOW_HP_PCT = 0.25
+const FLASH_MS = 220
+
+interface Props {
+  current: number
+  max: number
+  color: string
+}
+
+/** Base/unit HP bar — flashes white on any HP decrease and switches to a
+ *  pulsing danger state below 25% so a base about to fall reads as urgent,
+ *  not just "a shorter bar than before". */
+export function HpBar({ current, max, color }: Props) {
+  const pct = Math.max(0, (current / max) * 100)
+  const low = pct > 0 && pct <= LOW_HP_PCT * 100
+  const prevRef = useRef(current)
+  const [flashing, setFlashing] = useState(false)
+
+  useEffect(() => {
+    if (current < prevRef.current) {
+      setFlashing(true)
+      const id = setTimeout(() => setFlashing(false), FLASH_MS)
+      prevRef.current = current
+      return () => clearTimeout(id)
+    }
+    prevRef.current = current
+  }, [current])
+
+  return (
+    <div className={`hp-bar-track${low ? ' hp-bar-track--low' : ''}${flashing ? ' hp-bar-track--flash' : ''}`}>
+      <div className="hp-bar-fill" style={{ width: `${pct}%`, background: color }} />
+      <span className="hp-bar-text">{current}/{max}</span>
+    </div>
+  )
+}

--- a/web/src/components/battle/battlefield/ManaBar.stories.tsx
+++ b/web/src/components/battle/battlefield/ManaBar.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ManaBar } from './ManaBar';
+
+const meta = {
+  component: ManaBar,
+  parameters: { layout: 'centered' },
+  title: 'Battle/ManaBar',
+  decorators: [(Story) => <div style={{ background: '#0a0a0a', padding: 12 }}><Story /></div>],
+} satisfies Meta<typeof ManaBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: { mana: 0, maxMana: 6, manaAccum: 0 },
+};
+
+export const Regenerating: Story = {
+  args: { mana: 2, maxMana: 6, manaAccum: 0.6 },
+};
+
+export const Full: Story = {
+  args: { mana: 6, maxMana: 6, manaAccum: 0 },
+};
+
+export const HighMaxMana: Story = {
+  args: { mana: 7, maxMana: 10, manaAccum: 0.3 },
+};

--- a/web/src/components/battle/battlefield/ManaBar.tsx
+++ b/web/src/components/battle/battlefield/ManaBar.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+interface Props {
+  mana: number
+  maxMana: number
+  manaAccum: number
+}
+
+/** Mana pips — one per max-mana point, the next one filling shows live
+ *  regeneration progress instead of just popping full when it completes. */
+export function ManaBar({ mana, maxMana, manaAccum }: Props) {
+  const pips = Array.from({ length: maxMana }, (_, i) => {
+    if (i < mana) return 'full'
+    if (i === mana) return 'partial'
+    return 'empty'
+  })
+  return (
+    <div className="mana-bar u-flex u-items-c">
+      {pips.map((pipState, i) => (
+        <span key={i} className={`mana-pip mana-pip--${pipState}`}>
+          {pipState === 'partial'
+            ? <span className="mana-pip-fill" style={{ width: `${manaAccum * 100}%` }} />
+            : null}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/battle/battlefield/StanceBar.stories.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.stories.tsx
@@ -1,0 +1,69 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { StanceBar } from './StanceBar';
+
+const meta = {
+  component: StanceBar,
+  parameters: { layout: 'centered' },
+  title: 'Battle/StanceBar',
+  decorators: [(Story) => <div style={{ background: '#0a0a0a', padding: 12 }}><Story /></div>],
+} satisfies Meta<typeof StanceBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const callbacks = { onSetStance: fn(), onCycleSpeed: fn() };
+
+export const Default: Story = {
+  args: {
+    ...callbacks,
+    stance: 'auto',
+    allowedStances: null,
+    suddenDeath: false,
+    onCooldown: false,
+    cooldownSecsLeft: 0,
+    durationSecsLeft: 0,
+    speedMultiplier: 1,
+  },
+};
+
+export const ActiveWithDuration: Story = {
+  args: {
+    ...callbacks,
+    stance: 'attack',
+    allowedStances: null,
+    suddenDeath: false,
+    onCooldown: false,
+    cooldownSecsLeft: 0,
+    durationSecsLeft: 8,
+    speedMultiplier: 2,
+  },
+};
+
+export const OnCooldown: Story = {
+  args: {
+    ...callbacks,
+    stance: 'auto',
+    allowedStances: null,
+    suddenDeath: false,
+    onCooldown: true,
+    cooldownSecsLeft: 12,
+    durationSecsLeft: 0,
+    speedMultiplier: 1,
+  },
+};
+
+export const SuddenDeath: Story = {
+  args: {
+    ...callbacks,
+    stance: 'attack',
+    allowedStances: null,
+    suddenDeath: true,
+    onCooldown: false,
+    cooldownSecsLeft: 0,
+    durationSecsLeft: 0,
+    speedMultiplier: 4,
+  },
+};

--- a/web/src/components/battle/battlefield/StanceBar.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Button } from '../../ui/Button'
+
+type Stance = 'attack' | 'hold' | 'defend' | 'auto'
+
+const STANCE_LABEL: Record<Stance, string> = {
+  attack: 'CHARGE',
+  hold:   'HOLD',
+  defend: 'DEFEND',
+  auto:   'ATTACK',
+}
+
+interface Props {
+  stance: Stance
+  allowedStances: Stance[] | null
+  suddenDeath: boolean
+  onCooldown: boolean
+  cooldownSecsLeft: number
+  durationSecsLeft: number
+  speedMultiplier: 1 | 2 | 4 | 8
+  onSetStance?: (s: Stance) => void
+  onCycleSpeed?: () => void
+}
+
+/** Stance selector + speed-cycle control, unchanged behavior from the inline
+ *  version — same allowed/cooldown/duration rules, now on ui/Button so it
+ *  gets real :disabled/focus handling instead of a raw <button>. */
+export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, cooldownSecsLeft, durationSecsLeft, speedMultiplier, onSetStance, onCycleSpeed }: Props) {
+  return (
+    <div className="stance-bar">
+      {(['attack', 'hold', 'defend', 'auto'] as const).map(s => {
+        const isAllowed = !allowedStances || allowedStances.includes(s)
+        if (!isAllowed) return null
+        const isActive = stance === s
+        const isCoolingDown = onCooldown && s !== 'auto' && !isActive
+        const showCountdown = isActive && s !== 'auto' && durationSecsLeft > 0
+        const showCooldown = isCoolingDown && cooldownSecsLeft > 0
+        return (
+          <Button
+            key={s}
+            className={`filter-btn${isActive ? ' filter-btn--active' : ''}${isCoolingDown ? ' filter-btn--cooldown' : ''}`}
+            onClick={() => onSetStance?.(s)}
+            disabled={(suddenDeath && s !== 'attack') || isCoolingDown}
+            title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
+          >
+            {STANCE_LABEL[s]}
+            {showCountdown && <span className="stance-timer"> {durationSecsLeft}s</span>}
+            {showCooldown && <span className="stance-timer stance-timer--cd"> {cooldownSecsLeft}s</span>}
+          </Button>
+        )
+      })}
+      <Button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
+        x{speedMultiplier}
+      </Button>
+    </div>
+  )
+}

--- a/web/src/components/battle/battlefield/TopBar.stories.tsx
+++ b/web/src/components/battle/battlefield/TopBar.stories.tsx
@@ -1,0 +1,69 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TopBar } from './TopBar';
+
+const meta = {
+  component: TopBar,
+  parameters: { layout: 'centered' },
+  title: 'Battle/TopBar',
+  decorators: [(Story) => <div style={{ width: 380, background: '#0a0a0a', padding: 12 }}><Story /></div>],
+} satisfies Meta<typeof TopBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const callbacks = { onToggleLog: fn(), onPause: fn() };
+
+export const Default: Story = {
+  args: {
+    ...callbacks,
+    timeStr: '2:14',
+    suddenDeath: false,
+    endlessMode: false,
+    endlessTruceSecs: 0,
+    playerScore: 3,
+    opponentScore: 1,
+    eventType: null,
+    activeRelic: null,
+    devMode: false,
+    logAvailable: true,
+    logOpen: false,
+  },
+};
+
+export const EndlessWithTruce: Story = {
+  args: {
+    ...callbacks,
+    timeStr: '5:02',
+    suddenDeath: false,
+    endlessMode: true,
+    endlessWave: 4,
+    endlessTruceSecs: 8,
+    playerScore: 0,
+    opponentScore: 0,
+    eventType: null,
+    activeRelic: null,
+    devMode: false,
+    logAvailable: true,
+    logOpen: false,
+  },
+};
+
+export const SuddenDeathWithEventAndRelic: Story = {
+  args: {
+    ...callbacks,
+    timeStr: '3:00',
+    suddenDeath: true,
+    endlessMode: false,
+    endlessTruceSecs: 0,
+    playerScore: 2,
+    opponentScore: 2,
+    eventType: 'bloodMoon',
+    activeRelic: { icon: '🗡️', name: 'Bloodied Edge', desc: 'Units deal +10% damage.' },
+    devMode: true,
+    logAvailable: true,
+    logOpen: true,
+  },
+};

--- a/web/src/components/battle/battlefield/TopBar.tsx
+++ b/web/src/components/battle/battlefield/TopBar.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { Button } from '../../ui/Button'
+import type { BattleEventType } from '../../../game/types'
+
+const EVENT_LABEL: Record<BattleEventType, string> = {
+  bloodMoon:   '🌑 BLOOD MOON',
+  fogOfWar:    '🌫 FOG OF WAR',
+  supplyDrop:  '📦 SUPPLY DROP',
+  earthquake:  '🌋 QUAKE',
+}
+
+interface RelicChip {
+  icon: string
+  name: string
+  desc: string
+}
+
+interface Props {
+  timeStr: string
+  suddenDeath: boolean
+  endlessMode?: boolean
+  endlessWave?: number
+  endlessTruceSecs: number
+  playerScore: number
+  opponentScore: number
+  eventType: BattleEventType | null
+  activeRelic: RelicChip | null
+  devMode: boolean
+  logAvailable: boolean
+  logOpen: boolean
+  onToggleLog: () => void
+  onPause: () => void
+}
+
+/** The always-visible top strip: pause, clock, endless-mode chips, score,
+ *  active event/relic chips, dev badge, and the combat-log toggle. */
+export function TopBar({ timeStr, suddenDeath, endlessMode, endlessWave, endlessTruceSecs, playerScore, opponentScore, eventType, activeRelic, devMode, logAvailable, logOpen, onToggleLog, onPause }: Props) {
+  return (
+    <div className={`top-bar${suddenDeath ? ' top-bar--sudden-death' : ''}`}>
+      <Button size="xs" className="bf-pause-btn" onClick={onPause} title="Menu">MENU</Button>
+      <span className="game-clock">{timeStr}</span>
+      {endlessMode && (
+        <span className="endless-wave-chip">WAVE {endlessWave ?? 1}</span>
+      )}
+      {endlessMode && endlessTruceSecs > 0 && (
+        <span className="endless-truce-chip">TRUCE {endlessTruceSecs}s</span>
+      )}
+      <span className="score-display">
+        <span className="score-player">{playerScore}</span>
+        <span className="score-sep"> – </span>
+        <span className="score-opponent">{opponentScore}</span>
+      </span>
+      {eventType && (
+        <span className={`event-status-chip event-status-chip--${eventType}`}>
+          {EVENT_LABEL[eventType]}
+        </span>
+      )}
+      {activeRelic && (
+        <span className="relic-chip" title={activeRelic.desc}>
+          {activeRelic.icon} {activeRelic.name}
+        </span>
+      )}
+      {devMode && (
+        <span className="dev-badge">DEV MODE</span>
+      )}
+      {logAvailable && (
+        <Button
+          size="xs"
+          className={`bf-log-toggle${logOpen ? ' bf-log-toggle--active' : ''}`}
+          onClick={onToggleLog}
+          title="Battle log"
+        >LOG</Button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -194,7 +194,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
 
 
 
-      <div className="card-cost">{displayCost ?? card.cost}</div>
+      <div className={`card-cost${!canAfford ? ' card-cost--unaffordable' : ''}`}>{displayCost ?? card.cost}</div>
       {upgradeable && <div className="card-upgrade-badge">UPGRADE</div>}
       <div className={`card-title${isSecret ? ' card-title--badge' : ''}`}>{card.name}</div>
       <div className="card-art u-flex u-items-c u-just-c">

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -61,17 +61,19 @@ body {
   .game-title { font-size: var(--font-base); letter-spacing: 1px; }
 
   .hand-cards { gap: 4px; padding-bottom: 4px; }
-  .card-tile { width: 78px; padding: 6px 8px; }
-  .card-title { font-size: var(--font-xxs); }
-  .card-stats { font-size: 0.571rem; }
-  .card-tag   { font-size: 0.5rem; }
+  /* Cards are the primary interactive element of the game — sized for a
+     thumb tap, not just legibility (#2176). */
+  .card-tile { width: 88px; padding: 7px 9px; }
+  .card-title { font-size: var(--font-xs); }
+  .card-stats { font-size: var(--font-xxs); }
+  .card-tag   { font-size: 0.571rem; }
 
   .lane-unit-name { font-size: 0.571rem; }
-  .mana-pip { width: 8px; height: 8px; }
+  .mana-pip { width: 10px; height: 10px; }
 
   .base-bar { padding: 3px 8px; gap: 6px; }
   .base-bar-info { font-size: var(--font-xs); gap: 4px; }
-  .hp-bar-track { height: 13px; }
+  .hp-bar-track { height: 14px; }
 }
 
 /* Very small phones (≤380px — iPhone SE, older Android) */
@@ -80,8 +82,8 @@ body {
   .game-title { font-size: var(--font-md); padding: 2px 0 3px; }
 
   .hand-cards { gap: 3px; }
-  .hand-cards .card-tile { padding: 4px 5px; }
-  .card-title { font-size: 0.571rem; }
+  .hand-cards .card-tile { padding: 5px 6px; }
+  .card-title { font-size: var(--font-xxs); }
 }
 
 /* ─── Intro Screen ───────────────────────────────────── */

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -21,9 +21,16 @@
   overflow: hidden;
   /* Fixed bands reserved for the floating bar clusters. The lane fills the space
      between them, so the play area's size depends only on the frame — never on
-     bar content (long scores, wave status, event tags, card-bar height changes). */
-  --bf-top-buffer: 80px;
-  --bf-bottom-buffer: 230px;
+     bar content (long scores, wave status, event tags, card-bar height changes).
+     Retuned for #2176's HUD pass by measuring actual cluster height in a real
+     battle (see PR description) — the previous values already under-reserved
+     space before this pass (a pre-existing gap this issue called out), and the
+     larger card hand/base-bar surfaces need a little more. BATTLEFIELD_ASPECT_RATIO
+     is tall/narrow (9:19.5), so in practice almost every real viewport letterboxes
+     down to the --compact or --tiny tier — this default tier is a rarely-hit
+     ceiling for unusually tall windows, kept in proportion with the other two. */
+  --bf-top-buffer: 92px;
+  --bf-bottom-buffer: 255px;
 }
 
 /* Narrower-frame tuning — keyed off the letterboxed frame's own computed width
@@ -32,8 +39,8 @@
    real phone gets, which a viewport @media query alone could never detect.
    The lane has no min-height override here: it is letterboxed to a fixed ratio
    (see .lane below), and a minimum on one axis would silently break that ratio. */
-.battlefield-frame--compact { --bf-top-buffer: 74px; --bf-bottom-buffer: 200px; }
-.battlefield-frame--tiny { --bf-top-buffer: 68px; --bf-bottom-buffer: 182px; }
+.battlefield-frame--compact { --bf-top-buffer: 88px; --bf-bottom-buffer: 250px; }
+.battlefield-frame--tiny { --bf-top-buffer: 86px; --bf-bottom-buffer: 244px; }
 
 /* Floating bar clusters: absolutely positioned in the reserved bands above/below
    the lane. Their content can grow/wrap without ever resizing or reflowing the lane. */
@@ -57,13 +64,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 6px;
   flex-wrap: nowrap;
   white-space: nowrap;
   overflow: hidden;
-  padding: 3px 8px;
-  border: 1px solid var(--game-border);
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.02);
+  padding: 4px 8px;
+  border: 1px solid var(--border-edge-dark);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  box-shadow: var(--elevation-raised);
 }
 
 .top-bar--sudden-death {
@@ -154,8 +163,13 @@
   gap: 10px;
   padding: 5px 10px;
   border: 2px solid;
-  border-radius: 3px;
+  border-radius: var(--radius-md);
   font-size: var(--font-base);
+  /* A solid backing so text/pips stay legible over the lane's bright terrain
+     art, which otherwise shows straight through (base-bar had no background
+     at all before #2176). */
+  background: var(--surface-1);
+  box-shadow: var(--elevation-raised);
 }
 
 .base-bar--opponent {
@@ -210,6 +224,32 @@
   overflow: hidden;
 }
 
+/* Below 25% HP: pulsing red glow so a base about to fall reads as urgent,
+   not just "a shorter bar than before". */
+.hp-bar-track--low {
+  border-color: var(--accent-ember);
+  animation: hp-bar-low-pulse 1s ease-in-out infinite;
+}
+@keyframes hp-bar-low-pulse {
+  0%, 100% { box-shadow: 0 0 0 rgba(255, 68, 68, 0); }
+  50%      { box-shadow: 0 0 8px color-mix(in srgb, var(--accent-ember) 70%, transparent); }
+}
+
+/* Brief flash on any HP decrease. */
+.hp-bar-track--flash::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  opacity: 0.55;
+  animation: hp-bar-flash 220ms ease-out;
+  pointer-events: none;
+}
+@keyframes hp-bar-flash {
+  from { opacity: 0.55; }
+  to   { opacity: 0; }
+}
+
 .hp-bar-fill {
   height: 100%;
   transition: width 0.15s ease-out;
@@ -226,20 +266,23 @@
   color: #fff;
   text-shadow: 0 0 3px #000;
   font-weight: bold;
+  font-variant-numeric: tabular-nums;
 }
 
 /* ─── Mana Pips ──────────────────────────────────────── */
 
 .mana-bar {
-  gap: 3px;
+  gap: 4px;
 }
 
+/* Arcane-accent tone rather than the CRT green — mana is magic, not the
+   "friendly" semantic colour, per the epic's palette direction (#2166). */
 .mana-pip {
   display: inline-block;
-  width: 10px;
-  height: 10px;
-  border: 1px solid #33ff33;
-  border-radius: 2px;
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--accent-arcane);
+  border-radius: var(--radius-sm);
   position: relative;
   overflow: hidden;
   vertical-align: middle;
@@ -247,7 +290,8 @@
 }
 
 .mana-pip--full {
-  background: #33ff33;
+  background: var(--accent-arcane);
+  box-shadow: 0 0 4px color-mix(in srgb, var(--accent-arcane) 60%, transparent);
 }
 
 .mana-pip--empty {
@@ -257,6 +301,11 @@
 
 .mana-pip--partial {
   background: transparent;
+  animation: mana-pip-regen-pulse 1.2s ease-in-out infinite;
+}
+@keyframes mana-pip-regen-pulse {
+  0%, 100% { box-shadow: 0 0 0 rgba(0, 0, 0, 0); }
+  50%      { box-shadow: 0 0 5px color-mix(in srgb, var(--accent-arcane) 55%, transparent); }
 }
 
 .mana-pip-fill {
@@ -264,7 +313,7 @@
   position: absolute;
   left: 0; top: 0;
   height: 100%;
-  background: rgba(51, 255, 51, 0.55);
+  background: color-mix(in srgb, var(--accent-arcane) 65%, transparent);
   transition: width 0.1s linear;
 }
 
@@ -435,23 +484,64 @@
   border-radius: 2px;
 }
 
-/* ─── Combat Log ─────────────────────────────────────── */
+/* ─── Combat Log (CombatLogPanel.tsx) ─────────────────── */
 
-.combat-log {
-  flex-shrink: 0;
-  border: 1px solid #222;
-  padding: 4px 8px;
-  max-height: 58px;
-  overflow-y: auto;
-  font-size: var(--font-sm);
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 3px;
+.bf-log-toggle {
+  margin-left: auto;
+}
+.bf-log-toggle--active {
+  color: var(--accent-gold) !important;
+  border-color: var(--accent-gold) !important;
 }
 
-.log-entry {
-  color: #777;
+.bf-log-panel {
+  position: absolute;
+  top: 36px;
+  right: 8px;
+  z-index: 20;
+  width: min(260px, 60vw);
+  max-height: 240px;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-2);
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-overlay);
+  overflow: hidden;
+}
+
+.bf-log-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 4px 4px 8px;
+  font-size: var(--font-xs);
+  letter-spacing: 1px;
+  color: var(--game-text-color-dim);
+  border-bottom: 1px solid var(--border-edge-dark);
+  flex-shrink: 0;
+}
+
+.bf-log-panel-list {
+  overflow-y: auto;
+  padding: 4px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bf-log-entry {
+  font-size: var(--font-xs);
   line-height: 1.5;
 }
+
+/* Colour-coded by best-effort keyword classification (see CombatLogPanel's
+   classify()) — routine ticks stay dim so kills/damage/buffs stand out. */
+.bf-log-entry--important { color: var(--accent-gold); font-weight: bold; }
+.bf-log-entry--kill      { color: var(--accent-ember); }
+.bf-log-entry--damage    { color: var(--color-orange); }
+.bf-log-entry--buff      { color: var(--game-text-color); }
+.bf-log-entry--routine   { color: var(--game-text-color-muted); }
 
 /* ─── Hand Panel ─────────────────────────────────────── */
 
@@ -461,6 +551,7 @@
   padding: 4px 6px;
   border-top: 1px solid var(--game-border);
   flex-shrink: 0;
+  background: var(--surface-1);
 }
 
 .stance-bar .filter-btn {

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -24,6 +24,14 @@
   box-shadow: 0 0 12px rgba(51, 255, 51, 0.3);
 }
 
+/* Press/tap feedback — the hand's only interaction is a tap, so it needs its
+   own acknowledgement distinct from :hover (which touch devices don't fire
+   until after the tap anyway). */
+.card-tile:not(.card-tile--disabled):active {
+  transform: translateY(-1px) scale(0.97);
+  transition-duration: 0.05s;
+}
+
 .card-tile--disabled,
 .fm-hold-btn--blocked,
 .td-selected-action-btn--disabled,
@@ -145,6 +153,13 @@
   font-weight: bold;
   color: #6cf;
   text-shadow: 0 0 6px rgba(100, 200, 255, 0.5);
+}
+
+/* Distinct from the whole-tile disabled dimming — a red cost badge reads as
+   "you can't pay this" specifically, rather than just "inactive". */
+.card-cost--unaffordable {
+  color: var(--accent-ember);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--accent-ember) 50%, transparent);
 }
 
 .card-upgrade-badge {


### PR DESCRIPTION
Resolves #2176 — Phase 2 of the #2165 UI overhaul epic (stacked after #2195/#2175, and Phase 0/1 #2186-#2194).

## Problem

The battlefield HUD was the least-designed part of the game: flat bordered strips in terminal green with no background (text bled straight into the lane's bright terrain art underneath), no urgency signal on HP, 8-10px mana pips, cramped hand cards on mobile, and a dead `.combat-log` CSS class that nothing ever rendered.

## HUD reskin

- **Top bar / base bars / stance bar** all had `background: transparent` or nothing at all — literally see-through onto the lane. Gave all three a `--surface-1` backing + elevation shadow (the #2170 Panel treatment) so score/mana/HP text is actually legible over bright terrain.
- **HP bars**: brief white flash on any HP decrease, pulsing ember border below 25% HP, tabular-nums for the digits. A base at 5% now reads as urgent, not just "a shorter green bar."
- **Mana pips**: moved off the CRT-green palette onto `--accent-arcane` (mana is magic, not the "friendly" semantic colour — #2166's direction), bumped 10px→12px (8px→10px at the mobile breakpoint), and the currently-regenerating pip pulses instead of just popping full silently.
- **Pause/stance/speed controls**: now render through `ui/Button` instead of raw `<button>` elements (kept their existing `.bf-pause-btn`/`.filter-btn` classes layered on top for byte-identical visuals — `battle.css`/`collection.css` still load after `buttons.css`, so those classes keep winning the cascade).

## Combat log — actually wired up

`state.log` has always existed, but only ever got read for `!!`-prefixed important messages (shown as an auto-pause banner). `.combat-log`/`.log-entry` CSS sat dead in `battle.css` since at least #2169's split — zero `.tsx` files referenced them. New **LOG** toggle in the top bar opens a floating panel (doesn't pause the game) showing the most recent 40 entries, colour-coded by a best-effort keyword classifier (entries are free-form engine text with no structured event type — documented as a heuristic in the code, not a source of truth).

## Card hand, for touch

- `.card-tile` was 78px/~8px text at ≤480px, shrinking further below 380px — the game's primary interactive element at roughly 8px font. Bumped to 88px / `--font-xs` title at ≤480px; the ≤380px tier now only tightens padding instead of shrinking text a second time.
- Added `:active` press feedback (the hand's only interaction is a tap; `:hover` doesn't fire until after a touch's own tap anyway).
- Unaffordable cards now get a **red cost badge**, distinct from the whole-tile dimming shared with hero-lock/max-upgrade states.

## Buffer bands — revisited, not just left as magic numbers

The issue flagged `--bf-top-buffer`/`--bf-bottom-buffer` (and the `--compact`/`--tiny` tiers) as magic numbers likely to fight any HUD restyle. They did — and it turned out they already didn't fit *before* this PR: measuring actual rendered cluster height in a real battle showed the bottom cluster was **35-41px taller** than its reserved band pre-existing (confirmed by testing the same measurement against `main`), and my larger cards/reskinned surfaces made it worse (43-59px). Retuned all three tiers from real measurements with a small safety margin — verified `overlapsLane: false` (a script-measured DOM check, not just eyeballing) at 370px/470px/1400px viewport widths afterward. Also discovered `BATTLEFIELD_ASPECT_RATIO` (9:19.5, portrait) means the "default" (non-compact) tier is essentially never hit on real screens — documented that in the CSS comment for the next person who touches this.

## Sub-components (per `AGENTS.md`'s convention)

`HpBar`, `ManaBar`, and `BaseBar` were local functions/inline JSX inside `Battlefield.tsx` with no stories; `TopBar`, `StanceBar`, and `CombatLogPanel` didn't exist as separate pieces at all. All six now live under `components/battle/battlefield/`, each pure-visual (props only) with its own `.stories.tsx`.

## Verified in a real browser — build/test alone can't catch this

Per the issue's own note, copied `web/.env.test` to `web/.env.local` (not committed) to get Storybook/dev-server Firebase init working, then:

- Played an actual live Training Mode battle (not just a Storybook fixture) at 370px/470px/1400px viewports, screenshotting each
- Used `page.evaluate()` to measure real DOM rects for the lane/cluster overlap check described above, both before and after the buffer-band fix, and against `main` to separate the pre-existing bug from what my changes added
- Screenshotted `HpBar`'s Low/Critical stories to confirm the danger-pulse border renders
- Clicked the LOG toggle in a live battle and confirmed the panel opens/closes and colour-codes a real log entry
- Screenshotted `CardTile`'s `CanAffordFalse` story to confirm the red cost badge

## Test plan

- [x] HUD reads clearly during an actual battle (verified above, not just in isolation)
- [x] Card hand tiles/text meaningfully larger at 380px, checked in a real running battle
- [x] Damage flash, low-HP pulse, and mana regen states are visually distinct (screenshotted)
- [x] Lane keeps its fixed aspect ratio; HUD content growth no longer reflows/overlaps it (measured, not just eyeballed — includes a pre-existing overlap this PR also fixes)
- [x] Sub-components extracted with stories per `AGENTS.md` (6 new components)
- [x] `npm run build`, `npx tsc --noEmit`, `npm run test` (2861/2861) all pass clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_