### PR TITLE
Deck builder: consolidate the header stack, size the split to content, unify the card footers

### DIFF
--- a/web/src/components/cards/CardCellFooter.tsx
+++ b/web/src/components/cards/CardCellFooter.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { MasteryBar } from '../ui/MasteryBar'
+
+interface Props {
+  /**
+   * The count line. Left free-form because the three call sites genuinely
+   * count different things — the Collection screen shows copies owned
+   * (`×4`), the deck builder's deck panel shows copies in the deck (`×2`),
+   * and its collection panel shows the ratio (`1/4`). Everything *around*
+   * the count is fixed here so the three stop drifting apart.
+   */
+  children: React.ReactNode
+  /** Mastery bar is rendered whenever there is any XP at all. */
+  xp?: number
+  /** Opens the card detail modal. Omit to hide the ⓘ button. */
+  onInfo?: () => void
+}
+
+/**
+ * The strip under a card tile in any card grid.
+ *
+ * This markup used to be copy-pasted at three call sites, which is how they
+ * ended up disagreeing: the deck panel had no ⓘ button at all (so a card in
+ * your deck could not be inspected without hunting for it in the collection
+ * below), and only two of the three rendered a mastery bar.
+ */
+export function CardCellFooter({ children, xp, onInfo }: Props) {
+  return (
+    <div className="cell-footer">
+      {/* Count and ⓘ share a line; the mastery bar gets the full width
+          underneath. The ⓘ previously used .extra-btn, whose `flex: 1` in
+          this column-direction footer stretched it into a tall block
+          detached from its own card. */}
+      <div className="cell-footer-top">
+        {children}
+        {onInfo && (
+          <button
+            className="cell-info-btn"
+            onClick={e => { e.stopPropagation(); onInfo() }}
+            title="Card details"
+            aria-label="Card details"
+          >ⓘ</button>
+        )}
+      </div>
+      {xp !== undefined && xp > 0 && <MasteryBar xp={xp} />}
+    </div>
+  )
+}

--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -29,7 +29,7 @@ import {
   decodeDeck,
 } from '../../game/collection'
 import { CardTile } from './CardTile'
-import { MasteryBar } from '../ui/MasteryBar'
+import { CardCellFooter } from './CardCellFooter'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { useCardDetail } from './useCardDetail'
 import { OverlayScreen } from '../ui/OverlayScreen'
@@ -361,6 +361,25 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
     })
   }
 
+  /**
+   * Collapsing one panel always expands the other, so "you can never collapse
+   * both" is enforced by construction. The two call sites previously had
+   * hand-rolled three-branch conditionals whose trailing comments ("do nothing
+   * if the other is already collapsed") described behaviour the code did not
+   * actually have — the final branch swapped the panels.
+   */
+  function togglePanel(which: 'deck' | 'collection') {
+    if (which === 'deck') {
+      const next = !deckCollapsed
+      setDeckCollapsed(next)
+      if (next) setCollectionCollapsed(false)
+    } else {
+      const next = !collectionCollapsed
+      setCollectionCollapsed(next)
+      if (next) setDeckCollapsed(false)
+    }
+  }
+
   function handleAutoBuild(strategy: AutoStrategy) {
     const built = buildAutoDeck(strategy, collection, fatiguedCards)
     setDeck(built)
@@ -448,18 +467,48 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
       title="DECK BUILDER"
       onBack={handleBack}
       right={
-        <span className={`overlay-count${valid ? ' overlay-count--valid' : ' overlay-count--invalid'}`}>
-          {total}/{playerDeckMax} cards
-          {total < DECK_MIN && ` (need ${DECK_MIN - total} more)`}
-        </span>
+        /* Deck status lives in one place. The mana warning used to sit in a
+           row of action buttons below the header, where it was the only
+           *state* among *actions* and shifted the whole layout whenever it
+           appeared. It belongs next to the size counter — the other signal
+           that says "this deck isn't ready". */
+        <div className="deckbuilder-status u-col u-items-end u-gap-1">
+          <span className={`overlay-count${valid ? ' overlay-count--valid' : ' overlay-count--invalid'}`}>
+            {total}/{playerDeckMax} cards
+            {total < DECK_MIN && ` (need ${DECK_MIN - total} more)`}
+          </span>
+          {showManaWarning && (
+            <span className="deckbuilder-mana-warn" title={`Deck has ${maxDeckCost}-cost cards but no mana structure`}>
+              ⚠ no mana building
+            </span>
+          )}
+        </div>
       }
     >
-<div className="deckbuilder-header-actions u-flex u-items-c u-gap-2 u-wrap">
-   {showManaWarning && (
-                <span className="deckbuilder-mana-warn" title={`Deck has ${maxDeckCost}-cost cards but no mana structure`}>
-                  ⚠ no mana building
-                </span>
-              )}
+      <div className="deckbuilder-split u-col u-grow">
+
+        {/* ── TOP PANEL: current deck ── */}
+        <div className={`deckbuilder-top-panel${deckCollapsed ? ' deckbuilder-panel--collapsed' : ''}`}>
+          {/* Deck-scoped actions live in the deck's own header. They used to
+              sit in a loose, unpadded row between the page header and this
+              one — a fourth stacked band belonging to neither. */}
+          <div className="deckbuilder-panel-header">
+            <span className="deckbuilder-panel-label">
+              DECK<span className="deckbuilder-panel-hint"> — click to remove</span>
+            </span>
+            <div className="deck-slot-toggle u-flex u-items-c u-gap-1">
+              <button
+                className={`deck-slot-btn${activeSlot === 'a' ? ' deck-slot-btn--active' : ''}`}
+                onClick={() => handleSwitchSlot('a')}
+                title="Deck A"
+              >A</button>
+              <button
+                className={`deck-slot-btn${activeSlot === 'b' ? ' deck-slot-btn--active' : ''}`}
+                onClick={() => handleSwitchSlot('b')}
+                title="Deck B"
+              >B</button>
+            </div>
+            <div className="deckbuilder-header-actions">
               <button
                 className="action-btn db-action-sm"
                 onClick={() => setShowAutoBuild(true)}
@@ -475,44 +524,9 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
                 onClick={() => setShowShare(true)}
                 title="Share Deck"
               >🔗 SHARE</button>
-</div>
-
-      <div className="deckbuilder-split u-col u-grow">
-
-        {/* ── TOP PANEL: current deck ── */}
-        <div className={`deckbuilder-top-panel${deckCollapsed ? ' deckbuilder-panel--collapsed' : ''}`}>
-          <div className="deckbuilder-panel-header">
-            <span className="deckbuilder-panel-label">
-              DECK — click to remove
-            </span>
-            <div className="deck-slot-toggle u-flex u-items-c u-gap-1">
-              <button
-                className={`deck-slot-btn${activeSlot === 'a' ? ' deck-slot-btn--active' : ''}`}
-                onClick={() => handleSwitchSlot('a')}
-                title="Deck A"
-              >A</button>
-              <button
-                className={`deck-slot-btn${activeSlot === 'b' ? ' deck-slot-btn--active' : ''}`}
-                onClick={() => handleSwitchSlot('b')}
-                title="Deck B"
-              >B</button>
-            </div>
-            <div className="deckbuilder-header-actions u-flex u-items-c u-gap-2 u-wrap">
-           
               <button
                 className="db-collapse-btn"
-                onClick={() => {
-                  if (!deckCollapsed && !collectionCollapsed) {
-                    setDeckCollapsed(true)           // collapse deck, collection stays open
-                  } else if (deckCollapsed) {
-                    setDeckCollapsed(false)           // expand deck
-                  } else {
-
-setDeckCollapsed(true)
-setCollectionCollapsed(false)
-}
-                  // do nothing if collection is already collapsed (can't collapse both)
-                }}
+                onClick={() => togglePanel('deck')}
                 title={deckCollapsed ? 'Expand deck panel' : 'Collapse deck panel'}
               >{deckCollapsed ? '▼' : '▲'}</button>
             </div>
@@ -527,33 +541,37 @@ setCollectionCollapsed(false)
                 ) : deckList.length === 0 ? (
                   <div className="deck-empty">No deck cards match "{search}".</div>
                 ) : (
-                  <div className="collection-grid u-flex u-wrap u-just-c u-gap-4 u-grow">
+                  /* Gaps are asymmetric (see .collection-grid) — no u-gap-* here. */
+                  <div className="collection-grid u-flex u-wrap u-just-c u-grow">
                     {deckList.map(entry => {
                       const card    = catalog.find(c => c.name === entry.cardName)!
                       const resting = fatiguedCards.includes(entry.cardName)
-                      const lvl     = masteryLevel(getMasteryXp(collection, entry.cardName))
+                      const xp      = getMasteryXp(collection, entry.cardName)
+                      const lvl     = masteryLevel(xp)
                       return (
                         <div
                           key={entry.cardName}
-                          className={`collection-cell u-col deck-cell${resting ? ' deck-cell--resting' : ''}`}
+                          className={`collection-cell u-col${resting ? ' collection-cell--resting' : ''}`}
                         >
-                          {resting && (
-                            <div className="resting-overlay">
-                              <span className="resting-badge">💤 RESTING</span>
-                            </div>
-                          )}
-                          <CardTile
-                            card={card}
-                            onClick={() => removeCard(entry.cardName)}
-                            deckMatches={synergyOf(card).combos}
-                            showDetails={true}
-                          />
-                          <div className="cell-footer">
+                          <div className="card-cell-tile">
+                            {resting && (
+                              <div className="resting-overlay">
+                                <span className="resting-badge">💤 RESTING</span>
+                              </div>
+                            )}
+                            <CardTile
+                              card={card}
+                              onClick={() => removeCard(entry.cardName)}
+                              deckMatches={synergyOf(card).combos}
+                              showDetails={true}
+                            />
+                          </div>
+                          <CardCellFooter xp={xp} onInfo={() => openDetail(card)}>
                             <span className="cell-count">
                               ×{entry.count}
                               {lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
                             </span>
-                          </div>
+                          </CardCellFooter>
                         </div>
                       )
                     })}
@@ -564,43 +582,26 @@ setCollectionCollapsed(false)
           )}
         </div>
 
-        {/* ── DIVIDER ── */}
-        <div
-          className="deckbuilder-divider u-flex u-items-c u-just-c u-pointer u-no-select"
-          title="Swap expanded panel"
-          onClick={() => {
-            if (deckCollapsed) {
-              setDeckCollapsed(false)
-              setCollectionCollapsed(true)
-            } else if (collectionCollapsed) {
-              setCollectionCollapsed(false)
-              setDeckCollapsed(true)
-            }
-            // both open — no-op; use the panel collapse buttons
-          }}
-        >
-          <span className="deckbuilder-divider-handle">⠿</span>
-        </div>
+        {/* The panels used to be separated by a bar carrying a ⠿ drag handle.
+            Nothing was draggable: it swapped which panel was collapsed, and
+            in the default state (both panels open) clicking it did nothing at
+            all. The collapse buttons already do that job, so the separator is
+            now a plain rule on the panel below. */}
 
         {/* ── BOTTOM PANEL: collection ── */}
         <div className={`deckbuilder-bottom-panel${collectionCollapsed ? ' deckbuilder-panel--collapsed' : ''}`}>
           <div className="deckbuilder-panel-header">
-            <span className="deckbuilder-panel-label">COLLECTION — click to add</span>
-            <div className="deckbuilder-header-actions u-flex u-items-c u-gap-2 u-wrap">
-              <span className="filter-owned" style={{ fontSize: '10px' }}>{filtered.length} cards</span>
+            <span className="deckbuilder-panel-label">
+              COLLECTION<span className="deckbuilder-panel-hint"> — click to add</span>
+            </span>
+            <div className="deckbuilder-header-actions">
+              {/* "shown", not "cards": this is the count of distinct owned
+                  cards after filtering, not a number of copies. Matches the
+                  Collection screen's wording. */}
+              <span className="filter-owned">{filtered.length} shown</span>
               <button
                 className="db-collapse-btn"
-                onClick={() => {
-                  if (!collectionCollapsed && !deckCollapsed) {
-                    setCollectionCollapsed(true)      // collapse collection, deck stays open
-                  } else if (collectionCollapsed) {
-                    setCollectionCollapsed(false)     // expand collection
-                  } else {
-setDeckCollapsed(false)
-setCollectionCollapsed(true)
- }
-                  // do nothing if deck is already collapsed (can't collapse both)
-                }}
+                onClick={() => togglePanel('collection')}
                 title={collectionCollapsed ? 'Expand collection panel' : 'Collapse collection panel'}
               >{collectionCollapsed ? '▲' : '▼'}</button>
             </div>
@@ -617,7 +618,15 @@ setCollectionCollapsed(true)
                   value={search}
                   onChange={e => setSearch(e.target.value)}
                 />
-                <input type="reset" value="X" alt="Clear the search form" className="action-btn action-btn--xs" onClick={() => setSearch('')} />
+                {/* Was an <input type="reset"> carrying an `alt` attribute —
+                    not valid on a reset input, so it had no accessible name. */}
+                <button
+                  type="button"
+                  className="action-btn action-btn--xs"
+                  aria-label="Clear search"
+                  title="Clear search"
+                  onClick={() => setSearch('')}
+                >✕</button>
               </div>
 
               {/* Filter / Sort / Group bar */}
@@ -761,7 +770,8 @@ setCollectionCollapsed(true)
 
               {/* Collection grid */}
               <div className="deckbuilder-collection-grid">
-                <div className="collection-grid u-flex u-wrap u-just-c u-gap-4 u-grow">
+                {/* Gaps are asymmetric (see .collection-grid) — no u-gap-* here. */}
+                <div className="collection-grid u-flex u-wrap u-just-c u-grow">
                   {(() => {
                     let lastGroup: string | null = null
                     return sorted.map(card => {
@@ -782,29 +792,29 @@ setCollectionCollapsed(true)
                             <div className="collection-group-header">{label}</div>
                           )}
                           <div className={`collection-cell u-col${resting ? ' collection-cell--resting' : ''}${synergy.combos > 0 ? ' collection-cell--combo' : synergy.groups > 0 ? ' collection-cell--synergy' : ''}`}>
-                            <CardTile
-                              card={card}
-                              canAfford={canAdd}
-                              deckMatches={synergy.combos}
-                              onClick={canAdd ? () => addCard(card.name) : undefined}
-                            />
-                            <div className="cell-footer">
-                              <span className="cell-count">
-                                {resting
-                                  ? <><span className="cell-resting-label">💤</span> {inDeck}/{owned}</>
-                                  : <>
-                                      {inDeck}/{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
-                                      {atCopyLimit && <span className="cell-copy-limit-badge">MAX</span>}
-                                    </>
-                                }
-                              </span>
-                              {xp > 0 && <MasteryBar xp={xp} />}
-                              <button
-                                className="extra-btn cdm-info-btn"
-                                onClick={e => { e.stopPropagation(); openDetail(card) }}
-                                title="Card details"
-                              >ⓘ</button>
+                            {/* Same resting treatment as the deck panel above —
+                                the two used to differ (striped overlay + badge
+                                there, a bare 💤 in the footer here). */}
+                            <div className="card-cell-tile">
+                              {resting && (
+                                <div className="resting-overlay">
+                                  <span className="resting-badge">💤 RESTING</span>
+                                </div>
+                              )}
+                              <CardTile
+                                card={card}
+                                canAfford={canAdd}
+                                deckMatches={synergy.combos}
+                                onClick={canAdd ? () => addCard(card.name) : undefined}
+                              />
                             </div>
+                            <CardCellFooter xp={xp} onInfo={() => openDetail(card)}>
+                              <span className="cell-count">
+                                {inDeck}/{owned}
+                                {lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
+                                {atCopyLimit && <span className="cell-copy-limit-badge">MAX</span>}
+                              </span>
+                            </CardCellFooter>
                           </div>
                         </React.Fragment>
                       )

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -24,7 +24,7 @@ import { CardTile } from '../cards/CardTile'
 import { CardDetailModal } from '../cards/CardDetailModal'
 import { CardAugmentScreen } from '../cards/CardAugmentScreen'
 import { OverlayScreen } from '../ui/OverlayScreen'
-import { MasteryBar } from '../ui/MasteryBar'
+import { CardCellFooter } from '../cards/CardCellFooter'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { Button } from '../ui/Button'
 import { ProgressBar } from '../ui/ProgressBar'
@@ -521,14 +521,13 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
                     }}
                   />
 
-                  <div className="cell-footer">
+                  <CardCellFooter xp={xp}>
                     {owned === 0 && questTargetCards.has(card.name)
                       ? <span className="earn-via-quest-badge">EARN VIA QUEST</span>
                       : <span className="cell-count">
                           ×{owned}{lvl > 0 && <span className="cell-mastery-badge">★{lvl}</span>}
                         </span>}
-                    {xp > 0 && <MasteryBar xp={xp} />}
-                  </div>
+                  </CardCellFooter>
                 </LazyCell>
               </React.Fragment>
             )

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -819,12 +819,6 @@
   box-shadow: 0 0 10px rgba(255, 204, 0, 0.45);
 }
 
-.cell-resting-label {
-  color: var(--color-orange-alt);
-  font-size: var(--font-xxs);
-  letter-spacing: 1px;
-}
-
 /* ── Card Augment Screen ──────────────────────────────────────────────────────── */
 .cas-backdrop {
   position: fixed;

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -586,9 +586,33 @@
   width: 100%;
 }
 
-.cell-footer-buttons {
-  width: 100%;
+/* Count on the left, ⓘ on the right, one line. */
+.cell-footer-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-2);
+  min-height: 14px;
 }
+
+/* A quiet icon button sized to its glyph. It used to reuse .extra-btn +
+   .cdm-info-btn — a card-detail-modal pairing whose `flex: 1` and
+   `margin-left: auto` made it stretch to the full height of the footer
+   column, so the ⓘ read as a separate floating control rather than as
+   part of the card above it. */
+.cell-info-btn {
+  background: none;
+  border: none;
+  padding: 0 1px;
+  font-family: inherit;
+  font-size: var(--font-sm);
+  line-height: 1;
+  color: var(--color-gray-7);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+.cell-info-btn:hover { color: var(--accent-gold); }
 
 .cell-count {
   font-size: var(--font-xs);
@@ -1003,13 +1027,6 @@
   border-top: 1px solid #222;
   margin-top: 4px;
 }
-.cdm-info-btn {
-  border-color: var(--game-border);
-  color: var(--game-text-color-muted);
-  margin-left: auto;
-}
-.cdm-info-btn:hover { border-color: var(--game-text-color-muted); color: var(--game-text-color-muted); }
-
 .deck-list-info-btn {
   background: none;
   border: none;

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -655,27 +655,36 @@
   padding-top: 6px;
 }
 
-/* Top panel — current deck */
+/* Top panel — current deck.
+   Sizes to its content rather than claiming a fixed 40% share: a six-card
+   deck used to reserve the same slab as a thirty-card one, and a full deck
+   was cut off mid-row. `flex: 0 1 auto` lets it be as tall as it needs to
+   be, and the cap hands the rest of the screen to the collection below. */
 .deckbuilder-top-panel {
-  flex: 1 1 40%;
+  flex: 0 1 auto;
+  max-height: 45%;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: flex 0.2s ease;
+  transition: max-height 0.2s ease;
 }
 .deckbuilder-top-panel.deckbuilder-panel--collapsed {
   flex: 0 0 32px;
+  max-height: 32px;
 }
 
-/* Bottom panel — owned collection */
+/* Bottom panel — owned collection. Takes whatever the deck panel leaves. */
 .deckbuilder-bottom-panel {
-  flex: 1 1 60%;
+  flex: 1 1 auto;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: flex 0.2s ease;
+  /* Separates the two panels. Used to be an 8px bar carrying a ⠿ handle
+     that looked draggable and wasn't. */
+  border-top: 1px solid var(--border-edge-dark);
+  margin-top: var(--gap-3);
 }
 .deckbuilder-bottom-panel.deckbuilder-panel--collapsed {
   flex: 0 0 32px;
@@ -685,7 +694,11 @@
 .deckbuilder-panel-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--gap-2);
+  /* Wraps rather than crushing: the deck header now carries the AUTO /
+     SAVED / SHARE actions that used to float in a band of their own. */
+  flex-wrap: wrap;
+  row-gap: var(--gap-2);
   padding: 4px 8px;
   background: rgba(0, 0, 0, 0.35);
   border-bottom: 1px solid #222;
@@ -694,11 +707,40 @@
   box-sizing: border-box;
 }
 
+/* Neutral grey, not the theme green: panel chrome is metadata, not a
+   semantic signal. --game-text-color-dim is a translucent mix of the
+   terminal green. */
 .deckbuilder-panel-label {
   font-size: var(--font-xs);
   letter-spacing: 1px;
   color: var(--game-text-color-dim);
   white-space: nowrap;
+}
+
+/* The affordance hint. Dropped on narrow screens so the header's actions
+   keep their line — the deck-builder tutorial covers it anyway. */
+.deckbuilder-panel-hint {
+  color: var(--color-gray-7);
+  letter-spacing: 0;
+}
+@media (max-width: 420px) {
+  .deckbuilder-panel-hint { display: none; }
+}
+
+/* Right-hand action cluster in either panel header. This class was applied
+   at three call sites and had no rule at all — everything it looked like it
+   was doing came from u-* utilities sitting beside it. */
+.deckbuilder-header-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--gap-2);
+  margin-left: auto;
+}
+
+/* Deck size + any deck warnings, stacked in the page header's right slot. */
+.deckbuilder-status {
+  flex-shrink: 0;
 }
 
 .deck-slot-toggle {
@@ -751,10 +793,16 @@
   color: var(--game-text-color);
 }
 
+/* Matches .overlay-count--invalid's pill treatment — both say "this deck
+   isn't ready", and they now sit together in the page header. */
 .deckbuilder-mana-warn {
   font-size: var(--font-xs);
   color: var(--color-gold-alt);
   white-space: nowrap;
+  border: 1px solid color-mix(in srgb, var(--color-gold-alt) 50%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
+  background: color-mix(in srgb, var(--color-gold-alt) 10%, transparent);
 }
 
 /* Scrollable deck card grid */
@@ -764,14 +812,10 @@
   padding: 6px 4px;
 }
 
-/* Deck tile — relative so the resting overlay can be absolute */
-.deck-cell {
+/* Wraps just the card tile, so the resting overlay covers the art and not
+   the count/mastery footer underneath it. */
+.card-cell-tile {
   position: relative;
-}
-
-/* Resting card overlay in the deck panel */
-.deck-cell--resting {
-  cursor: default;
 }
 
 .resting-overlay {
@@ -803,26 +847,6 @@
   letter-spacing: 1px;
 }
 
-/* Divider between panels */
-.deckbuilder-divider {
-  height: 8px;
-  flex-shrink: 0;
-  background: #0d0d0d;
-  border-top: 1px solid #1e1e1e;
-  border-bottom: 1px solid #1e1e1e;
-}
-.deckbuilder-divider:hover {
-  background: #161616;
-}
-.deckbuilder-divider-handle {
-  color: #333;
-  font-size: var(--font-md);
-  line-height: 1;
-}
-.deckbuilder-divider:hover .deckbuilder-divider-handle {
-  color: #555;
-}
-
 /* Collection inner — wraps search + filter bar + grid */
 .deckbuilder-collection-inner {
   min-height: 0;
@@ -839,6 +863,14 @@
   flex: 1;
   overflow-y: auto;
   padding: 2px 4px 4px;
+}
+
+/* .collection-grid is the scroll container on the Collection screen, but in
+   the deck builder each panel body already scrolls — leaving it set here
+   nested a second (never-scrolling) scroller inside the real one. */
+.deckbuilder-deck-grid .collection-grid,
+.deckbuilder-collection-grid .collection-grid {
+  overflow: visible;
 }
 
 .deck-empty {

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -447,13 +447,14 @@
   border-color: #994444;
 }
 
-/* Active filter pills in the filter bar */
+/* Active filter pills in the filter bar. These used to be nowrap with a
+   hidden-scrollbar horizontal overflow, so with three or four filters on,
+   the ones past the fold were simply invisible. Wrapping costs a few
+   pixels of height and shows all of them. */
 .filter-active-pills {
-  flex-wrap: nowrap;
-  overflow-x: auto;
-  scrollbar-width: none;
+  flex-wrap: wrap;
+  row-gap: var(--gap-1);
 }
-.filter-active-pills::-webkit-scrollbar { display: none; }
 
 /* Active-filter chip — a UI state indicator, so gold rather than the old
    terminal green. */
@@ -485,12 +486,6 @@
 
 /* ─── Deck builder search + filter ──────────────────── */
 
-.deckbuilder-filters {
-  padding: 4px 0 6px;
-  border-bottom: 1px solid #222;
-  margin-bottom: 4px;
-}
-
 .deckbuilder-search {
   background: rgba(0, 0, 0, 0.5);
   border: 1px solid var(--game-border);
@@ -505,10 +500,6 @@
 }
 .deckbuilder-search:focus { border-color: #555; }
 .deckbuilder-search::placeholder { color: var(--game-text-color-muted); }
-
-.deckbuilder-filter-row {
-  gap: 3px;
-}
 
 /* ─── Collection Grid ────────────────────────────────── */
 
@@ -701,7 +692,7 @@
   row-gap: var(--gap-2);
   padding: 4px 8px;
   background: rgba(0, 0, 0, 0.35);
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--color-gray-3);
   flex-shrink: 0;
   min-height: 32px;
   box-sizing: border-box;
@@ -713,7 +704,7 @@
 .deckbuilder-panel-label {
   font-size: var(--font-xs);
   letter-spacing: 1px;
-  color: var(--game-text-color-dim);
+  color: var(--color-gray-9);
   white-space: nowrap;
 }
 
@@ -751,18 +742,20 @@
   font-weight: bold;
   letter-spacing: 1px;
   padding: 2px 8px;
-  border: 1px solid #444;
-  border-radius: 3px;
+  border: 1px solid var(--border-edge);
+  border-radius: var(--radius-sm);
   background: rgba(255,255,255,0.05);
-  color: var(--game-text-color-dim);
+  color: var(--color-gray-9);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
-.deck-slot-btn:hover { background: rgba(255,255,255,0.12); color: #fff; }
+.deck-slot-btn:hover { background: rgba(255,255,255,0.12); color: var(--text-primary); }
+/* Gold, like every other active tab in the game (.player-tab--active,
+   .hoa-tab--active, .filter-pill). This was the last green tab left. */
 .deck-slot-btn--active {
-  background: #4a7c59;
-  border-color: #6ab07a;
-  color: #fff;
+  background: color-mix(in srgb, var(--accent-gold) 18%, transparent);
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
 }
 
 /* Small action buttons in the deck panel header */
@@ -770,18 +763,13 @@
   font-size: var(--font-xs) !important;
   padding: 3px 7px !important;
   border-color: var(--border-edge) !important;
-  color: var(--game-text-color-dim) !important;
-}
-
-.db-save-btn {
-  border-color: rgba(51, 255, 51, 0.7) !important;
-  color: var(--game-text-color) !important;
+  color: var(--color-gray-9) !important;
 }
 
 .db-collapse-btn {
   background: none;
-  border: 1px solid #333;
-  color: var(--game-text-color-dim);
+  border: 1px solid var(--game-border);
+  color: var(--color-gray-9);
   font-size: var(--font-xs);
   padding: 2px 6px;
   cursor: pointer;
@@ -789,8 +777,8 @@
   line-height: 1.2;
 }
 .db-collapse-btn:hover {
-  border-color: #555;
-  color: var(--game-text-color);
+  border-color: var(--color-gray-6);
+  color: var(--text-primary);
 }
 
 /* Matches .overlay-count--invalid's pill treatment — both say "this deck
@@ -838,12 +826,12 @@
 
 .resting-badge {
   background: rgba(0, 0, 0, 0.88);
-  border: 1px solid #555;
-  color: #999;
-  font-size: var(--font-xs);
+  border: 1px solid var(--color-gray-6);
+  color: var(--color-gray-9);
+  font-size: var(--font-xxs);
   font-weight: bold;
-  padding: 3px 8px;
-  border-radius: 3px;
+  padding: 2px 5px;
+  border-radius: var(--radius-sm);
   letter-spacing: 1px;
 }
 
@@ -874,7 +862,7 @@
 }
 
 .deck-empty {
-  color: var(--game-text-color-dim);
+  color: var(--color-gray-9);
   font-size: var(--font-md);
   padding: 16px 8px;
   text-align: center;


### PR DESCRIPTION
Follow-up to the #2178 pass. The deck builder read as messy for structural reasons rather than cosmetic ones, so this covers the layout as well as the styling.

## Header stack: four bands → two

The screen opened with the page header, a loose action row, the deck panel header, and the deck size bar before a single card — then repeated the pattern for the collection.

The loose row had no padding of its own and sat outside `.deckbuilder-split`, belonging to neither the header above nor the panel below. It also mixed a *state* (`⚠ no mana building`) in with three *actions*, and wrapped, so the header changed shape depending on deck contents.

- `AUTO` / `SAVED` / `SHARE` move into the deck panel's own header — they all act on the deck.
- The mana warning moves beside the deck-size counter and picks up the same pill treatment as `.overlay-count--invalid`. Both say "this deck isn't ready"; they now say it in one place.
- The affordance hints become a dimmed span that drops below 420px so the actions keep their line.

## Split panel

`.deckbuilder-top-panel` claimed a fixed `flex: 1 1 40%` regardless of content: a six-card deck reserved the same slab as a thirty-card one, and a full deck was clipped mid-row. It now sizes to content and caps at 45%, handing the rest to the collection.

The separator carried a `⠿` drag handle. Nothing was draggable — it swapped which panel was collapsed, and with both panels open (the default) clicking it did nothing. Removed in favour of a plain rule.

The two collapse buttons had hand-rolled three-branch conditionals whose trailing comments ("do nothing if the other is already collapsed") described behaviour the code didn't have — the final branch swapped the panels. One `togglePanel` helper now makes "you can never collapse both" hold by construction.

## One card-cell footer

The strip under a card tile was copy-pasted at three call sites, which is how they drifted — the deck panel had no ⓘ at all, so **a card in your deck couldn't be inspected** without hunting for it in the collection below. Extracted as `CardCellFooter`, with the count line left free-form since the three grids genuinely count different things.

The ⓘ no longer borrows `.extra-btn`/`.cdm-info-btn` from the card detail modal; their `flex: 1` and `margin-left: auto` were written for a row and stretched the glyph into a tall floating block in this column footer.

Resting cards were shown two ways on the same screen — striped overlay plus badge in the deck panel, a bare 💤 in the footer in the collection. Both use the overlay now, scoped to the tile so it stops covering the card's own count.

## Stragglers and dead rules

- `.deck-slot-btn--active` was `#4a7c59`, a raw green that isn't even the project's green. Every other active tab is gold now — the A/B toggle was the last one.
- `.db-save-btn` was `rgba(51,255,51,0.7)` with no consumer.
- Panel labels, collapse buttons and the empty state took `--game-text-color-dim`, a translucent mix of the terminal green. Chrome metadata goes neutral grey, matching `.filter-owned`.
- Raw `#222`/`#333`/`#444`/`#555` → the tokens holding those exact values (#2202).
- Removed: `.deckbuilder-filters`, `.deckbuilder-filter-row`, `.cell-footer-buttons`, `.cdm-info-btn`, `.cell-resting-label`.
- `.deckbuilder-header-actions` was the inverse — applied at three call sites with **no rule behind it**. It now carries its own layout.
- Active filter pills were nowrap over a hidden-scrollbar overflow, so with three or four filters on the ones past the fold were invisible. They wrap now.
- The collection count said "N cards" for a count of distinct owned cards after filtering — now "N shown", matching the Collection screen.
- The clear-search control was an `<input type="reset">` carrying an `alt` attribute, which isn't valid there, so it had no accessible name. Now a real button with `aria-label`.

## Verification

- `npx tsc --noEmit -p .` — clean
- `npm run build` — succeeds
- `npm run test` — **2861 passed** (the `chrome-headless-shell` cleanup error is the known noise per AGENTS.md)
- Storybook + Playwright at 400×760 and 740×900, both stories, plus the Collection screen to confirm the shared footer didn't regress it. The wide shot confirms the content-sizing: a 14-card deck fits one row, so the deck panel takes only that much and the collection gets the rest.

## Not in scope

`.filter-bar`'s `flex-wrap: nowrap` on the three menu buttons themselves, the broader literal sweep (#2202), and the PixiJS token bridge (#2203).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_