### PR TITLE
CI: fix the Playwright browser cache so it actually caches something

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Playwright's own default cache location varies by OS/version; pinning
+      # it explicitly keeps this workflow's cache step actually caching
+      # something, and matches the path the Claude Code sandbox uses so
+      # behavior is consistent between local dev and CI (#2211).
+      PLAYWRIGHT_BROWSERS_PATH: /opt/pw-browsers
     steps:
       - uses: actions/checkout@v4
 
@@ -41,7 +47,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /opt/pw-browsers
-          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+          # Includes the installed browser list so adding or removing one
+          # (e.g. #2212's webkit addition) invalidates the cache instead of
+          # restoring a stale, incomplete one — the lockfile hash alone
+          # doesn't change when only the browser list does.
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('web/package-lock.json') }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
Closes #2211.

## Problem

`.github/workflows/test.yml`'s "Cache Playwright browsers" step had two independent faults:

1. **Wrong path.** It cached `/opt/pw-browsers`, but `PLAYWRIGHT_BROWSERS_PATH` was never set anywhere in the repo. Without it, `playwright install` uses its own default (`~/.cache/ms-playwright` on Linux), so `/opt/pw-browsers` was empty on the runner and the step cached nothing — every CI run re-downloaded the browser from scratch. (`/opt/pw-browsers` *is* correct in the Claude Code sandbox, which does set that env var — the workflow looks like it inherited the path without the variable that makes it correct.)
2. **Wrong key.** The key hashed only `web/package-lock.json`, which changes when the Playwright *package* version changes but not when the set of *installed browsers* does. Adding a browser produces a cache hit on the old key, restoring an incomplete cache — and since `actions/cache` only writes on a miss, the new browser then re-downloads on every subsequent run and is never saved.

## Fix

- `PLAYWRIGHT_BROWSERS_PATH: /opt/pw-browsers` set at job level, so install and test steps agree with the cache step.
- Cache key now includes the browser list: `playwright-${{ runner.os }}-chromium-${{ hashFiles('web/package-lock.json') }}`.

## Verification

YAML parses cleanly. This is CI plumbing with no local build/test surface to exercise — the real verification is watching the next couple of CI runs: a cache miss on the first run after merge (expected, since the key format changed), then a hit on every run after that with an unchanged lockfile.

## Related

Filed while scoping #2212 (adding WebKit to the test matrix) — landing this first means that addition doesn't make every CI run pay a full second-browser download.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_