### PR TITLE
Fix card detail modal: wrong spawn-rate preview, duplicated lore/XP, rarity colour drift

### DIFF
--- a/web/src/components/cards/AugmentPickerModal.tsx
+++ b/web/src/components/cards/AugmentPickerModal.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const RARITY_COLOUR: Record<string, string> = {
-  common:    '#55cc55',
+  common:    '#999999',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
   epic:      '#ff8800',

--- a/web/src/components/cards/CardDetailHeader.tsx
+++ b/web/src/components/cards/CardDetailHeader.tsx
@@ -20,7 +20,7 @@ export function CardDetailHeader({ card,collection, colour, onClose }: Props) {
                 <div className="cdm-header" style={colour ? { '--cdm-rarity-color': colour } as CSSProperties : undefined}>
           <span className="cdm-name" style={{ color: colour }}>{card.name}</span>
               {masteryLvl > 0 && (
-                <div style={{ fontSize: 11, color: '#ffcc55' }}>Mastery ★{masteryLvl} · {xpCur}/{xpNeeded} XP</div>
+                <div className="cdm-header-mastery">Mastery ★{masteryLvl} · {xpCur}/{xpNeeded} XP</div>
               )}
 
           <span className="cdm-rarity" style={{ color: colour }}>

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -51,8 +51,11 @@ interface Props {
   onBreakdown?: () => void
 }
 
+// Keep in step with .card-tile--* (--card-frame in cards.css) and
+// .rarity-badge--* in collection.css. There are five copies of this mapping
+// across the app today — see the consolidation issue.
 const RARITY_COLOUR: Record<string, string> = {
-  common:    '#55cc55',
+  common:    '#999999',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
   epic:      '#ff8800',
@@ -194,7 +197,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
           {/* Right: stats */}
           <div className="cdm-info-col u-grow u-col u-gap-4">
               <div className="cdm-desc">{card.description}</div>
-              {card.lore && <div className="cdm-lore" style={{ fontStyle: 'italic', opacity: 0.7, fontSize: 11 }}>{card.lore}</div>}
+              {card.lore && <div className="cdm-lore">{card.lore}</div>}
 
               {/* Unit stats */}
               {u && u.moveSpeed > 0 && (
@@ -250,12 +253,13 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
             {u && u.moveSpeed === 0 && u.maxHp > 0 && (
               <div className="cdm-stats-block u-flex u-wrap">
                 {u.structureEffect?.type === 'spawn' && (() => {
-                  const rates: number[] = []
-                  let ms = u.structureEffect.intervalMs
-                  for (let i = 0; i < 4; i++) {
-                    rates.push(ms)
-                    ms = Math.max(1500, Math.floor(ms / 2))
-                  }
+                  // Mirrors applyMasteryBonus in game/collection.ts: the engine
+                  // applies intervalMs * 0.95^level. This preview used to halve
+                  // per level (with an invented 1500ms floor), so it promised a
+                  // 25s spawner would reach 3.1s at Lv4 when the engine gives
+                  // ~20.4s. Keep this in step with collection.ts if that changes.
+                  const base = u.structureEffect.intervalMs
+                  const rates = [base, ...[2, 3, 4].map(lvl => Math.round(base * Math.pow(0.95, lvl)))]
                   return (
                     <>
                       <StatRow compact label="Spawn" value={`${(rates[0] / 1000).toFixed(1)}s`} />
@@ -393,10 +397,12 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
             {/* Mastery (not shown for augments) */}
             {card.cardType !== 'augment' && <div className="cdm-mastery-block">
               <div className="cdm-mastery-header">
-                <span style={{ color: masteryLvl >= 5 ? '#ff9900' : '#ffd700' }}>
+                <span className={masteryLvl >= 5 ? 'cdm-mastery-elite' : 'cdm-mastery-title'}>
                   {masteryLvl >= 5 ? '⚡' : '★'} Mastery {masteryLvl}{masteryLvl >= 5 ? ' — ELITE' : ''}
                 </span>
-                {masteryLvl < 5 && <span className="cdm-mastery-xp">{xpCur}/{xpNeeded} to Lv{masteryLvl + 1}</span>}
+                {/* Just the target level — the bar below already states the
+                    raw xpCur/xpNeeded, as does the modal header. */}
+                {masteryLvl < 5 && <span className="cdm-mastery-xp">to Lv{masteryLvl + 1}</span>}
               </div>
               <MasteryBar xp={xp} />
               {u && u.moveSpeed > 0 && (
@@ -550,10 +556,8 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
           />
         )}
 
-        {/* Lore */}
-        {card.lore && (
-          <div className="cdm-lore">"{card.lore}"</div>
-        )}
+        {/* Lore is rendered once, up next to the description — it used to also
+            repeat verbatim here at the foot of the modal. */}
 
         {/* Augment upgrade action */}
         {onUpgrade && (

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -14,10 +14,10 @@ const RARITY_ORDER: Record<string, number> = {
 }
 
 const RARITY_COLORS: Record<string, string> = {
-  common:    '#55cc55',
+  common:    '#999999',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
-  epic:      '#ff8844',
+  epic:      '#ff8800',
   legendary: '#ffcc00',
   mythic:    '#e040fb',
   shiny:     '#ffe066',

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -110,7 +110,7 @@
 /* Sits between rare and legendary. Previously absent entirely, so an epic card
    silently fell back to the base frame. */
 .card-tile--epic {
-  --card-frame: #ff7ac6;
+  --card-frame: #ff8800;
   background:
     linear-gradient(160deg, color-mix(in srgb, var(--card-frame) 11%, transparent) 0%, transparent 55%),
     color-mix(in srgb, var(--card-frame) 4%, transparent);

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -410,7 +410,14 @@
   font-size: var(--font-sm);
   margin-bottom: 2px;
 }
-.cdm-mastery-xp     { font-size: var(--font-xxs); color: #777; }
+/* Was an inline style={{ fontSize: 11, color: '#ffcc55' }} — a raw px size
+   outside the type scale and a hex outside the palette. */
+.cdm-header-mastery { font-size: var(--font-xs); color: var(--color-gold-light); }
+
+/* Was two inline style={{ color }} objects in CardDetailModal. */
+.cdm-mastery-title  { color: var(--color-gold); }
+.cdm-mastery-elite  { color: var(--color-orange); }
+.cdm-mastery-xp     { font-size: var(--font-xxs); color: var(--color-gray-7); }
 .cdm-mastery-bonus  { font-size: var(--font-xxs); color: var(--game-text-color-muted); margin-top: 3px; }
 .cdm-stat-bonus     { font-size: var(--font-xxs); color: var(--color-gold); margin-left: 3px; }
 .cdm-locked-note    { color: #ff6655; font-size: var(--font-xxs); margin-bottom: 4px; }


### PR DESCRIPTION
## Summary

From a review of the card detail modal. One of these turned out to be a **correctness bug, not a cosmetic one**.

### The spawn-rate preview was lying to players

`CardDetailModal.tsx` previewed a spawner's future intervals by **halving** per mastery level (plus an invented 1500ms floor), while the engine (`game/collection.ts:542`) applies `intervalMs * Math.pow(0.95, lvl)` — genuinely −5% per level, exactly as the milestone text rendered one section below it already said.

So **Dragon Lair told players its 25s spawn would reach 3.1s at Lv4, when the engine actually gives ~20.4s** — off by roughly 6.5×. The label was right; the preview was wrong. Now mirrors the engine, with a comment on each side noting they must stay in step.

Verified on a 9.0s spawner: preview reads **8.1 / 7.7 / 7.3s** (matching `9000 × 0.95ⁿ`), where it previously read 4.5 / 2.3 / 1.5s.

### Rarity colour is defined five times, and they'd drifted

| Source | common | epic | legendary |
|---|---|---|---|
| `CardDetailModal.tsx` | `#55cc55` green | `#ff8800` | `#ffcc00` |
| `AugmentPickerModal.tsx` | `#55cc55` green | `#ff8800` | `#ffcc00` |
| `CodexScreen.tsx` (`RARITY_COLORS`, US spelling) | `#55cc55` green | **`#ff8844`** | `#ffcc00` |
| `collection.css` `.rarity-badge--*` | **`#999` grey** | `#ff8800` | **`#ffaa22`** |
| `cards.css` `--card-frame` | `#555` steel | **`#ff7ac6`** | `#ffcc00` |

Epic had **three** different values. Notably `.rarity-badge--common` was *already* grey, so the green in the TS maps was the long-standing outlier — and #2204's `--card-frame` work made the mismatch visible by turning tiles steel while modals stayed green.

Aligned to the established majority (epic `#ff8800`, common grey). **This is a stop-the-bleeding fix, not the real one** — a genuine single source of truth needs the shared palette module from #2203, filed separately rather than bolted on here.

### Duplicated content
- **Lore rendered twice** on every card — beside the description and again verbatim at the foot of the modal, so long cards like Dragon ended on a repeat of their own opening. Now renders once, up top where it's visible without scrolling.
- **Mastery XP stated three times** in one modal: header summary, a `59/80 to Lv5` label, and the bar's own `59/80`. The label keeps the useful part (`to Lv5`) and drops the duplicated numbers.

### Tidying
Four hardcoded inline styles moved onto classes and tokens — including a raw `fontSize: 11` outside the type scale and three hexes outside the palette.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 2861/2861 passing
- [x] Storybook + Playwright with **computed-DOM assertions** rather than eyeballing: `.cdm-lore` count **2 → 1**, mastery label reads `to Lv1`, common card title is `rgb(153,153,153)` (was green), uncommon `rgb(68,153,255)`
- [x] Spawn preview arithmetic checked against `9000 × 0.95ⁿ` and against the engine formula in `collection.ts:542`
- [x] Confirmed every token referenced (`--color-orange`, `--color-gray-7`, `--color-gold-light`) actually exists

## Not fixed here — raised for triage

Observed while reviewing, deliberately left alone:
- **Dragon Lair has no Details/Augments tabs** while unit cards do. Presumably structures can't take augments, but the chrome vanishing entirely makes it look like a different component rather than the same one with a disabled tab.
- **Stat bonuses show inconsistently** — Goblin at ★4 shows `ATK 12 (+9)`; Dragon at ★5 shows bare `ATK 10`. Needs a gameplay answer on whether those come from augments or mastery before changing the display.
- **"Units lost" on a structure** reads oddly — presumably means units it spawned that died.
- Stat rows wrap awkwardly at five stats (Dragon orphans `CD 3`) and look sparse at one (Dragon Lair's lone `HP 30`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_