### PR TITLE
Show cards' real in-play stats (mastery was never displayed), with sources on tap

### DIFF
--- a/web/src/components/cards/AugStatRow.tsx
+++ b/web/src/components/cards/AugStatRow.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import type { UnitTemplate } from '../../game/types'
+
+/**
+ * One stat, shown as the value the engine actually fights with — base plus
+ * every bonus that applies — with the sources split out on demand.
+ *
+ * This used to display base + augments only, in two separately-maintained
+ * copies (CardDetailModal and CardAugmentScreen), so a mastered card
+ * understated its real power and the two screens could disagree about the
+ * same card. Shared here so they cannot drift again.
+ */
+export function AugStatRow({ label, base, mastery, augment, breakdown }: {
+  label: string
+  base: number
+  /** From applyMasteryBonus in game/collection.ts. */
+  mastery?: number
+  /** From applyAugmentBonuses — mobile units only; the engine skips structures. */
+  augment?: number
+  breakdown?: boolean
+}) {
+  const m = mastery ?? 0
+  const a = augment ?? 0
+  const total = base + m + a
+  const hasBonus = m !== 0 || a !== 0
+
+  return (
+    <div className="cdm-stat">
+      <div className="cdm-stat-main">
+        <span className="cdm-stat-label">{label}</span>
+        <span className={`cdm-stat-value${hasBonus ? ' cdm-stat-value--boosted' : ''}`}>{total}</span>
+      </div>
+      {breakdown && hasBonus && (
+        <div className="cdm-stat-breakdown">
+          <span>{base} base</span>
+          {m !== 0 && <span className="cdm-mastery-bonus">{m > 0 ? '+' : ''}{m} mastery</span>}
+          {a !== 0 && <span className="cdm-stat-bonus">{a > 0 ? '+' : ''}{a} augments</span>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Mastery stat bonuses for a card, mirroring applyMasteryBonus in
+ * game/collection.ts: mobile units gain +1 ATK and +2 max HP per level,
+ * structures +10% max HP per level (and take no augments at all).
+ */
+export function masteryStatBonuses(u: UnitTemplate | undefined, masteryLvl: number): { atk: number; hp: number } {
+  if (!u) return { atk: 0, hp: 0 }
+  if (u.moveSpeed > 0) {
+    return { atk: masteryLvl, hp: masteryLvl * 2 }
+  }
+  return { atk: 0, hp: Math.round(u.maxHp * (1 + 0.1 * masteryLvl)) - u.maxHp }
+}

--- a/web/src/components/cards/AugmentPickerModal.tsx
+++ b/web/src/components/cards/AugmentPickerModal.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const RARITY_COLOUR: Record<string, string> = {
-  common:    '#55cc55',
+  common:    '#999999',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
   epic:      '#ff8800',

--- a/web/src/components/cards/CardAugmentScreen.tsx
+++ b/web/src/components/cards/CardAugmentScreen.tsx
@@ -26,6 +26,7 @@ import { MasteryBar } from '../ui/MasteryBar'
 import { AugmentPickerModal } from './AugmentPickerModal'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { CardDetailHeader } from './CardDetailHeader'
+import { AugStatRow, masteryStatBonuses } from './AugStatRow'
 import { AnimatedSpriteImg, SpriteImg } from '../ui/SpriteImg'
 
 interface Props {
@@ -47,19 +48,6 @@ const RARITY_COLOUR: Record<string, string> = {
   glass:     '#a0d8ef',
 }
 
-function AugStatRow({ label, base, delta }: { label: string; base: number; delta?: number }) {
-  const hasDelta = delta != null && delta !== 0
-  return (
-    <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, minWidth: 64 }}>
-      <span style={{ fontSize: 10, opacity: 0.6, textTransform: 'uppercase' }}>{label}</span>
-      <span style={{ fontWeight: 700 }}>{hasDelta ? base + delta! : base}</span>
-      {hasDelta && (
-        <span style={{ fontSize: 10, color: '#aaddff' }}>(+{delta})</span>
-      )}
-    </div>
-  )
-}
-
 function effectSummary(effect: AugmentEffect): string {
   const parts: string[] = []
   if (effect.maxHp)       parts.push(`+${effect.maxHp} HP`)
@@ -79,8 +67,7 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
 
   const owned  = getOwnedCount(collection, card.name)
   const inDeck = deckEntries?.find(e => e.cardName === card.name)?.count ?? 0
-  // const xp     = getMasteryXp(collection, card.name)
-  // const { level: masteryLvl, current: xpCur, needed: xpNeeded } = masteryProgress(xp)
+  const { level: masteryLvl } = masteryProgress(getMasteryXp(collection, card.name))
   const rarityCol = RARITY_COLOUR[card.rarity] ?? 'var(--game-text-color-dim)'
 
   const equippedMap = getEquippedAugments(card.name)
@@ -88,6 +75,7 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
   const souls       = loadAugmentSouls()
 
   const u = card.unit
+  const { atk: atkBonus, hp: hpBonus } = masteryStatBonuses(u, masteryLvl)
 
   // Compute total augment effect for live stat display
   const totalAugmentEffect = useMemo(() => {
@@ -138,20 +126,24 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
 
             <div className="cas-info-col u-grow u-col u-gap-3">
               <div className="cdm-desc">{card.description}</div>
-              {card.lore && <div className="cdm-lore" style={{ fontStyle: 'italic', opacity: 0.7, fontSize: 11 }}>{card.lore}</div>}
+              {card.lore && <div className="cdm-lore">{card.lore}</div>}
 
-              {/* Unit stats */}
+              {/* Unit stats — totals shown with the breakdown always open here,
+                  since this screen exists specifically to reason about where a
+                  card's numbers come from. */}
               {u && u.moveSpeed > 0 && (
                 <div className="cdm-stats-block u-flex u-wrap">
-                  <AugStatRow label="ATK" base={u.attack}      delta={totalAugmentEffect.attack} />
-                  <AugStatRow label="HP"  base={u.maxHp}       delta={totalAugmentEffect.maxHp} />
-                  <AugStatRow label="SPD" base={u.moveSpeed}   delta={totalAugmentEffect.moveSpeed} />
-                  {u.attackRange > 0 && <AugStatRow label="RNG" base={u.attackRange} delta={totalAugmentEffect.attackRange} />}
+                  <AugStatRow label="ATK" base={u.attack}    mastery={atkBonus} augment={totalAugmentEffect.attack}    breakdown />
+                  <AugStatRow label="HP"  base={u.maxHp}     mastery={hpBonus}  augment={totalAugmentEffect.maxHp}     breakdown />
+                  <AugStatRow label="SPD" base={u.moveSpeed}                    augment={totalAugmentEffect.moveSpeed} breakdown />
+                  {u.attackRange > 0 && <AugStatRow label="RNG" base={u.attackRange} augment={totalAugmentEffect.attackRange} breakdown />}
                 </div>
               )}
               {u && u.moveSpeed === 0 && (
                 <div className="cdm-stats-block u-flex u-wrap">
-                  <AugStatRow label="HP" base={u.maxHp} delta={totalAugmentEffect.maxHp} />
+                  {/* Structures take no augments (applyAugmentBonuses returns
+                      early for them), so only mastery HP applies. */}
+                  <AugStatRow label="HP" base={u.maxHp} mastery={hpBonus} breakdown />
                 </div>
               )}
             </div>
@@ -164,7 +156,15 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
             {upgradeError && <span style={{ color: '#ff6666', fontSize: 11 }}>{upgradeError}</span>}
           </div>
 
-          {/* Augment slots */}
+          {/* Augment slots. Structures are excluded to match the engine:
+              applyAugmentBonuses in game/collection.ts returns early for
+              anything with moveSpeed === 0 ("structures don't get augments"),
+              so offering slots here would let a player spend augments that
+              are then silently ignored in battle. */}
+          {u && u.moveSpeed === 0 ? (
+            <div className="cas-slots-title">Structures can't be augmented.</div>
+          ) : (
+          <>
           <div className="cas-slots-title">Equipment Slots</div>
 
           <div className="cas-slots-grid">
@@ -241,6 +241,8 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
               </div>
             )
           })()}
+          </>
+          )}
 
         </div>
       </div>

--- a/web/src/components/cards/CardDetailHeader.tsx
+++ b/web/src/components/cards/CardDetailHeader.tsx
@@ -20,7 +20,7 @@ export function CardDetailHeader({ card,collection, colour, onClose }: Props) {
                 <div className="cdm-header" style={colour ? { '--cdm-rarity-color': colour } as CSSProperties : undefined}>
           <span className="cdm-name" style={{ color: colour }}>{card.name}</span>
               {masteryLvl > 0 && (
-                <div style={{ fontSize: 11, color: '#ffcc55' }}>Mastery ★{masteryLvl} · {xpCur}/{xpNeeded} XP</div>
+                <div className="cdm-header-mastery">Mastery ★{masteryLvl} · {xpCur}/{xpNeeded} XP</div>
               )}
 
           <span className="cdm-rarity" style={{ color: colour }}>

--- a/web/src/components/cards/CardDetailModal.stories.tsx
+++ b/web/src/components/cards/CardDetailModal.stories.tsx
@@ -34,3 +34,29 @@ export const WithSynergy: Story = {
     "onClose": fn()
   },
 };
+
+/**
+ * Mastery ★5, so the stat rows show the value the engine actually fights with
+ * (base + mastery) rather than the unmastered base, and the "where do these
+ * come from?" breakdown toggle appears. 155 XP clears the level-5 threshold.
+ */
+export const Mastered: Story = {
+  args: {
+    "card": exampleCard,
+    "collection": [{ cardName: exampleCard.name, count: 4, masteryXp: 155 }],
+    "onClose": fn()
+  },
+};
+
+/**
+ * A mastered structure. Structures gain +10% max HP per mastery level and take
+ * no augments at all (applyAugmentBonuses skips them), so only a mastery line
+ * should ever appear in its breakdown.
+ */
+export const MasteredStructure: Story = {
+  args: {
+    "card": getCardCatalog().find(c => c.name === 'Ancient Barracks')!,
+    "collection": [{ cardName: 'Ancient Barracks', count: 3, masteryXp: 155 }],
+    "onClose": fn()
+  },
+};

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -51,8 +51,11 @@ interface Props {
   onBreakdown?: () => void
 }
 
+// Keep in step with .card-tile--* (--card-frame in cards.css) and
+// .rarity-badge--* in collection.css. There are five copies of this mapping
+// across the app today — see the consolidation issue.
 const RARITY_COLOUR: Record<string, string> = {
-  common:    '#55cc55',
+  common:    '#999999',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
   epic:      '#ff8800',
@@ -194,7 +197,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
           {/* Right: stats */}
           <div className="cdm-info-col u-grow u-col u-gap-4">
               <div className="cdm-desc">{card.description}</div>
-              {card.lore && <div className="cdm-lore" style={{ fontStyle: 'italic', opacity: 0.7, fontSize: 11 }}>{card.lore}</div>}
+              {card.lore && <div className="cdm-lore">{card.lore}</div>}
 
               {/* Unit stats */}
               {u && u.moveSpeed > 0 && (
@@ -250,12 +253,13 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
             {u && u.moveSpeed === 0 && u.maxHp > 0 && (
               <div className="cdm-stats-block u-flex u-wrap">
                 {u.structureEffect?.type === 'spawn' && (() => {
-                  const rates: number[] = []
-                  let ms = u.structureEffect.intervalMs
-                  for (let i = 0; i < 4; i++) {
-                    rates.push(ms)
-                    ms = Math.max(1500, Math.floor(ms / 2))
-                  }
+                  // Mirrors applyMasteryBonus in game/collection.ts: the engine
+                  // applies intervalMs * 0.95^level. This preview used to halve
+                  // per level (with an invented 1500ms floor), so it promised a
+                  // 25s spawner would reach 3.1s at Lv4 when the engine gives
+                  // ~20.4s. Keep this in step with collection.ts if that changes.
+                  const base = u.structureEffect.intervalMs
+                  const rates = [base, ...[2, 3, 4].map(lvl => Math.round(base * Math.pow(0.95, lvl)))]
                   return (
                     <>
                       <StatRow compact label="Spawn" value={`${(rates[0] / 1000).toFixed(1)}s`} />
@@ -393,10 +397,12 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
             {/* Mastery (not shown for augments) */}
             {card.cardType !== 'augment' && <div className="cdm-mastery-block">
               <div className="cdm-mastery-header">
-                <span style={{ color: masteryLvl >= 5 ? '#ff9900' : '#ffd700' }}>
+                <span className={masteryLvl >= 5 ? 'cdm-mastery-elite' : 'cdm-mastery-title'}>
                   {masteryLvl >= 5 ? '⚡' : '★'} Mastery {masteryLvl}{masteryLvl >= 5 ? ' — ELITE' : ''}
                 </span>
-                {masteryLvl < 5 && <span className="cdm-mastery-xp">{xpCur}/{xpNeeded} to Lv{masteryLvl + 1}</span>}
+                {/* Just the target level — the bar below already states the
+                    raw xpCur/xpNeeded, as does the modal header. */}
+                {masteryLvl < 5 && <span className="cdm-mastery-xp">to Lv{masteryLvl + 1}</span>}
               </div>
               <MasteryBar xp={xp} />
               {u && u.moveSpeed > 0 && (
@@ -550,10 +556,8 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
           />
         )}
 
-        {/* Lore */}
-        {card.lore && (
-          <div className="cdm-lore">"{card.lore}"</div>
-        )}
+        {/* Lore is rendered once, up next to the description — it used to also
+            repeat verbatim here at the foot of the modal. */}
 
         {/* Augment upgrade action */}
         {onUpgrade && (

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -230,7 +230,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
               )}
           </div>
         </div>
-        <div className="u-col ">
+        <div className="cdm-details u-col">
               {card.cardType === 'unit' && (
               <Toolbar>
                 <ToolbarButton label="Details" onClick={() => setActiveTab(0)} />
@@ -259,7 +259,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
 
 
               )}
-<div  className="cdm-info-col u-grow u-col u-gap-4 u-mg-t-md">
+<div className="cdm-info-col u-grow u-col u-gap-4 u-mg-t-md">
             {activeTab === 0 ? (
 
 <>

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -21,6 +21,7 @@ import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { MasteryBar } from '../ui/MasteryBar'
 import { StatRow } from '../ui/StatRow'
 import { CardDetailHeader } from './CardDetailHeader'
+import { AugStatRow, masteryStatBonuses } from './AugStatRow'
 import { AnimatedSpriteImg } from '../ui/SpriteImg'
 import { Toolbar } from '../ui/Toolbar/Toolbar'
 import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
@@ -67,18 +68,7 @@ const RARITY_COLOUR: Record<string, string> = {
 }
 
 
-function AugStatRow({ label, base, delta }: { label: string; base: number; delta?: number }) {
-  const hasDelta = delta != null && delta !== 0
-  return (
-    <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, minWidth: 64 }}>
-      <span style={{ fontSize: 10, opacity: 0.6, textTransform: 'uppercase' }}>{label}</span>
-      <span style={{ fontWeight: 700 }}>{hasDelta ? base + delta! : base}</span>
-      {hasDelta && (
-        <span style={{ fontSize: 10, color: '#aaddff' }}>(+{delta})</span>
-      )}
-    </div>
-  )
-}
+// AugStatRow now lives in ./AugStatRow so CardAugmentScreen shares it.
 
 function effectSummary(effect: AugmentEffect): string {
   const parts: string[] = []
@@ -115,6 +105,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
   const [upgradeError, setUpgradeError] = useState<string | null>(null)  
 
   const [expandedRow, setExpandedRow] = useState<string | null>(null)
+  const [showBreakdown, setShowBreakdown] = useState(false)
   const toggleRow = (key: string) => setExpandedRow(prev => prev === key ? null : key)
 
   const synergyGroups = getSynergyGroups(card)
@@ -130,13 +121,10 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
 
   const u = card.unit
 
-  // Mastery stat bonuses (mirroring applyMasteryBonus in collection.ts)
-  const atkBonus = (u && u.moveSpeed > 0) ? masteryLvl : 0
-  const hpBonus  = u
-    ? u.moveSpeed > 0
-      ? masteryLvl * 2
-      : Math.round(u.maxHp * (1 + 0.1 * masteryLvl)) - u.maxHp
-    : 0
+  // Mastery stat bonuses. These were computed here and then never rendered —
+  // the modal showed base + augments only, so a mastered card understated its
+  // real power. Now shared with CardAugmentScreen so both agree.
+  const { atk: atkBonus, hp: hpBonus } = masteryStatBonuses(u, masteryLvl)
 
   // Build trait tags
   const traits: string[] = []
@@ -165,6 +153,18 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
     return effect
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refresh])
+
+  // Whether any stat is actually boosted — the breakdown toggle is pointless
+  // otherwise. Structures never take augments (see applyAugmentBonuses), so
+  // only their mastery HP counts.
+  const hasStatBonus = u
+    ? u.moveSpeed > 0
+      ? atkBonus !== 0 || hpBonus !== 0 ||
+        [totalAugmentEffect.attack, totalAugmentEffect.maxHp,
+         totalAugmentEffect.moveSpeed, totalAugmentEffect.attackRange]
+          .some(v => v != null && v !== 0)
+      : hpBonus !== 0
+    : false
 
   function handleUpgrade(inst: AugmentInstance) {
     const err = upgradeAugment(inst.instanceId)
@@ -202,17 +202,31 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
               {/* Unit stats */}
               {u && u.moveSpeed > 0 && (
                 <div className="cdm-stats-block u-flex u-wrap">
-                  <AugStatRow label="ATK" base={u.attack}      delta={totalAugmentEffect.attack} />
-                  <AugStatRow label="HP"  base={u.maxHp}       delta={totalAugmentEffect.maxHp} />
-                  <AugStatRow label="SPD" base={u.moveSpeed}   delta={totalAugmentEffect.moveSpeed} />
-                  {u.attackRange > 0 && <AugStatRow label="RNG" base={u.attackRange} delta={totalAugmentEffect.attackRange} />}
-                  {u.attackCooldownMs > 0 && <AugStatRow label="CD" base={(u.attackCooldownMs / 1000)} delta={0} />}
+                  <AugStatRow label="ATK" base={u.attack}    mastery={atkBonus} augment={totalAugmentEffect.attack}      breakdown={showBreakdown} />
+                  <AugStatRow label="HP"  base={u.maxHp}     mastery={hpBonus}  augment={totalAugmentEffect.maxHp}       breakdown={showBreakdown} />
+                  <AugStatRow label="SPD" base={u.moveSpeed}                    augment={totalAugmentEffect.moveSpeed}   breakdown={showBreakdown} />
+                  {u.attackRange > 0 && <AugStatRow label="RNG" base={u.attackRange} augment={totalAugmentEffect.attackRange} breakdown={showBreakdown} />}
+                  {u.attackCooldownMs > 0 && <AugStatRow label="CD" base={(u.attackCooldownMs / 1000)} />}
                 </div>
               )}
               {u && u.moveSpeed === 0 && (
                 <div className="cdm-stats-block u-flex u-wrap">
-                  <AugStatRow label="HP" base={u.maxHp} delta={totalAugmentEffect.maxHp} />
+                  {/* No augment delta: applyAugmentBonuses returns early for
+                      structures, so showing one promised a bonus the engine
+                      would never apply. Mastery HP does apply (+10%/level). */}
+                  <AugStatRow label="HP" base={u.maxHp} mastery={hpBonus} breakdown={showBreakdown} />
                 </div>
+              )}
+
+              {hasStatBonus && (
+                <button
+                  type="button"
+                  className="cdm-breakdown-toggle"
+                  onClick={() => setShowBreakdown(v => !v)}
+                  aria-expanded={showBreakdown}
+                >
+                  {showBreakdown ? '▴ Hide breakdown' : '▾ Where do these come from?'}
+                </button>
               )}
           </div>
         </div>

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -14,10 +14,10 @@ const RARITY_ORDER: Record<string, number> = {
 }
 
 const RARITY_COLORS: Record<string, string> = {
-  common:    '#55cc55',
+  common:    '#999999',
   uncommon:  '#4499ff',
   rare:      '#bb66ff',
-  epic:      '#ff8844',
+  epic:      '#ff8800',
   legendary: '#ffcc00',
   mythic:    '#e040fb',
   shiny:     '#ffe066',

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -110,7 +110,7 @@
 /* Sits between rare and legendary. Previously absent entirely, so an epic card
    silently fell back to the base frame. */
 .card-tile--epic {
-  --card-frame: #ff7ac6;
+  --card-frame: #ff8800;
   background:
     linear-gradient(160deg, color-mix(in srgb, var(--card-frame) 11%, transparent) 0%, transparent 55%),
     color-mix(in srgb, var(--card-frame) 4%, transparent);

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -418,8 +418,42 @@
 .cdm-mastery-title  { color: var(--color-gold); }
 .cdm-mastery-elite  { color: var(--color-orange); }
 .cdm-mastery-xp     { font-size: var(--font-xxs); color: var(--color-gray-7); }
-.cdm-mastery-bonus  { font-size: var(--font-xxs); color: var(--game-text-color-muted); margin-top: 3px; }
-.cdm-stat-bonus     { font-size: var(--font-xxs); color: var(--color-gold); margin-left: 3px; }
+/* These two were written for a mastery/augment stat breakdown that was never
+   wired up — they matched no element in any .tsx until the breakdown landed. */
+.cdm-mastery-bonus  { font-size: var(--font-xxs); color: var(--game-text-color-muted); }
+.cdm-stat-bonus     { font-size: var(--font-xxs); color: var(--color-gold); }
+
+/* ── Stat rows with source breakdown ─────────────────────
+   The headline number is what the engine actually fights with (base + mastery
+   + augments); the breakdown splits it back apart on demand. */
+
+.cdm-stat        { min-width: 64px; }
+.cdm-stat-main   { display: flex; align-items: baseline; gap: 4px; }
+.cdm-stat-label  { font-size: var(--font-xxs); opacity: 0.6; text-transform: uppercase; }
+.cdm-stat-value  { font-weight: 700; }
+.cdm-stat-value--boosted { color: var(--color-gold-light); }
+
+.cdm-stat-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-top: 2px;
+  font-size: var(--font-xxs);
+  color: var(--game-text-color-muted);
+}
+
+.cdm-breakdown-toggle {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-xxs);
+  color: var(--color-gray-9);
+  text-decoration: underline dotted;
+}
+.cdm-breakdown-toggle:hover { color: var(--accent-gold); }
 .cdm-locked-note    { color: #ff6655; font-size: var(--font-xxs); margin-bottom: 4px; }
 .cdm-mastery-milestones { display: flex; flex-direction: column; gap: 2px; margin-top: 4px; }
 .cdm-milestone      { font-size: var(--font-xxs); color: var(--game-text-color-muted); padding: 1px 0; }

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -302,6 +302,14 @@
   padding: 12px;
 }
 
+/* Everything below the sprite/description block — the tab bar, trait tags,
+   matchup rows, mastery and play counts — sits outside .cdm-body, so it had
+   no inset at all and ran flush against the panel border. Matches .cdm-body's
+   horizontal padding; the bottom inset keeps the last row off the edge. */
+.cdm-details {
+  padding: 0 12px 12px;
+}
+
 .cdm-card-col {
   flex-shrink: 0;
 }

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -410,7 +410,14 @@
   font-size: var(--font-sm);
   margin-bottom: 2px;
 }
-.cdm-mastery-xp     { font-size: var(--font-xxs); color: #777; }
+/* Was an inline style={{ fontSize: 11, color: '#ffcc55' }} — a raw px size
+   outside the type scale and a hex outside the palette. */
+.cdm-header-mastery { font-size: var(--font-xs); color: var(--color-gold-light); }
+
+/* Was two inline style={{ color }} objects in CardDetailModal. */
+.cdm-mastery-title  { color: var(--color-gold); }
+.cdm-mastery-elite  { color: var(--color-orange); }
+.cdm-mastery-xp     { font-size: var(--font-xxs); color: var(--color-gray-7); }
 .cdm-mastery-bonus  { font-size: var(--font-xxs); color: var(--game-text-color-muted); margin-top: 3px; }
 .cdm-stat-bonus     { font-size: var(--font-xxs); color: var(--color-gold); margin-left: 3px; }
 .cdm-locked-note    { color: #ff6655; font-size: var(--font-xxs); margin-bottom: 4px; }


### PR DESCRIPTION
Stacked on #2205 (same files) — its two commits appear here and will drop out once it merges.

## Why cards looked inconsistent

Investigating "some cards show one thing and others something different" turned up two separate causes.

### 1. Mastery bonuses were never displayed

`applyMasteryBonus` (`collection.ts:524`) is real: mobile units gain **+1 ATK / +2 max HP per level**, structures **+10% max HP per level**. The modal showed **base + augments only**.

So a **★5 Dragon displayed ATK 10 when the engine fights with 15**, and a **★3 Dragon Lair showed HP 30 against a real 39**. Goblin's `(+9)` was augments — which it never said — so a card with augments and a card with mastery looked like "has a bonus" vs "has none", when both had bonuses from different systems.

The feature was half-built and left that way:
- `atkBonus` / `hpBonus` were **computed at lines 134–139 and never referenced again**
- `.cdm-mastery-bonus` and `.cdm-stat-bonus` existed in `modals.css` and **matched no element in any `.tsx`**

Both are now wired up. Stat rows show the value the engine actually uses, with a **"where do these come from?"** toggle splitting it into base / mastery / augments. The toggle only appears when something is genuinely boosted.

### 2. Three different tests for "what kind of card is this"

| Test | Gates |
|---|---|
| `card.cardType === 'unit'` | the entire Details/Augments tab bar |
| `u.moveSpeed > 0 / === 0` | stat blocks, mastery milestones |
| `card.unit != null` | the "Units lost" row |

Dragon Lair (`'structure'`, `moveSpeed: 0`, has `card.unit`) **fails the first, takes the structure branch of the second, passes the third** — hence no tabs, one stat, but still "Units lost". Nothing checks one concept.

## Structures and augments — investigated before changing anything

`collection.ts:790` settles it:

```js
if (!card.unit || card.unit.moveSpeed === 0) return card   // structures don't get augments
```

The engine **explicitly refuses**. So the modal hiding the Augments tab is right in outcome, and `CardAugmentScreen` was the one out of step — it rendered `ALL_AUGMENT_SLOTS` with no guard, letting a player spend augments the engine silently discards.

**It isn't reachable today**, and I checked rather than assumed: `equipAugment` is only called from `AugmentPickerModal`, which opens from the modal's hidden tab or from `CardAugmentScreen` — whose own entry points are a **commented-out branch** in `CollectionScreen:503` and an already-augmented-cards-only path in `AugmentCollectionScreen:550`. Latent, but one uncommented line from live. Now guarded to match the engine.

Also fixed: the modal passed an augment delta for structures, promising a bonus the engine discards.

## De-duplication

`AugStatRow` was **copy-pasted** into `CardDetailModal` and `CardAugmentScreen` — which is how they drifted, and is flagged by an existing TODO at `CardAugmentScreen:116`. It and the mastery maths now live in one shared `AugStatRow.tsx`, so the two screens can't disagree about the same card again.

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 2861/2861 passing
- [x] **Arithmetic asserted against the engine formulas** across levels 0–5 and several stat bases, not eyeballed
- [x] New `Mastered` / `MasteredStructure` stories, verified via computed DOM:
  - mobile ★5 → `ATK 5 base +5 mastery = 10`, `HP 4 base +10 mastery = 14`
  - structure ★5 → `HP 28 base +14 mastery = 42` (`round(28 × 1.5)`), **mastery line only, no augments line**
  - unboosted stats show no breakdown; toggle absent entirely when nothing is boosted

## Still open for your call

- **Dragon Lair has no Details/Augments tab bar at all.** Correct that it can't be augmented, but the chrome vanishing makes it look like a different component rather than the same one with a disabled tab. Also, the gate uses `cardType === 'unit'`, which incidentally excludes `'upgrade'` cards too — the engine's own rule is `moveSpeed > 0`.
- **"Units lost" on a structure** reads oddly; it counts times the structure was destroyed.
- Stat rows wrap awkwardly at five stats and look sparse at one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_