### PR TITLE
[UI 2.4] Collection and deck builder visual pass

### DIFF
--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -30,11 +30,15 @@ import {
 } from '../../game/collection'
 import { CardTile } from './CardTile'
 import { MasteryBar } from '../ui/MasteryBar'
+import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { useCardDetail } from './useCardDetail'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { ProgressBar } from '../ui/ProgressBar'
 import { TutorialOverlay } from '../modals/TutorialOverlay'
 import { hasSeen, markSeen } from '../../game/tutorial'
+import { FilterPopup } from '../ui/filters/FilterPopup'
+import { FilterOption } from '../ui/filters/FilterOption'
+import { FilterPill } from '../ui/filters/FilterPill'
 
 const DECK_TUTORIAL_ID = 'deckbuilder'
 const DECK_TUTORIAL_STEPS = [
@@ -196,46 +200,7 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
   const [affinityFilter, setAffinityFilter] = useState<string | null>(null)
   const [sortKey, setSortKey]             = useState<SortKey>('default')
   const [groupKey, setGroupKey]           = useState<GroupKey>('none')
-  const [filterMenuOpen, setFilterMenuOpen] = useState(false)
-  const [sortMenuOpen, setSortMenuOpen]     = useState(false)
-  const [groupMenuOpen, setGroupMenuOpen]   = useState(false)
-  const filterMenuRef = useRef<HTMLDivElement>(null)
-  const sortMenuRef   = useRef<HTMLDivElement>(null)
-  const groupMenuRef  = useRef<HTMLDivElement>(null)
-
-  // Close dropdowns on outside click
-  useEffect(() => {
-    if (!filterMenuOpen) return
-    function handleClick(e: MouseEvent) {
-      if (filterMenuRef.current && !filterMenuRef.current.contains(e.target as Node)) {
-        setFilterMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [filterMenuOpen])
-
-  useEffect(() => {
-    if (!sortMenuOpen) return
-    function handleClick(e: MouseEvent) {
-      if (sortMenuRef.current && !sortMenuRef.current.contains(e.target as Node)) {
-        setSortMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [sortMenuOpen])
-
-  useEffect(() => {
-    if (!groupMenuOpen) return
-    function handleClick(e: MouseEvent) {
-      if (groupMenuRef.current && !groupMenuRef.current.contains(e.target as Node)) {
-        setGroupMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [groupMenuOpen])
+  const [openMenu, setOpenMenu] = useState<'filters' | 'sort' | 'group' | null>(null)
 
   // Affinity label → card name set (both sides of each pair)
   const allAffinityLabels = useMemo(() =>
@@ -658,166 +623,137 @@ setCollectionCollapsed(true)
               {/* Filter / Sort / Group bar */}
               <div className="filter-bar">
                 {/* FILTERS */}
-                <div className="filter-popup-wrap" ref={filterMenuRef}>
-                  <button
-                    className={`filter-btn${activeFilterCount > 0 ? ' filter-btn--active' : ''}`}
-                    onClick={() => { setFilterMenuOpen(o => !o); setSortMenuOpen(false); setGroupMenuOpen(false) }}
-                  >
-                    ▼ FILTERS{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
-                  </button>
-                  {filterMenuOpen && (
-                    <div className="filter-popup">
-                      <div className="filter-popup-section u-col">
-                        <span className="filter-group-label">TYPE</span>
-                        <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                          {(['all', 'unit', 'structure', 'upgrade'] as const).map(val => (
-                            <button
-                              key={val}
-                              className={`filter-btn filter-btn--sm${typeFilter === val ? ' filter-btn--active' : ''}`}
-                              onClick={() => setTypeFilter(val)}
-                            >
-                              {val === 'all' ? 'All' : val.charAt(0).toUpperCase() + val.slice(1) + 's'}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                      <div className="filter-popup-section u-col">
-                        <span className="filter-group-label">RARITY</span>
-                        <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                          {(['all', 'common', 'uncommon', 'rare', 'legendary'] as const).map(val => (
-                            <button
-                              key={val}
-                              className={`filter-btn filter-btn--sm${rarityFilter === val ? ' filter-btn--active' : ''}`}
-                              onClick={() => setRarityFilter(val)}
-                            >
-                              {val.charAt(0).toUpperCase() + val.slice(1)}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                      <div className="filter-popup-section u-col">
-                        <span className="filter-group-label">TAGS <span className="filter-group-hint">(any match)</span></span>
-                        <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                          {ALL_TAGS.map(tag => (
-                            <button
-                              key={tag}
-                              className={`filter-btn filter-btn--sm${tagFilter.includes(tag) ? ' filter-btn--active' : ''}`}
-                              onClick={() => toggleTag(tag)}
-                            >
-                              {tag}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                      {allAffinityLabels.length > 0 && (
-                        <div className="filter-popup-section u-col">
-                          <span className="filter-group-label">AFFINITY</span>
-                          <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                            {allAffinityLabels.map(label => (
-                              <button
-                                key={label}
-                                className={`filter-btn filter-btn--sm${affinityFilter === label ? ' filter-btn--active' : ''}`}
-                                onClick={() => setAffinityFilter(prev => prev === label ? null : label)}
-                              >
-                                {label}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                      {activeFilterCount > 0 && (
-                        <div className="filter-popup-footer">
-                          <button className="filter-btn filter-btn--sm filter-btn--reset" onClick={resetFilters}>
-                            ✕ Clear all filters
-                          </button>
-                        </div>
-                      )}
+                <FilterPopup
+                  label="▼ FILTERS"
+                  activeSuffix={activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+                  isActive={activeFilterCount > 0}
+                  open={openMenu === 'filters'}
+                  onToggle={() => setOpenMenu(m => m === 'filters' ? null : 'filters')}
+                  onClose={() => setOpenMenu(m => m === 'filters' ? null : m)}
+                  footer={activeFilterCount > 0 && (
+                    <div className="filter-popup-footer">
+                      <button className="filter-btn filter-btn--sm filter-btn--reset" onClick={resetFilters}>
+                        ✕ Clear all filters
+                      </button>
                     </div>
                   )}
-                </div>
+                >
+                  <div className="filter-popup-section u-col">
+                    <span className="filter-group-label">TYPE</span>
+                    <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+                      {(['all', 'unit', 'structure', 'upgrade'] as const).map(val => (
+                        <FilterOption key={val} active={typeFilter === val} onClick={() => setTypeFilter(val)}>
+                          {val === 'all' ? 'All' : val.charAt(0).toUpperCase() + val.slice(1) + 's'}
+                        </FilterOption>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="filter-popup-section u-col">
+                    <span className="filter-group-label">RARITY</span>
+                    <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+                      {(['all', 'common', 'uncommon', 'rare', 'legendary'] as const).map(val => (
+                        <FilterOption key={val} active={rarityFilter === val} onClick={() => setRarityFilter(val)}>
+                          {val.charAt(0).toUpperCase() + val.slice(1)}
+                        </FilterOption>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="filter-popup-section u-col">
+                    <span className="filter-group-label">TAGS <span className="filter-group-hint">(any match)</span></span>
+                    <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+                      {ALL_TAGS.map(tag => (
+                        <FilterOption key={tag} active={tagFilter.includes(tag)} onClick={() => toggleTag(tag)}>
+                          {tag}
+                        </FilterOption>
+                      ))}
+                    </div>
+                  </div>
+                  {allAffinityLabels.length > 0 && (
+                    <div className="filter-popup-section u-col">
+                      <span className="filter-group-label">AFFINITY</span>
+                      <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+                        {allAffinityLabels.map(label => (
+                          <FilterOption
+                            key={label}
+                            active={affinityFilter === label}
+                            onClick={() => setAffinityFilter(prev => prev === label ? null : label)}
+                          >
+                            {label}
+                          </FilterOption>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </FilterPopup>
 
                 {/* SORT */}
-                <div className="filter-popup-wrap" ref={sortMenuRef}>
-                  <button
-                    className={`filter-btn${sortKey !== 'default' ? ' filter-btn--active' : ''}`}
-                    onClick={() => { setSortMenuOpen(o => !o); setFilterMenuOpen(false); setGroupMenuOpen(false) }}
-                  >
-                    ↕ SORT{sortKey !== 'default' ? ` (${sortKey})` : ''}
-                  </button>
-                  {sortMenuOpen && (
-                    <div className="filter-popup">
-                      <div className="filter-popup-section u-col">
-                        <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                          {([
-                            ['default',   'Default'],
-                            ['az',        'A → Z'],
-                            ['za',        'Z → A'],
-                            ['mana-asc',  'Mana ↑'],
-                            ['mana-desc', 'Mana ↓'],
-                            ['rarity',    'Rarity'],
-                            ['synergy',   '⚡ Synergy'],
-                          ] as [SortKey, string][]).map(([val, label]) => (
-                            <button
-                              key={val}
-                              className={`filter-btn filter-btn--sm${sortKey === val ? ' filter-btn--active' : ''}`}
-                              onClick={() => setSortKey(val)}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
+                <FilterPopup
+                  label="↕ SORT"
+                  activeSuffix={sortKey !== 'default' ? ` (${sortKey})` : ''}
+                  isActive={sortKey !== 'default'}
+                  open={openMenu === 'sort'}
+                  onToggle={() => setOpenMenu(m => m === 'sort' ? null : 'sort')}
+                  onClose={() => setOpenMenu(m => m === 'sort' ? null : m)}
+                >
+                  <div className="filter-popup-section u-col">
+                    <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+                      {([
+                        ['default',   'Default'],
+                        ['az',        'A → Z'],
+                        ['za',        'Z → A'],
+                        ['mana-asc',  'Mana ↑'],
+                        ['mana-desc', 'Mana ↓'],
+                        ['rarity',    'Rarity'],
+                        ['synergy',   '⚡ Synergy'],
+                      ] as [SortKey, string][]).map(([val, label]) => (
+                        <FilterOption key={val} active={sortKey === val} onClick={() => setSortKey(val)}>
+                          {label}
+                        </FilterOption>
+                      ))}
                     </div>
-                  )}
-                </div>
+                  </div>
+                </FilterPopup>
 
                 {/* GROUP */}
-                <div className="filter-popup-wrap" ref={groupMenuRef}>
-                  <button
-                    className={`filter-btn${groupKey !== 'none' ? ' filter-btn--active' : ''}`}
-                    onClick={() => { setGroupMenuOpen(o => !o); setFilterMenuOpen(false); setSortMenuOpen(false) }}
-                  >
-                    ⊞ GROUP{groupKey !== 'none' ? ` (${groupKey})` : ''}
-                  </button>
-                  {groupMenuOpen && (
-                    <div className="filter-popup">
-                      <div className="filter-popup-section u-col">
-                        <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                          {([
-                            ['none',    'None'],
-                            ['type',    'Type'],
-                            ['rarity',  'Rarity'],
-                            ['mana',    'Mana'],
-                            ['act',     'Act'],
-                          ] as [GroupKey, string][]).map(([val, label]) => (
-                            <button
-                              key={val}
-                              className={`filter-btn filter-btn--sm${groupKey === val ? ' filter-btn--active' : ''}`}
-                              onClick={() => setGroupKey(val)}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
+                <FilterPopup
+                  label="⊞ GROUP"
+                  activeSuffix={groupKey !== 'none' ? ` (${groupKey})` : ''}
+                  isActive={groupKey !== 'none'}
+                  open={openMenu === 'group'}
+                  onToggle={() => setOpenMenu(m => m === 'group' ? null : 'group')}
+                  onClose={() => setOpenMenu(m => m === 'group' ? null : m)}
+                >
+                  <div className="filter-popup-section u-col">
+                    <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+                      {([
+                        ['none',    'None'],
+                        ['type',    'Type'],
+                        ['rarity',  'Rarity'],
+                        ['mana',    'Mana'],
+                        ['act',     'Act'],
+                      ] as [GroupKey, string][]).map(([val, label]) => (
+                        <FilterOption key={val} active={groupKey === val} onClick={() => setGroupKey(val)}>
+                          {label}
+                        </FilterOption>
+                      ))}
                     </div>
-                  )}
-                </div>
+                  </div>
+                </FilterPopup>
 
                 {/* Active filter pills */}
                 {activeFilterCount > 0 && (
                   <div className="filter-active-pills u-flex u-gap-2 u-grow u-items-c">
                     {typeFilter !== 'all' && (
-                      <span className="filter-pill">{typeFilter}s <button onClick={() => setTypeFilter('all')}>✕</button></span>
+                      <FilterPill onRemove={() => setTypeFilter('all')}>{typeFilter}s</FilterPill>
                     )}
                     {rarityFilter !== 'all' && (
-                      <span className="filter-pill">{rarityFilter} <button onClick={() => setRarityFilter('all')}>✕</button></span>
+                      <FilterPill onRemove={() => setRarityFilter('all')}>{rarityFilter}</FilterPill>
                     )}
                     {tagFilter.map(t => (
-                      <span key={t} className="filter-pill">{t} <button onClick={() => toggleTag(t)}>✕</button></span>
+                      <FilterPill key={t} onRemove={() => toggleTag(t)}>{t}</FilterPill>
                     ))}
                     {affinityFilter && (
-                      <span className="filter-pill">affinity:{affinityFilter} <button onClick={() => setAffinityFilter(null)}>✕</button></span>
+                      <FilterPill onRemove={() => setAffinityFilter(null)}>affinity:{affinityFilter}</FilterPill>
                     )}
                   </div>
                 )}
@@ -832,7 +768,8 @@ setCollectionCollapsed(true)
                       const owned   = getOwnedCount(collection, card.name)
                       const inDeck  = inDeckCount(card.name)
                       const resting = fatiguedCards.includes(card.name)
-                      const canAdd  = inDeck < Math.min(owned, COPIES_MAX) && total < playerDeckMax
+                      const atCopyLimit = owned > 0 && inDeck >= Math.min(owned, COPIES_MAX)
+                      const canAdd  = !atCopyLimit && total < playerDeckMax
                       const xp      = getMasteryXp(collection, card.name)
                       const { level: lvl } = masteryProgress(xp)
                       const label   = groupLabel(card)
@@ -855,16 +792,19 @@ setCollectionCollapsed(true)
                               <span className="cell-count">
                                 {resting
                                   ? <><span className="cell-resting-label">💤</span> {inDeck}/{owned}</>
-                                  : <>{inDeck}/{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}</>
+                                  : <>
+                                      {inDeck}/{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
+                                      {atCopyLimit && <span className="cell-copy-limit-badge">MAX</span>}
+                                    </>
                                 }
                               </span>
+                              {xp > 0 && <MasteryBar xp={xp} />}
                               <button
                                 className="extra-btn cdm-info-btn"
                                 onClick={e => { e.stopPropagation(); openDetail(card) }}
                                 title="Card details"
                               >ⓘ</button>
                             </div>
-                            {xp > 0 && <MasteryBar xp={xp} />}
                           </div>
                         </React.Fragment>
                       )
@@ -880,8 +820,8 @@ setCollectionCollapsed(true)
 
       {/* ── Auto-build modal ── */}
       {showAutoBuild && (
-        <div className="autobuild-backdrop" onClick={() => setShowAutoBuild(false)}>
-          <div className="autobuild-panel" onClick={e => e.stopPropagation()}>
+        <ModalBackdrop onClose={() => setShowAutoBuild(false)} title="Auto Build">
+          <div className="autobuild-panel">
             <div>
               <div className="autobuild-title">⚡ AUTO BUILD</div>
               <div className="autobuild-sub">
@@ -905,13 +845,13 @@ setCollectionCollapsed(true)
               CANCEL
             </button>
           </div>
-        </div>
+        </ModalBackdrop>
       )}
 
       {/* ── Saved Decks modal ── */}
       {showSavedDecks && (
-        <div className="autobuild-backdrop" onClick={() => setShowSavedDecks(false)}>
-          <div className="autobuild-panel saveddecks-panel" onClick={e => e.stopPropagation()}>
+        <ModalBackdrop onClose={() => setShowSavedDecks(false)} title="Saved Decks">
+          <div className="autobuild-panel saveddecks-panel">
             <div className="autobuild-title">💾 SAVED DECKS</div>
             {savedDecks.length === 0 ? (
               <div className="saveddecks-empty">No saved decks yet.</div>
@@ -950,13 +890,13 @@ setCollectionCollapsed(true)
               CLOSE
             </button>
           </div>
-        </div>
+        </ModalBackdrop>
       )}
 
       {/* ── Share modal ── */}
       {showShare && (
-        <div className="autobuild-backdrop" onClick={() => setShowShare(false)}>
-          <div className="autobuild-panel share-panel" onClick={e => e.stopPropagation()}>
+        <ModalBackdrop onClose={() => setShowShare(false)} title="Share Deck">
+          <div className="autobuild-panel share-panel">
             <div className="autobuild-title">🔗 SHARE DECK</div>
             <div className="share-section u-col u-gap-3">
               <div className="share-label">EXPORT — copy this code and share it:</div>
@@ -999,7 +939,7 @@ setCollectionCollapsed(true)
               CLOSE
             </button>
           </div>
-        </div>
+        </ModalBackdrop>
       )}
 
       {cardDetailNode}

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -13,6 +13,7 @@ import {
   disenchantAllExtras,
   masterAllExtras,
   syncDeckToCollection,
+  getCollectionCompletion,
   CollectionEntry,
   DISENCHANT_VALUE,
   COPIES_MAX,
@@ -26,7 +27,11 @@ import { OverlayScreen } from '../ui/OverlayScreen'
 import { MasteryBar } from '../ui/MasteryBar'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { Button } from '../ui/Button'
+import { ProgressBar } from '../ui/ProgressBar'
 import { useToast } from '../ui/Toast'
+import { FilterPopup } from '../ui/filters/FilterPopup'
+import { FilterOption } from '../ui/filters/FilterOption'
+import { FilterPill } from '../ui/filters/FilterPill'
 
 interface Props {
   crystals: number
@@ -97,55 +102,18 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const [affinityFilter, setAffinityFilter] = useState<AffinityFilter | null>(null)
   const [sortKey,  setSortKey]  = useState<SortKey>('default')
   const [groupKey, setGroupKey] = useState<GroupKey>('none')
-  const [filterMenuOpen, setFilterMenuOpen] = useState(false)
-  const [sortMenuOpen,   setSortMenuOpen]   = useState(false)
-  const [groupMenuOpen,  setGroupMenuOpen]  = useState(false)
+  const [openMenu, setOpenMenu] = useState<'filters' | 'sort' | 'group' | null>(null)
   const [upgradeModal, setUpgradeModal] = useState<Array<{cardName: string, xpGained: number}> | null>(null)
   const [disenchantModal, setDisenchantModal] = useState<Array<{cardName: string, crystals: number}> | null>(null)
   const [detailCard, setDetailCard] = useState<import('../../game/types').Card | null>(null)
   const [augmentCard, setAugmentCard] = useState<import('../../game/types').Card | null>(null)
   const [levelUpCard, setLevelUpCard] = useState<string | null>(null)
   const legendaryViewCount = useRef(0)
-  const filterMenuRef = useRef<HTMLDivElement>(null)
-  const sortMenuRef   = useRef<HTMLDivElement>(null)
-  const groupMenuRef  = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!filterMenuOpen) return
-    function handleClick(e: MouseEvent) {
-      if (filterMenuRef.current && !filterMenuRef.current.contains(e.target as Node)) {
-        setFilterMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [filterMenuOpen])
-
-  useEffect(() => {
-    if (!sortMenuOpen) return
-    function handleClick(e: MouseEvent) {
-      if (sortMenuRef.current && !sortMenuRef.current.contains(e.target as Node)) {
-        setSortMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [sortMenuOpen])
-
-  useEffect(() => {
-    if (!groupMenuOpen) return
-    function handleClick(e: MouseEvent) {
-      if (groupMenuRef.current && !groupMenuRef.current.contains(e.target as Node)) {
-        setGroupMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [groupMenuOpen])
 
   const totalOwned  = collection.reduce((s, e) => s + e.count, 0)
   const totalExtras = collection.reduce((s, e) => s + Math.max(0, e.count - COPIES_MAX), 0)
   const totalUpgradeable = collection.reduce((s, e) => s + (Math.max(0, e.count - COPIES_MAX) > 0 ? 1 : 0), 0)
+  const { distinctOwned, pct: completionPct } = getCollectionCompletion(collection)
 
   const filtered = catalog.filter(c => {
     // Secret rarities are hidden until the player has obtained at least one copy —
@@ -344,196 +312,169 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
       {/* Filter / Sort / Group bar */}
       <div className="filter-bar">
         {/* FILTERS */}
-        <div className="filter-popup-wrap" ref={filterMenuRef}>
-          <button
-            className={`filter-btn${activeFilterCount > 0 ? ' filter-btn--active' : ''}`}
-            onClick={() => { setFilterMenuOpen(o => !o); setSortMenuOpen(false); setGroupMenuOpen(false) }}
-          >
-            ▼ FILTERS{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
-          </button>
-
-          {filterMenuOpen && (
-            <div className="filter-popup">
-              {/* TYPE */}
-              <div className="filter-popup-section u-col">
-                <span className="filter-group-label">TYPE</span>
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  {(['all', 'unit', 'structure', 'upgrade'] as const).map(val => (
-                    <button
-                      key={val}
-                      className={`filter-btn filter-btn--sm${typeFilter === val ? ' filter-btn--active' : ''}`}
-                      onClick={() => setTypeFilter(val)}
-                    >
-                      {val === 'all' ? 'All' : val.charAt(0).toUpperCase() + val.slice(1) + 's'}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* RARITY */}
-              <div className="filter-popup-section u-col">
-                <span className="filter-group-label">RARITY</span>
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  {(['all', 'common', 'uncommon', 'rare', 'legendary'] as const).map(val => (
-                    <button
-                      key={val}
-                      className={`filter-btn filter-btn--sm${rarityFilter === val ? ' filter-btn--active' : ''}`}
-                      onClick={() => setRarityFilter(val)}
-                    >
-                      {val.charAt(0).toUpperCase() + val.slice(1)}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* TAGS */}
-              <div className="filter-popup-section u-col">
-                <span className="filter-group-label">TAGS <span className="filter-group-hint">(any match)</span></span>
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  {ALL_TAGS.map(tag => (
-                    <button
-                      key={tag}
-                      className={`filter-btn filter-btn--sm${tagFilter.includes(tag) ? ' filter-btn--active' : ''}`}
-                      onClick={() => toggleTag(tag)}
-                    >
-                      {tag}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* AFFINITY */}
-              <div className="filter-popup-section u-col">
-                <span className="filter-group-label">AFFINITY</span>
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  {allAffinityLabels.map(label => (
-                    <button
-                      key={label}
-                      className={`filter-btn filter-btn--sm${affinityFilter === label ? ' filter-btn--active' : ''}`}
-                      onClick={() => setAffinityFilter(prev => prev === label ? null : label)}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* SPECIAL */}
-              <div className="filter-popup-section u-col">
-                <span className="filter-group-label">SPECIAL</span>
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  <button
-                    className={`filter-btn filter-btn--sm${specialFilter === 'upgradeable' ? ' filter-btn--active filter-btn--gold' : ''}`}
-                    onClick={() => setSpecialFilter(prev => prev === 'upgradeable' ? null : 'upgradeable')}
-                  >
-                    ★ Upgradeable
-                  </button>
-                </div>
-              </div>
-
-              {/* Reset */}
-              {activeFilterCount > 0 && (
-                <div className="filter-popup-footer">
-                  <button className="filter-btn filter-btn--sm filter-btn--reset" onClick={resetFilters}>
-                    ✕ Clear all filters
-                  </button>
-                </div>
-              )}
+        <FilterPopup
+          label="▼ FILTERS"
+          activeSuffix={activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+          isActive={activeFilterCount > 0}
+          open={openMenu === 'filters'}
+          onToggle={() => setOpenMenu(m => m === 'filters' ? null : 'filters')}
+          onClose={() => setOpenMenu(m => m === 'filters' ? null : m)}
+          footer={activeFilterCount > 0 && (
+            <div className="filter-popup-footer">
+              <button className="filter-btn filter-btn--sm filter-btn--reset" onClick={resetFilters}>
+                ✕ Clear all filters
+              </button>
             </div>
           )}
-        </div>
+        >
+          {/* TYPE */}
+          <div className="filter-popup-section u-col">
+            <span className="filter-group-label">TYPE</span>
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              {(['all', 'unit', 'structure', 'upgrade'] as const).map(val => (
+                <FilterOption key={val} active={typeFilter === val} onClick={() => setTypeFilter(val)}>
+                  {val === 'all' ? 'All' : val.charAt(0).toUpperCase() + val.slice(1) + 's'}
+                </FilterOption>
+              ))}
+            </div>
+          </div>
+
+          {/* RARITY */}
+          <div className="filter-popup-section u-col">
+            <span className="filter-group-label">RARITY</span>
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              {(['all', 'common', 'uncommon', 'rare', 'legendary'] as const).map(val => (
+                <FilterOption key={val} active={rarityFilter === val} onClick={() => setRarityFilter(val)}>
+                  {val.charAt(0).toUpperCase() + val.slice(1)}
+                </FilterOption>
+              ))}
+            </div>
+          </div>
+
+          {/* TAGS */}
+          <div className="filter-popup-section u-col">
+            <span className="filter-group-label">TAGS <span className="filter-group-hint">(any match)</span></span>
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              {ALL_TAGS.map(tag => (
+                <FilterOption key={tag} active={tagFilter.includes(tag)} onClick={() => toggleTag(tag)}>
+                  {tag}
+                </FilterOption>
+              ))}
+            </div>
+          </div>
+
+          {/* AFFINITY */}
+          <div className="filter-popup-section u-col">
+            <span className="filter-group-label">AFFINITY</span>
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              {allAffinityLabels.map(label => (
+                <FilterOption
+                  key={label}
+                  active={affinityFilter === label}
+                  onClick={() => setAffinityFilter(prev => prev === label ? null : label)}
+                >
+                  {label}
+                </FilterOption>
+              ))}
+            </div>
+          </div>
+
+          {/* SPECIAL */}
+          <div className="filter-popup-section u-col">
+            <span className="filter-group-label">SPECIAL</span>
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              <FilterOption
+                active={specialFilter === 'upgradeable'}
+                gold={specialFilter === 'upgradeable'}
+                onClick={() => setSpecialFilter(prev => prev === 'upgradeable' ? null : 'upgradeable')}
+              >
+                ★ Upgradeable
+              </FilterOption>
+            </div>
+          </div>
+        </FilterPopup>
 
         {/* SORT */}
-        <div className="filter-popup-wrap" ref={sortMenuRef}>
-          <button
-            className={`filter-btn${sortKey !== 'default' ? ' filter-btn--active' : ''}`}
-            onClick={() => { setSortMenuOpen(o => !o); setFilterMenuOpen(false); setGroupMenuOpen(false) }}
-          >
-            ↕ SORT{sortKey !== 'default' ? ` (${sortKey})` : ''}
-          </button>
-
-          {sortMenuOpen && (
-            <div className="filter-popup">
-              <div className="filter-popup-section u-col">
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  {([
-                    ['default',   'Default'],
-                    ['az',        'A → Z'],
-                    ['za',        'Z → A'],
-                    ['mana-asc',  'Mana ↑'],
-                    ['mana-desc', 'Mana ↓'],
-                    ['rarity',    'Rarity'],
-                  ] as [SortKey, string][]).map(([val, label]) => (
-                    <button
-                      key={val}
-                      className={`filter-btn filter-btn--sm${sortKey === val ? ' filter-btn--active' : ''}`}
-                      onClick={() => setSortKey(val)}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
+        <FilterPopup
+          label="↕ SORT"
+          activeSuffix={sortKey !== 'default' ? ` (${sortKey})` : ''}
+          isActive={sortKey !== 'default'}
+          open={openMenu === 'sort'}
+          onToggle={() => setOpenMenu(m => m === 'sort' ? null : 'sort')}
+          onClose={() => setOpenMenu(m => m === 'sort' ? null : m)}
+        >
+          <div className="filter-popup-section u-col">
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              {([
+                ['default',   'Default'],
+                ['az',        'A → Z'],
+                ['za',        'Z → A'],
+                ['mana-asc',  'Mana ↑'],
+                ['mana-desc', 'Mana ↓'],
+                ['rarity',    'Rarity'],
+              ] as [SortKey, string][]).map(([val, label]) => (
+                <FilterOption key={val} active={sortKey === val} onClick={() => setSortKey(val)}>
+                  {label}
+                </FilterOption>
+              ))}
             </div>
-          )}
-        </div>
+          </div>
+        </FilterPopup>
 
         {/* GROUP */}
-        <div className="filter-popup-wrap" ref={groupMenuRef}>
-          <button
-            className={`filter-btn${groupKey !== 'none' ? ' filter-btn--active' : ''}`}
-            onClick={() => { setGroupMenuOpen(o => !o); setFilterMenuOpen(false); setSortMenuOpen(false) }}
-          >
-            ⊞ GROUP{groupKey !== 'none' ? ` (${groupKey})` : ''}
-          </button>
-
-          {groupMenuOpen && (
-            <div className="filter-popup">
-              <div className="filter-popup-section u-col">
-                <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-                  {([
-                    ['none',    'None'],
-                    ['type',    'Type'],
-                    ['rarity',  'Rarity'],
-                    ['mana',    'Mana'],
-                    ['act',     'Act'],
-                  ] as [GroupKey, string][]).map(([val, label]) => (
-                    <button
-                      key={val}
-                      className={`filter-btn filter-btn--sm${groupKey === val ? ' filter-btn--active' : ''}`}
-                      onClick={() => setGroupKey(val)}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
+        <FilterPopup
+          label="⊞ GROUP"
+          activeSuffix={groupKey !== 'none' ? ` (${groupKey})` : ''}
+          isActive={groupKey !== 'none'}
+          open={openMenu === 'group'}
+          onToggle={() => setOpenMenu(m => m === 'group' ? null : 'group')}
+          onClose={() => setOpenMenu(m => m === 'group' ? null : m)}
+        >
+          <div className="filter-popup-section u-col">
+            <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+              {([
+                ['none',    'None'],
+                ['type',    'Type'],
+                ['rarity',  'Rarity'],
+                ['mana',    'Mana'],
+                ['act',     'Act'],
+              ] as [GroupKey, string][]).map(([val, label]) => (
+                <FilterOption key={val} active={groupKey === val} onClick={() => setGroupKey(val)}>
+                  {label}
+                </FilterOption>
+              ))}
             </div>
-          )}
-        </div>
+          </div>
+        </FilterPopup>
 
         {/* Active filter pills */}
         {activeFilterCount > 0 && (
           <div className="filter-active-pills u-flex u-gap-2 u-grow u-items-c">
             {typeFilter !== 'all' && (
-              <span className="filter-pill">{typeFilter}s <button onClick={() => setTypeFilter('all')}>✕</button></span>
+              <FilterPill onRemove={() => setTypeFilter('all')}>{typeFilter}s</FilterPill>
             )}
             {rarityFilter !== 'all' && (
-              <span className="filter-pill">{rarityFilter} <button onClick={() => setRarityFilter('all')}>✕</button></span>
+              <FilterPill onRemove={() => setRarityFilter('all')}>{rarityFilter}</FilterPill>
             )}
             {tagFilter.map(t => (
-              <span key={t} className="filter-pill">{t} <button onClick={() => toggleTag(t)}>✕</button></span>
+              <FilterPill key={t} onRemove={() => toggleTag(t)}>{t}</FilterPill>
             ))}
             {affinityFilter && (
-              <span className="filter-pill">affinity:{affinityFilter} <button onClick={() => setAffinityFilter(null)}>✕</button></span>
+              <FilterPill onRemove={() => setAffinityFilter(null)}>affinity:{affinityFilter}</FilterPill>
             )}
             {specialFilter && (
-              <span className="filter-pill">★upgradeable <button onClick={() => setSpecialFilter(null)}>✕</button></span>
+              <FilterPill onRemove={() => setSpecialFilter(null)}>★upgradeable</FilterPill>
             )}
           </div>
         )}
 
         <span className="filter-owned">{filtered.length} cards</span>
+      </div>
+
+      {/* Collection progress */}
+      <div className="collection-progress u-flex u-items-c u-gap-3">
+        <ProgressBar pct={completionPct} className="collection-progress-bar" />
+        <span className="collection-progress-label">{distinctOwned}/{catalog.length} discovered ({completionPct}%)</span>
       </div>
 
       {/* Grid */}
@@ -581,9 +522,8 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
                       : <span className="cell-count">
                           ×{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
                         </span>}
+                    {xp > 0 && <MasteryBar xp={xp} />}
                   </div>
-
-                  {xp > 0 && <MasteryBar xp={xp} />}
                 </LazyCell>
               </React.Fragment>
             )

--- a/web/src/components/title/TitleScreen.tsx
+++ b/web/src/components/title/TitleScreen.tsx
@@ -1,8 +1,7 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react'
 import { type User } from 'firebase/auth'
-import { loadDeck, loadCollection, deckTotalCards, isDeckValid, COPIES_MAX, loadWinStreak, loadBestStreak } from '../../game/collection'
+import { loadDeck, loadCollection, deckTotalCards, isDeckValid, COPIES_MAX, loadWinStreak, loadBestStreak, getCollectionCompletion } from '../../game/collection'
 import { loadPlayerName, loadRunRaw } from '../../game/questline'
-import { getCardCatalog } from '../../game/cards'
 import { hasUnclaimedAchievements } from '../../game/achievements'
 import { getDailyShopSellSlots } from '../../game/shopSchedule'
 import { loadInventory } from '../../game/dailyLogin'
@@ -90,9 +89,7 @@ export function TitleScreen({ crystals, onPlay, onEndless, onCampaign, onCollect
   const collection       = loadCollection()
   const totalOwned       = collection.reduce((s, e) => s + e.count, 0)
   const campaignUnlocked = savedRun !== null || totalOwned >= CAMPAIGN_UNLOCK_CARDS
-  const catalog             = getCardCatalog()
-  const distinctUnlocked    = collection.filter(e => e.count > 0 && catalog.some(c => c.name === e.cardName)).length
-  const catalogTotal        = catalog.length
+  const { distinctOwned: distinctUnlocked, catalogTotal } = getCollectionCompletion(collection)
   const achievementAlert    = hasUnclaimedAchievements()
   const collectionAlert     = collection.some(e => e.count > COPIES_MAX)
   const shopAlert           = (() => { const inv = loadInventory(); return getDailyShopSellSlots().some(s => inv.some(i => i.id === s.id)) })()

--- a/web/src/components/ui/filters/FilterOption.stories.tsx
+++ b/web/src/components/ui/filters/FilterOption.stories.tsx
@@ -1,0 +1,19 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { FilterOption } from './FilterOption';
+
+const meta = {
+  component: FilterOption,
+  parameters: { layout: 'centered' },
+  title: 'UI/Filters/FilterOption',
+  decorators: [(Story) => <div style={{ background: 'var(--game-bg)', padding: 20, display: 'flex', gap: 8 }}><Story /></div>],
+} satisfies Meta<typeof FilterOption>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Inactive: Story = { args: { active: false, onClick: fn(), children: 'Common' } };
+export const Active: Story = { args: { active: true, onClick: fn(), children: 'Common' } };
+export const GoldActive: Story = { args: { active: true, gold: true, onClick: fn(), children: '★ Upgradeable' } };

--- a/web/src/components/ui/filters/FilterOption.tsx
+++ b/web/src/components/ui/filters/FilterOption.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+interface Props {
+  active: boolean
+  gold?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}
+
+/** One selectable option inside a FilterPopup (TYPE/RARITY/SORT/... rows). */
+export function FilterOption({ active, gold, onClick, children }: Props) {
+  return (
+    <button
+      className={`filter-btn filter-btn--sm${active ? ' filter-btn--active' : ''}${gold ? ' filter-btn--gold' : ''}`}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  )
+}

--- a/web/src/components/ui/filters/FilterPill.stories.tsx
+++ b/web/src/components/ui/filters/FilterPill.stories.tsx
@@ -1,0 +1,28 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { FilterPill } from './FilterPill';
+
+const meta = {
+  component: FilterPill,
+  parameters: { layout: 'centered' },
+  title: 'UI/Filters/FilterPill',
+  decorators: [(Story) => <div style={{ background: 'var(--game-bg)', padding: 20, display: 'flex', gap: 8 }}><Story /></div>],
+} satisfies Meta<typeof FilterPill>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { onRemove: fn(), children: 'units' } };
+
+export const Row: Story = {
+  args: { onRemove: fn(), children: 'units' },
+  render: () => (
+    <>
+      <FilterPill onRemove={fn()}>units</FilterPill>
+      <FilterPill onRemove={fn()}>rare</FilterPill>
+      <FilterPill onRemove={fn()}>affinity:Death Rally</FilterPill>
+    </>
+  ),
+};

--- a/web/src/components/ui/filters/FilterPill.tsx
+++ b/web/src/components/ui/filters/FilterPill.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+interface Props {
+  onRemove: () => void
+  children: React.ReactNode
+}
+
+/** One active-filter chip in the bar's pill row, with its own remove button. */
+export function FilterPill({ onRemove, children }: Props) {
+  return (
+    <span className="filter-pill">
+      {children} <button onClick={onRemove}>✕</button>
+    </span>
+  )
+}

--- a/web/src/components/ui/filters/FilterPopup.stories.tsx
+++ b/web/src/components/ui/filters/FilterPopup.stories.tsx
@@ -1,0 +1,55 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { FilterPopup } from './FilterPopup';
+import { FilterOption } from './FilterOption';
+
+const meta = {
+  component: FilterPopup,
+  parameters: { layout: 'centered' },
+  title: 'UI/Filters/FilterPopup',
+  decorators: [(Story) => <div style={{ background: 'var(--game-bg)', padding: 40 }}><Story /></div>],
+} satisfies Meta<typeof FilterPopup>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const options = ['All', 'Unit', 'Structure', 'Upgrade'];
+
+export const Closed: Story = {
+  args: {
+    label: '▼ FILTERS',
+    isActive: false,
+    open: false,
+    onToggle: fn(),
+    onClose: fn(),
+    children: null,
+  },
+};
+
+export const Open: Story = {
+  args: {
+    label: '▼ FILTERS',
+    isActive: true,
+    activeSuffix: ' (2)',
+    open: true,
+    onToggle: fn(),
+    onClose: fn(),
+    children: (
+      <div className="filter-popup-section u-col">
+        <span className="filter-group-label">TYPE</span>
+        <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+          {options.map((label, i) => (
+            <FilterOption key={label} active={i === 1} onClick={fn()}>{label}</FilterOption>
+          ))}
+        </div>
+      </div>
+    ),
+    footer: (
+      <div className="filter-popup-footer">
+        <button className="filter-btn filter-btn--sm filter-btn--reset" onClick={fn()}>✕ Clear all filters</button>
+      </div>
+    ),
+  },
+};

--- a/web/src/components/ui/filters/FilterPopup.tsx
+++ b/web/src/components/ui/filters/FilterPopup.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react'
+
+interface Props {
+  label: string
+  activeSuffix?: string
+  isActive: boolean
+  open: boolean
+  onToggle: () => void
+  onClose: () => void
+  children: React.ReactNode
+  footer?: React.ReactNode
+}
+
+/** One filter/sort/group trigger + its dropdown popup — the shared shell
+ *  CollectionScreen and DeckBuilder both compose instead of each hand-rolling
+ *  their own trigger button, outside-click-to-close effect, and popup panel
+ *  (#2178: previously three near-identical implementations). The set of
+ *  options inside the popup is still screen-specific (children). */
+export function FilterPopup({ label, activeSuffix, isActive, open, onToggle, onClose, children, footer }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open, onClose])
+
+  return (
+    <div className="filter-popup-wrap" ref={ref}>
+      <button
+        className={`filter-btn${isActive ? ' filter-btn--active' : ''}`}
+        onClick={onToggle}
+      >
+        {label}{activeSuffix}
+      </button>
+      {open && (
+        <div className="filter-popup">
+          {children}
+          {footer}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/game/collection.ts
+++ b/web/src/game/collection.ts
@@ -609,6 +609,23 @@ export function getOwnedCount(collection: CollectionEntry[], cardName: string): 
   return collection.find(e => e.cardName === cardName)?.count ?? 0
 }
 
+export interface CollectionCompletion {
+  distinctOwned: number
+  catalogTotal: number
+  pct: number
+}
+
+/** Distinct-cards-owned vs. the full catalogue — was only ever computed
+ *  ad hoc (e.g. TitleScreen's footer stat); pulled out here so the
+ *  Collection screen can surface the same number as real progress (#2178). */
+export function getCollectionCompletion(collection: CollectionEntry[]): CollectionCompletion {
+  const catalog = getCardCatalog()
+  const distinctOwned = collection.filter(e => e.count > 0 && catalog.some(c => c.name === e.cardName)).length
+  const catalogTotal = catalog.length
+  const pct = catalogTotal > 0 ? Math.round((distinctOwned / catalogTotal) * 100) : 0
+  return { distinctOwned, catalogTotal, pct }
+}
+
 // ─── Deck CRUD ────────────────────────────────────────────
 
 export type DeckSlot = 'a' | 'b'

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -374,21 +374,11 @@
    AUTO-BUILD MODAL (deck builder)
    ═══════════════════════════════════════════════════════════ */
 
-.autobuild-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.8);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 300;
-  animation: fadeIn 0.15s ease-out;
-}
-
 .autobuild-panel {
-  background: var(--game-bg);
-  border: 1px solid var(--game-border);
-  border-radius: 6px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-overlay);
   width: min(440px, 95vw);
   padding: 24px;
   display: flex;

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -225,8 +225,19 @@
   font-weight: bold;
 }
 
-.overlay-count--valid   { color: var(--game-text-color); }
-.overlay-count--invalid { color: var(--color-orange); }
+.overlay-count--valid { color: var(--game-text-color); }
+
+/* A colour change alone is easy to miss — deck invalidity blocks play, so
+   give it a pill treatment that reads as a warning state, not just dimmer
+   text (#2178). */
+.overlay-count--invalid {
+  color: var(--accent-ember);
+  font-weight: bold;
+  border: 1px solid var(--accent-ember);
+  border-radius: var(--radius-sm);
+  padding: 2px 8px;
+  background: color-mix(in srgb, var(--accent-ember) 12%, transparent);
+}
 
 @media (max-width: 400px) {
   .shop-card-deal {
@@ -275,6 +286,24 @@
   white-space: nowrap;
   flex-shrink: 0;
   padding-left: 8px;
+}
+
+/* Collection completion — previously buried (only the title screen's
+   footer computed this number at all); surfaced here without needing a
+   submenu (#2178). */
+.collection-progress {
+  padding: 4px 0 8px;
+  flex-shrink: 0;
+}
+.collection-progress-bar {
+  flex: 1;
+  height: 6px;
+}
+.collection-progress-label {
+  font-size: var(--font-xs);
+  color: var(--game-text-color-dim);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .filter-label {
@@ -570,6 +599,19 @@
   border-radius: 2px;
   padding: 0 2px;
   line-height: 1.4;
+}
+
+/* Copy-limit reached — previously silent (the tile just stopped being
+   clickable); now an explicit "you're at the cap" signal (#2178). */
+.cell-copy-limit-badge {
+  font-size: 0.571rem;
+  color: var(--accent-ember);
+  background: color-mix(in srgb, var(--accent-ember) 15%, transparent);
+  border: 1px solid var(--accent-ember);
+  border-radius: 2px;
+  padding: 0 2px;
+  line-height: 1.4;
+  margin-left: 2px;
 }
 
 /* ─── Deck Builder (split panel layout) ─────────────── */


### PR DESCRIPTION
Resolves #2178 — Phase 2 of the #2165 UI overhaul epic (stacked after #2197/#2177, and Phase 0/1/2.1-2.3 #2186-#2196).

## Problem

Three parallel filter treatments (`.filter-btn`, a "smaller variant," a filter popup, active pills) that don't read as one system; deck validity/copy-limit violations communicated with small text easy to miss; no collection progress visible anywhere; three of DeckBuilder's modals predate #2174's `ModalBackdrop` standardization.

## One filter system

`CollectionScreen` and `DeckBuilder` each hand-rolled the *same* three-popup (FILTERS/SORT/GROUP) filter bar independently — ~190 near-identical lines per screen, including three separate outside-click-to-close `useEffect`+ref pairs each. Extracted the shared shell into `components/ui/filters/`:
- **`FilterPopup`** — trigger button + outside-click handling + popup panel
- **`FilterOption`** — one selectable row inside a popup
- **`FilterPill`** — one active-filter chip

The actual filter fields stay screen-specific (TYPE/RARITY/TAGS/AFFINITY/SPECIAL differ between the two screens), but both now compose the same three building blocks instead of two independent implementations. Also collapsed each screen's three separate `filterMenuOpen`/`sortMenuOpen`/`groupMenuOpen` booleans + refs into one `openMenu` state — same mutual-exclusion behavior (opening one closes the others), less code.

## Deck validity / copy limits — impossible to miss now

- The deck-invalid count pill (`10/30 cards (need 4 more)`) gets a real warning treatment — ember border/background/bold, not just a colour change on plain text.
- DeckBuilder's copy-limit gating was previously silent: a card just stopped being clickable at `COPIES_MAX` copies, no visible reason why. Split the overloaded `canAdd` check (which conflated "at copy limit" with "deck already full") into an explicit `atCopyLimit` flag and added a small **MAX** badge next to the count.

## Collection progress — surfaced, not buried

`distinctOwned/catalogTotal` completion was only ever computed ad hoc inline in `TitleScreen.tsx`'s footer stat — `CollectionScreen` (the screen this number is actually about) never showed it at all, just a raw "N cards" count of whatever the current filter matched. Extracted `getCollectionCompletion()` into `game/collection.ts` (one source of truth instead of two copies of the same filter/length logic) and added a completion progress bar + "X/Y discovered (Z%)" to the collection header, visible without opening a submenu.

## MasteryBar — integrated, not appended

Was a floating sibling rendered *after* `.cell-footer` in both screens (so cell height visibly jumped depending on whether a card happened to have XP). Moved it inside `.cell-footer` in both `CollectionScreen` and `DeckBuilder`, so it reads as part of the same footer group.

## DeckBuilder modals → ModalBackdrop

Auto-Build, Saved Decks, and Share were each a hand-rolled `position: fixed` backdrop + panel div predating #2174 — none had a focus trap, Esc-to-close, or scroll lock. Migrated all three onto `ModalBackdrop`, kept their existing bespoke inner layouts unchanged (same call as #2174's `LoginModal`/`GiftClaimModal`/`DailyLoginModal`: standardize the backdrop, don't force a generic shell onto layouts that don't fit it). Removed the now-dead `.autobuild-backdrop` rule; `.autobuild-panel` moves onto `--surface-2`/`--elevation-overlay` tokens.

## Scoping notes

- **"Support wider layouts so desktop shows more columns"**: `.game-container`'s `max-width: 740px` is a single, truly global constraint applied once at the app root (`App.tsx`) — there's no per-screen override mechanism today, and building one is a structural `App.tsx` change that the issue itself cross-references to **[UI 3.2] Responsive** (#2183, not yet started). Didn't touch it here to avoid a global layout change as a side effect of a collection-screen PR; flagging for #2183 instead.
- **Saved-decks/share "brought onto `ui/Panel.tsx`"**: interpreted as "standardize on the shared modal infrastructure" (done — see above) rather than literally wrapping the bespoke `.autobuild-panel`/`.saveddecks-panel`/`.share-panel` layouts in the `Panel` component, which would require restructuring their internal markup for no visible difference (the token-based CSS already gives them the same surface/border/elevation `Panel` would).

## Verified in a real browser

- Screenshotted both screens' filter bars: opened FILTERS, applied a rarity filter, confirmed the pill appears, the button shows the active state, and the grid re-filters (958 → 242 cards) — popup stays open (multi-select), matching the original behavior exactly
- Screenshotted the collection completion progress bar rendering correctly
- Screenshotted all three DeckBuilder modals (Auto-Build, Saved Decks, Share) — zero console errors, and confirmed Esc now closes each one (it didn't before, since they weren't on `ModalBackdrop`)
- Confirmed all three new `FilterPopup`/`FilterOption`/`FilterPill` stories render clean

## Test plan

- [x] One filter system, one visual language, used by both screens
- [x] Deck validity and copy-limit violations get an explicit visual treatment (pill + MAX badge), not just silent/small-text
- [x] Collection progress visible without opening a submenu
- [x] Sub-components extracted with stories per `AGENTS.md`
- [x] `npm run build`, `npx tsc --noEmit`, `npm run test` (2861/2861) all pass clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_