### PR TITLE
Fix: deck builder shows only one panel — percentage max-height doesn't resolve

### DIFF
--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -651,19 +651,36 @@
    deck used to reserve the same slab as a thirty-card one, and a full deck
    was cut off mid-row. `flex: 0 1 auto` lets it be as tall as it needs to
    be, and the cap hands the rest of the screen to the collection below. */
+/* The cap is expressed in flex, not as `max-height: 45%`.
+   A percentage max-height resolves against the containing block's height,
+   and .deckbuilder-split is a flex item with `height: auto` — the case where
+   engines disagree about whether the percentage resolves at all or falls
+   back to `none`. Where it falls back, this panel takes its full content
+   height (eight-plus rows for a 30-card deck) and pushes the collection off
+   the bottom of the screen, so the builder only ever shows one panel.
+
+   Instead: this panel is content-sized and absorbs all the shrinkage, while
+   the collection below holds a non-shrinkable 55% basis. That leaves this
+   one at most 45% by construction, using only percentage flex-basis — the
+   same mechanism the pre-#2208 layout used, so it behaves the same
+   everywhere that one did. */
 .deckbuilder-top-panel {
   flex: 0 1 auto;
-  max-height: 45%;
-  min-height: 0;
+  /* Floor, so the deck panel survives even if the collection's percentage
+     basis below fails to resolve on some engine and it claims everything.
+     The deck grid scrolls inside this, so a floor costs nothing. */
+  min-height: 108px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: max-height 0.2s ease;
 }
 
-/* Bottom panel — owned collection. Takes whatever the deck panel leaves. */
+/* Bottom panel — owned collection. flex-shrink: 0 against a 55% basis is
+   what caps the deck panel above: the collection never gives ground, so the
+   deck can only take what is left. It still grows past 55% when the deck is
+   small enough not to need its share. */
 .deckbuilder-bottom-panel {
-  flex: 1 1 auto;
+  flex: 1 0 55%;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -681,7 +698,8 @@
    only control that could expand it again. */
 .deckbuilder-panel--collapsed {
   flex: 0 0 auto;
-  max-height: none;
+  /* Clears the deck panel's floor — collapsed means header-height, period. */
+  min-height: 0;
 }
 
 /* Whichever panel is still open takes the whole split. Without this the
@@ -690,7 +708,6 @@
 .deckbuilder-split--deck-only .deckbuilder-top-panel,
 .deckbuilder-split--collection-only .deckbuilder-bottom-panel {
   flex: 1 1 auto;
-  max-height: none;
 }
 
 /* Shared panel header bar */


### PR DESCRIPTION
Reported: the deck builder only ever shows a deck view or a collection view, never both, from the moment it opens.

## Cause

#2208 capped the deck panel with `max-height: 45%`.

A percentage `max-height` resolves against the containing block's height. `.deckbuilder-split` is a flex item with `height: auto` — precisely the case where engines disagree about whether the percentage resolves or falls back to `none`.

Where it falls back, the panel is `flex: 0 1 auto` with **no cap at all**, so a 30-card deck takes its full eight-plus rows and pushes the collection off the bottom of the screen. Collapsing the deck then swaps to a collection-only view — which is exactly the two states described.

This did not reproduce in Chromium, which is all I verified against in #2208 and #2209. The reporter is on iOS Safari.

## Fix

The cap becomes structural rather than a percentage max-height:

```css
.deckbuilder-top-panel    { flex: 0 1 auto; min-height: 108px; }  /* absorbs all shrinkage */
.deckbuilder-bottom-panel { flex: 1 0 55%; }                      /* never gives ground */
```

The collection holds a non-shrinkable 55% basis, so the deck panel can only take the remaining 45%. Same outcome, but it leans only on **percentage flex-basis** — which is what the pre-#2208 layout used (`flex: 1 1 40%`) and which demonstrably resolved on the reporter's device, since half-and-half worked there before.

The `min-height` floor keeps the deck panel alive should that basis fail to resolve somewhere too. The deck grid scrolls inside it, so the floor costs nothing; `.deckbuilder-panel--collapsed` clears it so a collapsed panel is still exactly its header.

## Verification

Chromium at 400×780, inside a `.game-container` equivalent:

| deck | initial split | content-sized? |
|---|---|---|
| 30/30 cards | deck 44% / collection 55% | capped ✅ |
| 4/30 cards | deck 34% / collection 64% | ✅ |

Collapse/restore round trips both directions land back on the split; each panel fills to the viewport bottom when the other is collapsed; the collapse toggle stays visible at 45px.

Plus `tsc` clean, `npm run build` succeeds, `npm run test` **2861 passed**.

## Limitation

**No WebKit build is available in this environment** (`/opt/pw-browsers` has Chromium only), so the engine-specific behaviour is reasoned from the spec and from the fact that the pre-#2208 flex-basis layout worked on the affected device — not directly observed. Worth a confirmation on an actual iPhone before this is considered closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_