### PR TITLE
Campaign map, rewards, and run-end screens visual pass (#2179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,7 @@ usePixiApp(canvasRef, W, H, (app) => {
 | Component | File | Status |
 |---|---|---|
 | TowerDefence grid | `towerdefence/GameGrid.tsx` | ✅ PixiJS |
-| NodeMap terrain + connectors | `campaign/NodeMap.tsx` | Pending |
+| NodeMap terrain + connectors | `ui/NodeMap/NodeMapRederer.tsx` | ✅ PixiJS |
 | Battlefield lane canvas | `battle/BattlefieldCanvas.tsx` | ✅ PixiJS |
 | CityBuilder road wear | `citybuilder/CityTerrainCanvas.tsx` | ✅ PixiJS |
 | CityBuilder walkers | `citybuilder/CityWalkerCanvas.tsx` | ✅ PixiJS |

--- a/web/src/components/battle/ActComplete.tsx
+++ b/web/src/components/battle/ActComplete.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { RunEndCard } from '../ui/RunEndCard'
 
 interface Props {
   actTitle: string
@@ -12,8 +13,6 @@ interface Props {
 export function ActComplete({ actTitle, actSubtitle, relicName, relicDesc, onContinue, hasNextAct = false }: Props) {
   return (
     <div className="act-complete u-col u-items-c u-gap-8 u-grow u-text-c u-relative">
-      <div className="ac-glow" />
-
       <div className="ac-header">
         <div className="ac-cleared">ACT CLEARED</div>
         <div className="ac-act">{actTitle} — {actSubtitle}</div>
@@ -21,18 +20,18 @@ export function ActComplete({ actTitle, actSubtitle, relicName, relicDesc, onCon
 
       <div className="ac-divider">══════════════════════</div>
 
-      <div className="ac-relic">
+      <RunEndCard tone="gold" className="ac-relic u-items-c">
         <div className="ac-relic-label">RELIC EARNED</div>
         <div className="ac-relic-name">⬡ {relicName}</div>
         <div className="ac-relic-desc">{relicDesc}</div>
-      </div>
+      </RunEndCard>
 
       <div className="ac-flavour">
         The shard falls silent. The Fracture's pull grows stronger.<br />
         Your collection endures. Your mastery carries on.
       </div>
 
-      <button className="action-btn action-btn--large ac-continue-btn" onClick={onContinue}>
+      <button className="action-btn action-btn--large action-btn--gold ac-continue-btn" onClick={onContinue}>
         {hasNextAct ? 'CONTINUE TO NEXT ACT' : 'RETURN TO MENU'}
       </button>
     </div>

--- a/web/src/components/battle/BattleSummary.tsx
+++ b/web/src/components/battle/BattleSummary.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BattleStats } from '../../game/types'
 import { StatRow } from '../ui/StatRow'
+import { RunEndCard } from '../ui/RunEndCard'
 
 interface Props {
   stats: BattleStats
@@ -25,7 +26,7 @@ export function BattleSummary({ stats, gameTime, playerScore, onContinue }: Prop
 
   return (
     <div className="bsummary-backdrop">
-      <div className="bsummary-panel">
+      <RunEndCard tone="gold">
         <div className="bsummary-title">— BATTLE COMPLETE —</div>
 
         <div className="bsummary-stats u-col u-gap-3">
@@ -48,10 +49,10 @@ export function BattleSummary({ stats, gameTime, playerScore, onContinue }: Prop
           </div>
         )}
 
-        <button className="action-btn action-btn--large bsummary-continue" onClick={onContinue}>
+        <button className="action-btn action-btn--large action-btn--gold bsummary-continue" onClick={onContinue}>
           CLAIM REWARD →
         </button>
-      </div>
+      </RunEndCard>
     </div>
   )
 }

--- a/web/src/components/battle/CampaignFailedScreen.tsx
+++ b/web/src/components/battle/CampaignFailedScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { RunEndCard } from '../ui/RunEndCard'
 
 interface Props {
   onReturnToMenu: () => void
@@ -7,14 +8,13 @@ interface Props {
 export function CampaignFailedScreen({ onReturnToMenu }: Props) {
   return (
     <div className="campaign-failed u-col u-items-c u-just-c u-relative u-text-c">
-      <div className="cf-glow" />
       <pre className="cf-ascii">{`  ╔══════════════════╗
   ║ CAMPAIGN  FAILED ║
   ╚══════════════════╝`}</pre>
-      <div className="cf-body">
+      <RunEndCard tone="ember" className="cf-body u-items-c">
         <p>All lives lost. The Fracture claims another wanderer.</p>
         <p className="cf-reward">You earned <strong>50 ◆</strong> for your effort.</p>
-      </div>
+      </RunEndCard>
       <button className="action-btn action-btn--large" onClick={onReturnToMenu}>
         [ Return to Menu ]
       </button>

--- a/web/src/components/battle/CampaignVictoryScreen.tsx
+++ b/web/src/components/battle/CampaignVictoryScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { loadPlayerName } from '../../game/questline'
+import { RunEndCard } from '../ui/RunEndCard'
 
 interface Props {
   onBeginAnew: () => void
@@ -34,17 +35,16 @@ export function CampaignVictoryScreen({ onBeginAnew, campaignId = 'c1' }: Props)
   const copy = VICTORY_COPY[campaignId] ?? VICTORY_COPY.c1
   return (
     <div className="campaign-victory u-col u-items-c u-just-c u-relative u-text-c">
-      <div className="cv-glow" />
       <pre className="cv-ascii">{`  ╔══════════════════════╗
   ║  QUESTLINE  COMPLETE ║
   ╚══════════════════════╝`}</pre>
-      <div className="cv-body">
+      <RunEndCard tone="gold" className="cv-body u-items-c">
         <p className="cv-title">{copy.title}</p>
         {copy.lines.map((line, i) => (
           <p key={i}>{line.replace('{playerName}', playerName)}</p>
         ))}
         <p className="cv-reward">+500 ◆ awarded for completing the questline.</p>
-      </div>
+      </RunEndCard>
       <button className="action-btn action-btn--large action-btn--gold" onClick={onBeginAnew}>
         [ Claim Reward ]
       </button>

--- a/web/src/components/battle/ToBeContinuedScreen.tsx
+++ b/web/src/components/battle/ToBeContinuedScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { RunEndCard } from '../ui/RunEndCard'
 
 interface Props {
   /** Display name of the campaign arc, e.g. "The Forgotten Kingdom". */
@@ -14,15 +15,14 @@ interface Props {
 export function ToBeContinuedScreen({ campaignName, onContinue }: Props) {
   return (
     <div className="campaign-victory u-col u-items-c u-just-c u-relative u-text-c">
-      <div className="cv-glow" />
       <pre className="cv-ascii">{`  ╔══════════════════════╗
   ║  TO  BE  CONTINUED…  ║
   ╚══════════════════════╝`}</pre>
-      <div className="cv-body">
+      <RunEndCard tone="arcane" className="cv-body u-items-c">
         <p className="cv-title">🕯️ {campaignName} 🕯️</p>
         <p>You have reached the edge of the story — for now.</p>
         <p>The next act of {campaignName} is still being written. Your progress, rewards, and relics are safe.</p>
-      </div>
+      </RunEndCard>
       <button className="action-btn action-btn--large action-btn--gold" onClick={onContinue}>
         [ Return ]
       </button>

--- a/web/src/components/battle/VictoryPanel.tsx
+++ b/web/src/components/battle/VictoryPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { StatRow } from '../ui/StatRow'
+import { RunEndCard } from '../ui/RunEndCard'
 
 interface Props {
   playerScore: number
@@ -20,7 +21,7 @@ function formatTime(ms: number): string {
 export function VictoryPanel({ playerScore, opponentScore, playerBaseHp, playerBaseMaxHp, unitsDefeated, gameTime, onContinue }: Props) {
   return (
     <div className="bsummary-backdrop">
-      <div className="bsummary-panel vpanel u-text-c u-items-c">
+      <RunEndCard tone="gold" className="vpanel u-text-c u-items-c">
         <div className="victory-text vpanel-headline">YOU WIN!</div>
 
         <div className="bsummary-stats u-col u-gap-3">
@@ -30,10 +31,10 @@ export function VictoryPanel({ playerScore, opponentScore, playerBaseHp, playerB
           <StatRow accent label="TIME"           value={formatTime(gameTime)} />
         </div>
 
-        <button className="action-btn action-btn--large bsummary-continue" onClick={onContinue}>
+        <button className="action-btn action-btn--large action-btn--gold bsummary-continue" onClick={onContinue}>
           Continue →
         </button>
-      </div>
+      </RunEndCard>
     </div>
   )
 }

--- a/web/src/components/campaign/NodeMapHpBar.stories.tsx
+++ b/web/src/components/campaign/NodeMapHpBar.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { NodeMapHpBar } from './NodeMapHpBar';
+
+const meta = {
+  component: NodeMapHpBar,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof NodeMapHpBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Full: Story = { args: { hp: 100, maxHp: 100 } };
+export const Mid: Story = { args: { hp: 45, maxHp: 100 } };
+export const Low: Story = { args: { hp: 20, maxHp: 100 } };
+export const Critical: Story = { args: { hp: 5, maxHp: 100 } };

--- a/web/src/components/campaign/NodeMapHpBar.tsx
+++ b/web/src/components/campaign/NodeMapHpBar.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
 
+const LOW_HP_PCT = 0.3
+
 function hpColor(hp: number, max: number): string {
   const pct = hp / max
-  if (pct > 0.6) return '#33ff33'
-  if (pct > 0.3) return '#ffcc00'
-  return '#ff4444'
+  if (pct > 0.6) return 'var(--color-green-bright)'
+  if (pct > LOW_HP_PCT) return 'var(--accent-gold)'
+  return 'var(--accent-ember)'
 }
 
 export function NodeMapHpBar({ hp, maxHp }: { hp: number; maxHp: number }) {
   const color = hpColor(hp, maxHp)
+  const low = maxHp > 0 && hp / maxHp <= LOW_HP_PCT && hp > 0
   return (
     <div className="nm-hp-area u-flex u-items-c u-gap-3">
       <span className="nm-hp-label">HP</span>
-      <div className="nm-hp-track">
+      <div className={`nm-hp-track${low ? ' nm-hp-track--low' : ''}`}>
         <div className="nm-hp-fill" style={{ width: `${Math.max(0, hp / maxHp) * 100}%`, background: color }} />
       </div>
       <span className="nm-hp-text" style={{ color }}>{hp}/{maxHp}</span>

--- a/web/src/components/campaign/RelicSelectScreen.tsx
+++ b/web/src/components/campaign/RelicSelectScreen.tsx
@@ -35,10 +35,11 @@ export function RelicSelectScreen({ earnedRelics, currentRelic, brokenRelic, onS
       </div>
 
       <div className="relic-select-grid u-col u-gap-5">
-        {defs.map(({ name, def }) => (
+        {defs.map(({ name, def }, i) => (
           <button
             key={name}
             className={`relic-select-card${def!.exotic ? ' relic-select-card--exotic' : ''}${picked === name ? ' relic-select-card--chosen' : ''}`}
+            style={{ animationDelay: `${i * 60}ms` }}
             onClick={() => setPicked(name)}
           >
             {def!.exotic && <div className="relic-exotic-tag">EXOTIC</div>}
@@ -50,6 +51,7 @@ export function RelicSelectScreen({ earnedRelics, currentRelic, brokenRelic, onS
 
         <button
           className={`relic-select-card relic-select-card--none${picked === null ? ' relic-select-card--chosen' : ''}`}
+          style={{ animationDelay: `${defs.length * 60}ms` }}
           onClick={() => setPicked(null)}
         >
           <div className="relic-select-icon">✕</div>

--- a/web/src/components/campaign/StatUpgradeScreen.tsx
+++ b/web/src/components/campaign/StatUpgradeScreen.tsx
@@ -58,10 +58,11 @@ export function StatUpgradeScreen({ onSelect }: Props) {
       </div>
 
       <div className="relic-select-grid u-col u-gap-5">
-        {OPTIONS.map(opt => (
+        {OPTIONS.map((opt, i) => (
           <button
             key={opt.stat}
             className={`relic-select-card${picked === opt.stat ? ' relic-select-card--chosen' : ''}`}
+            style={{ animationDelay: `${i * 60}ms` }}
             onClick={() => setPicked(opt.stat)}
           >
             <div className="relic-select-icon">{opt.icon}</div>

--- a/web/src/components/ui/RunEndCard.stories.tsx
+++ b/web/src/components/ui/RunEndCard.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { RunEndCard, type RunEndTone } from './RunEndCard';
+import { StatRow } from './StatRow';
+
+const meta = {
+  title: 'UI/RunEndCard',
+  component: RunEndCard,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof RunEndCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const wrapper = (children: React.ReactNode) => (
+  <div style={{ position: 'relative', background: 'var(--game-bg)', padding: 48, display: 'flex', justifyContent: 'center' }}>
+    {children}
+  </div>
+);
+
+const sampleStats = (
+  <>
+    <div className="u-text-c" style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--accent-gold)' }}>YOU WIN!</div>
+    <div className="u-col u-gap-3">
+      <StatRow accent label="SCORE" value="12 — 4" />
+      <StatRow accent label="TIME" value="2m 14s" />
+    </div>
+  </>
+);
+
+export const Gold: Story = {
+  args: { tone: 'gold', children: sampleStats },
+  render: (args) => wrapper(<RunEndCard {...args} />),
+};
+
+export const Ember: Story = {
+  args: { tone: 'ember', children: sampleStats },
+  render: (args) => wrapper(<RunEndCard {...args} />),
+};
+
+export const Arcane: Story = {
+  args: { tone: 'arcane', children: sampleStats },
+  render: (args) => wrapper(<RunEndCard {...args} />),
+};
+
+const TONES: RunEndTone[] = ['gold', 'ember', 'arcane'];
+
+export const AllTones: Story = {
+  args: { tone: 'gold', children: null },
+  render: () => (
+    <div style={{ display: 'flex', gap: 24, background: 'var(--game-bg)', padding: 48 }}>
+      {TONES.map((tone) => (
+        <div key={tone} style={{ position: 'relative', display: 'flex', justifyContent: 'center' }}>
+          <RunEndCard tone={tone}>{sampleStats}</RunEndCard>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/web/src/components/ui/RunEndCard.tsx
+++ b/web/src/components/ui/RunEndCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Panel } from './Panel'
+
+export type RunEndTone = 'gold' | 'ember' | 'arcane'
+
+const PANEL_TONE = { gold: 'gold', ember: 'danger', arcane: 'arcane' } as const
+
+interface Props {
+  tone: RunEndTone
+  glow?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Shared "run outcome" card shape — glow + framed panel + entrance pop —
+ * used by victory/defeat/summary/act-complete screens so the game speaks
+ * one visual language for "your run just resolved" moments.
+ */
+export function RunEndCard({ tone, glow = true, className, children }: Props) {
+  return (
+    <>
+      {glow && <div className={`run-end-glow run-end-glow--${tone}`} aria-hidden="true" />}
+      <Panel
+        elevation="floating"
+        tone={PANEL_TONE[tone]}
+        runeCorners
+        className={['run-end-card', className].filter(Boolean).join(' ')}
+      >
+        {children}
+      </Panel>
+    </>
+  )
+}

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -554,38 +554,26 @@
   z-index: 200;
 }
 
-.bsummary-panel {
-  background: var(--game-bg);
-  border: 1px solid #2a4a2a;
-  max-width: 320px;
-  width: 100%;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  box-shadow: 0 0 32px rgba(51, 255, 51, 0.1);
-}
-
 .bsummary-title {
   font-size: var(--font-sm);
   letter-spacing: 2px;
-  color: #4a8a4a;
+  color: var(--accent-gold);
   text-align: center;
   padding-bottom: 8px;
-  border-bottom: 1px solid #1e2e1e;
+  border-bottom: 1px solid var(--border-edge-dark);
 }
 
 /* bsummary rows → .stat-row / .stat-label / .stat-value--accent */
 
 .bsummary-cards {
-  border-top: 1px solid #1e2e1e;
+  border-top: 1px solid var(--border-edge-dark);
   padding-top: 10px;
 }
 
 .bsummary-cards-label {
   font-size: var(--font-xxs);
   letter-spacing: 1.5px;
-  color: #4a8a4a;
+  color: var(--accent-gold);
   margin-bottom: 4px;
 }
 
@@ -595,12 +583,12 @@
 
 .bsummary-card-name {
   font-size: var(--font-sm);
-  color: #88cc88;
+  color: var(--game-text-color-dim);
 }
 
 .bsummary-card-count {
   font-size: var(--font-sm);
-  color: #33ff33;
+  color: var(--accent-gold);
 }
 
 .bsummary-continue {
@@ -608,13 +596,11 @@
 }
 
 /* ── Victory Panel overlay (celebration phase) ────────────── */
-.vpanel {
-  border-color: #2a6a2a;
-  box-shadow: 0 0 48px rgba(51, 255, 51, 0.18);
-}
 .vpanel-headline {
   font-size: clamp(2rem, 8vw, 3.5rem);
   margin-bottom: 4px;
+  color: var(--accent-gold);
+  text-shadow: 0 0 24px color-mix(in srgb, var(--accent-gold) 60%, transparent);
 }
 
 /* ── Quick Battle Screen ────────────────────────────────────────────────── */

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -650,11 +650,6 @@
   font-size: clamp(2.5rem, 10vw, 5rem);
   font-weight: bold;
   letter-spacing: 0.12em;
-  color: #7ddd7d;
-  text-shadow:
-    0 0 12px #7ddd7d,
-    0 0 30px #4a9a4a,
-    2px 2px 0 #0d1a0d;
   animation: victory-pulse 0.6s ease-in-out infinite alternate;
 }
 @keyframes victory-pulse {

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -1121,8 +1121,9 @@
 .boss-dialogue-speaker {
   font-size: var(--font-md);
   letter-spacing: 3px;
-  color: #cc4444;
-  border-bottom: 1px solid #331111;
+  color: var(--accent-ember);
+  text-shadow: 0 0 10px color-mix(in srgb, var(--accent-ember) 50%, transparent);
+  border-bottom: 1px solid var(--border-edge-dark);
   padding-bottom: 16px;
 }
 
@@ -1139,7 +1140,7 @@
 
 .boss-dialogue-footer {
   padding-top: 24px;
-  border-top: 1px solid #1a1a1a;
+  border-top: 1px solid var(--border-edge-dark);
 }
 
 .boss-dialogue-continue {
@@ -1151,8 +1152,9 @@
 
 .boss-dialogue-fight {
   font-size: var(--font-sm);
-  color: #cc4444;
+  color: var(--accent-ember);
   letter-spacing: 3px;
+  text-shadow: 0 0 8px color-mix(in srgb, var(--accent-ember) 60%, transparent);
   animation: blink 0.9s step-end infinite;
 }
 

--- a/web/src/styles/campaign.css
+++ b/web/src/styles/campaign.css
@@ -522,6 +522,12 @@
   transition: border-color 0.15s, background 0.15s;
   font-family: inherit;
   color: inherit;
+  animation: relic-card-enter 0.35s ease-out both;
+}
+
+@keyframes relic-card-enter {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .relic-select-card:hover {
@@ -603,7 +609,7 @@
   position: relative;
   border: 1px solid #d4a017;
   background: rgba(90, 70, 10, 0.18);
-  animation: exotic-glow 2.2s ease-in-out infinite;
+  animation: relic-card-enter 0.35s ease-out both, exotic-glow 2.2s ease-in-out infinite;
 }
 
 .relic-select-card--exotic:hover {

--- a/web/src/styles/campaign.css
+++ b/web/src/styles/campaign.css
@@ -192,161 +192,16 @@
   flex-shrink: 0;
 }
 
-/* ── Columns (each act-row renders as a vertical column in L→R layout) ── */
-
-.nm-col {
-  display: grid;
-  align-items: center;
-  justify-items: center;
-  flex-shrink: 0;
-}
-
-/* ── Node buttons ── */
-
-.nm-node {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  padding: 8px 12px 10px;
-  border: 1px solid transparent;
-  border-top-width: 2px;
-  border-radius: 6px;
-  background: transparent;
-  cursor: default;
-  min-width: 96px;
-  transition: all 0.15s;
-  font-family: var(--font-body);
-}
-
-.nm-node-type-badge {
-  font-size: 0.571rem;
-  letter-spacing: 1.5px;
-  font-weight: bold;
-  opacity: 0.7;
-  margin-bottom: 1px;
-}
+/* ── Node type badge colors ──────────────────────────────
+   The node map itself renders on a PixiJS canvas (NodeMapRederer.tsx);
+   these modifier classes are the one surviving DOM consumer, applied by
+   NodePeekModal directly (base font-size/opacity live on .nm-peek-type). */
 .nm-node-type-badge--battle   { color: var(--game-text-color-dim); }
 .nm-node-type-badge--elite    { color: #c8a020; }
 .nm-node-type-badge--boss     { color: #c03030; }
 .nm-node-type-badge--rest     { color: #4090b0; }
 .nm-node-type-badge--event    { color: #8050b0; }
 .nm-node-type-badge--merchant { color: #a06020; }
-
-.nm-node-icon   { font-size: 1.571rem; line-height: 1; }
-.nm-node-sprite { width: 38px; height: 38px; object-fit: contain; image-rendering: pixelated; }
-.nm-node-name  { font-size: var(--font-sm); color: var(--game-text-color-dim); letter-spacing: 0.5px; text-align: center; line-height: 1.3; }
-.nm-node-status { font-size: var(--font-xxs); letter-spacing: 1px; min-height: 12px; }
-
-/* Available nodes */
-.nm-node--available {
-  cursor: pointer;
-}
-.nm-node--available .nm-node-name { color: var(--game-text-color-dim); }
-.nm-node--available .nm-node-status { color: var(--game-text-color); }
-.nm-node--available .nm-node-type-badge { opacity: 1; }
-.nm-node--available:hover {
-  transform: translateY(-2px);
-}
-.nm-node--available .nm-node-sprite,
-.nm-node--available .nm-node-icon {
-  filter: drop-shadow(0 0 6px rgba(51, 255, 51, 0.55));
-  animation: nm-sprite-pulse 2s ease-in-out infinite;
-}
-
-@keyframes nm-sprite-pulse {
-  0%, 100% { filter: drop-shadow(0 0 4px rgba(51, 255, 51, 0.4)); }
-  50%       { filter: drop-shadow(0 0 10px rgba(51, 255, 51, 0.75)); }
-}
-
-/* Dim modifier — applied to completed, skipped, and unreachable-locked nodes */
-.nm-node--dim {
-  opacity: 0.28;
-  filter: grayscale(55%);
-}
-
-/* Completed nodes */
-.nm-node--completed .nm-node-status { color: #33ff33; font-size: 1rem; }
-
-/* Skipped nodes */
-.nm-node--skipped .nm-node-status { color: var(--color-red); }
-
-/* Pending (in battle) */
-.nm-node--pending .nm-node-status { color: #ffc832; }
-.nm-node--pending .nm-node-sprite,
-.nm-node--pending .nm-node-icon {
-  animation: nm-pending 1s ease-in-out infinite;
-}
-@keyframes nm-pending {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.6; }
-}
-
-/* Type-specific sprite glows for available nodes */
-.nm-node--boss.nm-node--available .nm-node-sprite,
-.nm-node--boss.nm-node--available .nm-node-icon {
-  filter: drop-shadow(0 0 6px rgba(255, 68, 68, 0.6));
-  animation: nm-boss-sprite-pulse 1.5s ease-in-out infinite;
-}
-.nm-node--boss.nm-node--available .nm-node-type-badge { color: #ff5555; opacity: 1; }
-@keyframes nm-boss-sprite-pulse {
-  0%, 100% { filter: drop-shadow(0 0 4px rgba(255, 68, 68, 0.5)); }
-  50%       { filter: drop-shadow(0 0 12px rgba(255, 68, 68, 0.9)); }
-}
-
-.nm-node--elite.nm-node--available .nm-node-sprite,
-.nm-node--elite.nm-node--available .nm-node-icon {
-  filter: drop-shadow(0 0 6px rgba(255, 200, 50, 0.6));
-  animation: nm-elite-sprite-pulse 2s ease-in-out infinite;
-}
-.nm-node--elite.nm-node--available .nm-node-type-badge { color: #ffc832; opacity: 1; }
-@keyframes nm-elite-sprite-pulse {
-  0%, 100% { filter: drop-shadow(0 0 4px rgba(255, 200, 50, 0.4)); }
-  50%       { filter: drop-shadow(0 0 10px rgba(255, 200, 50, 0.8)); }
-}
-
-.nm-node--rest.nm-node--available .nm-node-sprite,
-.nm-node--rest.nm-node--available .nm-node-icon {
-  filter: drop-shadow(0 0 6px rgba(100, 200, 255, 0.6));
-}
-.nm-node--rest.nm-node--available .nm-node-type-badge { color: #64c8ff; opacity: 1; }
-.nm-node--rest.nm-node--available .nm-node-status { color: #64c8ff; }
-
-.nm-node--event.nm-node--available .nm-node-sprite,
-.nm-node--event.nm-node--available .nm-node-icon {
-  filter: drop-shadow(0 0 6px rgba(160, 100, 255, 0.6));
-}
-.nm-node--event.nm-node--available .nm-node-type-badge { color: #b078ff; opacity: 1; }
-
-.nm-node--merchant.nm-node--available .nm-node-sprite,
-.nm-node--merchant.nm-node--available .nm-node-icon {
-  filter: drop-shadow(0 0 6px rgba(255, 170, 50, 0.6));
-}
-.nm-node--merchant.nm-node--available .nm-node-type-badge { color: #ffaa32; opacity: 1; }
-
-/* ── Player avatar ── */
-
-.nm-avatar {
-  position: absolute;
-  z-index: 2;
-  pointer-events: none;
-}
-
-@keyframes nm-avatar-idle {
-  0%, 100% { transform: translateY(0); }
-  50%       { transform: translateY(-2px); }
-}
-
-.nm-avatar:not(.nm-avatar--walking) img {
-  animation: nm-avatar-idle 2s ease-in-out infinite;
-}
-
-.nm-back-btn {
-  margin-top: auto;
-  margin-bottom: 8px;
-  flex-shrink: 0;
-  align-self: flex-start;
-}
 
 /* ── Node Peek Modal ── */
 
@@ -689,9 +544,9 @@
 
 /* ── Build Identity panel (campaign node map) ── */
 .build-identity {
-  border: 1px solid var(--game-border);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
   margin: 4px 0;
 }
 
@@ -712,6 +567,7 @@
   font-size: var(--font-xs);
   font-weight: bold;
   letter-spacing: 1px;
+  color: var(--accent-gold);
 }
 
 .build-identity-chevron {
@@ -721,7 +577,7 @@
 
 .build-identity-body {
   padding: 2px 10px 8px;
-  border-top: 1px solid var(--game-border);
+  border-top: 1px solid var(--border-edge-dark);
 }
 
 .build-identity-row {

--- a/web/src/styles/campaign.css
+++ b/web/src/styles/campaign.css
@@ -85,36 +85,31 @@
   min-height: 100dvh;
   padding: 32px 24px;
   gap: 24px;
-  background: #000a05;
-}
-.cv-glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(ellipse at center, rgba(0,200,100,0.12) 0%, rgba(255,215,0,0.06) 50%, transparent 70%);
-  pointer-events: none;
+  background: var(--game-bg);
 }
 .cv-ascii {
-  color: var(--color-gold);
+  color: var(--accent-gold);
   font-size: clamp(10px, 2.5vw, 14px);
   line-height: 1.5;
   margin: 0;
-  text-shadow: 0 0 14px rgba(255,215,0,0.7);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--accent-gold) 70%, transparent);
 }
 .cv-body {
   color: var(--game-text-color-muted);
   font-size: 1rem;
   line-height: 1.8;
   max-width: 340px;
+  text-align: center;
 }
 .cv-title {
-  color: var(--color-gold);
+  color: var(--accent-gold);
   font-size: 1.286rem;
   font-weight: bold;
   letter-spacing: 2px;
-  text-shadow: 0 0 10px rgba(255,215,0,0.8);
+  text-shadow: 0 0 10px color-mix(in srgb, var(--accent-gold) 80%, transparent);
 }
 .cv-reward {
-  color: #55ff99;
+  color: var(--color-green-bright);
   margin-top: 8px;
 }
 
@@ -122,22 +117,15 @@
   min-height: 100dvh;
   padding: 32px 24px;
   gap: 24px;
-  background: #0a0000;
-}
-
-.cf-glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(ellipse at center, rgba(180,0,0,0.15) 0%, transparent 70%);
-  pointer-events: none;
+  background: var(--game-bg);
 }
 
 .cf-ascii {
-  color: #cc2222;
+  color: var(--accent-ember);
   font-size: clamp(10px, 2.5vw, 14px);
   line-height: 1.5;
   margin: 0;
-  text-shadow: 0 0 12px rgba(200,0,0,0.6);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--accent-ember) 60%, transparent);
 }
 
 .cf-body {
@@ -145,10 +133,11 @@
   font-size: 1rem;
   line-height: 1.8;
   max-width: 320px;
+  text-align: center;
 }
 
 .cf-reward {
-  color: var(--color-gold-light);
+  color: var(--accent-gold);
   margin-top: 8px;
 }
 
@@ -899,24 +888,14 @@
   animation: fadeIn 0.4s ease-out;
 }
 
-.ac-glow {
-  position: absolute;
-  top: 0; left: 50%;
-  transform: translateX(-50%);
-  width: 300px;
-  height: 200px;
-  background: radial-gradient(ellipse at center, rgba(255, 200, 50, 0.08) 0%, transparent 70%);
-  pointer-events: none;
-}
-
 .ac-header { display: flex; flex-direction: column; gap: 4px; }
 
 .ac-cleared {
   font-size: 1.714rem;
   font-weight: bold;
-  color: #ffc832;
+  color: var(--accent-gold);
   letter-spacing: 5px;
-  text-shadow: 0 0 20px rgba(255, 200, 50, 0.5);
+  text-shadow: 0 0 20px color-mix(in srgb, var(--accent-gold) 50%, transparent);
 }
 
 .ac-act {
@@ -932,13 +911,6 @@
 }
 
 .ac-relic {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 16px 24px;
-  border: 1px solid rgba(255, 200, 50, 0.25);
-  border-radius: 6px;
-  background: rgba(255, 200, 50, 0.03);
   min-width: 220px;
 }
 
@@ -951,7 +923,7 @@
 
 .ac-relic-name {
   font-size: var(--font-xl);
-  color: #ffc832;
+  color: var(--accent-gold);
   font-weight: bold;
   letter-spacing: 2px;
 }

--- a/web/src/styles/minigames-1.css
+++ b/web/src/styles/minigames-1.css
@@ -164,7 +164,7 @@
 
 .nm-act-title {
   font-size: var(--font-sm);
-  color: #ffc832;
+  color: var(--accent-gold);
   letter-spacing: 2px;
   font-weight: bold;
 }
@@ -186,17 +186,27 @@
 }
 
 .nm-hp-track {
-  width: 80px;
-  height: 6px;
+  width: 100px;
+  height: 8px;
   background: var(--game-bg-card);
-  border: 1px solid var(--game-border);
-  border-radius: 3px;
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-sm);
   overflow: hidden;
+}
+
+.nm-hp-track--low {
+  border-color: var(--accent-ember);
+  animation: nm-hp-low-pulse 1s ease-in-out infinite;
+}
+
+@keyframes nm-hp-low-pulse {
+  0%, 100% { box-shadow: 0 0 0 rgba(255, 68, 68, 0); }
+  50%      { box-shadow: 0 0 8px color-mix(in srgb, var(--accent-ember) 70%, transparent); }
 }
 
 .nm-hp-fill {
   height: 100%;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   transition: width 0.4s ease, background 0.4s ease;
 }
 
@@ -212,13 +222,13 @@
 }
 
 .nm-life-pip {
-  font-size: var(--font-base);
+  font-size: var(--font-lg);
   line-height: 1;
   transition: color 0.2s;
 }
 
-.nm-life-pip--full  { color: #ff4466; }
-.nm-life-pip--empty { color: #333; }
+.nm-life-pip--full  { color: var(--accent-ember); text-shadow: 0 0 4px color-mix(in srgb, var(--accent-ember) 50%, transparent); }
+.nm-life-pip--empty { color: var(--border-edge-dark); }
 
 /* ─── Shared projectile/hit/AOE-ring effects (TowerDefence AttackEffect.tsx) ── */
 

--- a/web/src/styles/panels.css
+++ b/web/src/styles/panels.css
@@ -63,6 +63,39 @@
 .panel--danger .panel-corner { border-color: var(--accent-ember); }
 .panel--arcane .panel-corner { border-color: var(--accent-arcane); }
 
+/* ─── RunEndCard (#2179) ─────────────────────────────────
+   Shared "run outcome" shape for victory/defeat/summary/act-complete
+   screens — a floating panel with an ambient tinted glow behind it and a
+   bouncy entrance pop, replacing per-screen backdrop/panel duplication. */
+
+.run-end-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-3);
+  padding: 20px;
+  max-width: 360px;
+  width: 100%;
+  animation: run-end-card-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes run-end-card-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.run-end-glow {
+  position: absolute;
+  top: 0; left: 50%;
+  transform: translateX(-50%);
+  width: 320px;
+  height: 220px;
+  pointer-events: none;
+}
+
+.run-end-glow--gold   { background: radial-gradient(ellipse at center, color-mix(in srgb, var(--accent-gold) 16%, transparent) 0%, transparent 70%); }
+.run-end-glow--ember  { background: radial-gradient(ellipse at center, color-mix(in srgb, var(--accent-ember) 16%, transparent) 0%, transparent 70%); }
+.run-end-glow--arcane { background: radial-gradient(ellipse at center, color-mix(in srgb, var(--accent-arcane) 16%, transparent) 0%, transparent 70%); }
+
 /* ─── Section ────────────────────────────────────────── */
 
 .section {


### PR DESCRIPTION
## Summary

Closes #2179 — the sixth Phase 2 screen pass in the dark-fantasy UI epic (#2165).

Research going in confirmed the node map's canvas layer (`NodeMapRederer.tsx`) is already fully PixiJS-based, so this pass focused on the DOM/CSS surfaces instead: run-end screens, reward-reveal pacing, node-map HUD chrome, and boss framing.

- **Shared `RunEndCard` component** (`ui/RunEndCard.tsx`): a Panel-based glow + card + bouncy entrance-pop shape. Migrates `VictoryPanel`, `BattleSummary`, `ActComplete`, `CampaignVictoryScreen`, `CampaignFailedScreen`, and `ToBeContinuedScreen` onto it, replacing six independently hand-rolled backdrop/panel implementations with one shared shape (gold/ember/arcane tones).
- Retints the victory-panel/battle-summary green identity and the campaign-victory/campaign-failed screen backgrounds off literal greens/reds onto `--accent-gold`/`--accent-ember`/`--color-green-bright` tokens, consistent with the epic's "green demoted to semantic-only" direction. Fixed a cascade bug found via a Storybook screenshot where `VictoryPanel`'s "YOU WIN!" headline was still rendering green under the new gold panel.
- **Reward-reveal consistency**: `RelicSelectScreen` and `StatUpgradeScreen` cards now get a staggered entrance animation (matching `PackOpening`'s cascade language), bringing them into the same reward-reveal feel as the existing `PackOpening`/`RelicSpinScreen`.
- **Node-map HUD polish**: `NodeMapHpBar` and the `Lives` pips get more visual weight — token-based colors, a bigger track, and a pulsing ember glow below 30% HP mirroring the battle HUD's low-HP treatment from #2176.
- **Boss framing**: light-touch ember glow on `BossDialogueScreen`'s speaker name and fight prompt (left `BossEpilogueScreen` alone since it intentionally shares the generic cutscene system).
- **Cleanup**: deleted the confirmed-dead `.nm-node`/`.nm-avatar`/`.nm-col`/`.nm-back-btn` CSS family in `campaign.css` (the node map renders on Pixi now; only the `.nm-node-type-badge--*` color variants survive, consumed by `NodePeekModal`). Fixed `AGENTS.md`'s stale "Pending" PixiJS migration status for the node map.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 2861/2861 passing (known-noise `chrome-headless-shell` cleanup error unrelated to test results)
- [x] Verified visually via Storybook + Playwright screenshots: `RunEndCard` (all tones), `NodeMapHpBar` (full/low/critical), `RelicSelectScreen`, `StatUpgradeScreen`, `ActComplete`, `BattleSummary`, `CampaignFailedScreen`, `CampaignVictoryScreen`, `ToBeContinuedScreen`, `VictoryPanel`, `BossDialogueScreen`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_