### PR TITLE
Fix Collection screen: mastery-bar grouping, clipped labels, and green stragglers

### DIFF
--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -220,7 +220,10 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
         <div className="card-rarity">{rarityStars(card.rarity)}</div>
         <div className={`card-type-badge card-type-badge--${getCardCategory(card)}`}>
           {CATEGORY_ICON[getCardCategory(card)]}
-          <span>{CATEGORY_LABEL[getCardCategory(card)]}</span>
+          {/* The label carries its own ellipsis: text-overflow can't act on the
+              badge itself, since that's a flex container and this span is a
+              flex item rather than inline content it clips. */}
+          <span className="card-type-badge-label">{CATEGORY_LABEL[getCardCategory(card)]}</span>
         </div>
         {showDetails && (
           <button

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -286,28 +286,30 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
   const inner = (
     <>
 
-      {/* Action row */}
-      <div className="collection-action-row u-flex u-items-c u-gap-4 u-wrap">
-        <Button
-          size="sm"
-          className="collection-disenchant-btn"
-          onClick={handleDisenchantAll}
-          disabled={totalExtras === 0}
-          style={{ flex: 1 }}
-        >
-          🔮 Disenchant extras ({totalExtras})
-        </Button>
-        <Button
-          size="sm"
-          className="collection-master-btn"
-          onClick={handleMasterAll}
-          disabled={totalUpgradeable === 0}
-          title="Convert all extra copies into mastery XP"
-          style={{ flex: 1 }}
-        >
-          ★ Upgrade all ({totalUpgradeable})
-        </Button>
-      </div>
+      {/* Action row — hidden entirely when there's nothing to act on, rather
+          than sitting there as two greyed-out full-width bars. Each button
+          still disables individually when only one of the two applies. */}
+      {(totalExtras > 0 || totalUpgradeable > 0) && (
+        <div className="collection-action-row u-flex u-items-c u-gap-4 u-wrap">
+          <Button
+            size="sm"
+            className="collection-disenchant-btn"
+            onClick={handleDisenchantAll}
+            disabled={totalExtras === 0}
+          >
+            🔮 Disenchant extras ({totalExtras})
+          </Button>
+          <Button
+            size="sm"
+            className="collection-master-btn"
+            onClick={handleMasterAll}
+            disabled={totalUpgradeable === 0}
+            title="Convert all extra copies into mastery XP"
+          >
+            ★ Upgrade all ({totalUpgradeable})
+          </Button>
+        </div>
+      )}
 
       {/* Filter / Sort / Group bar */}
       <div className="filter-bar">
@@ -468,7 +470,10 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
           </div>
         )}
 
-        <span className="filter-owned">{filtered.length} cards</span>
+        {/* "shown", not "cards" — this is the filtered catalog count, which is
+            not the same as how many copies you own (and differs from the
+            discovery denominator below, which includes hidden secrets). */}
+        <span className="filter-owned">{filtered.length} shown · {totalOwned.toLocaleString()} copies</span>
       </div>
 
       {/* Collection progress */}
@@ -477,8 +482,8 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
         <span className="collection-progress-label">{distinctOwned}/{catalog.length} discovered ({completionPct}%)</span>
       </div>
 
-      {/* Grid */}
-      <div className="collection-grid u-flex u-wrap u-just-c u-gap-4 u-grow">
+      {/* Grid — gaps are asymmetric (see .collection-grid), so no u-gap-* here */}
+      <div className="collection-grid u-flex u-wrap u-just-c u-grow">
         {(() => {
           let lastGroup: string | null = null
           return sorted.map(card => {

--- a/web/src/components/ui/MasteryBar.tsx
+++ b/web/src/components/ui/MasteryBar.tsx
@@ -11,8 +11,15 @@ export function MasteryBar({ xp }: Props) {
   const pct = needed > 0 ? Math.round((current / needed) * 100) : 100
   return (
     <div className="mastery-bar-wrap u-flex u-items-c">
-      <span className="mastery-level">★{level}</span>
-      <ProgressBar pct={pct} color="linear-gradient(90deg, #b8860b, #ffd700)" className="mastery-bar-track" />
+      {/* No "★0" — callers show the gold ★N badge only from level 1, so
+          labelling a level-0 bar contradicted it. Below level 1 the bar just
+          shows raw progress toward the first level. */}
+      {level > 0 && <span className="mastery-level">★{level}</span>}
+      <ProgressBar
+        pct={pct}
+        color="linear-gradient(90deg, var(--color-gold-dim), var(--color-gold))"
+        className="mastery-bar-track"
+      />
       <span className="mastery-xp">{current}/{needed}</span>
     </div>
   )

--- a/web/src/styles/buttons.css
+++ b/web/src/styles/buttons.css
@@ -202,9 +202,12 @@
   overflow: hidden;
 }
 
+/* Gold by default: progress/collection/economy is gold under the #2165 art
+   direction, and green is now semantic-only. Callers needing a different
+   meaning pass ProgressBar's `color` prop (as MasteryBar does). */
 .progress-bar-fill {
   height: 100%;
-  background: #33ff33;
+  background: var(--accent-gold);
   border-radius: 2px;
   transition: width 0.2s ease-out;
 }

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -2,11 +2,17 @@
 
 /* ─── Card Tile ──────────────────────────────────────── */
 
+/* --card-frame is the single colour every part of the tile's frame derives
+   from: border, background tint, hover glow and corner ornaments. Each rarity
+   overrides just that one value below. Before this, the base tile and :hover
+   hard-coded green, so hovering a legendary replaced its gold frame with green
+   and destroyed the rarity signal. */
 .card-tile {
+  --card-frame: var(--color-gray-6);
   flex-shrink: 0;
   cursor: pointer;
   padding: 8px 10px;
-  border: 2px solid rgba(51, 255, 51, 0.4);
+  border: 2px solid color-mix(in srgb, var(--card-frame) 55%, transparent);
   border-radius: 4px;
   transition: all 0.15s;
   width: 90px;
@@ -14,14 +20,15 @@
   flex-direction: column;
   gap: 3px;
   position: relative;
-  background: rgba(51, 255, 51, 0.03);
+  background: color-mix(in srgb, var(--card-frame) 4%, transparent);
 }
 
+/* Hover intensifies the card's OWN rarity colour rather than overriding it. */
 .card-tile:hover {
-  border-color: var(--game-text-color);
-  background: rgba(51, 255, 51, 0.08);
+  border-color: var(--card-frame);
+  background: color-mix(in srgb, var(--card-frame) 10%, transparent);
   transform: translateY(-3px);
-  box-shadow: 0 0 12px rgba(51, 255, 51, 0.3);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--card-frame) 35%, transparent);
 }
 
 /* Press/tap feedback — the hand's only interaction is a tap, so it needs its
@@ -43,7 +50,7 @@
 .card-tile--disabled:hover {
   transform: none;
   box-shadow: none;
-  background: rgba(51, 255, 51, 0.03);
+  background: color-mix(in srgb, var(--card-frame) 4%, transparent);
 }
 
 /* Selection ring — an outline (not border) so it never competes with the
@@ -78,36 +85,57 @@
    box-shadows (no infinite animation) since a full collection grid can have
    hundreds of these on screen; the secret rarities below keep their existing
    animated treatments since there are always few of them at once. */
+/* Common is neutral steel, not green — green is reserved for semantic use
+   (friendly units, positive deltas) per the #2165 art direction, so it can't
+   also mean "lowest rarity". */
 .card-tile--common {
-  border-color: rgba(85, 204, 85, 0.45);
+  --card-frame: var(--color-gray-6);
 }
 
 .card-tile--uncommon {
-  border-color: rgba(68, 153, 255, 0.5);
-  background: rgba(68, 153, 255, 0.04);
-  box-shadow: inset 0 0 0 1px rgba(150, 200, 255, 0.1);
+  --card-frame: #4499ff;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--card-frame) 25%, transparent);
 }
 
 .card-tile--rare {
-  border-color: rgba(187, 102, 255, 0.6);
+  --card-frame: #bb66ff;
   background:
-    linear-gradient(160deg, rgba(187,102,255,0.10) 0%, transparent 55%),
-    rgba(187, 102, 255, 0.04);
-  box-shadow: inset 0 0 0 1px rgba(220, 170, 255, 0.15), 0 0 6px rgba(187, 102, 255, 0.15);
+    linear-gradient(160deg, color-mix(in srgb, var(--card-frame) 10%, transparent) 0%, transparent 55%),
+    color-mix(in srgb, var(--card-frame) 4%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--card-frame) 30%, transparent),
+    0 0 6px color-mix(in srgb, var(--card-frame) 15%, transparent);
+}
+
+/* Sits between rare and legendary. Previously absent entirely, so an epic card
+   silently fell back to the base frame. */
+.card-tile--epic {
+  --card-frame: #ff7ac6;
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--card-frame) 11%, transparent) 0%, transparent 55%),
+    color-mix(in srgb, var(--card-frame) 4%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--card-frame) 30%, transparent),
+    0 0 8px color-mix(in srgb, var(--card-frame) 18%, transparent);
 }
 
 .card-tile--legendary {
-  border-color: rgba(255, 204, 0, 0.65);
+  --card-frame: var(--color-gold-alt);
   background:
-    linear-gradient(160deg, rgba(255,204,0,0.12) 0%, transparent 55%),
-    rgba(255, 204, 0, 0.04);
-  box-shadow: inset 0 0 0 1px rgba(255, 224, 130, 0.2), 0 0 10px rgba(255, 204, 0, 0.2);
+    linear-gradient(160deg, color-mix(in srgb, var(--card-frame) 12%, transparent) 0%, transparent 55%),
+    color-mix(in srgb, var(--card-frame) 4%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--card-frame) 35%, transparent),
+    0 0 10px color-mix(in srgb, var(--card-frame) 20%, transparent);
 }
 
-/* Corner ornaments — rare gets two, legendary gets all four, echoing the
-   rune-corner treatment ui/Panel.tsx uses for gold/arcane panels elsewhere. */
+/* Corner ornaments — rare/epic get two, legendary gets all four, echoing the
+   rune-corner treatment ui/Panel.tsx uses for gold/arcane panels elsewhere.
+   Colour comes from --card-frame, so it tracks the rarity automatically. */
 .card-tile--rare::before,
 .card-tile--rare::after,
+.card-tile--epic::before,
+.card-tile--epic::after,
 .card-tile--legendary::before,
 .card-tile--legendary::after {
   content: '';
@@ -116,23 +144,22 @@
   height: 7px;
   pointer-events: none;
   z-index: 1;
+  border-color: var(--card-frame);
 }
 .card-tile--rare::before,
+.card-tile--epic::before,
 .card-tile--legendary::before {
   top: -1px; left: -1px;
   border-top: 2px solid;
   border-left: 2px solid;
 }
 .card-tile--rare::after,
+.card-tile--epic::after,
 .card-tile--legendary::after {
   bottom: -1px; right: -1px;
   border-bottom: 2px solid;
   border-right: 2px solid;
 }
-.card-tile--rare::before,
-.card-tile--rare::after       { border-color: #bb66ff; }
-.card-tile--legendary::before,
-.card-tile--legendary::after  { border-color: var(--color-gold-alt); }
 
 /* ─── Secret-rarity card tiles ────────────────────────────────────────────── */
 @keyframes secret-shimmer {
@@ -153,8 +180,13 @@
   93%, 97%      { opacity: 0.4; }
 }
 
+/* Secret rarities keep their bespoke animated fills, but still declare
+   --card-frame so the shared :hover rule (which outranks these by specificity)
+   glows in their own colour instead of the base grey. */
+
 /* Shiny: warm gold shimmer sweep */
 .card-tile--shiny {
+  --card-frame: #ffdc3c;
   border-color: rgba(255, 220, 60, 0.8);
   background: linear-gradient(
     105deg,
@@ -169,6 +201,7 @@
 
 /* Holofoil: rainbow prism shift */
 .card-tile--holofoil {
+  --card-frame: #40e0d0;
   border-color: rgba(64, 224, 208, 0.75);
   background: linear-gradient(
     120deg,
@@ -185,6 +218,7 @@
 
 /* Glass: frosted crystal look, subtle crack flash */
 .card-tile--glass {
+  --card-frame: #a0d8ef;
   border-color: rgba(160, 216, 239, 0.8);
   background: rgba(200, 235, 255, 0.06);
   backdrop-filter: blur(1px);
@@ -209,6 +243,7 @@
 
 /* Mythic: deep void purple with cosmic pulse */
 .card-tile--mythic {
+  --card-frame: var(--accent-arcane);
   border-color: rgba(224, 64, 251, 0.85);
   background: linear-gradient(160deg, rgba(40,0,60,0.55) 0%, rgba(10,0,20,0.55) 100%);
   animation: mythic-pulse 2s ease-in-out infinite;
@@ -319,17 +354,22 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
 }
 
+/* 3 lines, not 2: the effective text width is only ~50px (66px content box
+   less the 16px reserved for the absolutely-positioned cost badge), so longer
+   names like "Grand Dragon Roost" were being clamped to an ellipsis. The
+   matching min-height keeps every tile the same height, which the collection
+   grid relies on. */
 .card-title {
   font-size: var(--font-sm);
   font-weight: bold;
-  color: var(--game-text-color);
+  color: var(--text-primary);
   letter-spacing: 0.5px;
   padding-right: 16px;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  min-height: 30px;
+  min-height: 42px;
 }
 
 .card-title--badge {
@@ -350,11 +390,19 @@
 
 /* Bottom row text floors at --font-xs (0.714rem) — nothing on the tile
    should read smaller than that, even the rarity stars/type label (#2177). */
+/* min-width:0 lets the star string shrink. Without it its automatic minimum
+   size is the full 5-star width, which forced all the overflow onto the type
+   badge and clipped the label mid-glyph ("SPAWN" → "SPAWI"). */
 .card-rarity {
   font-size: var(--font-xs);
   color: var(--game-text-color-muted);
+  min-width: 0;
+  overflow: hidden;
 }
 
+/* The type label is more informative than an exact star count (rarity is
+   already encoded in the frame colour), so the badge holds its width and the
+   stars give way instead. */
 .card-type-badge {
   display: flex;
   align-items: center;
@@ -365,6 +413,11 @@
   line-height: 1;
   opacity: 0.9;
   white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.card-type-badge-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/web/src/styles/collection-meta.css
+++ b/web/src/styles/collection-meta.css
@@ -478,18 +478,21 @@
 
 .player-tab {
   background: none;
-  border: 1px solid #444;
+  border: 1px solid var(--border-edge);
   color: var(--game-text-color-dim);
   font-family: inherit;
   font-size: var(--font-sm);
   padding: 4px 12px;
   cursor: pointer;
   position: relative;
+  border-radius: var(--radius-sm);
 }
 
+/* Was a raw #0f0 — brighter than any green in the palette, and green is now
+   semantic-only. Gold matches the active-tab treatment used elsewhere. */
 .player-tab--active {
-  border-color: #0f0;
-  color: #0f0;
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
 }
 
 .player-tab-badge {

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -279,10 +279,12 @@
   flex-shrink: 0;
 }
 
+/* Neutral grey, not the theme green: these are plain metadata counts sitting
+   beside gold chrome, and green would read as a semantic signal it isn't. */
 .filter-owned {
   margin-left: auto;
   font-size: var(--font-xs);
-  color: var(--game-text-color-dim);
+  color: var(--color-gray-9);
   white-space: nowrap;
   flex-shrink: 0;
   padding-left: 8px;
@@ -301,7 +303,7 @@
 }
 .collection-progress-label {
   font-size: var(--font-xs);
-  color: var(--game-text-color-dim);
+  color: var(--color-gray-9);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -453,15 +455,17 @@
 }
 .filter-active-pills::-webkit-scrollbar { display: none; }
 
+/* Active-filter chip — a UI state indicator, so gold rather than the old
+   terminal green. */
 .filter-pill {
   display: inline-flex;
   align-items: center;
   gap: 3px;
   font-size: var(--font-xxs);
-  color: var(--game-text-color);
-  background: rgba(51, 255, 51, 0.08);
-  border: 1px solid var(--game-text-color);
-  border-radius: 2px;
+  color: var(--accent-gold);
+  background: color-mix(in srgb, var(--accent-gold) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-gold) 60%, transparent);
+  border-radius: var(--radius-sm);
   padding: 1px 4px;
   white-space: nowrap;
   flex-shrink: 0;
@@ -519,10 +523,16 @@
   margin-bottom: 4px;
 }
 
+/* Asymmetric gaps on purpose: each cell's footer (count + mastery bar) sits
+   ~19px below its own card, so a symmetric 8px gap left the bar nearer the
+   NEXT row's card than the one it describes. The row gap has to clear the
+   footer for the grouping to read correctly. */
 .collection-grid {
   padding: 8px 0;
   overflow-y: auto;
   align-content: flex-start;
+  column-gap: var(--gap-4);
+  row-gap: 18px;
 }
 
 .collection-cell {
@@ -693,7 +703,7 @@
 .db-action-sm {
   font-size: var(--font-xs) !important;
   padding: 3px 7px !important;
-  border-color: rgba(51, 255, 51, 0.3) !important;
+  border-color: var(--border-edge) !important;
   color: var(--game-text-color-dim) !important;
 }
 
@@ -920,6 +930,13 @@
   padding: 5px 0 3px;
 }
 
+/* Was an inline style={{ flex: 1 }} on each button, which no stylesheet could
+   override. Lives here now so the split is adjustable. */
+.collection-action-row > .collection-disenchant-btn,
+.collection-action-row > .collection-master-btn {
+  flex: 1;
+}
+
 .collection-disenchant-btn {
   border-color: rgba(136, 204, 255, 0.5);
   color: #88ccff;
@@ -928,12 +945,13 @@
   background: rgba(136, 204, 255, 0.12);
   box-shadow: 0 0 10px rgba(136, 204, 255, 0.3);
 }
+/* No extra opacity knock-down here: .action-btn:disabled already dims via
+   tokens, and stacking 0.3 on top made these read as invisible dead weight. */
 .collection-disenchant-btn:disabled,
 .extra-btn--disabled,
 .extra-btn:disabled,
 .event-choice--disabled,
 .collection-master-btn:disabled {
-  opacity: 0.3;
   cursor: not-allowed;
 }
 
@@ -1007,9 +1025,10 @@
 
 /* ─── Mastery Bar ────────────────────────────────────── */
 
+/* No margin-top: the containing .cell-footer already supplies a 3px gap, and
+   having both double-counted the spacing below each card. */
 .mastery-bar-wrap {
   gap: 3px;
-  margin-top: 3px;
 }
 .mastery-level {
   font-size: var(--font-xxs);

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -117,7 +117,11 @@
   --accent-arcane: #e040fb;
   --accent-blood:  #6a2288;
 
-  /* Text */
+  /* Text — --text-primary is the neutral reading colour for content that
+     isn't part of the CRT-green theme (card names, and anything else that
+     shouldn't inherit --game-text-color just because it needed to be legible).
+     Its absence is why so much content text reaches for the green token. */
+  --text-primary: #e8e8e8;
   --text-inverse: #fff;
 
   /* Borders / edging */


### PR DESCRIPTION
## Summary

Defects spotted on the live Collection screen after Phase 2 of #2165 landed. Some are genuine bugs the screen-by-screen passes missed, others are pre-token holdovers the "green demoted to semantic-only" direction should have swept.

**The most serious one wasn't visible in the screenshot that prompted this:** `.card-tile:hover` hard-set `border-color: var(--game-text-color)` plus a green glow, so **hovering a legendary card replaced its gold frame with green** — the rarity signal was destroyed by the interaction. The base tile, its background tint and the hover state were all still terminal green; #2177's rarity frames only painted over the *resting* border for three tiers. The secret rarities (shiny/holo/glass/mythic) had the same bug, since the shared `:hover` rule outranks them by specificity.

### Card tile — one `--card-frame` per rarity
Every part of the frame (border, tint, hover glow, corner ornaments) now derives from a single `--card-frame` custom property each rarity sets once, so hover **intensifies the card's own colour** rather than overriding it. Also:
- **Common → neutral steel.** Green is semantic-only, so it can't also mean "lowest rarity".
- **Added the missing `.card-tile--epic` rule** — none existed, so an epic card silently fell back to the base frame. Latent today (no card uses `epic`), but a real gap.
- **Added `--text-primary`** — the token layer had no neutral reading colour, which is *why* card titles reached for the green theme token.

### `SPAWN` → `SPAWI`
Not a fixed width. Three things compounded: `.card-rarity` had no `min-width: 0` so the 5-star string refused to shrink; `.card-type-badge` *did* have `overflow: hidden`, so it absorbed 100% of the overflow; and its `text-overflow: ellipsis` was **inert** because the element is `display: flex` — `text-overflow` can't act on a child flex item. The label now carries its own ellipsis and the badge holds its width. Card titles get a third line so `"Grand Dragon Lair"` stops truncating.

### Mastery bars were attached to the wrong card
Each footer sat ~19px below its own tile but only **8px above the next row's**. `.collection-grid` is a flex-wrap container taking one flat gap for both axes, and `.cell-footer`'s gap was double-counted by a redundant `margin-top`. Gaps are now asymmetric. Measured in-browser after the fix: card→own footer **0px**, footer→next row **18px**.

### Also
- **Dead buttons.** "Disenchant extras (0)" / "Upgrade all (0)" were always rendered, only conditionally *disabled*, and doubly dimmed (an extra `opacity: 0.3` on top of the shared `:disabled` treatment). Now hidden when both counts are zero; `flex: 1` moved out of an inline style into CSS.
- **Misleading counts.** "958 cards" was the *filtered catalog* count, beside a "636/960 discovered" whose denominator includes hidden secrets — neither being copies owned. Now reads `958 shown · N copies`, surfacing the `totalOwned` value that was already computed and then discarded.
- **Mastery `★0`.** The badge rendered at `lvl > 0` but the bar at `xp > 0`, so a 1–4 XP card showed a `★0` bar with no badge. The bar no longer labels level 0.
- **Shared green.** `.progress-bar-fill` was a literal `#33ff33`; `.player-tab--active` a raw `#0f0` (brighter than anything in the palette). Both now gold.

## Blast radius of the shared fixes

Measured before changing them, since these are game-wide:
- `.progress-bar-fill` — only **CollectionScreen** and **DeckBuilder** use the default; MasteryBar passes its own colour. Both are progress readouts where gold is correct. DeckBuilder verified by screenshot.
- `.player-tab--active` — exactly 2 screens (**PlayerScreen**, **CollectionTabScreen**).

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 2861/2861 passing
- [x] All `--card-frame`/token references confirmed to resolve (checked after `--text-primary` turned out **not** to exist despite being referenced in an earlier plan — would have been a silently-dead rule)
- [x] Storybook + Playwright: rarity grid at rest **and hovered per-tile** — legendary verified to stay gold on hover, common to stay steel
- [x] Computed-style assertions rather than eyeballing: fill is `rgb(255,204,0)`, common frame `#555`, and the `UNIT` label has `scrollWidth === clientWidth` (no overflow)
- [x] Collection screen re-shot: `SPAWN` renders in full, "Grand Dragon Lair" no longer truncates, counts sit under their own cards, dead button row gone
- [x] DeckBuilder and CollectionTabScreen checked for the shared changes

## Notes

`AchievementsScreen.tsx:42` declares its **own** local `ProgressBar`, shadowing the shared one — left alone here, but worth reconciling. Broader literal sweeps remain tracked in #2202 / #2203.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_