### PR TITLE
Accessibility: keyboard focus ring, keyboard-operable cards/toggles, dialog and control names, contrast fixes

### DIFF
--- a/web/src/components/cards/AugmentPickerModal.tsx
+++ b/web/src/components/cards/AugmentPickerModal.tsx
@@ -43,11 +43,11 @@ export function AugmentPickerModal({ slot, cardName, onClose }: Props) {
   }
 
   return (
-    <ModalBackdrop onClose={onClose} zIndex={400}>
+    <ModalBackdrop onClose={onClose} zIndex={400} title={`Equip ${augmentSlotLabel(slot)}`}>
       <div className="apm-panel">
         <div className="apm-header">
           Equip {augmentSlotLabel(slot)}
-          <button className="cdm-close" onClick={onClose}>✕</button>
+          <button className="cdm-close" onClick={onClose} aria-label="Close">✕</button>
         </div>
 
         {matching.length === 0 ? (

--- a/web/src/components/cards/CardAugmentScreen.tsx
+++ b/web/src/components/cards/CardAugmentScreen.tsx
@@ -103,7 +103,7 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
   return (
 // TODO: There is a lot of common structure between this and the CardDetailModal, consider unifying into a single component with some conditional rendering for the augment-specific parts
 
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop onClose={onClose} title={`${card.name} — Augments`}>
       <div className="cas-panel" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
 
         {/* Header */}

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -176,7 +176,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
   }
 
   return (
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop onClose={onClose} title={card.name}>
       <div className="cdm-panel">
 
         {/* Header */}

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -167,6 +167,18 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
   const isSecret = card.rarity === 'mythic' || card.rarity === 'shiny' || card.rarity === 'holofoil' || card.rarity === 'glass'
   const secretLabel: Record<string, string> = { mythic: 'MYTHIC', shiny: 'SHINY', holofoil: 'HOLO', glass: 'GLASS' }
 
+  // The tile is the most-repeated interactive surface in the game — every
+  // card grid in Collection, the deck builder, hand and pickers renders one
+  // per card. Until now it was a plain <div onClick>: no role, no tab stop,
+  // no keyboard activation, and its only name-ish attribute was `title`,
+  // which isn't a reliable accessible name. A keyboard or screen-reader user
+  // could not play, add, or pick a single card anywhere in the game (#2182).
+  const ariaLabel = [
+    card.name,
+    CATEGORY_LABEL[getCardCategory(card)],
+    `cost ${displayCost ?? card.cost}`,
+  ].join(', ')
+
   return (
     <div
       className={[
@@ -175,64 +187,76 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
         clickable ? '' : 'card-tile--disabled',
         selected ? 'card-tile--selected' : '',
       ].filter(Boolean).join(' ')}
-      onClick={clickable ? onClick : undefined}
       title={heroLocked ? `Hero cards unlock after 30 seconds (${lockedSecs}s remaining)` : card.description}
     >
-      {isSecret && (
-        <div className={`card-secret-badge card-secret-badge--${card.rarity}`}>
-          {secretLabel[card.rarity]}
-        </div>
-      )}
-      {isNew && !isSecret && (
-        <div className="card-new-badge">NEW</div>
-      )}
-      {card.rarity === 'glass' && card.glassBreakChance && (
-        <div className="card-glass-warning" title={`${Math.round(card.glassBreakChance * 100)}% chance to shatter on play`}>💎</div>
-      )}
-      {card.isHero && <>
-
-
-        <div className="hero-badge-wrap">
-         <span className="hero-badge">HERO</span>
-        </div>
-      </>}
-
-
-
-
-      <div className={`card-cost${!canAfford ? ' card-cost--unaffordable' : ''}`}>{displayCost ?? card.cost}</div>
-      {upgradeable && <div className="card-upgrade-badge">UPGRADE</div>}
-      <div className={`card-title${isSecret || isNew ? ' card-title--badge' : ''}`}>{card.name}</div>
-      <div className="card-art u-flex u-items-c u-just-c">
-        <SynergyBadges groups={synergyGroups} deckMatches={deckMatches} />
-        {card.unit
-          ? <SpriteImg name={card.unit.name} className="card-sprite" />
-          : card.upgradeEffect
-            ? <SpriteImg name={card.name} fallbackName={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
-            : card.augmentSlot
-              ? <SpriteImg name={card.name} fallbackName={AUGMENT_SPRITE[card.augmentSlot] ?? 'augment-amulet'} className="card-sprite" />
-              : null
-        }
-      </div>
-
-      <div className="card-stats">{stats}</div>
-      <div className="card-bottom-row">
-        <div className="card-rarity">{rarityStars(card.rarity)}</div>
-        <div className={`card-type-badge card-type-badge--${getCardCategory(card)}`}>
-          {CATEGORY_ICON[getCardCategory(card)]}
-          {/* The label carries its own ellipsis: text-overflow can't act on the
-              badge itself, since that's a flex container and this span is a
-              flex item rather than inline content it clips. */}
-          <span className="card-type-badge-label">{CATEGORY_LABEL[getCardCategory(card)]}</span>
-        </div>
-        {showDetails && (
-          <button
-            className="card-bottom-info-btn"
-            onClick={e => { e.stopPropagation(); openDetail(card) }}
-            title="Card details"
-          >ⓘ</button>
+      {/* The actual interactive surface. Used to be the outer div itself
+          (role="button" + a manual keydown handler), but that nested a real
+          <button> — the showDetails info button below — inside a role="button"
+          ancestor, which axe (and several screen readers) flag as broken:
+          nested interactive controls don't reliably expose both to assistive
+          tech. A real <button> gets keyboard activation for free and can't
+          contain another button, so the info button moves out to be its
+          sibling instead, positioned back into the same corner with CSS. */}
+      <button
+        type="button"
+        className="card-tile-btn"
+        onClick={clickable ? onClick : undefined}
+        disabled={!clickable}
+        aria-label={ariaLabel}
+        aria-pressed={selected ? true : undefined}
+      >
+        {isSecret && (
+          <div className={`card-secret-badge card-secret-badge--${card.rarity}`}>
+            {secretLabel[card.rarity]}
+          </div>
         )}
-      </div>
+        {isNew && !isSecret && (
+          <div className="card-new-badge">NEW</div>
+        )}
+        {card.rarity === 'glass' && card.glassBreakChance && (
+          <div className="card-glass-warning" title={`${Math.round(card.glassBreakChance * 100)}% chance to shatter on play`}>💎</div>
+        )}
+        {card.isHero && (
+          <div className="hero-badge-wrap">
+           <span className="hero-badge">HERO</span>
+          </div>
+        )}
+
+        <div className={`card-cost${!canAfford ? ' card-cost--unaffordable' : ''}`}>{displayCost ?? card.cost}</div>
+        {upgradeable && <div className="card-upgrade-badge">UPGRADE</div>}
+        <div className={`card-title${isSecret || isNew ? ' card-title--badge' : ''}`}>{card.name}</div>
+        <div className="card-art u-flex u-items-c u-just-c">
+          <SynergyBadges groups={synergyGroups} deckMatches={deckMatches} />
+          {card.unit
+            ? <SpriteImg name={card.unit.name} className="card-sprite" />
+            : card.upgradeEffect
+              ? <SpriteImg name={card.name} fallbackName={UPGRADE_SPRITE[card.upgradeEffect.type] ?? 'upgrade'} className="card-sprite" />
+              : card.augmentSlot
+                ? <SpriteImg name={card.name} fallbackName={AUGMENT_SPRITE[card.augmentSlot] ?? 'augment-amulet'} className="card-sprite" />
+                : null
+          }
+        </div>
+
+        <div className="card-stats">{stats}</div>
+        <div className={`card-bottom-row${showDetails ? ' card-bottom-row--with-info' : ''}`}>
+          <div className="card-rarity">{rarityStars(card.rarity)}</div>
+          <div className={`card-type-badge card-type-badge--${getCardCategory(card)}`}>
+            {CATEGORY_ICON[getCardCategory(card)]}
+            {/* The label carries its own ellipsis: text-overflow can't act on the
+                badge itself, since that's a flex container and this span is a
+                flex item rather than inline content it clips. */}
+            <span className="card-type-badge-label">{CATEGORY_LABEL[getCardCategory(card)]}</span>
+          </div>
+        </div>
+      </button>
+      {showDetails && (
+        <button
+          className="card-bottom-info-btn"
+          onClick={e => { e.stopPropagation(); openDetail(card) }}
+          title="Card details"
+          aria-label={`${card.name} card details`}
+        >ⓘ</button>
+      )}
       {heroLocked && (
         <div className="card-hero-lock u-absolute u-col u-items-c u-just-c">
           <span className="card-hero-lock-icon">⏳</span>

--- a/web/src/components/cards/DeckBuilder.tsx
+++ b/web/src/components/cards/DeckBuilder.tsx
@@ -531,6 +531,7 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
                 className="db-collapse-btn"
                 onClick={() => togglePanel('deck')}
                 title={deckCollapsed ? 'Expand deck panel' : 'Collapse deck panel'}
+                aria-label={deckCollapsed ? 'Expand deck panel' : 'Collapse deck panel'}
               >{deckCollapsed ? '▼' : '▲'}</button>
             </div>
           </div>
@@ -606,6 +607,7 @@ export function DeckBuilder({ onBack, fatiguedCards = [] }: Props) {
                 className="db-collapse-btn"
                 onClick={() => togglePanel('collection')}
                 title={collectionCollapsed ? 'Expand collection panel' : 'Collapse collection panel'}
+                aria-label={collectionCollapsed ? 'Expand collection panel' : 'Collapse collection panel'}
               >{collectionCollapsed ? '▲' : '▼'}</button>
             </div>
           </div>

--- a/web/src/components/cards/DeckSelectorModal.tsx
+++ b/web/src/components/cards/DeckSelectorModal.tsx
@@ -79,7 +79,7 @@ export function DeckSelectorModal({ fatiguedCards = [], onConfirm, onCancel }: P
   }
 
   return (
-    <ModalBackdrop onClose={onCancel}>
+    <ModalBackdrop onClose={onCancel} title="Choose Your Deck">
       <div className="deck-selector-modal">
         <div className="deck-selector-title">CHOOSE YOUR DECK</div>
         <div className="deck-selector-panels u-flex u-gap-6">

--- a/web/src/components/cards/PackOpening.tsx
+++ b/web/src/components/cards/PackOpening.tsx
@@ -291,7 +291,7 @@ export function PackOpening({ packs, onDone }: Props) {
       })()}
 
       {showSummary && (
-        <ModalBackdrop onClose={onDone} zIndex={300}>
+        <ModalBackdrop onClose={onDone} zIndex={300} title="All Cards">
           <div className="daily-modal" style={{ maxWidth: 360, textAlign: 'left' }}>
             <div className="daily-modal-header">✦ ALL CARDS</div>
             <div className="daily-modal-sub">

--- a/web/src/components/cards/StarterPackSelect.tsx
+++ b/web/src/components/cards/StarterPackSelect.tsx
@@ -38,7 +38,15 @@ export function StarterPackSelect({ onPick, fatiguedCards = [], bonusCards = [],
         {STARTER_PACK_OPTIONS.map(pack => {
           const isRecommended = recommendedPackId === pack.id
           return (
-          <div key={pack.id} className={`starter-pack u-col u-gap-4 u-grow u-pointer${isRecommended ? ' starter-pack--recommended' : ''}`} onClick={() => onPick(pack.cards)}>
+          <div
+            key={pack.id}
+            className={`starter-pack u-col u-gap-4 u-grow u-pointer${isRecommended ? ' starter-pack--recommended' : ''}`}
+            onClick={() => onPick(pack.cards)}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onPick(pack.cards) } }}
+            role="button"
+            tabIndex={0}
+            aria-label={`${pack.name}${isRecommended ? ', recommended' : ''}`}
+          >
             {isRecommended && <div className="starter-pack-recommended">⭐ RECOMMENDED</div>}
             <div className="starter-pack-name">{pack.name}</div>
             <div className="starter-pack-desc">{pack.description}</div>
@@ -55,7 +63,7 @@ export function StarterPackSelect({ onPick, fatiguedCards = [], bonusCards = [],
                 )
               })}
             </ul>
-            <button className="action-btn starter-pack-btn">CHOOSE</button>
+            <div className="action-btn starter-pack-btn" aria-hidden="true">CHOOSE</div>
           </div>
           )
         })}

--- a/web/src/components/hub/BountyBoardModal.tsx
+++ b/web/src/components/hub/BountyBoardModal.tsx
@@ -39,13 +39,13 @@ export function BountyBoardModal({ onClose, resolveNpcName = (id) => id, townNpc
   const completed = bounties.filter(b => isBountyCompleted(b.id))
 
   return (
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop onClose={onClose} title="Bounty Board">
       <Panel elevation="floating" className="bounty-board-modal">
         <div className="bounty-board-modal__header">
           <span>📋 Bounty Board</span>
           <span className="bounty-board-modal__meta">
             {completed.length} of {bounties.length}
-            <button className="bounty-board-modal__close" onClick={onClose}>✕</button>
+            <button className="bounty-board-modal__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 

--- a/web/src/components/hub/HomeShelf.tsx
+++ b/web/src/components/hub/HomeShelf.tsx
@@ -527,7 +527,7 @@ export function HomeShelf({ onBack, houseKey = 'default', initialTab = 'shelf' }
       )}
 
       {detail && (
-        <ModalBackdrop onClose={() => setDetail(null)}>
+        <ModalBackdrop onClose={() => setDetail(null)} title={detail.kind === 'item' ? detail.item.name : detail.relic.name}>
           <Panel elevation="floating" className="shelf-modal">
             <div className="shelf-modal-icon">
               {detail.kind === 'item' ? detail.item.icon : detail.relic.icon}

--- a/web/src/components/hub/HubInventoryModal.tsx
+++ b/web/src/components/hub/HubInventoryModal.tsx
@@ -66,7 +66,7 @@ export function HubInventoryContent({ onClose, questDefs }: Props) {
         <div className="quests-modal__header">
           <span>🎒 Inventory</span>
           <span className="quests-modal__meta">
-            <button className="quests-modal__close" onClick={onClose}>✕</button>
+            <button className="quests-modal__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 
@@ -117,7 +117,7 @@ export function HubInventoryContent({ onClose, questDefs }: Props) {
 
 export function HubInventoryModal(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="Inventory">
       <HubInventoryContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -221,6 +221,7 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
           className="hub-minimap-toggle"
           onClick={toggle}
           title={visible ? 'Hide minimap' : 'Show minimap'}
+          aria-label={visible ? 'Hide minimap' : 'Show minimap'}
         >
           🗺
         </button>

--- a/web/src/components/hub/HubTabbedModal.tsx
+++ b/web/src/components/hub/HubTabbedModal.tsx
@@ -69,9 +69,10 @@ export function HubTabbedModal(props: Props) {
 
   const tabs = ALL_TABS.filter(t => t.id !== 'pet' || hasPet)
   const tab = activeTab === 'pet' && !hasPet ? 'quests' : activeTab
+  const tabLabel = ALL_TABS.find(t => t.id === tab)?.label ?? 'Hub'
 
   return (
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop onClose={onClose} title={tabLabel}>
       <Panel elevation="floating" className="hub-tabbed-modal">
         <div className="hoa-tabs">
           {tabs.map(t => (

--- a/web/src/components/hub/HubTownUpgrades.tsx
+++ b/web/src/components/hub/HubTownUpgrades.tsx
@@ -55,7 +55,7 @@ export function HubTownUpgradesContent({
           <span>🏗️ {townName} — Standing &amp; Upgrades</span>
           <span className="town-directory__meta">
             💎 {crystals.toLocaleString()}
-            <button className="town-directory__close" onClick={onClose}>✕</button>
+            <button className="town-directory__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 
@@ -138,7 +138,7 @@ export function HubTownUpgradesContent({
 
 export function HubTownUpgrades(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title={`${props.townName} — Standing & Upgrades`}>
       <HubTownUpgradesContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/PetModal.tsx
+++ b/web/src/components/hub/PetModal.tsx
@@ -93,7 +93,7 @@ export function PetContent({ onClose, petActionRef }: Props) {
       <Panel elevation="floating" className="pet-modal">
         <div className="pet-modal__header">
           <span>🐾 My Pet</span>
-          <button className="pet-modal__close" onClick={onClose}>✕</button>
+          <button className="pet-modal__close" onClick={onClose} aria-label="Close">✕</button>
         </div>
 
         {!pet && (
@@ -147,7 +147,7 @@ export function PetContent({ onClose, petActionRef }: Props) {
 
 export function PetModal(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="My Pet">
       <PetContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/PetShelterModal.tsx
+++ b/web/src/components/hub/PetShelterModal.tsx
@@ -50,7 +50,7 @@ export function PetShelterContent({ onClose, onAdopted }: Props) {
     <Panel elevation="floating" className="pet-modal">
       <div className="pet-modal__header">
         <span>🏚️ Ravenwatch Shelter</span>
-        <button className="pet-modal__close" onClick={onClose}>✕</button>
+        <button className="pet-modal__close" onClick={onClose} aria-label="Close">✕</button>
       </div>
 
       <div className="pet-modal__section-label">I have these pets to adopt</div>
@@ -76,7 +76,7 @@ export function PetShelterContent({ onClose, onAdopted }: Props) {
 
 export function PetShelterModal(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="Ravenwatch Shelter">
       <PetShelterContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/QuestsModal.tsx
+++ b/web/src/components/hub/QuestsModal.tsx
@@ -55,7 +55,7 @@ export function QuestsContent({ onClose, onAbandon, questDefs, resolveNpcName = 
           <span>📜 Quests</span>
           <span className="quests-modal__meta">
             {discovered} of {total}
-            <button className="quests-modal__close" onClick={onClose}>✕</button>
+            <button className="quests-modal__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 
@@ -146,7 +146,7 @@ export function QuestsContent({ onClose, onAbandon, questDefs, resolveNpcName = 
 
 export function QuestsModal(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="Quests">
       <QuestsContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/TownDirectory.tsx
+++ b/web/src/components/hub/TownDirectory.tsx
@@ -39,7 +39,7 @@ export function TownDirectoryContent({ onClose, locationData, pinnedNpcId, onTog
           <span>🧭 Where is…?</span>
           <span className="town-directory__meta">
             {visible.length} {visible.length === 1 ? 'person' : 'people'}
-            <button className="town-directory__close" onClick={onClose}>✕</button>
+            <button className="town-directory__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 
@@ -96,7 +96,7 @@ export function TownDirectoryContent({ onClose, locationData, pinnedNpcId, onTog
 
 export function TownDirectory(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="Where is…?">
       <TownDirectoryContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/TownJournal.tsx
+++ b/web/src/components/hub/TownJournal.tsx
@@ -107,7 +107,7 @@ export function TownJournalContent({ onClose, locationData }: Props) {
           <span>📖 Town Journal</span>
           <span className="town-directory__meta">
             {overallPct}% complete
-            <button className="town-directory__close" onClick={onClose}>✕</button>
+            <button className="town-directory__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 
@@ -249,7 +249,7 @@ export function TownJournalContent({ onClose, locationData }: Props) {
 
 export function TownJournal(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="Town Journal">
       <TownJournalContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/TradeJournalModal.tsx
+++ b/web/src/components/hub/TradeJournalModal.tsx
@@ -49,7 +49,7 @@ export function TradeJournalContent({ onClose }: Props) {
         <div className="quests-modal__header">
           <span>💱 Trade Journal</span>
           <span className="quests-modal__meta">
-            <button className="quests-modal__close" onClick={onClose}>✕</button>
+            <button className="quests-modal__close" onClick={onClose} aria-label="Close">✕</button>
           </span>
         </div>
 
@@ -72,7 +72,7 @@ export function TradeJournalContent({ onClose }: Props) {
 
 export function TradeJournalModal(props: Props) {
   return (
-    <ModalBackdrop onClose={props.onClose}>
+    <ModalBackdrop onClose={props.onClose} title="Trade Journal">
       <TradeJournalContent {...props} />
     </ModalBackdrop>
   )

--- a/web/src/components/hub/TreasureModal.tsx
+++ b/web/src/components/hub/TreasureModal.tsx
@@ -21,7 +21,7 @@ export function TreasureModal({ treasure, onClose }: Props) {
   }
 
   return (
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop onClose={onClose} title={title}>
       <RunEndCard tone="gold" className="treasure-modal u-items-c u-text-c">
         <div className="treasure-modal__icon">🎁</div>
         <div className="treasure-modal__title">{title}</div>

--- a/web/src/components/minigames/CityBuilder.tsx
+++ b/web/src/components/minigames/CityBuilder.tsx
@@ -1820,7 +1820,7 @@ export function CityBuilder({ onBack }: Props) {
         )}
 
         {showFarmLockModal && (
-          <ModalBackdrop onClose={() => setShowFarmLockModal(false)}>
+          <ModalBackdrop onClose={() => setShowFarmLockModal(false)} title="Farm — Locked">
             <div className="city-info-modal">
               <div className="city-info-modal-title">🌾 FARM — LOCKED</div>
               <div className="city-info-modal-body">
@@ -1839,7 +1839,7 @@ export function CityBuilder({ onBack }: Props) {
         )}
 
         {showExpandModal && (
-          <ModalBackdrop onClose={() => setShowExpandModal(false)}>
+          <ModalBackdrop onClose={() => setShowExpandModal(false)} title="City Expansion">
             <div className="city-info-modal">
               <div className="city-info-modal-title">🏢 CITY EXPANSION</div>
               <div className="city-info-modal-body">

--- a/web/src/components/minigames/FarmingSim.tsx
+++ b/web/src/components/minigames/FarmingSim.tsx
@@ -707,7 +707,7 @@ export function FarmingSim({ city, onSaveCity, onBack }: Props) {
         />
 
         {showExpandModal && (
-          <ModalBackdrop onClose={() => setShowExpandModal(false)}>
+          <ModalBackdrop onClose={() => setShowExpandModal(false)} title="Farm Expansion">
             <div className="city-info-modal">
               <div className="city-info-modal-title">🌱 FARM EXPANSION</div>
               <div className="city-info-modal-body">

--- a/web/src/components/minigames/TowerDefence.tsx
+++ b/web/src/components/minigames/TowerDefence.tsx
@@ -419,7 +419,7 @@ export function TowerDefence({ pool, mode, onDone, environment }: Props) {
           >⚡Auto</button>
         </div>
 
-        <button className="action-btn action-btn--danger td-header-btn" onClick={handleQuit}>
+        <button className="action-btn action-btn--danger td-header-btn" onClick={handleQuit} aria-label="Quit">
           ✕
         </button>
       </div>

--- a/web/src/components/minigames/citybuilder/CityZoomControls.tsx
+++ b/web/src/components/minigames/citybuilder/CityZoomControls.tsx
@@ -12,7 +12,7 @@ export interface Props {
 export function CityZoomControls({ scale, onZoomIn, onZoomOut, onZoomTo }: Props) {
   return (
     <div className="city-zoom-controls" onPointerDown={e => e.stopPropagation()}>
-      <button className="city-zoom-btn" onClick={onZoomOut} title="Zoom out" disabled={scale <= 1}>−</button>
+      <button className="city-zoom-btn" onClick={onZoomOut} title="Zoom out" aria-label="Zoom out" disabled={scale <= 1}>−</button>
       <div className="city-zoom-bar">
         {ZOOM_STEPS.map((z, i) => (
           <button
@@ -20,12 +20,13 @@ export function CityZoomControls({ scale, onZoomIn, onZoomOut, onZoomTo }: Props
             className={`city-zoom-tick${scale >= z - 0.01 ? ' city-zoom-tick--active' : ''}`}
             onClick={() => onZoomTo(z)}
             title={`${z}×`}
+            aria-label={`Zoom to ${z}×`}
           >
             {i === ZOOM_STEPS.length - 1 ? '|' : '·'}
           </button>
         ))}
       </div>
-      <button className="city-zoom-btn" onClick={onZoomIn} title="Zoom in" disabled={scale >= 4}>+</button>
+      <button className="city-zoom-btn" onClick={onZoomIn} title="Zoom in" aria-label="Zoom in" disabled={scale >= 4}>+</button>
     </div>
   )
 }

--- a/web/src/components/minigames/citybuilder/StatsSparkline.tsx
+++ b/web/src/components/minigames/citybuilder/StatsSparkline.tsx
@@ -184,7 +184,7 @@ export function StatsSparkline({ data, attacks, color, height = 54, dimColor, ca
       </div>
 
       {expanded && label && (
-        <ModalBackdrop onClose={() => setExpanded(false)}>
+        <ModalBackdrop onClose={() => setExpanded(false)} title={label}>
           <div className="city-sparkline-modal">
             <div className="city-sparkline-modal-header">
               <span>{label}</span>

--- a/web/src/components/minigames/citybuilder/farming/FarmRaidModal.tsx
+++ b/web/src/components/minigames/citybuilder/farming/FarmRaidModal.tsx
@@ -19,7 +19,7 @@ export function FarmRaidModal({ raid, onClose }: Props) {
   const stolenEntries = Object.entries(raid.stolenResources).filter(([, v]) => (v as number) > 0) as [ResourceType, number][]
 
   return (
-    <ModalBackdrop onClose={onClose}>
+    <ModalBackdrop onClose={onClose} title={meta.label}>
       <div className={`farm-raid-modal ${meta.cls}`}>
         <div className="farm-raid-icon">{meta.icon}</div>
         <div className="farm-raid-outcome">{meta.label}</div>

--- a/web/src/components/modals/FeedbackModal.tsx
+++ b/web/src/components/modals/FeedbackModal.tsx
@@ -38,7 +38,7 @@ export function FeedbackModal({ user, onClose }: Props) {
   }
 
   return (
-    <ModalBackdrop onClose={status === 'sending' ? () => {} : onClose}>
+    <ModalBackdrop onClose={status === 'sending' ? () => {} : onClose} title="Send Feedback">
       <div className="confirm-modal" style={{ maxWidth: 400, textAlign: 'left' }}>
         <div className="confirm-modal-title">SEND FEEDBACK</div>
 

--- a/web/src/components/modals/StreakBrokenModal.tsx
+++ b/web/src/components/modals/StreakBrokenModal.tsx
@@ -11,7 +11,7 @@ export function StreakBrokenModal({ streak, bestStreak, onClose }: Props) {
   const wasPersonalBest = streak >= bestStreak
 
   return (
-    <ModalBackdrop onClose={onClose} zIndex={600}>
+    <ModalBackdrop onClose={onClose} zIndex={600} title="Streak Over">
       <div className="streak-broken-modal">
         <div className="streak-broken-icon">💔</div>
         <div className="streak-broken-heading">STREAK OVER</div>

--- a/web/src/components/modals/TutorialOverlay.tsx
+++ b/web/src/components/modals/TutorialOverlay.tsx
@@ -16,7 +16,7 @@ export function TutorialOverlay({ steps, onDone }: Props) {
   const isLast = index === steps.length - 1
 
   return (
-    <div className="tutorial-backdrop" role="dialog" aria-modal="true">
+    <div className="tutorial-backdrop" role="dialog" aria-modal="true" aria-label={step.title}>
       <div className="tutorial-panel">
         <div className="tutorial-step-indicator">[ {index + 1} / {steps.length} ]</div>
         <div className="tutorial-title">{step.title}</div>

--- a/web/src/components/screens/AugmentCollectionScreen.tsx
+++ b/web/src/components/screens/AugmentCollectionScreen.tsx
@@ -143,11 +143,11 @@ function UnitPickerModal({ stack, onEquip, onClose }: UnitPickerProps) {
   )
 
   return (
-    <ModalBackdrop onClose={onClose} zIndex={400}>
+    <ModalBackdrop onClose={onClose} zIndex={400} title={`Equip ${stack.setName} Set to Unit`}>
       <div className="apm-panel">
         <div className="apm-header">
           Equip {stack.setName} Set to Unit
-          <button className="cdm-close" onClick={onClose}>✕</button>
+          <button className="cdm-close" onClick={onClose} aria-label="Close">✕</button>
         </div>
         {unitCards.length === 0 ? (
           <div className="apm-empty">No unit cards owned.</div>

--- a/web/src/components/screens/CollectionScreen.tsx
+++ b/web/src/components/screens/CollectionScreen.tsx
@@ -564,7 +564,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
       })()}
 
       {disenchantModal && (
-        <ModalBackdrop onClose={() => setDisenchantModal(null)} zIndex={300}>
+        <ModalBackdrop onClose={() => setDisenchantModal(null)} zIndex={300} title="Disenchant All">
           <div className="daily-modal" style={{ maxWidth: 360, textAlign: 'left' }}>
             <div className="daily-modal-header">🔮 DISENCHANT ALL</div>
             <div className="daily-modal-sub">
@@ -587,7 +587,7 @@ export function CollectionScreen({ crystals, onCrystalsChanged, onBack, commande
       )}
 
       {upgradeModal && (
-        <ModalBackdrop onClose={() => setUpgradeModal(null)} zIndex={300}>
+        <ModalBackdrop onClose={() => setUpgradeModal(null)} zIndex={300} title="Upgrade All">
           <div className="daily-modal" style={{ maxWidth: 360, textAlign: 'left' }}>
             <div className="daily-modal-header">★ UPGRADE ALL</div>
             <div className="daily-modal-sub">

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -365,11 +365,19 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
             </div>
 
                          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>     <span className="settings-value">Sound On/Off</span>
-                            <div className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select" onClick={handleSoundToggle}>
+                            <div
+                              className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+                              onClick={handleSoundToggle}
+                              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSoundToggle() } }}
+                              role="switch"
+                              aria-checked={soundOn}
+                              aria-label="Sound"
+                              tabIndex={0}
+                            >
                 <div className={`settings-toggle-track${soundOn ? ' settings-toggle-track--on' : ''}`}>
                   <div className="settings-toggle-thumb" />
                 </div>
-              </div>
+                            </div>
             </div>
            
           </div>
@@ -388,6 +396,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 value={soundVolume}
                 disabled={!soundOn}
                 onChange={e => handleSoundVolumeChange(Number(e.target.value))}
+                aria-label="Effects volume"
               />
               <span className="settings-value">{Math.round(soundVolume * 100)}%</span>
             </div>
@@ -406,6 +415,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 step={0.05}
                 value={musicVolume}
                 onChange={e => handleMusicVolumeChange(Number(e.target.value))}
+                aria-label="Music volume"
               />
               <span className="settings-value">{Math.round(musicVolume * 100)}%</span>
             </div>
@@ -418,7 +428,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               <div className="settings-label">Skip intro on startup</div>
               <div className="settings-sublabel">Skip the Awesome Software splash screens</div>
             </div>
-            <div className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select" onClick={handleSkipIntroToggle}>
+            <div
+              className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+              onClick={handleSkipIntroToggle}
+              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSkipIntroToggle() } }}
+              role="switch"
+              aria-checked={skipIntro}
+              aria-label="Skip intro on startup"
+              tabIndex={0}
+            >
               <div className={`settings-toggle-track${skipIntro ? ' settings-toggle-track--on' : ''}`}>
                 <div className="settings-toggle-thumb" />
               </div>
@@ -487,7 +505,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">8-bit visual filter</div>
                 <div className="settings-sublabel">Posterised palette + pixelated sprites</div>
               </div>
-              <div className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select" onClick={handleEightbitToggle}>
+              <div
+                className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+                onClick={handleEightbitToggle}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleEightbitToggle() } }}
+                role="switch"
+                aria-checked={eightbitOn}
+                aria-label="8-bit visual filter"
+                tabIndex={0}
+              >
                 <div className={`settings-toggle-track${eightbitOn ? ' settings-toggle-track--on' : ''}`}>
                   <div className="settings-toggle-thumb" />
                 </div>
@@ -502,7 +528,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 <div className="settings-label">Monochrome visual filter</div>
                 <div className="settings-sublabel">Green and black terminal-style palette</div>
               </div>
-              <div className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select" onClick={handleMonochromeToggle}>
+              <div
+                className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+                onClick={handleMonochromeToggle}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleMonochromeToggle() } }}
+                role="switch"
+                aria-checked={monochromeOn}
+                aria-label="Monochrome visual filter"
+                tabIndex={0}
+              >
                 <div className={`settings-toggle-track${monochromeOn ? ' settings-toggle-track--on' : ''}`}>
                   <div className="settings-toggle-thumb" />
                 </div>
@@ -516,7 +550,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               <div className="settings-label">Battle event popups</div>
               <div className="settings-sublabel">Show mid-battle popups for notable events (e.g. hero summons)</div>
             </div>
-            <div className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select" onClick={handleBattlePopupsToggle}>
+            <div
+              className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+              onClick={handleBattlePopupsToggle}
+              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleBattlePopupsToggle() } }}
+              role="switch"
+              aria-checked={battlePopups}
+              aria-label="Battle event popups"
+              tabIndex={0}
+            >
               <div className={`settings-toggle-track${battlePopups ? ' settings-toggle-track--on' : ''}`}>
                 <div className="settings-toggle-thumb" />
               </div>
@@ -527,7 +569,15 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               <div className="settings-label">Light mode</div>
               <div className="settings-sublabel">Switch to a light parchment background</div>
             </div>
-            <div className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select" onClick={handleLightModeToggle}>
+            <div
+              className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+              onClick={handleLightModeToggle}
+              onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleLightModeToggle() } }}
+              role="switch"
+              aria-checked={lightModeOn}
+              aria-label="Light mode"
+              tabIndex={0}
+            >
               <div className={`settings-toggle-track${lightModeOn ? ' settings-toggle-track--on' : ''}`}>
                 <div className="settings-toggle-thumb" />
               </div>
@@ -547,6 +597,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
                 step={1}
                 value={textSize}
                 onChange={e => handleSizeChange(Number(e.target.value))}
+                aria-label="Text size"
               />
               <span className="settings-value">{textSize}px</span>
             </div>

--- a/web/src/components/ui/filters/FilterPill.tsx
+++ b/web/src/components/ui/filters/FilterPill.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function FilterPill({ onRemove, children }: Props) {
   return (
     <span className="filter-pill">
-      {children} <button onClick={onRemove}>✕</button>
+      {children} <button onClick={onRemove} aria-label="Remove filter">✕</button>
     </span>
   )
 }

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -9,6 +9,16 @@
   user-select: none;
 }
 
+/* Keyboard focus ring (#2182), defined once and applied to every element
+   that can take focus — not just buttons carrying .action-btn, which was
+   previously the only focus-visible treatment in the entire stylesheet.
+   :focus-visible (not :focus) so mouse/touch activation stays silent and
+   only keyboard/programmatic focus shows the ring. */
+:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
 body {
   background: var(--game-bg);
   color: var(--game-text-color);

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -287,7 +287,7 @@
 
 .settings-sublabel {
   font-size: var(--font-xs);
-  color: #777;
+  color: var(--color-gray-9);
   margin-top: 2px;
 }
 
@@ -329,9 +329,10 @@
   height: 4px;
   border-radius: 2px;
   background: #333;
-  outline: none;
   cursor: pointer;
 }
+.settings-slider:focus:not(:focus-visible) { outline: none; }
+
 
 .settings-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
@@ -713,7 +714,8 @@
   border-radius: 4px;
   margin-bottom: 1rem;
 }
-.training-search:focus { outline: none; border-color: #4a7a4a; }
+.training-search:focus { border-color: #4a7a4a; }
+.training-search:focus:not(:focus-visible) { outline: none; }
 
 .training-unit-grid {
   display: grid;

--- a/web/src/styles/buttons.css
+++ b/web/src/styles/buttons.css
@@ -75,10 +75,6 @@
   transition-duration: 0.05s;
 }
 
-.action-btn:focus-visible {
-  outline: 2px solid var(--accent-gold);
-  outline-offset: 2px;
-}
 
 @keyframes nodeTargetPulse {
   0%, 100% { box-shadow: 0 0 8px color-mix(in srgb, var(--game-text-color) 40%, transparent); }

--- a/web/src/styles/campaign-events.css
+++ b/web/src/styles/campaign-events.css
@@ -345,7 +345,7 @@
 
 .cutscene-progress {
   font-size: var(--font-xs);
-  color: #333;
+  color: var(--color-gray-9);
   letter-spacing: 1px;
 }
 

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -53,6 +53,28 @@
   background: color-mix(in srgb, var(--card-frame) 4%, transparent);
 }
 
+/* The real interactive element inside .card-tile (#2182) — resets button
+   chrome so it reads as part of the tile, not as its own control. .card-tile
+   still owns the outer box (width, border, background, hover/active) so
+   nothing here needs to repeat it. */
+.card-tile-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: inherit;
+  border-radius: inherit;
+}
+.card-tile-btn:disabled {
+  cursor: not-allowed;
+}
+
 /* Selection ring — an outline (not border) so it never competes with the
    rarity frame's own border colour underneath, in any picker/deck-builder
    context. */
@@ -436,7 +458,21 @@
   gap: var(--gap-1);
 }
 
+/* Reserves room for the absolutely-positioned info button below, so the
+   type badge doesn't extend under it now that the button is no longer a
+   flex item in this row (#2182 — it used to be, but that nested a real
+   <button> inside .card-tile's role="button", which is invalid). */
+.card-bottom-row--with-info {
+  padding-right: 18px;
+}
+
+/* Positioned directly rather than as a flex item, so it can be a sibling of
+   .card-tile-btn instead of nested inside it. Sits in the same corner the
+   old flex-item version occupied — flush against .card-tile's own padding. */
 .card-bottom-info-btn {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
   flex-shrink: 0;
   width: 14px;
   height: 14px;
@@ -804,7 +840,10 @@
   margin-left: 6px;
 }
 
-.collection-cell--resting {
+/* Targets the card surface only, not the whole cell — same fix as
+   .collection-cell--unowned in collection.css (#2182): dimming the footer
+   along with the art took its count/mastery text below AA contrast. */
+.collection-cell--resting .card-tile {
   opacity: 0.5;
 }
 

--- a/web/src/styles/collection-meta.css
+++ b/web/src/styles/collection-meta.css
@@ -151,7 +151,7 @@
 
 .codex-conversation-stage-label {
   font-size: 0.62rem;
-  color: #557755;
+  color: #669966;
   letter-spacing: 0.05em;
   margin-bottom: 0.25rem;
 }
@@ -225,8 +225,9 @@
   padding: 0.4rem 0.6rem;
   width: 100%;
   box-sizing: border-box;
-  outline: none;
 }
+.character-name-input:focus:not(:focus-visible) { outline: none; }
+
 .character-name-input:focus {
   border-color: #aaffaa;
   box-shadow: 0 0 6px rgba(51, 255, 51, 0.3);

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -494,10 +494,11 @@
   font-family: inherit;
   font-size: var(--font-sm);
   padding: 4px 8px;
-  outline: none;
   width: 100%;
   box-sizing: border-box;
 }
+.deckbuilder-search:focus:not(:focus-visible) { outline: none; }
+
 .deckbuilder-search:focus { border-color: #555; }
 .deckbuilder-search::placeholder { color: var(--game-text-color-muted); }
 
@@ -536,7 +537,11 @@
   min-height: 14px; /* always reserve 1 stats line */
 }
 
-.collection-cell--unowned {
+/* Targets the card surface only, not the whole cell (#2182) — dimming the
+   .cell-count text along with it took the "×0" readout down to ~3:1 against
+   the page background, failing AA. The card art carries the "you don't own
+   this" signal on its own; the count stays legible at full contrast. */
+.collection-cell--unowned .card-tile {
   opacity: 0.45;
   filter: grayscale(60%);
 }
@@ -740,7 +745,7 @@
 /* The affordance hint. Dropped on narrow screens so the header's actions
    keep their line — the deck-builder tutorial covers it anyway. */
 .deckbuilder-panel-hint {
-  color: var(--color-gray-7);
+  color: var(--color-gray-8);
   letter-spacing: 0;
 }
 
@@ -1297,7 +1302,7 @@
 
 .hoa-modal-claimed {
   font-size: 11px;
-  color: #557755;
+  color: #669966;
   font-family: var(--font-mono);
   letter-spacing: 0.08em;
 }

--- a/web/src/styles/hub.css
+++ b/web/src/styles/hub.css
@@ -13,7 +13,7 @@
 
 .shelf-section-label {
   font-size: 10px;
-  color: #557755;
+  color: #669966;
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.15em;
@@ -762,12 +762,12 @@
   align-items: center;
   gap: 10px;
   font-size: 10px;
-  color: #557755;
+  color: #669966;
 }
 .quests-modal__close {
   background: none;
   border: none;
-  color: #557755;
+  color: #669966;
   cursor: pointer;
   font-size: 12px;
   padding: 0 2px;
@@ -800,13 +800,13 @@
 }
 .quests-modal__empty {
   font-size: 11px;
-  color: #557755;
+  color: #669966;
   text-align: center;
   padding: 20px 0;
 }
 .quests-modal__section-label {
   font-size: 10px;
-  color: #557755;
+  color: #669966;
   text-transform: uppercase;
   letter-spacing: 0.15em;
   margin: 12px 0 6px;
@@ -828,15 +828,15 @@
   justify-content: space-between;
   align-items: center;
 }
-.quests-modal__desc   { font-size: 10px; color: #667766; font-style: italic; }
-.quests-modal__hint   { font-size: 10px; color: #667766; margin-top: 6px; font-style: italic; }
+.quests-modal__desc   { font-size: 10px; color: #77aa77; font-style: italic; }
+.quests-modal__hint   { font-size: 10px; color: #77aa77; margin-top: 6px; font-style: italic; }
 .quests-modal__reward { font-size: 10px; color: #88cc88; margin-top: 4px; }
 .quests-modal__title-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
 .quests-modal__title-row .quests-modal__title { margin-bottom: 0; }
 .quests-modal__abandon-btn {
   background: none;
   border: 1px solid #334433;
-  color: #557755;
+  color: #669966;
   font-size: 9px;
   padding: 2px 5px;
   cursor: pointer;
@@ -883,12 +883,12 @@
   align-items: center;
   gap: 10px;
   font-size: 10px;
-  color: #557755;
+  color: #669966;
 }
 .bounty-board-modal__close {
   background: none;
   border: none;
-  color: #557755;
+  color: #669966;
   cursor: pointer;
   font-size: 12px;
   padding: 0 2px;
@@ -897,7 +897,7 @@
 .bounty-board-modal__close:hover { color: #88cc88; }
 .bounty-board-modal__section-label {
   font-size: 10px;
-  color: #557755;
+  color: #669966;
   text-transform: uppercase;
   letter-spacing: 0.15em;
   margin: 12px 0 6px;
@@ -913,8 +913,8 @@
 .bounty-board-modal__title { font-size: 12px; font-weight: bold; margin-bottom: 4px; }
 .bounty-board-modal__title-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
 .bounty-board-modal__title-row .bounty-board-modal__title { margin-bottom: 0; }
-.bounty-board-modal__desc   { font-size: 10px; color: #667766; font-style: italic; }
-.bounty-board-modal__hint   { font-size: 10px; color: #667766; margin-top: 6px; font-style: italic; }
+.bounty-board-modal__desc   { font-size: 10px; color: #77aa77; font-style: italic; }
+.bounty-board-modal__hint   { font-size: 10px; color: #77aa77; margin-top: 6px; font-style: italic; }
 .bounty-board-modal__reward { font-size: 10px; color: #88cc88; margin-top: 4px; }
 
 /* ── Pet adoption / management ──────────────────────────────────────────────── */
@@ -939,7 +939,7 @@
 .pet-modal__close {
   background: none;
   border: none;
-  color: #557755;
+  color: #669966;
   cursor: pointer;
   font-size: 12px;
   padding: 0 2px;
@@ -948,7 +948,7 @@
 .pet-modal__close:hover { color: #88cc88; }
 .pet-modal__section-label {
   font-size: 10px;
-  color: #557755;
+  color: #669966;
   text-transform: uppercase;
   letter-spacing: 0.15em;
   margin: 12px 0 6px;
@@ -1022,7 +1022,7 @@
 .pet-modal__accessory--equipped { border-color: #88cc88; background: rgba(60, 120, 60, 0.25); }
 .pet-modal__accessory--locked { opacity: 0.5; cursor: default; }
 .pet-modal__accessory-name { font-size: 12px; font-weight: bold; }
-.pet-modal__accessory-status { font-size: 9px; color: #557755; letter-spacing: 0.05em; }
+.pet-modal__accessory-status { font-size: 9px; color: #669966; letter-spacing: 0.05em; }
 
 /* ── Town Directory ("Where is…?") ─────────────────────────────────────────── */
 .town-directory {
@@ -1048,12 +1048,12 @@
   align-items: center;
   gap: 10px;
   font-size: 10px;
-  color: #557755;
+  color: #669966;
 }
 .town-directory__close {
   background: none;
   border: none;
-  color: #557755;
+  color: #669966;
   cursor: pointer;
   font-size: 12px;
   padding: 0 2px;
@@ -1063,7 +1063,7 @@
 .town-directory__filter {
   background: none;
   border: 1px solid #2a4a2a;
-  color: #557755;
+  color: #669966;
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.08em;
@@ -1076,7 +1076,7 @@
 .town-directory__filter:hover { color: #88cc88; }
 .town-directory__empty {
   font-size: 11px;
-  color: #557755;
+  color: #669966;
   text-align: center;
   padding: 20px 0;
 }

--- a/web/src/styles/minigames-2.css
+++ b/web/src/styles/minigames-2.css
@@ -970,8 +970,9 @@
   font-size: 11px;
   padding: 5px 8px;
   margin-bottom: 8px;
-  outline: none;
 }
+.city-search:focus:not(:focus-visible) { outline: none; }
+
 .city-search::placeholder { color: #3a5a3a; }
 .city-search:focus { border-color: #40a040; }
 

--- a/web/src/styles/minigames-4.css
+++ b/web/src/styles/minigames-4.css
@@ -287,7 +287,7 @@
   gap: 6px;
   flex-shrink: 0;
 }
-.td-wave-preview-label { color: #666; }
+.td-wave-preview-label { color: var(--color-gray-9); }
 .td-wave-preview-group { color: #ccc; }
 .td-wave-preview-group--boss { color: var(--color-gold); font-weight: bold; }
 
@@ -738,7 +738,7 @@
 }
 .td-panel-log {
   font-size: 10px;
-  color: #666;
+  color: var(--color-gray-9);
   padding: 0 10px;
   min-height: 14px;
   white-space: nowrap;

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -124,6 +124,14 @@
   --text-primary: #e8e8e8;
   --text-inverse: #fff;
 
+  /* Keyboard focus ring (#2182). One definition, applied to every
+     interactive element via the global :focus-visible rule in base.css —
+     previously only .action-btn had a focus-visible treatment at all, so
+     every other control (links, tabs, filter pills, card tiles, custom
+     toggles) gave a keyboard user no indication of where they were. */
+  --focus-ring: 2px solid var(--accent-gold);
+  --focus-ring-offset: 2px;
+
   /* Borders / edging */
   --border-edge:      var(--color-gray-5);
   --border-edge-dark: #1e1e1e;


### PR DESCRIPTION
Closes part of #2182 (Phase 3.1 — Accessibility pass). First slice: focus visibility, keyboard operability of the highest-traffic custom controls, accessible names for dialogs and icon-only controls, and the contrast failures a real audit turned up. Not the whole issue — see "Not in this PR" below.

## Why these four, in this order

The epic's own audit (#2165) measured **0 `:focus-visible` rules**, **19 `aria-label`s across ~700 buttons**, and unverified contrast. Re-measuring before starting: `:focus-visible` was up to 1 (only `.action-btn`), `aria-label` to 32 — real progress from Phase 1/2, but still leaving every other control invisible to keyboard focus and most icon-only buttons unnamed.

Rather than guess at what else was broken, I ran `axe-core` (already a devDependency via `@storybook/addon-a11y`) directly against the Storybook build for a representative set of stories and fixed what it found. Every fix below is traceable to either a manual WCAG contrast calculation or a real axe violation — nothing here is guessed.

## 1. A keyboard focus ring that reaches every control

One global `:focus-visible` rule (`--focus-ring` / `--focus-ring-offset` tokens) replaces the single `.action-btn`-only one. Five inputs had `outline: none` with equal-or-greater specificity than the new global rule, silently winning the cascade — rescoped each to `:focus:not(:focus-visible)` so keyboard Tab still reaches the ring.

## 2. CardTile, starter packs, and settings toggles become keyboard-operable

**CardTile** is the single most-repeated interactive control in the game — every card grid renders one per card — and was a plain `<div onClick>`: no role, no tab stop, no keyboard activation. A keyboard or screen-reader user could not play, add, or pick a single card anywhere in the game.

The first version of this fix (`role="button"` + manual keydown) nested a real `<button>` inside it — the `showDetails` info button — which axe correctly flags as broken (nested interactive controls aren't reliably exposed to assistive tech). Fixed properly: the tile's interactive surface is now a real `<button>` (free keyboard activation, and a button can't contain another button), with the info button moved out to a CSS-positioned sibling in the same corner it occupied as a flex item.

Same nested-interactive bug, smaller: `StarterPackSelect`'s decorative "CHOOSE" `<button>` had no handler of its own — redundant with the card's own click. Now a `<div aria-hidden>`.

`SettingsScreen`'s six toggles (sound, skip-intro, 8-bit, monochrome, battle popups, light mode) get `role="switch"` + `aria-checked` + keyboard handling; its three volume/text-size sliders get `aria-label` (axe's `label` rule, critical severity — they had none).

## 3. Every dialog and icon-only control gets an accessible name

`ModalBackdrop` (#2174) has always accepted a `title` prop for its dialog's `aria-label` — but of ~30 consumers, only ~4 ever passed one. The other **26** — every hub modal, every card/augment modal, every minigame confirmation — were anonymous `role="dialog"`s. Fixed by passing `title` from each dialog's own visible heading (several derive it dynamically — `HubTabbedModal`'s tracks the active tab).

Icon-only controls with no name or an unreliable one (emoji/glyph as the only content): the deck builder's ▲/▼ toggles, every `FilterPill`'s ✕, nine hub modals' ✕ close buttons, `TowerDefence`'s quit, the hub minimap toggle, `CityBuilder`'s zoom controls.

## 4. A systemic low-contrast green, plus two isolated failures

`hub.css` ran two literal greens for secondary text — `#557755` (18 uses) and `#667766` (4 uses) — both below AA's 4.5:1 (3.92:1 and 4.14:1 measured). Brightened in place to `#669966` / `#77aa77`, same hue, real headroom. Plus `TowerDefence`'s wave-preview/log text and the cutscene progress counter (`#333`, **1.57:1** — essentially unreadable), moved to the existing `--color-gray-9` token.

Two contrast fixes also ride in commits 1 and 2 (`.collection-cell--unowned` / `--resting` dimming retargeted from the whole cell to just the card art, so the count/mastery footer text underneath stays legible) — called out in those commit messages since they land in files those commits already touch.

## Verification

- `npx tsc --noEmit -p .`, `npm run build`, `npm run test` — **2861 passed** (the `chrome-headless-shell` cleanup error is the known noise per AGENTS.md)
- `axe-core` run directly against ~25 Storybook stories spanning cards, deck builder, settings, collection, nine hub modals, tower defence, augments, filters, and cutscenes — before/after diffed. `nested-interactive`, `aria-dialog-name`, `label`, and `color-contrast` all clear to zero on every tested story except two narrow, documented exceptions below.
- Playwright screenshots at rest, hover, and keyboard-focus for CardTile across rarities, confirming the gold ring traces the tile's own shape and the repositioned info button doesn't overlap the type badge.

### Known remaining gaps (not silently dropped)

- **`region` (moderate, landmark structure)** — axe flags this on every story tested, including two already-`ci`-tagged baseline stories untouched by this PR (`SynergyBadges`, `Battlefield`). The app has no `<main>`/`<nav>` landmarks anywhere; fixing it properly means deciding real landmark roles across ~40 screens, not a mechanical wrapper add. Left for a follow-up rather than a shallow fix.
- **Two marginal `color-contrast` hits** on `CollectionScreen`'s dimmed/unowned card face text, specific to two particular rarity/opacity combinations — narrow, not systemic; a proper fix belongs with #2202 (literal sweep) / #2206 (rarity colour consolidation), which would define the dimmed states as tokens instead of raw opacity math.
- Full manual keyboard walkthrough (title → deck builder → battle → reward → hub) and a systematic contrast audit of every remaining screen are still outstanding, per #2182's acceptance criteria.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_