### PR TITLE
Minigame shells — shared header/result panel, migrate 12 games (part of #2181)

### DIFF
--- a/web/src/components/hub/TheatreScreen.tsx
+++ b/web/src/components/hub/TheatreScreen.tsx
@@ -8,6 +8,8 @@ import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
 import { addTickets } from '../../game/miniGames'
 import { incrementAchievementProgress, setAchievementProgress } from '../../game/achievements'
 import { loadPlayerAvatar } from '../../game/questline'
+import { MinigameShell } from '../minigames/MinigameShell'
+import { MinigameResultPanel } from '../minigames/MinigameResultPanel'
 
 interface Props {
   onBack: () => void
@@ -169,9 +171,7 @@ export function TheatreScreen({ onBack }: Props) {
   const halfWidth = actZoneHalfWidth(act)
 
   return (
-    <div className="minigame-screen theatre-screen">
-      <div className="minigame-title">🎭 CURTAIN CALL</div>
-
+    <MinigameShell title="CURTAIN CALL" icon="🎭" className="theatre-screen">
       {phase !== 'ready' && (
         <div className="theatre-stage-wrap">
           <div className="theatre-avatar-platform">
@@ -220,19 +220,19 @@ export function TheatreScreen({ onBack }: Props) {
       )}
 
       {phase === 'result' && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">{applauseHeadline()}</div>
+        <MinigameResultPanel
+          headline={applauseHeadline()}
+          ctaLabel="COLLECT & EXIT"
+          onCta={onBack}
+        >
           <div className="minigame-result-breakdown">
             {grades.map((g, i) => (
               <div key={i}>Act {i + 1}: {GRADE_LABEL[g]} — +{TICKETS[g]} 🎫</div>
             ))}
             <div className="minigame-result-total">Total: {total} 🎫</div>
           </div>
-          <button className="action-btn action-btn--gold" onClick={onBack}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        </MinigameResultPanel>
       )}
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/CrystalCatch.tsx
+++ b/web/src/components/minigames/CrystalCatch.tsx
@@ -4,6 +4,8 @@
 
 import React, { useState, useEffect, useRef } from 'react'
 import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -141,9 +143,7 @@ export function CrystalCatch({ onDone }: Props) {
   const pct = timeLeft / GAME_DURATION_MS
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">💎 CRYSTAL CATCH</div>
-
+    <MinigameShell title="CRYSTAL CATCH" icon="💎">
       {phase === 'ready' && (
         <div className="minigame-ready u-col u-items-c u-gap-5">
           <p>Catch 🔮 crystals (+3) and 🪙 coins (+1).</p>
@@ -188,13 +188,12 @@ export function CrystalCatch({ onDone }: Props) {
       )}
 
       {phase === 'result' && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">You caught {ticketsRef.current} tickets!</div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(ticketsRef.current)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        <MinigameResultPanel
+          headline={`You caught ${ticketsRef.current} tickets!`}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(ticketsRef.current)}
+        />
       )}
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/Fishing.tsx
+++ b/web/src/components/minigames/Fishing.tsx
@@ -3,6 +3,7 @@
 // the leaderboard. 5% chance to snag an item or card instead of a fish.
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { MinigameShell } from './MinigameShell'
 import { addCollectible, addHubItem, getHubItemCount, removeHubItem } from '../../game/itemStore'
 import { addCardsToCollection } from '../../game/collection'
 import { getCardCatalog } from '../../game/cards'
@@ -398,12 +399,12 @@ export function Fishing({ onDone, rewardMode = 'tickets', variant = 'river' }: P
   const biteBarPct = Math.round((biteMs / BITE_WINDOW_MS) * 100)
 
   return (
-    <div className="fishing-screen">
-      <div className="fishing-header">
-        <div className="fishing-title">🎣 FISHING</div>
-        {usesBait && <div className="fishing-bait-counter">🪱 {baitCount}</div>}
-      </div>
-
+    <MinigameShell
+      title="FISHING"
+      icon="🎣"
+      className="fishing-screen"
+      stat={usesBait ? `🪱 ${baitCount}` : undefined}
+    >
       {/* Scene */}
       <div className="fishing-scene">
         {phase === 'idle' && (
@@ -545,6 +546,6 @@ export function Fishing({ onDone, rewardMode = 'tickets', variant = 'river' }: P
           </div>
         )}
       </div>
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/FruitMachine.tsx
+++ b/web/src/components/minigames/FruitMachine.tsx
@@ -27,6 +27,8 @@ import {
 } from '../../game/fruitMachineJackpot'
 import { loadPlayerName } from '../../game/questline'
 import { LedScroller, LedScrollerMessage } from '../ui/LedScroller/LedScroller'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -811,8 +813,7 @@ function regressBoardBy(steps: number) {
 
   if (phase === 'bonus' && bonusTiles.length > 0) {
     return (
-      <div className="minigame-screen">
-        <div className="minigame-title">🎰 FRUIT MACHINE</div>
+      <MinigameShell title="FRUIT MACHINE" icon="🎰">
         <div className="fm-bonus-game u-col u-items-c u-gap-5">
           <div className="fm-bonus-header">BONUS GAME — pick {bonusPicksLeft} {bonusPicksLeft === 1 ? 'prize' : 'prizes'}!</div>
           {bonusTotalWin > 0 && <div className="fm-bonus-running-total">Running total: +{bonusTotalWin} credits</div>}
@@ -831,7 +832,7 @@ function regressBoardBy(steps: number) {
             ))}
           </div>
         </div>
-      </div>
+      </MinigameShell>
     )
   }
 
@@ -839,8 +840,7 @@ function regressBoardBy(steps: number) {
 
   if (phase === 'jackpot-win' && jackpotWon) {
     return (
-      <div className="minigame-screen">
-        <div className="minigame-title">🎰 FRUIT MACHINE</div>
+      <MinigameShell title="FRUIT MACHINE" icon="🎰">
         <div className="fm-jackpot-win-overlay">
           <div className="fm-jackpot-win-tier">{jackpotWon.tier} JACKPOT!</div>
           <div className="fm-jackpot-win-amount">+{jackpotWon.amount} credits!</div>
@@ -848,7 +848,7 @@ function regressBoardBy(steps: number) {
             COLLECT
           </button>
         </div>
-      </div>
+      </MinigameShell>
     )
   }
 
@@ -856,12 +856,13 @@ function regressBoardBy(steps: number) {
 
   if (phase === 'done') {
     return (
-      <div className="minigame-screen">
-        <div className="minigame-title">🎰 FRUIT MACHINE</div>
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">
-            {cashOutTickets > 0 ? 'Cashed out!' : 'Out of credits!'}
-          </div>
+      <MinigameShell title="FRUIT MACHINE" icon="🎰">
+        <MinigameResultPanel
+          headline={cashOutTickets > 0 ? 'Cashed out!' : 'Out of credits!'}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(cashOutTickets)}
+          tone={cashOutTickets > 0 ? 'gold' : 'ember'}
+        >
           <div className="minigame-result-breakdown">
             {cashOutTickets > 0 ? (
               <>
@@ -873,11 +874,8 @@ function regressBoardBy(steps: number) {
             )}
             <div className="minigame-result-total">Total: {cashOutTickets} 🎫</div>
           </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(cashOutTickets)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
-      </div>
+        </MinigameResultPanel>
+      </MinigameShell>
     )
   }
 
@@ -903,9 +901,7 @@ function regressBoardBy(steps: number) {
 
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">🎰 FRUIT MACHINE</div>
-
+    <MinigameShell title="FRUIT MACHINE" icon="🎰">
       {/* Jackpot tiers */}
       <div className="fm-jackpots u-flex u-gap-3 u-just-c">
         {JACKPOT_TIERS.map(t => (
@@ -1110,6 +1106,6 @@ function regressBoardBy(steps: number) {
           </tbody>
         </table>
       </details>
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/HarbourRegatta.tsx
+++ b/web/src/components/minigames/HarbourRegatta.tsx
@@ -10,6 +10,9 @@ import {
   COURSE_LENGTH, TARGET_STROKE_MS, STROKE_TOLERANCE_MS,
   type RowState, type OarSide, type AiConfig,
 } from './HarbourRegatta.physics'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
+import { Panel } from '../ui/Panel'
 
 function oppositeSide(side: OarSide | null): OarSide | null {
   if (side === null) return null
@@ -192,8 +195,7 @@ export function HarbourRegatta({ onDone }: Props) {
   // ── Intro phase ────────────────────────────────────────────────────────────
   if (phase === 'intro') {
     return (
-      <div className="minigame-screen">
-        <div className="minigame-title">⛵ HARBOUR REGATTA</div>
+      <MinigameShell title="HARBOUR REGATTA" icon="⛵">
         <p className="minigame-subtitle">
           Row your skiff round the harbour buoys! Tap LEFT and RIGHT oars in a
           steady alternating rhythm to go straight — favour one oar and you'll veer that way.
@@ -209,12 +211,12 @@ export function HarbourRegatta({ onDone }: Props) {
           ))}
         </div>
 
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
+        <Panel elevation="floating" tone="gold" runeCorners className="minigame-result-panel u-col u-items-c u-gap-5">
           <button className="action-btn action-btn--gold" onClick={startRace}>
             ROW OUT!
           </button>
-        </div>
-      </div>
+        </Panel>
+      </MinigameShell>
     )
   }
 
@@ -227,9 +229,7 @@ export function HarbourRegatta({ onDone }: Props) {
   const spinnakerY  = progressToY(SPINNAKER_FRAC * COURSE_LENGTH)
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">⛵ HARBOUR REGATTA</div>
-
+    <MinigameShell title="HARBOUR REGATTA" icon="⛵">
       {phase === 'racing' && (
         <p className="minigame-subtitle">Racing… keep a steady L-R-L-R rhythm!</p>
       )}
@@ -366,16 +366,13 @@ export function HarbourRegatta({ onDone }: Props) {
       )}
 
       {phase === 'result' && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">
-            You earned {ticketsEarned} ticket{ticketsEarned !== 1 ? 's' : ''}!
-          </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(ticketsEarned)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        <MinigameResultPanel
+          headline={`You earned ${ticketsEarned} ticket${ticketsEarned !== 1 ? 's' : ''}!`}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(ticketsEarned)}
+        />
       )}
-    </div>
+    </MinigameShell>
   )
 }
 

--- a/web/src/components/minigames/HigherOrLower.tsx
+++ b/web/src/components/minigames/HigherOrLower.tsx
@@ -5,6 +5,8 @@
 
 import React, { useState } from 'react'
 import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -86,9 +88,7 @@ export function HigherOrLower({ onDone }: Props) {
   const isRed = (suit: string) => suit === '♥' || suit === '♦'
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">🎴 HIGHER OR LOWER</div>
-
+    <MinigameShell title="HIGHER OR LOWER" icon="🎴">
       <div className="hol-cards-row u-flex u-gap-5 u-just-c u-wrap">
         {cards.map((card, i) => {
           const faceUp = i < revealed
@@ -134,10 +134,12 @@ export function HigherOrLower({ onDone }: Props) {
       )}
 
       {(phase === 'won' || phase === 'lost') && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">
-            {phase === 'won' ? '🎉 JACKPOT!' : 'Bad luck!'}
-          </div>
+        <MinigameResultPanel
+          headline={phase === 'won' ? '🎉 JACKPOT!' : 'Bad luck!'}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(tickets)}
+          tone={phase === 'won' ? 'gold' : 'ember'}
+        >
           <div className="minigame-result-breakdown">
             {phase === 'won' ? (
               <>
@@ -155,10 +157,7 @@ export function HigherOrLower({ onDone }: Props) {
               </>
             )}
           </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(tickets)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        </MinigameResultPanel>
       )}
 
       <div className="hol-progress">
@@ -169,6 +168,6 @@ export function HigherOrLower({ onDone }: Props) {
           : `Out on card ${revealed} of 5`
         }
       </div>
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/LuckySpinner.tsx
+++ b/web/src/components/minigames/LuckySpinner.tsx
@@ -3,6 +3,8 @@
 // Jackpot = 50 tickets.
 
 import React, { useState, useRef } from 'react'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
 
 interface Props {
   onDone: (ticketsEarned: number, isJackpot: boolean) => void
@@ -50,9 +52,7 @@ export function LuckySpinner({ onDone }: Props) {
   const isJackpot = result === JACKPOT_VALUE
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">🎡 LUCKY SPINNER</div>
-
+    <MinigameShell title="LUCKY SPINNER" icon="🎡">
       <div className="spinner-wrap u-relative u-col u-items-c">
         {/* Pointer */}
         <div className="spinner-pointer">▼</div>
@@ -120,14 +120,17 @@ export function LuckySpinner({ onDone }: Props) {
       )}
 
       {phase === 'result' && result !== null && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          {isJackpot && <div className="spinner-jackpot-flash">⭐ JACKPOT! ⭐</div>}
-          <div className="minigame-result-headline">You won {result} tickets!</div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(result, isJackpot)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        <MinigameResultPanel
+          headline={
+            <>
+              {isJackpot && <div className="spinner-jackpot-flash">⭐ JACKPOT! ⭐</div>}
+              You won {result} tickets!
+            </>
+          }
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(result, isJackpot)}
+        />
       )}
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/MarbleRace.tsx
+++ b/web/src/components/minigames/MarbleRace.tsx
@@ -4,6 +4,9 @@
 // Obstacles randomly pause marbles for a tick. Prize is based on finishing place.
 
 import React, { useState, useEffect, useRef } from 'react'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
+import { Panel } from '../ui/Panel'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -163,8 +166,7 @@ export function MarbleRace({ onDone }: Props) {
   // ── Choose phase ─────────────────────────────────────────────────────────────
   if (phase === 'choose') {
     return (
-      <div className="minigame-screen">
-        <div className="minigame-title">🏁 MARBLE RACE</div>
+      <MinigameShell title="MARBLE RACE" icon="🏁">
         <p className="minigame-subtitle">Pick your marble, then race to the finish!</p>
 
         <div className="race-prize-table">
@@ -191,7 +193,7 @@ export function MarbleRace({ onDone }: Props) {
           ))}
         </div>
 
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
+        <Panel elevation="floating" tone="gold" runeCorners className="minigame-result-panel u-col u-items-c u-gap-5">
           <button
             className="action-btn action-btn--gold"
             onClick={startRace}
@@ -199,8 +201,8 @@ export function MarbleRace({ onDone }: Props) {
           >
             {chosen === null ? 'PICK A MARBLE' : `RACE WITH ${MARBLE_NAMES[chosen].toUpperCase()}!`}
           </button>
-        </div>
-      </div>
+        </Panel>
+      </MinigameShell>
     )
   }
 
@@ -209,9 +211,7 @@ export function MarbleRace({ onDone }: Props) {
   const placeLabel = phase === 'result' ? PLACE_LABELS[place] : null
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">🏁 MARBLE RACE</div>
-
+    <MinigameShell title="MARBLE RACE" icon="🏁">
       {phase === 'racing' && (
         <p className="minigame-subtitle">
           Racing… your marble: {MARBLE_EMOJIS[chosen!]} {MARBLE_NAMES[chosen!]}
@@ -339,15 +339,12 @@ export function MarbleRace({ onDone }: Props) {
       )}
 
       {phase === 'result' && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">
-            You earned {ticketsEarned} ticket{ticketsEarned !== 1 ? 's' : ''}!
-          </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(ticketsEarned)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        <MinigameResultPanel
+          headline={`You earned ${ticketsEarned} ticket${ticketsEarned !== 1 ? 's' : ''}!`}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(ticketsEarned)}
+        />
       )}
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/MarbleRun.tsx
+++ b/web/src/components/minigames/MarbleRun.tsx
@@ -4,6 +4,9 @@
 // obstacle pegs that force deflections.
 
 import React, { useState, useEffect, useRef } from 'react'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
+import { Panel } from '../ui/Panel'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -210,8 +213,7 @@ export function MarbleRun({ onDone }: Props) {
   }
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">🔮 MARBLE RUN</div>
+    <MinigameShell title="MARBLE RUN" icon="🔮">
       <div className="marble-pattern-label">Pattern: {pattern.name}</div>
       <p className="minigame-subtitle">
         {phase === 'choose' && dropsLeft > 0
@@ -285,17 +287,16 @@ export function MarbleRun({ onDone }: Props) {
       )}
 
       {phase === 'result' && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">You earned {totalTickets} tickets!</div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(totalTickets)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        <MinigameResultPanel
+          headline={`You earned ${totalTickets} tickets!`}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(totalTickets)}
+        />
       )}
 
       {/* Random Drop column */}
     {phase === 'choose' && (
-      <div className="minigame-result-panel u-col u-items-c u-gap-5">
+      <Panel elevation="floating" tone="gold" runeCorners className="minigame-result-panel u-col u-items-c u-gap-5">
         <button
           className="action-btn action-btn--gold"
           onClick={() => dropMarble(Math.floor(Math.random() * 9))}
@@ -303,9 +304,9 @@ export function MarbleRun({ onDone }: Props) {
         >
           Random
         </button>
-      </div>
+      </Panel>
     )}
 
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/MinigameResultPanel.stories.tsx
+++ b/web/src/components/minigames/MinigameResultPanel.stories.tsx
@@ -1,0 +1,53 @@
+import { fn } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { MinigameResultPanel } from './MinigameResultPanel';
+
+const meta = {
+  component: MinigameResultPanel,
+  parameters: { layout: 'centered' },
+  render: (args) => (
+    <div style={{ background: '#0a0a14', padding: 48 }}>
+      <MinigameResultPanel {...args} />
+    </div>
+  ),
+} satisfies Meta<typeof MinigameResultPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithBreakdown: Story = {
+  args: {
+    headline: '✨ PERFECT!',
+    ctaLabel: 'COLLECT & EXIT',
+    onCta: fn(),
+    children: (
+      <div className="minigame-result-breakdown">
+        <div>Base (8 pairs): +40 🎫</div>
+        <div>Perfect bonus: +30 🎫</div>
+        <div>Speed bonus: +10 🎫</div>
+        <div className="minigame-result-total">Total: 80 🎫</div>
+      </div>
+    ),
+  },
+};
+
+export const SimpleHeadline: Story = {
+  args: {
+    headline: 'Nice work!',
+    ctaLabel: 'COLLECT & EXIT',
+    onCta: fn(),
+    children: <div className="minigame-result-total">Total: 25 🎫</div>,
+  },
+};
+
+export const Ember: Story = {
+  args: {
+    headline: 'Out of credits!',
+    ctaLabel: 'EXIT',
+    onCta: fn(),
+    tone: 'ember',
+    children: <div className="minigame-result-total">Cashed out: 0 credits</div>,
+  },
+};

--- a/web/src/components/minigames/MinigameResultPanel.tsx
+++ b/web/src/components/minigames/MinigameResultPanel.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Panel } from '../ui/Panel'
+
+interface Props {
+  headline: React.ReactNode
+  ctaLabel: string
+  onCta: () => void
+  tone?: 'gold' | 'ember'
+  children?: React.ReactNode
+}
+
+/**
+ * Shared minigame result screen — formalizes the "minigame-result-panel"
+ * convention nearly every arcade game already reaches for by hand onto a
+ * real Panel, so "you won" reads the same everywhere (matching Tower
+ * Defence's EndScreen, the cleanest existing precedent).
+ */
+export function MinigameResultPanel({ headline, ctaLabel, onCta, tone = 'gold', children }: Props) {
+  return (
+    <Panel
+      elevation="floating"
+      tone={tone === 'gold' ? 'gold' : 'danger'}
+      runeCorners
+      className="minigame-result-panel u-col u-items-c u-gap-5"
+    >
+      <div className="minigame-result-headline">{headline}</div>
+      {children}
+      <button
+        className={`action-btn action-btn--large action-btn--${tone === 'gold' ? 'gold' : 'danger'}`}
+        onClick={onCta}
+      >
+        {ctaLabel}
+      </button>
+    </Panel>
+  )
+}

--- a/web/src/components/minigames/MinigameShell.stories.tsx
+++ b/web/src/components/minigames/MinigameShell.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { MinigameShell } from './MinigameShell';
+
+const meta = {
+  component: MinigameShell,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof MinigameShell>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const body = (
+  <div style={{ color: '#c8c8d8', padding: 24 }}>Game board goes here.</div>
+);
+
+export const Default: Story = {
+  args: { title: 'TILE FLIP', icon: '🃏', children: body },
+};
+
+export const WithStat: Story = {
+  args: { title: 'HIGHER OR LOWER', icon: '🎴', stat: 'Streak: 4 · Credits: 120', children: body },
+};
+
+export const NoIcon: Story = {
+  args: { title: 'CRYSTAL CATCH', children: body },
+};

--- a/web/src/components/minigames/MinigameShell.tsx
+++ b/web/src/components/minigames/MinigameShell.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+interface Props {
+  title: string
+  icon?: string
+  /** Right-aligned score/state readout (tickets, lives, credits, timer…). */
+  stat?: React.ReactNode
+  children: React.ReactNode
+}
+
+/**
+ * Shared minigame frame — title/icon on the left, a score-or-state readout
+ * on the right, body below. Formalizes the "minigame-screen" convention
+ * already used ad-hoc by nearly every arcade game so headers read the same
+ * everywhere instead of each game hand-rolling its own title row.
+ */
+export function MinigameShell({ title, icon, stat, children }: Props) {
+  return (
+    <div className="minigame-screen">
+      <div className="minigame-header">
+        <div className="minigame-title">{icon ? `${icon} ` : ''}{title}</div>
+        {stat && <div className="minigame-header-stat">{stat}</div>}
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/minigames/MinigameShell.tsx
+++ b/web/src/components/minigames/MinigameShell.tsx
@@ -5,6 +5,10 @@ interface Props {
   icon?: string
   /** Right-aligned score/state readout (tickets, lives, credits, timer…). */
   stat?: React.ReactNode
+  /** Extra class appended alongside "minigame-screen", for a game that needs
+   *  a little of its own layout on top of the shared frame (e.g. a gap
+   *  between scene/status/controls sections). */
+  className?: string
   children: React.ReactNode
 }
 
@@ -14,9 +18,9 @@ interface Props {
  * already used ad-hoc by nearly every arcade game so headers read the same
  * everywhere instead of each game hand-rolling its own title row.
  */
-export function MinigameShell({ title, icon, stat, children }: Props) {
+export function MinigameShell({ title, icon, stat, className, children }: Props) {
   return (
-    <div className="minigame-screen">
+    <div className={['minigame-screen', className].filter(Boolean).join(' ')}>
       <div className="minigame-header">
         <div className="minigame-title">{icon ? `${icon} ` : ''}{title}</div>
         {stat && <div className="minigame-header-stat">{stat}</div>}

--- a/web/src/components/minigames/TileFlip.tsx
+++ b/web/src/components/minigames/TileFlip.tsx
@@ -4,6 +4,8 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { playMinigameCorrect, playMinigameWrong } from '../../game/sound'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
 
 interface Props {
   onDone: (ticketsEarned: number, perfect: boolean) => void
@@ -106,15 +108,11 @@ export function TileFlip({ onDone }: Props) {
   const matchedCount = matched.filter(Boolean).length / 2
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">🃏 TILE FLIP</div>
-
-      <div className="tileflip-stats">
-        <span>Pairs: {matchedCount}/{ICONS.length}</span>
-        <span>Mistakes: {mistakes}</span>
-        <span>Time: {(elapsedMs / 1000).toFixed(1)}s</span>
-      </div>
-
+    <MinigameShell
+      title="TILE FLIP"
+      icon="🃏"
+      stat={`Pairs: ${matchedCount}/${ICONS.length} · Mistakes: ${mistakes} · Time: ${(elapsedMs / 1000).toFixed(1)}s`}
+    >
       <div className="tile-grid">
         {tiles.map((icon, idx) => (
           <button
@@ -130,21 +128,19 @@ export function TileFlip({ onDone }: Props) {
       </div>
 
       {phase === 'result' && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">
-            {mistakes === 0 ? '✨ PERFECT!' : 'Nice work!'}
-          </div>
+        <MinigameResultPanel
+          headline={mistakes === 0 ? '✨ PERFECT!' : 'Nice work!'}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(finalTickets, mistakes === 0)}
+        >
           <div className="minigame-result-breakdown">
             <div>Base ({ICONS.length} pairs): +{ICONS.length * TICKETS_PER_MATCH} 🎫</div>
             {mistakes === 0 && <div>Perfect bonus: +{PERFECT_BONUS} 🎫</div>}
             {elapsedMs < FAST_THRESHOLD_MS && <div>Speed bonus: +{FAST_BONUS} 🎫</div>}
             <div className="minigame-result-total">Total: {finalTickets} 🎫</div>
           </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(finalTickets, mistakes === 0)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
+        </MinigameResultPanel>
       )}
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/VideoPoker.tsx
+++ b/web/src/components/minigames/VideoPoker.tsx
@@ -5,6 +5,9 @@
 
 import React, { useState, useCallback } from 'react'
 import { loadCrystals, saveCrystals } from '../../game/collection'
+import { MinigameShell } from './MinigameShell'
+import { MinigameResultPanel } from './MinigameResultPanel'
+import { Panel } from '../ui/Panel'
 
 interface Props {
   onDone: (ticketsEarned: number) => void
@@ -171,12 +174,13 @@ export function VideoPoker({ onDone }: Props) {
 
   if (phase === 'done') {
     return (
-      <div className="minigame-screen">
-        <div className="minigame-title">♠ VIDEO POKER</div>
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
-          <div className="minigame-result-headline">
-            {cashOutTickets > 0 ? 'Cashed out!' : 'Out of credits!'}
-          </div>
+      <MinigameShell title="VIDEO POKER" icon="♠">
+        <MinigameResultPanel
+          headline={cashOutTickets > 0 ? 'Cashed out!' : 'Out of credits!'}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(cashOutTickets)}
+          tone={cashOutTickets > 0 ? 'gold' : 'ember'}
+        >
           <div className="minigame-result-breakdown">
             {cashOutTickets > 0 ? (
               <>
@@ -188,11 +192,8 @@ export function VideoPoker({ onDone }: Props) {
             )}
             <div className="minigame-result-total">Total: {cashOutTickets} 🎫</div>
           </div>
-          <button className="action-btn action-btn--gold" onClick={() => onDone(cashOutTickets)}>
-            COLLECT &amp; EXIT
-          </button>
-        </div>
-      </div>
+        </MinigameResultPanel>
+      </MinigameShell>
     )
   }
 
@@ -209,9 +210,7 @@ export function VideoPoker({ onDone }: Props) {
   })()
 
   return (
-    <div className="minigame-screen">
-      <div className="minigame-title">♠ VIDEO POKER</div>
-
+    <MinigameShell title="VIDEO POKER" icon="♠">
       <div className="fm-header u-flex u-items-c u-gap-7">
         <span className="fm-credits">Credits: {credits}</span>
         {phase === 'result' && result && result.multiplier > 0 && (
@@ -290,7 +289,12 @@ export function VideoPoker({ onDone }: Props) {
 
       {/* Result phase controls */}
       {phase === 'result' && result && (
-        <div className="minigame-result-panel u-col u-items-c u-gap-5">
+        <Panel
+          elevation="floating"
+          tone={isWin ? 'gold' : 'neutral'}
+          runeCorners={isWin}
+          className="minigame-result-panel u-col u-items-c u-gap-5"
+        >
           <div className={`vp-result-name${isWin ? ' vp-result-name--win' : ''}`}>
             {result.name}
           </div>
@@ -307,7 +311,7 @@ export function VideoPoker({ onDone }: Props) {
               CASH OUT ({credits * TICKETS_PER_CREDIT} 🎫)
             </button>
           </div>
-        </div>
+        </Panel>
       )}
 
       {canBuy && (
@@ -333,6 +337,6 @@ export function VideoPoker({ onDone }: Props) {
           </tbody>
         </table>
       </details>
-    </div>
+    </MinigameShell>
   )
 }

--- a/web/src/components/minigames/towerdefence/EndScreen.tsx
+++ b/web/src/components/minigames/towerdefence/EndScreen.tsx
@@ -1,4 +1,5 @@
 import { TDGameState, TD_TOTAL_WAVES } from "../../../game/towerDefence";
+import { MinigameResultPanel } from "../MinigameResultPanel";
 
 
 
@@ -12,16 +13,17 @@ export interface Props {
   export function TowerDefenceEndScreen({ game, reward, onDone, rewardLabel }: Props) {
     const won = game.phase === 'victory'
     return (
-      <div className="td-end-screen u-col u-items-c u-just-c u-gap-7 u-text-c">
-        <div className={`td-end-title ${won ? 'td-end-title--win' : 'td-end-title--lose'}`}>
-          {won ? '⚔ VICTORY!' : '💀 DEFEATED'}
-        </div>
-        <div className="td-end-stat">Waves cleared: {game.wavesCompleted} / {TD_TOTAL_WAVES}</div>
-        <div className="td-end-stat">Score: {game.score.toLocaleString()}</div>
-        <div className="td-end-reward">Reward: {rewardLabel}</div>
-        <button className="action-btn action-btn--gold" onClick={() => onDone(reward)}>
-          COLLECT &amp; EXIT
-        </button>
+      <div className="td-end-screen u-col u-items-c u-just-c">
+        <MinigameResultPanel
+          headline={won ? '⚔ VICTORY!' : '💀 DEFEATED'}
+          ctaLabel="COLLECT & EXIT"
+          onCta={() => onDone(reward)}
+          tone={won ? 'gold' : 'ember'}
+        >
+          <div className="td-end-stat">Waves cleared: {game.wavesCompleted} / {TD_TOTAL_WAVES}</div>
+          <div className="td-end-stat">Score: {game.score.toLocaleString()}</div>
+          <div className="td-end-reward">Reward: {rewardLabel}</div>
+        </MinigameResultPanel>
       </div>
     )
   }

--- a/web/src/styles/minigames-2.css
+++ b/web/src/styles/minigames-2.css
@@ -1100,6 +1100,12 @@
   font-size: var(--font-xl);
   color: var(--accent-gold);
   font-weight: bold;
+  text-shadow: 0 0 16px color-mix(in srgb, var(--accent-gold) 50%, transparent);
+}
+
+.minigame-result-panel.panel--danger .minigame-result-headline {
+  color: var(--accent-ember);
+  text-shadow: 0 0 16px color-mix(in srgb, var(--accent-ember) 50%, transparent);
 }
 
 .minigame-result-breakdown {

--- a/web/src/styles/minigames-2.css
+++ b/web/src/styles/minigames-2.css
@@ -1055,18 +1055,34 @@
   padding: 16px;
   height: 100%;
   overflow-y: auto;
-  background: #0a0a14;
+  background: var(--game-bg);
   color: #c8c8d8;
   font-family: var(--font-mono);
   box-sizing: border-box;
 }
 
+.minigame-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-6);
+  width: 100%;
+  max-width: 480px;
+  margin-bottom: 4px;
+}
+
+.minigame-header-stat {
+  font-size: var(--font-sm);
+  color: var(--game-text-color-dim);
+  letter-spacing: 1px;
+  margin-left: auto;
+}
+
 .minigame-title {
   font-size: 1.429rem;
   font-weight: bold;
-  color: var(--color-gold);
+  color: var(--accent-gold);
   letter-spacing: 2px;
-  margin-bottom: 4px;
 }
 
 .minigame-subtitle {
@@ -1077,14 +1093,12 @@
 
 .minigame-result-panel {
   margin-top: 16px;
-  border: 1px solid #5050a0;
-  background: #0e0e22;
   padding: 16px 24px;
 }
 
 .minigame-result-headline {
   font-size: var(--font-xl);
-  color: var(--color-gold);
+  color: var(--accent-gold);
   font-weight: bold;
 }
 

--- a/web/src/styles/minigames-3.css
+++ b/web/src/styles/minigames-3.css
@@ -2,14 +2,6 @@
 
 /* ── Tile Flip ────────────────────────────────────────────────────────────── */
 
-.tileflip-stats {
-  display: flex;
-  gap: 16px;
-  font-size: var(--font-md);
-  color: #8888aa;
-  margin-bottom: 12px;
-}
-
 .tile-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/web/src/styles/minigames-4.css
+++ b/web/src/styles/minigames-4.css
@@ -815,12 +815,9 @@
 /* ── End screen ── */
 .td-end-screen {
   height: 100%;
-  background: #0a0a0a;
+  background: var(--game-bg);
   padding: 24px;
 }
-.td-end-title { font-size: 28px; font-weight: bold; letter-spacing: 4px; }
-.td-end-title--win  { color: var(--color-green-bright); text-shadow: 0 0 20px rgba(76,175,80,0.6); }
-.td-end-title--lose { color: #f44336; text-shadow: 0 0 20px rgba(244,67,54,0.6); }
 .td-end-stat   { font-size: 15px; color: #aaa; }
 .td-end-reward { font-size: 17px; color: var(--color-gold); font-weight: bold; }
 

--- a/web/src/styles/minigames-4.css
+++ b/web/src/styles/minigames-4.css
@@ -3,34 +3,8 @@
 /* ── Fishing minigame ── */
 
 .fishing-screen {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   gap: 12px;
-  padding: 16px 12px;
   min-height: 100vh;
-  background: #0a0a0a;
-  font-family: var(--font-mono);
-  color: #ccc;
-}
-
-.fishing-header {
-  width: 100%;
-  text-align: center;
-}
-
-.fishing-title {
-  font-size: 1.3rem;
-  font-weight: bold;
-  letter-spacing: 3px;
-  color: #7ef;
-  text-transform: uppercase;
-}
-
-.fishing-bait-counter {
-  margin-top: 4px;
-  font-size: 0.9rem;
-  color: #999;
 }
 
 .fishing-scene {


### PR DESCRIPTION
## Summary

Progress on #2181 — the eighth Phase 2 screen pass in the dark-fantasy UI epic (#2165). **This PR does not close #2181** — see "Remaining scope" below.

Scoping research going in found the issue's true surface is much larger than it reads: ~15,000 lines across 108+ files once City Builder's ~25 sub-components and Farming Sim are counted, and "casino games" turned out to be a scoping question of its own — `Blackjack` doesn't exist as an arcade minigame (only `rare-events/BlackjackEvent.tsx`, a battle event on a completely different trigger/economy), and the hub's `CasinoScreen.tsx` is an unrelated standalone roulette game, not a host for the other five. Given that, this PR ships the cleanly-scoped, low-risk slice and leaves a comment on #2181 documenting what's left.

The research also surfaced good news: 9 of the 12 real arcade games had already independently converged on an identical ad-hoc convention (`minigame-screen`/`minigame-title` header, `minigame-result-panel` result box) — so most of this pass was formalizing an existing pattern rather than inventing one from scratch.

- **New shared primitives**: `MinigameShell` (title/icon + right-aligned score/state readout + body) and `MinigameResultPanel` (Panel-based, tone-aware result card — gold/ember — replacing the ad-hoc `minigame-result-panel` box), both with stories.
- **Migrated onto them**: TileFlip, Fishing (header only — it has no single end-of-session result screen, so only the header moved), HarbourRegatta, MarbleRace, MarbleRun, CrystalCatch, HigherOrLower, VideoPoker, FruitMachine (3 separate return paths), LuckySpinner, Tower Defence's `EndScreen.tsx` (its in-game HUD header stays bespoke — it's a dense live status bar, not a title+stat pattern, the same reasoning that kept Battlefield's TopBar bespoke in an earlier issue), and `TheatreScreen.tsx` (the Crown Theatre minigame — not in the issue's literal 14-game list, but it shared the exact same convention, so leaving it unmigrated would have broken it: `minigame-result-panel`'s box styling now lives on `Panel`, not the raw CSS class).
- Made `minigame-result-headline` tone-aware (gold vs ember) so win/lose coloring carries through to the headline text, not just the panel border.

## Remaining scope (left for follow-up, not attempted here)

- **City Builder + Farming Sim** (~2,766 lines, ~25 sub-components) — by far the largest and riskiest remaining piece; several of its modals (`AttackReportModal`, `BuildingInspectModal`, `DisasterModal`, `FortSlotModal`, `ResidentInfoModal`, `TradeRouteModal`) still hand-roll chrome on raw `ModalBackdrop` instead of `ui/Modal`, and `ResourceChip`/`ResourceStrip` (the acceptance criterion's named "best existing version" to promote) need a design pass to genericize before other games can reuse the pattern.
- **Casino coherence** — needs a scoping decision first: is `BlackjackEvent.tsx` being folded in as the 6th casino game despite living in `rare-events/` on a different economy, or does a new Blackjack arcade game need to be built? Recommend flagging this to the issue author before starting.
- **`MiniGamesMenu.tsx`** — not touched.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 2861/2861 passing (known-noise `chrome-headless-shell` cleanup error unrelated to test results)
- [x] Verified visually via Storybook + Playwright screenshots for all 9 migrated games with stories (CrystalCatch, HarbourRegatta, HigherOrLower, LuckySpinner, MarbleRace, MarbleRun, VideoPoker, FruitMachine, TileFlip) plus Tower Defence's `EndScreen` — headers, result panels, and tone coloring all render correctly
- [x] Grep-confirmed no bare `minigame-screen`/`minigame-result-panel` divs remain anywhere in the codebase outside the two new shell components themselves

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_