### PR TITLE
Fix: collapsing a deck builder panel hid the control that expands it again

### DIFF
--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -485,7 +485,10 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
         </div>
       }
     >
-      <div className="deckbuilder-split u-col u-grow">
+      <div className={`deckbuilder-split u-col u-grow${
+        collectionCollapsed ? ' deckbuilder-split--deck-only'
+        : deckCollapsed ? ' deckbuilder-split--collection-only' : ''
+      }`}>
 
         {/* ── TOP PANEL: current deck ── */}
         <div className={`deckbuilder-top-panel${deckCollapsed ? ' deckbuilder-panel--collapsed' : ''}`}>
@@ -513,17 +516,17 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
                 className="action-btn db-action-sm"
                 onClick={() => setShowAutoBuild(true)}
                 title="Auto Build"
-              >⚡ AUTO</button>
+              >⚡<span className="db-action-label"> AUTO</span></button>
               <button
                 className="action-btn db-action-sm"
                 onClick={() => { setSavedDecks(loadSavedDecks()); setShowSavedDecks(true) }}
                 title="Saved Decks"
-              >💾 SAVED</button>
+              >💾<span className="db-action-label"> SAVED</span></button>
               <button
                 className="action-btn db-action-sm"
                 onClick={() => setShowShare(true)}
                 title="Share Deck"
-              >🔗 SHARE</button>
+              >🔗<span className="db-action-label"> SHARE</span></button>
               <button
                 className="db-collapse-btn"
                 onClick={() => togglePanel('deck')}

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -660,10 +660,6 @@
   overflow: hidden;
   transition: max-height 0.2s ease;
 }
-.deckbuilder-top-panel.deckbuilder-panel--collapsed {
-  flex: 0 0 32px;
-  max-height: 32px;
-}
 
 /* Bottom panel — owned collection. Takes whatever the deck panel leaves. */
 .deckbuilder-bottom-panel {
@@ -677,8 +673,24 @@
   border-top: 1px solid var(--border-edge-dark);
   margin-top: var(--gap-3);
 }
-.deckbuilder-bottom-panel.deckbuilder-panel--collapsed {
-  flex: 0 0 32px;
+
+/* A collapsed panel is exactly its own header — never a fixed height.
+   Pinning it to 32px against the panel's `overflow: hidden` clipped any
+   header that had wrapped to a second line, and the collapse toggle lives
+   at the end of that header: collapsing a panel on a narrow screen hid the
+   only control that could expand it again. */
+.deckbuilder-panel--collapsed {
+  flex: 0 0 auto;
+  max-height: none;
+}
+
+/* Whichever panel is still open takes the whole split. Without this the
+   open panel kept its content-sized height (the deck panel its 45% cap)
+   and the space the collapsed panel gave up was left empty. */
+.deckbuilder-split--deck-only .deckbuilder-top-panel,
+.deckbuilder-split--collection-only .deckbuilder-bottom-panel {
+  flex: 1 1 auto;
+  max-height: none;
 }
 
 /* Shared panel header bar */
@@ -714,8 +726,16 @@
   color: var(--color-gray-7);
   letter-spacing: 0;
 }
-@media (max-width: 420px) {
+
+/* Phone widths: the deck header carries label + A/B + three actions + the
+   collapse toggle, which needs ~390px before it wraps. Shed the hint first,
+   then the action words, so the row stays one line down to the narrowest
+   supported width. */
+@media (max-width: 560px) {
   .deckbuilder-panel-hint { display: none; }
+}
+@media (max-width: 480px) {
+  .db-action-label { display: none; }
 }
 
 /* Right-hand action cluster in either panel header. This class was applied


### PR DESCRIPTION
Regression from #2208. On a phone, collapsing either panel left no way to expand it — the deck builder became unusable until reload.

## What broke

Three changes from #2208 compounded:

1. `.deckbuilder-panel-header` got `flex-wrap: wrap`, so at phone widths the deck header (label + hint + A/B + AUTO/SAVED/SHARE + toggle) ran to two lines.
2. `.deckbuilder-panel--collapsed` pinned the panel to a fixed `32px`, against the panel's own `overflow: hidden` — clipping that second line.
3. The collapse toggle sits at the **end** of the header, on the clipped line.

So collapsing a panel removed the only control that could expand it. #2208 had also removed the `⠿` divider that previously offered a swap out of this state, so there was no fallback.

Second, smaller bug in the same area: with one panel collapsed, the open one kept its content-sized height — the deck panel its `max-height: 45%` cap — so the space the collapsed panel gave up was left as dead void (visible in the reporter's second screenshot).

## Fix

- A collapsed panel is now `flex: 0 0 auto` — exactly its own header, whatever height that takes. The toggle can't be clipped.
- `.deckbuilder-split--deck-only` / `--collection-only` hand the whole split to whichever panel is still open.
- To stop the wrap happening at all on phones, the hint (`— click to remove`) drops at 560px and the AUTO/SAVED/SHARE labels drop to their icons at 480px, so the header holds one line down to the narrowest supported width.

## Verification

Driven through Playwright at **390px** and **460px** (the reported width class), against a `.game-container`-equivalent wrapper so the split has the definite height it has in the app — Storybook renders stories bare, which is why the void looked like it survived the fix at first:

| check | 390px | 460px |
|---|---|---|
| toggle visible after collapsing deck | ✅ | ✅ |
| re-expand via that same toggle | ✅ | ✅ |
| collection collapsed → deck fills | 676px + 33px, ends at viewport bottom | 676px + 33px, ends at viewport bottom |
| deck collapsed → collection fills | 45px + 664px, ends at viewport bottom | 45px + 664px, ends at viewport bottom |

Plus `tsc` clean, `npm run build` succeeds, `npm run test` **2861 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_