### PR TITLE
Design tokens: consolidate 280 literal colours that already exactly matched a token

### DIFF
--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -46,7 +46,7 @@ body {
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: var(--game-bg-raised); }
 ::-webkit-scrollbar-thumb { background: var(--game-border); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: #555; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-gray-6); }
 
 /* ─── Mobile ─────────────────────────────────────────── */
 
@@ -359,7 +359,7 @@ html.eightbit-mode .lane-layer {
 
 .news-item__date {
   font-size: var(--font-sm);
-  color: #888;
+  color: var(--color-gray-8);
   letter-spacing: 0.5px;
 }
 
@@ -378,7 +378,7 @@ html.eightbit-mode .lane-layer {
   margin-left: auto;
   background: none;
   border: none;
-  color: #555;
+  color: var(--color-gray-6);
   font-size: var(--font-md);
   cursor: pointer;
   padding: 2px 4px;
@@ -403,7 +403,7 @@ html.eightbit-mode .lane-layer {
 
 .news-item__body {
   font-size: var(--font-md);
-  color: #aaa;
+  color: var(--color-gray-9);
   line-height: 1.5;
   white-space: pre-wrap;
 }
@@ -411,7 +411,7 @@ html.eightbit-mode .lane-layer {
 .news-loading,
 .news-empty {
   font-size: var(--font-md);
-  color: #666;
+  color: var(--color-gray-7);
   padding: 16px 0;
   text-align: center;
 }
@@ -422,13 +422,13 @@ html.eightbit-mode .lane-layer {
   justify-content: center;
   gap: 12px;
   padding: 12px 0 4px;
-  border-top: 1px solid #333;
+  border-top: 1px solid var(--game-border);
   margin-top: 8px;
 }
 
 .news-pagination__label {
   font-size: var(--font-sm);
-  color: #aaa;
+  color: var(--color-gray-9);
   min-width: 48px;
   text-align: center;
 }

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -23,7 +23,7 @@
 }
 .spell-cast-banner-timer {
   font-variant-numeric: tabular-nums;
-  color: #fff;
+  color: var(--text-inverse);
 }
 .spell-cast-banner-bar {
   width: 70px;
@@ -34,7 +34,7 @@
 }
 .spell-cast-banner-bar-fill {
   height: 100%;
-  background: linear-gradient(90deg, #ff4444, #ff9944);
+  background: linear-gradient(90deg, var(--color-red), var(--color-orange-alt));
   transition: width 0.1s linear;
 }
 @keyframes spellCastBannerPulse {
@@ -274,7 +274,7 @@
 
 .settings-row {
   padding: 10px 14px;
-  border-bottom: 1px solid #111;
+  border-bottom: 1px solid var(--game-bg-raised);
 }
 
 .settings-row:last-child { border-bottom: none; }
@@ -295,7 +295,7 @@
   width: 36px;
   height: 18px;
   border-radius: 9px;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   background: var(--game-bg-card);
   position: relative;
   transition: background 0.2s, border-color 0.2s;
@@ -313,13 +313,13 @@
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  background: #555;
+  background: var(--color-gray-6);
   transition: transform 0.2s, background 0.2s;
 }
 
 .settings-toggle-track--on .settings-toggle-thumb {
   transform: translateX(18px);
-  background: #33ff33;
+  background: var(--game-text-color);
 }
 
 .settings-slider {
@@ -328,7 +328,7 @@
   width: 120px;
   height: 4px;
   border-radius: 2px;
-  background: #333;
+  background: var(--game-border);
   outline: none;
   cursor: pointer;
 }
@@ -338,7 +338,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #33ff33;
+  background: var(--game-text-color);
   cursor: pointer;
 }
 
@@ -346,7 +346,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #33ff33;
+  background: var(--game-text-color);
   border: none;
   cursor: pointer;
 }
@@ -705,7 +705,7 @@
   width: 100%;
   box-sizing: border-box;
   background: var(--game-bg-raised);
-  border: 1px solid var(--game-border, #333);
+  border: 1px solid var(--game-border, var(--game-border));
   color: var(--color-gray-10);
   font-family: inherit;
   font-size: 0.9rem;
@@ -728,7 +728,7 @@
   align-items: center;
   gap: 0.25rem;
   background: var(--game-bg-raised);
-  border: 1px solid var(--game-border, #333);
+  border: 1px solid var(--game-border, var(--game-border));
   color: var(--color-gray-10);
   border-radius: 6px;
   padding: 0.6rem 0.4rem;
@@ -776,7 +776,7 @@
 
 .training-rules {
   background: var(--game-bg-raised);
-  border: 1px solid var(--game-border, #333);
+  border: 1px solid var(--game-border, var(--game-border));
   border-radius: 6px;
   padding: 0.75rem 1rem;
   margin-top: 0.5rem;

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -240,7 +240,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: #fff;
+  background: var(--text-inverse);
   opacity: 0.55;
   animation: hp-bar-flash 220ms ease-out;
   pointer-events: none;
@@ -263,7 +263,7 @@
   align-items: center;
   justify-content: center;
   font-size: var(--font-xs);
-  color: #fff;
+  color: var(--text-inverse);
   text-shadow: 0 0 3px #000;
   font-weight: bold;
   font-variant-numeric: tabular-nums;
@@ -586,7 +586,7 @@
   text-align: center;
   font-size: 0.75rem;
   letter-spacing: 1px;
-  color: #aaa;
+  color: var(--color-gray-9);
   padding: 2px 0 4px;
 }
 .hand-truce-secs {
@@ -623,7 +623,7 @@
   height: 16px;
   font-size: var(--font-xxs);
   background: rgba(0, 0, 0, 0.75);
-  border: 1px solid #555;
+  border: 1px solid var(--color-gray-6);
   border-radius: 50%;
   color: var(--game-text-color-dim);
   cursor: pointer;
@@ -693,7 +693,7 @@
   color: var(--game-text-color-muted);
   text-align: center;
   font-style: italic;
-  border-top: 1px dashed #444;
+  border-top: 1px dashed var(--color-gray-5);
   padding-top: 6px;
 }
 .gameover-streak {
@@ -709,10 +709,10 @@
   text-align: center;
   padding: 6px 10px;
   border-radius: 4px;
-  border: 1px solid #555;
+  border: 1px solid var(--color-gray-6);
 }
 .gameover-daily--win  { color: #8bc34a; border-color: #8bc34a; }
-.gameover-daily--lose { color: #aaa; }
+.gameover-daily--lose { color: var(--color-gray-9); }
 
 /* Win streak corner ribbon on title screen */
 .streak-ribbon-wrap {
@@ -731,7 +731,7 @@
   left: -28px;
   width: 100px;
   background: #f90;
-  color: #111;
+  color: var(--game-bg-raised);
   text-align: center;
   transform: rotate(-45deg);
   font-size: var(--font-sm);
@@ -741,8 +741,8 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
 }
 .streak-ribbon--faded {
-  background: #555;
-  color: #ccc;
+  background: var(--color-gray-6);
+  color: var(--color-gray-10);
   opacity: 0.75;
 }
 
@@ -893,7 +893,7 @@
 .reward-skip-btn {
   font-size: var(--font-xs);
   color: var(--game-text-color-dim);
-  border-color: #444;
+  border-color: var(--color-gray-5);
 }
 .reward-skip-btn:hover {
   color: var(--game-text-color-dim);
@@ -1292,8 +1292,8 @@
 .gameover-highlights {
   width: 100%;
   max-width: 340px;
-  border-top: 1px dashed #444;
-  border-bottom: 1px dashed #444;
+  border-top: 1px dashed var(--color-gray-5);
+  border-bottom: 1px dashed var(--color-gray-5);
   padding: 10px 0;
   display: flex;
   flex-direction: column;

--- a/web/src/styles/buttons.css
+++ b/web/src/styles/buttons.css
@@ -243,6 +243,6 @@
 
 .stat-value--accent {
   font-size: 1rem;
-  color: #33ff33;
+  color: var(--game-text-color);
   font-weight: bold;
 }

--- a/web/src/styles/campaign-events.css
+++ b/web/src/styles/campaign-events.css
@@ -29,17 +29,17 @@
 }
 
 .card-rest-already {
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   padding: 10px 14px;
-  background: #111;
+  background: var(--game-bg-raised);
   width: 100%;
   max-width: 560px;
 }
 
 .card-rest-already-label {
   font-size: var(--font-xs);
-  color: #555;
+  color: var(--color-gray-6);
   letter-spacing: 0.1em;
   margin-bottom: 6px;
 }
@@ -75,12 +75,12 @@
 .card-rest-already-tag {
   font-size: var(--font-xs);
   letter-spacing: 0.2em;
-  color: #666;
+  color: var(--color-gray-7);
 }
 
 .card-rest-already-note {
   font-size: var(--font-xs);
-  color: #555;
+  color: var(--color-gray-6);
   font-style: italic;
 }
 
@@ -95,7 +95,7 @@
 }
 
 .card-rest-candidate:hover {
-  border-color: #555;
+  border-color: var(--color-gray-6);
   background: rgba(255, 255, 255, 0.02);
 }
 
@@ -325,7 +325,7 @@
   width: 100%;
   aspect-ratio: 5 / 3;
   object-fit: cover;
-  border: 1px solid #1a1a1a;
+  border: 1px solid var(--game-bg-card);
   margin-bottom: 24px;
   display: block;
 }
@@ -339,13 +339,13 @@
 
 .cutscene-footer {
   padding-top: 32px;
-  border-top: 1px solid #1a1a1a;
+  border-top: 1px solid var(--game-bg-card);
   margin-top: 32px;
 }
 
 .cutscene-progress {
   font-size: var(--font-xs);
-  color: #333;
+  color: var(--game-border);
   letter-spacing: 1px;
 }
 
@@ -635,7 +635,7 @@
   color: var(--game-text-color-muted);
   text-align: center;
   line-height: 1.5;
-  border: 1px dashed #444;
+  border: 1px dashed var(--color-gray-5);
   padding: 8px 12px;
   border-radius: 4px;
   max-width: 360px;
@@ -789,7 +789,7 @@
   margin: 0;
 }
 .chr-challenge {
-  border: 1px dashed #444;
+  border: 1px dashed var(--color-gray-5);
   border-radius: 4px;
   padding: 10px 12px;
   margin-top: 8px;
@@ -897,7 +897,7 @@
 
 .rb-act-label {
   font-size: var(--font-xs);
-  color: #666;
+  color: var(--color-gray-7);
   letter-spacing: 3px;
   text-transform: uppercase;
 }
@@ -910,13 +910,13 @@
 
 .rb-subtitle {
   font-size: var(--font-base);
-  color: var(--game-text-color, #ccc);
+  color: var(--game-text-color, var(--color-gray-10));
   line-height: 1.5;
 }
 
 .rb-rule {
   font-size: var(--font-sm);
-  color: #888;
+  color: var(--color-gray-8);
   line-height: 1.5;
   margin-top: 4px;
 }
@@ -937,7 +937,7 @@
   padding: 14px 16px;
   background: var(--game-bg-raised);
   border: 2px solid var(--game-border);
-  color: var(--game-text-color, #ccc);
+  color: var(--game-text-color, var(--color-gray-10));
   font-family: inherit;
   cursor: pointer;
   text-align: left;
@@ -947,7 +947,7 @@
 }
 
 .rb-tier:hover {
-  border-color: #555;
+  border-color: var(--color-gray-6);
   background: #161616;
 }
 
@@ -1095,7 +1095,7 @@
 
 .camp-stats {
   font-size: var(--font-sm);
-  color: #aaa;
+  color: var(--color-gray-9);
 }
 
 .camp-choices {
@@ -1105,9 +1105,9 @@
 
 .camp-choice {
   background: transparent;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   border-radius: 4px;
-  color: #ccc;
+  color: var(--color-gray-10);
   cursor: pointer;
   padding: 16px 20px;
   text-align: left;
@@ -1136,7 +1136,7 @@
 
 .camp-choice-desc {
   font-size: var(--font-sm);
-  color: #888;
+  color: var(--color-gray-8);
   line-height: 1.5;
 }
 
@@ -1146,7 +1146,7 @@
   align-items: center;
   gap: 24px;
   padding: 28px 24px;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   border-radius: 4px;
   width: 100%;
   text-align: center;
@@ -1184,7 +1184,7 @@
   gap: 6px 24px;
   justify-content: center;
   padding: 10px 16px;
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   margin-bottom: 4px;
   width: 100%;
@@ -1195,15 +1195,15 @@
   display: flex;
   gap: 8px;
   font-size: var(--font-xs);
-  color: #888;
+  color: var(--color-gray-8);
   letter-spacing: 1px;
 }
 
 .reward-summary-row span:first-child {
-  color: #555;
+  color: var(--color-gray-6);
 }
 
 .reward-summary-row span:last-child {
-  color: #aaa;
+  color: var(--color-gray-9);
 }
 

--- a/web/src/styles/campaign.css
+++ b/web/src/styles/campaign.css
@@ -39,7 +39,7 @@
 
 .nm-consumables-label {
   font-size: var(--font-xs);
-  color: #666;
+  color: var(--color-gray-7);
   letter-spacing: 1px;
   margin-right: 4px;
   flex-shrink: 0;
@@ -51,7 +51,7 @@
   gap: 4px;
   background: var(--game-bg-card);
   border: 1px solid #3a3a3a;
-  color: #ccc;
+  color: var(--color-gray-10);
   padding: 4px 8px;
   font-family: inherit;
   font-size: var(--font-sm);
@@ -63,7 +63,7 @@
 .nm-consumable-btn:hover:not(:disabled) {
   background: #252525;
   border-color: #33ff88;
-  color: #fff;
+  color: var(--text-inverse);
 }
 
 .nm-consumable-btn--empty {
@@ -370,7 +370,7 @@
   gap: 12px;
   padding: 12px 14px;
   background: rgba(255, 255, 255, 0.03);
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   border-radius: 6px;
   cursor: pointer;
   text-align: left;
@@ -1037,7 +1037,7 @@
 }
 
 .starter-pack {
-  border: 1px solid #222;
+  border: 1px solid var(--color-gray-3);
   padding: 16px;
   min-width: 160px;
   max-width: 200px;

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -73,7 +73,7 @@
   padding: 1px 5px;
   border-radius: 3px;
   background: var(--accent-ember);
-  color: #fff;
+  color: var(--text-inverse);
   pointer-events: none;
   z-index: 12;
 }
@@ -250,15 +250,15 @@
 }
 .card-tile--mythic .card-rarity { color: var(--accent-arcane); text-shadow: 0 0 10px rgba(224,64,251,1); }
 .card-tile--mythic .card-title  { color: #e8b0ff; }
-.card-tile--mythic .card-cost   { color: #e040fb; text-shadow: 0 0 10px rgba(224,64,251,0.9); }
+.card-tile--mythic .card-cost   { color: var(--accent-arcane); text-shadow: 0 0 10px rgba(224,64,251,0.9); }
 
 /* pack reveal / shop rarity labels */
-.pack-card-rarity--mythic   { color: #e040fb; text-shadow: 0 0 8px rgba(224,64,251,0.8); }
+.pack-card-rarity--mythic   { color: var(--accent-arcane); text-shadow: 0 0 8px rgba(224,64,251,0.8); }
 .pack-card-rarity--shiny    { color: #ffe066; text-shadow: 0 0 6px rgba(255,220,60,0.9); }
 .pack-card-rarity--holofoil { color: #40e0d0; text-shadow: 0 0 6px rgba(64,224,208,0.9); }
 .pack-card-rarity--glass    { color: #a0d8ef; text-shadow: 0 0 6px rgba(160,216,239,0.8); }
 
-.shop-card-deal--mythic   { border-top: 2px solid #e040fb; }
+.shop-card-deal--mythic   { border-top: 2px solid var(--accent-arcane); }
 .shop-card-deal--shiny    { border-top: 2px solid #ffe066; }
 .shop-card-deal--holofoil { border-top: 2px solid #40e0d0; }
 .shop-card-deal--glass    { border-top: 2px solid #a0d8ef; }
@@ -290,7 +290,7 @@
   font-size: var(--font-xs);
   font-weight: bold;
   letter-spacing: 1px;
-  color: #111;
+  color: var(--game-bg-raised);
   background: var(--color-gold);
   padding: 2px 0;
   text-shadow: none;
@@ -310,7 +310,7 @@
   z-index: 12;
   text-transform: uppercase;
 }
-.card-secret-badge--mythic   { background: rgba(224,64,251,0.25); color: #e040fb; border: 1px solid rgba(224,64,251,0.6); }
+.card-secret-badge--mythic   { background: rgba(224,64,251,0.25); color: var(--accent-arcane); border: 1px solid rgba(224,64,251,0.6); }
 .card-secret-badge--shiny    { background: rgba(255,220,60,0.2);  color: #ffe066; border: 1px solid rgba(255,220,60,0.6); }
 .card-secret-badge--holofoil { background: rgba(64,224,208,0.2);  color: #40e0d0; border: 1px solid rgba(64,224,208,0.6); }
 .card-secret-badge--glass    { background: rgba(160,216,239,0.15); color: #a0d8ef; border: 1px solid rgba(160,216,239,0.6); }
@@ -342,7 +342,7 @@
   top: 4px;
   right: -38px;
   width: 100px;
-  color: #111;
+  color: var(--game-bg-raised);
   background: #f5d208;
   text-align: center;
   text-wrap: auto;
@@ -442,7 +442,7 @@
   height: 14px;
   font-size: var(--font-xxs);
   background: rgba(0, 0, 0, 0.75);
-  border: 1px solid #555;
+  border: 1px solid var(--color-gray-6);
   border-radius: 50%;
   color: var(--game-text-color-dim);
   cursor: pointer;
@@ -846,7 +846,7 @@
   align-items: baseline;
   gap: 8px;
   padding: 10px 12px 8px;
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--color-gray-3);
   position: sticky;
   top: 0;
   background: var(--game-bg);
@@ -874,7 +874,7 @@
   text-transform: uppercase;
   color: var(--game-text-color-dim);
   padding-bottom: 4px;
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--color-gray-3);
 }
 .cas-slots-grid {
   display: grid;
@@ -882,7 +882,7 @@
   gap: 8px;
 }
 .cas-slot {
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   padding: 8px;
   display: flex;
@@ -896,12 +896,12 @@
 }
 .cas-slot-label { font-size: var(--font-xxs); text-transform: uppercase; letter-spacing: 1px; color: var(--game-text-color-dim); }
 .cas-slot-name  { font-size: var(--font-sm); font-weight: bold; }
-.cas-slot-level { font-size: var(--font-xxs); color: #aaa; }
+.cas-slot-level { font-size: var(--font-xxs); color: var(--color-gray-9); }
 .cas-slot-effect { font-size: var(--font-xs); color: #aaddff; }
 .cas-slot-actions { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
 .cas-slot-btn { font-size: 11px; padding: 2px 8px; }
 .cas-set-bonus {
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   padding: 10px;
   display: flex;
@@ -909,7 +909,7 @@
   gap: 4px;
   opacity: 0.5;
 }
-.cas-set-bonus--active { opacity: 1; border-color: #ffcc00; background: rgba(255,200,0,0.06); }
+.cas-set-bonus--active { opacity: 1; border-color: var(--color-gold-alt); background: rgba(255,200,0,0.06); }
 .cas-set-bonus-name { font-size: var(--font-sm); font-weight: bold; }
 .cas-set-bonus-desc { font-size: var(--font-xs); color: var(--game-text-color-muted); }
 .cas-set-bonus-effect { font-size: var(--font-xs); }
@@ -930,7 +930,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--color-gray-3);
   font-weight: bold;
 }
 .apm-empty { padding: 24px; text-align: center; opacity: 0.6; font-size: var(--font-sm); }
@@ -940,7 +940,7 @@
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
-  border-bottom: 1px solid #1a1a1a;
+  border-bottom: 1px solid var(--game-bg-card);
 }
 .apm-item--active { background: rgba(100,50,180,0.12); }
 .apm-item-info    { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }

--- a/web/src/styles/collection-meta.css
+++ b/web/src/styles/collection-meta.css
@@ -24,7 +24,7 @@
 }
 
 .codex-search {
-  background: var(--game-bg, #0a0a0a);
+  background: var(--game-bg, var(--game-bg));
   border: 1px solid var(--game-border, #2a5a2a);
   color: var(--game-text-color);
   font-family: inherit;
@@ -197,7 +197,7 @@
 
 .character-avatar-tab {
   background: none;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   color: var(--game-text-color-dim);
   font-family: inherit;
   font-size: var(--font-sm);
@@ -218,8 +218,8 @@
 
 .character-name-input {
   background: var(--game-bg-raised);
-  border: 1px solid #33ff33;
-  color: #33ff33;
+  border: 1px solid var(--game-text-color);
+  color: var(--game-text-color);
   font-family: inherit;
   font-size: 1rem;
   padding: 0.4rem 0.6rem;
@@ -241,7 +241,7 @@
 .character-avatar-btn {
   background: var(--game-bg);
   border: 1px solid var(--game-border);
-  color: #aaa;
+  color: var(--color-gray-9);
   cursor: pointer;
   padding: 0.5rem 0.3rem;
   display: flex;
@@ -251,11 +251,11 @@
   transition: border-color 0.15s, background 0.15s;
 }
 .character-avatar-btn:hover {
-  border-color: #33ff33;
+  border-color: var(--game-text-color);
   background: #0d1a0d;
 }
 .character-avatar-btn--chosen {
-  border-color: #33ff33;
+  border-color: var(--game-text-color);
   background: #0d1a0d;
   box-shadow: 0 0 6px rgba(51, 255, 51, 0.3);
 }
@@ -269,12 +269,12 @@
 
 .character-avatar-label {
   font-size: 0.6rem;
-  color: #aaa;
+  color: var(--color-gray-9);
   text-align: center;
   line-height: 1.2;
 }
 .character-avatar-btn--chosen .character-avatar-label {
-  color: #33ff33;
+  color: var(--game-text-color);
 }
 .character-avatar-btn--locked {
   opacity: 0.45;
@@ -312,11 +312,11 @@
   position: relative;
 }
 .character-archetype-btn:hover:not(.character-archetype-btn--locked) {
-  border-color: #33ff33;
+  border-color: var(--game-text-color);
   background: #0d1a0d;
 }
 .character-archetype-btn--chosen {
-  border-color: #33ff33;
+  border-color: var(--game-text-color);
   background: #0d2a0d;
   box-shadow: 0 0 8px rgba(51, 255, 51, 0.25);
 }
@@ -330,7 +330,7 @@
   top: 0.5rem;
   right: 0.65rem;
   font-size: 0.65rem;
-  color: #33ff33;
+  color: var(--game-text-color);
   font-weight: bold;
   letter-spacing: 0.05em;
 }
@@ -346,7 +346,7 @@
   color: #eeffee;
 }
 .character-archetype-btn--chosen .character-archetype-name {
-  color: #33ff33;
+  color: var(--game-text-color);
 }
 .character-archetype-identity {
   font-size: 0.7rem;
@@ -355,7 +355,7 @@
 }
 .character-archetype-passive {
   font-size: 0.68rem;
-  color: #aaa;
+  color: var(--color-gray-9);
   margin-top: 0.15rem;
 }
 
@@ -364,7 +364,7 @@
 .aug-stacks-section { display: flex; flex-direction: column; gap: 8px; width: 100%; }
 
 .aug-stack-tile {
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 6px;
   padding: 10px 12px;
   background: rgba(80,50,120,0.08);
@@ -380,7 +380,7 @@
 }
 
 .aug-stack-name   { font-size: var(--font-sm); font-weight: bold; }
-.aug-stack-levels { font-size: var(--font-xxs); color: #aaa; }
+.aug-stack-levels { font-size: var(--font-xxs); color: var(--color-gray-9); }
 
 .aug-stack-slots {
   display: flex;

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -73,7 +73,7 @@
   background: var(--game-bg);
   min-width: 110px;
 }
-.shop-card-deal--common    { border-top: 2px solid #666; }
+.shop-card-deal--common    { border-top: 2px solid var(--color-gray-7); }
 .shop-card-deal--uncommon  { border-top: 2px solid #44aaff; }
 .shop-card-deal--rare      { border-top: 2px solid #cc44ff; }
 .shop-card-deal--legendary { border-top: 2px solid #ffaa22; }
@@ -98,14 +98,14 @@
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   border-top-width: 3px;
   border-radius: 4px;
   width: 100%;
   max-width: 320px;
   box-sizing: border-box;
 }
-.shop-augment-deal--common    { border-top-color: #666; }
+.shop-augment-deal--common    { border-top-color: var(--color-gray-7); }
 .shop-augment-deal--uncommon  { border-top-color: #44aaff; }
 .shop-augment-deal--rare      { border-top-color: #cc44ff; }
 .shop-augment-deal--epic      { border-top-color: #ff8800; }
@@ -113,11 +113,11 @@
 .shop-augment-deal--bought    { opacity: 0.5; }
 .shop-augment-name  { font-size: var(--font-sm); font-weight: bold; text-align: center; }
 .shop-augment-meta  { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: center; }
-.shop-augment-slot  { font-size: var(--font-xxs); color: #aaa; text-transform: uppercase; letter-spacing: 1px; }
-.shop-augment-desc  { font-size: var(--font-xxs); color: #aaa; text-align: center; }
+.shop-augment-slot  { font-size: var(--font-xxs); color: var(--color-gray-9); text-transform: uppercase; letter-spacing: 1px; }
+.shop-augment-desc  { font-size: var(--font-xxs); color: var(--color-gray-9); text-align: center; }
 
 .rarity-badge { font-size: var(--font-xxs); text-transform: uppercase; letter-spacing: 1px; padding: 1px 5px; border-radius: 3px; }
-.rarity-badge--common    { color: #999; border: 1px solid #666; }
+.rarity-badge--common    { color: #999; border: 1px solid var(--color-gray-7); }
 .rarity-badge--uncommon  { color: #44aaff; border: 1px solid #44aaff; }
 .rarity-badge--rare      { color: #cc44ff; border: 1px solid #cc44ff; }
 .rarity-badge--epic      { color: #ff8800; border: 1px solid #ff8800; }
@@ -127,7 +127,7 @@
   top: -8px; right: -8px;
   font-size: 0.571rem;
   background: #cc4400;
-  color: #fff;
+  color: var(--text-inverse);
   padding: 1px 4px;
   border-radius: 2px;
   letter-spacing: 1px;
@@ -140,7 +140,7 @@
   color: var(--game-text-color-dim);
   letter-spacing: 1px;
   padding: 12px 0 4px;
-  border-top: 1px solid #222;
+  border-top: 1px solid var(--color-gray-3);
   margin-top: 4px;
   width: 100%;
 }
@@ -158,7 +158,7 @@
   align-items: center;
   gap: 10px;
   padding: 20px 24px;
-  border: 2px solid #444;
+  border: 2px solid var(--color-gray-5);
   background: var(--game-bg-raised);
   width: 100%;
   box-sizing: border-box;
@@ -216,7 +216,7 @@
   line-height: 1.6;
   font-style: italic;
   padding: 4px 8px;
-  border-left: 2px solid #555;
+  border-left: 2px solid var(--color-gray-6);
 }
 
 .shop-keeper-label {
@@ -266,7 +266,7 @@
   gap: 4px;
   padding: 6px 0;
   flex-shrink: 0;
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--color-gray-3);
   overflow: visible;
   position: relative;
   z-index: 10;
@@ -498,7 +498,7 @@
   width: 100%;
   box-sizing: border-box;
 }
-.deckbuilder-search:focus { border-color: #555; }
+.deckbuilder-search:focus { border-color: var(--color-gray-6); }
 .deckbuilder-search::placeholder { color: var(--game-text-color-muted); }
 
 /* ─── Collection Grid ────────────────────────────────── */
@@ -510,7 +510,7 @@
   color: var(--accent-gold);
   text-transform: uppercase;
   padding: 8px 4px 2px;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--game-border);
   margin-bottom: 4px;
 }
 
@@ -558,7 +558,7 @@
   bottom: 4px;
   right: 4px;
   background: rgba(0, 0, 0, 0.75);
-  border: 1px solid #555;
+  border: 1px solid var(--color-gray-6);
   color: var(--color-gold-alt);
   font-size: var(--font-xs);
   font-weight: bold;
@@ -1081,7 +1081,7 @@
   display: flex;
   gap: 8px;
   padding: 10px 0 0;
-  border-top: 1px solid #222;
+  border-top: 1px solid var(--color-gray-3);
   margin-top: 4px;
 }
 .deck-list-info-btn {
@@ -1115,7 +1115,7 @@
 .mastery-bar-track {
   flex: 1;
   background: var(--game-bg-card);
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
 }
 .mastery-xp { font-size: 0.571rem; color: var(--game-text-color-dim); white-space: nowrap; }
 
@@ -1165,7 +1165,7 @@
   position: absolute;
   top: -4px;
   right: -4px;
-  background: #ffcc00;
+  background: var(--color-gold-alt);
   color: #1a1000;
   font-size: 9px;
   font-weight: bold;
@@ -1212,7 +1212,7 @@
 }
 .hoa-tile:hover { border-color: #446644; background: rgba(20,36,20,0.8); }
 .hoa-tile--claimable { border-color: #aa8800; }
-.hoa-tile--claimable:hover { border-color: #ffcc00; }
+.hoa-tile--claimable:hover { border-color: var(--color-gold-alt); }
 
 .hoa-tile-icon { line-height: 0; }
 
@@ -1237,7 +1237,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #ffcc00;
+  background: var(--color-gold-alt);
 }
 
 /* ── Detail modal ── */

--- a/web/src/styles/hub.css
+++ b/web/src/styles/hub.css
@@ -221,7 +221,7 @@
 }
 .home-grid-piece:hover { border-color: #6a9a6a; }
 .home-grid-piece--selected {
-  border-color: #ffcc00;
+  border-color: var(--color-gold-alt);
   box-shadow: 0 0 6px rgba(255,204,0,0.6);
 }
 
@@ -260,7 +260,7 @@
   background: rgba(20,36,20,0.5);
 }
 .furniture-picker-item--armed {
-  border-color: #ffcc00;
+  border-color: var(--color-gold-alt);
   background: rgba(60,50,10,0.4);
 }
 .furniture-picker-item--locked { opacity: 0.6; }
@@ -303,7 +303,7 @@
 
 .action-btn--remove-armed {
   background: #f44336;
-  color: #fff;
+  color: var(--text-inverse);
   border-color: #f44336;
   animation: td-sell-armed-pulse 0.6s ease-in-out infinite alternate;
 }

--- a/web/src/styles/minigames-1.css
+++ b/web/src/styles/minigames-1.css
@@ -61,7 +61,7 @@
 .bj-card {
   display: inline-block;
   background: #eee;
-  color: #111;
+  color: var(--game-bg-raised);
   font-size: var(--font-base);
   font-weight: bold;
   padding: 4px 7px;
@@ -69,7 +69,7 @@
   min-width: 34px;
   text-align: center;
   font-family: var(--font-mono);
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-gray-10);
 }
 .bj-card--red    { color: #cc0000; }
 .bj-card--hidden { background: #334; color: #334; border-color: #556; }
@@ -154,7 +154,7 @@
 
 .nm-header {
   padding: 8px 0 10px;
-  border-bottom: 1px solid #1e1e1e;
+  border-bottom: 1px solid var(--border-edge-dark);
   flex-shrink: 0;
 }
 
@@ -241,7 +241,7 @@
 /* Base projectile — magic (default, golden) */
 .anim-projectile {
   height: 4px;
-  background: linear-gradient(90deg, transparent, rgba(255,220,80,0.9), #fff);
+  background: linear-gradient(90deg, transparent, rgba(255,220,80,0.9), var(--text-inverse));
   border-radius: 2px;
   box-shadow: 0 0 4px 1px rgba(255,200,50,0.7);
   animation: projectile-travel 0.5s ease-out forwards;
@@ -282,7 +282,7 @@
 /* Lightning — very thin bright-white/yellow flash */
 .anim-projectile--lightning {
   height: 2px;
-  background: linear-gradient(90deg, transparent, rgba(200,220,255,0.9), #fff);
+  background: linear-gradient(90deg, transparent, rgba(200,220,255,0.9), var(--text-inverse));
   box-shadow: 0 0 6px 2px rgba(180,200,255,0.9);
   border-radius: 1px;
   animation: projectile-travel 0.15s ease-out forwards;
@@ -304,10 +304,10 @@
 }
 /* Typed hit sparks */
 .anim-hit--arrow     { background: radial-gradient(circle, rgba(200,160,80,0.95) 0%, rgba(120,80,20,0.5) 60%, transparent 80%); }
-.anim-hit--fireball  { background: radial-gradient(circle, #fff 0%, rgba(255,140,0,0.9) 40%, rgba(200,40,0,0.4) 70%, transparent 90%); width: 34px; height: 34px; }
+.anim-hit--fireball  { background: radial-gradient(circle, var(--text-inverse) 0%, rgba(255,140,0,0.9) 40%, rgba(200,40,0,0.4) 70%, transparent 90%); width: 34px; height: 34px; }
 .anim-hit--icebolt   { background: radial-gradient(circle, #e8f8ff 0%, rgba(100,200,255,0.8) 50%, transparent 80%); }
 .anim-hit--poisonblob{ background: radial-gradient(circle, rgba(180,255,180,0.95) 0%, rgba(40,160,40,0.7) 55%, transparent 80%); }
-.anim-hit--lightning { background: radial-gradient(circle, #fff 0%, rgba(200,220,255,0.9) 50%, transparent 80%); width: 20px; height: 20px; }
+.anim-hit--lightning { background: radial-gradient(circle, var(--text-inverse) 0%, rgba(200,220,255,0.9) 50%, transparent 80%); width: 20px; height: 20px; }
 
 /* AOE ring: expanding ring at impact */
 @keyframes aoe-ring-expand {
@@ -371,8 +371,8 @@
   position: absolute;
   top: calc(100% + 4px);
   z-index: 20;
-  background: #111;
-  border: 1px solid #333;
+  background: var(--game-bg-raised);
+  border: 1px solid var(--game-border);
   border-radius: 3px;
   display: flex;
   flex-direction: column;
@@ -1239,7 +1239,7 @@
   bottom: 0;
   left: 0;
   height: 100%;
-  background: #33ff33;
+  background: var(--game-text-color);
   opacity: 0.35;
   transition: width 0.4s;
   pointer-events: none;

--- a/web/src/styles/minigames-2.css
+++ b/web/src/styles/minigames-2.css
@@ -116,7 +116,7 @@
   font-size: 7px;
   line-height: 1.1;
   background: rgba(0,0,0,0.55);
-  color: #fff;
+  color: var(--text-inverse);
   padding: 0 2px;
   border-radius: 2px;
   letter-spacing: -0.2px;
@@ -241,7 +241,7 @@
   display: flex;
   gap: 8px;
   padding: 10px 14px;
-  border-top: 1px solid #1a1a1a;
+  border-top: 1px solid var(--game-bg-card);
   flex-wrap: wrap;
 }
 .city-disaster-cure-btn { flex: 1; }
@@ -326,7 +326,7 @@
 }
 
 .city-picker-rarity           { font-size: 8px; letter-spacing: 0.5px; }
-.city-picker-rarity--common   { color: #888; }
+.city-picker-rarity--common   { color: var(--color-gray-8); }
 .city-picker-rarity--uncommon { color: #4a9a4a; }
 .city-picker-rarity--rare     { color: #4a6aba; }
 .city-picker-rarity--legendary{ color: #c08020; }
@@ -453,7 +453,7 @@
 .city-star          { font-size: 18px; color: #2a4a2a; }
 .city-star--filled  { color: var(--color-gold-dim); }
 .city-level-stats   { font-size: 12px; color: #60d060; text-align: center; }
-.city-level-cost    { font-size: 12px; color: #aaa; }
+.city-level-cost    { font-size: 12px; color: var(--color-gray-9); }
 
 .city-level-costs-table {
   width: 100%;
@@ -504,7 +504,7 @@
   bottom: 22px;
   left: 50%;
   transform: translateX(-50%);
-  background: #111;
+  background: var(--game-bg-raised);
   border: 1px solid #40a040;
   border-radius: 4px;
   padding: 2px 3px;

--- a/web/src/styles/minigames-3.css
+++ b/web/src/styles/minigames-3.css
@@ -548,8 +548,8 @@
 
 .hol-card--face-up {
   background: #f0f0f0;
-  border: 2px solid #aaa;
-  color: #111;
+  border: 2px solid var(--color-gray-9);
+  color: var(--game-bg-raised);
 }
 
 .hol-card--face-down {
@@ -566,13 +566,13 @@
 .hol-card-rank {
   font-size: 1.571rem;
   line-height: 1;
-  color: #111;
+  color: var(--game-bg-raised);
 }
 
 .hol-card-suit {
   font-size: 1.286rem;
   line-height: 1;
-  color: #111;
+  color: var(--game-bg-raised);
 }
 
 .hol-card-red {
@@ -632,7 +632,7 @@
 .fm-word-letter {
   font-size: 1.1rem;
   font-weight: bold;
-  color: #444;
+  color: var(--color-gray-5);
   text-shadow: none;
   transition: color 0.2s, text-shadow 0.2s;
   letter-spacing: 1px;
@@ -673,7 +673,7 @@
 .fm-reel {
   width: 80px;
   height: 96px;
-  border: 2px solid #444;
+  border: 2px solid var(--color-gray-5);
   border-radius: 6px;
   background: #0d0d1e;
   display: flex;
@@ -723,17 +723,17 @@
   font-size: var(--font-sm);
   font-family: inherit;
   font-weight: bold;
-  background: #111;
-  color: #888;
-  border: 1px solid #333;
+  background: var(--game-bg-raised);
+  color: var(--color-gray-8);
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   cursor: pointer;
   letter-spacing: 1px;
 }
 
 .fm-hold-btn:not(:disabled):hover {
-  border-color: #aaa;
-  color: #ccc;
+  border-color: var(--color-gray-9);
+  color: var(--color-gray-10);
 }
 
 .fm-hold-btn:disabled {
@@ -756,7 +756,7 @@
   padding: 6px 14px;
   font-size: var(--font-sm);
   font-family: inherit;
-  background: #111;
+  background: var(--game-bg-raised);
   color: #7799cc;
   border: 1px solid #2a3a5a;
   border-radius: 4px;
@@ -811,10 +811,10 @@
   width: 52px;
   height: 36px;
   background: #0d0d1e;
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   font-size: var(--font-xs);
-  color: #888;
+  color: var(--color-gray-8);
   transition: all 0.3s ease;
 }
 
@@ -883,9 +883,9 @@
   width: 80px;
   height: 60px;
   background: #0d0d1e;
-  border: 2px solid #555;
+  border: 2px solid var(--color-gray-6);
   border-radius: 6px;
-  color: #aaa;
+  color: var(--color-gray-9);
   font-size: 1.286rem;
   cursor: pointer;
   transition: all 0.15s;
@@ -906,7 +906,7 @@
 }
 
 .fm-bonus-tile--revealed {
-  border-color: #333;
+  border-color: var(--game-border);
   color: #55ff55;
   font-size: var(--font-md);
   font-weight: bold;
@@ -950,8 +950,8 @@
   width: 80px;
   padding: 6px 0;
   background: #0d0d1e;
-  border: 1px solid #555;
-  color: #ccc;
+  border: 1px solid var(--color-gray-6);
+  color: var(--color-gray-10);
   border-radius: 4px;
   cursor: pointer;
   font-size: var(--font-xl);
@@ -1000,12 +1000,12 @@
 .fm-ladder-reel-wrap {
   margin-left: 8px;
   padding-left: 8px;
-  border-left: 1px solid #333;
+  border-left: 1px solid var(--game-border);
 }
 
 .fm-ladder-reel-label {
   font-size: 1rem;
-  color: #666;
+  color: var(--color-gray-7);
   letter-spacing: 1px;
   text-transform: uppercase;
 }
@@ -1038,7 +1038,7 @@
   flex-direction: column;
   align-items: center;
   background: #0d0d1e;
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   padding: 3px 8px;
   min-width: 56px;
@@ -1046,7 +1046,7 @@
 
 .fm-jackpot-name {
   font-size: var(--font-xs);
-  color: #aaa;
+  color: var(--color-gray-9);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }

--- a/web/src/styles/minigames-4.css
+++ b/web/src/styles/minigames-4.css
@@ -10,8 +10,8 @@
 .fishing-scene {
   width: 100%;
   max-width: 320px;
-  background: #111;
-  border: 1px solid #333;
+  background: var(--game-bg-raised);
+  border: 1px solid var(--game-border);
   border-radius: 4px;
   padding: 20px 12px;
   text-align: center;
@@ -24,11 +24,11 @@
 .fishing-art {
   font-size: 1.1rem;
   line-height: 1.4;
-  color: #aaa;
+  color: var(--color-gray-9);
 }
 
 .fishing-art--missed {
-  color: #888;
+  color: var(--color-gray-8);
   opacity: 0.7;
 }
 
@@ -41,13 +41,13 @@
 }
 
 .fishing-line {
-  color: #666;
+  color: var(--color-gray-7);
   font-size: 1rem;
   line-height: 1;
 }
 
 .fishing-line--taut {
-  color: #aaa;
+  color: var(--color-gray-9);
   animation: fishing-taut 0.15s ease-in-out infinite alternate;
 }
 
@@ -121,7 +121,7 @@
 
 .fishing-prompt {
   font-size: 0.9rem;
-  color: #888;
+  color: var(--color-gray-8);
   margin: 0;
   letter-spacing: 1px;
 }
@@ -151,7 +151,7 @@
 }
 
 .fishing-prompt--missed {
-  color: #666;
+  color: var(--color-gray-7);
   font-style: italic;
 }
 
@@ -159,8 +159,8 @@
   margin: 8px auto 0;
   width: 200px;
   height: 8px;
-  background: #222;
-  border: 1px solid #444;
+  background: var(--color-gray-3);
+  border: 1px solid var(--color-gray-5);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -178,7 +178,7 @@
 .fishing-result-tier {
   font-size: 0.75rem;
   letter-spacing: 3px;
-  color: #888;
+  color: var(--color-gray-8);
   text-transform: uppercase;
 }
 
@@ -194,12 +194,12 @@
 }
 
 .fishing-result-sep {
-  color: #444;
+  color: var(--color-gray-5);
 }
 
 .fishing-result-desc {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--color-gray-8);
   max-width: 260px;
 }
 
@@ -226,13 +226,13 @@
 
 #theMarquee{
   height: 20px;
-  background: linear-gradient(0deg, #111, #222);
+  background: linear-gradient(0deg, var(--game-bg-raised), var(--color-gray-3));
   box-shadow: 
-    0px 0px 2px 0px #aaa inset,
-    0px -1px 2px 0px #aaa inset,
-    2px -5px 5px 0px #111 inset,
-    0px -5px 5px 0px #111 inset,
-    2px 5px 5px 0px #111;
+    0px 0px 2px 0px var(--color-gray-9) inset,
+    0px -1px 2px 0px var(--color-gray-9) inset,
+    2px -5px 5px 0px var(--game-bg-raised) inset,
+    0px -5px 5px 0px var(--game-bg-raised) inset,
+    2px 5px 5px 0px var(--game-bg-raised);
   border-radius: 5px;
 }
 .light {
@@ -260,7 +260,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: #0a0a0a;
+  background: var(--game-bg);
   color: #e0e0e0;
   font-family: var(--font-mono);
   overflow: hidden;
@@ -280,26 +280,26 @@
   background: #0d1a0d;
   border-bottom: 1px solid #2a3a2a;
   font-size: 10px;
-  color: #aaa;
+  color: var(--color-gray-9);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
 }
-.td-wave-preview-label { color: #666; }
-.td-wave-preview-group { color: #ccc; }
+.td-wave-preview-label { color: var(--color-gray-7); }
+.td-wave-preview-group { color: var(--color-gray-10); }
 .td-wave-preview-group--boss { color: var(--color-gold); font-weight: bold; }
 
 /* ── Header ── */
 .td-header {
   padding: 6px 10px;
-  background: #111;
-  border-bottom: 1px solid #333;
+  background: var(--game-bg-raised);
+  border-bottom: 1px solid var(--game-border);
   flex-shrink: 0;
 }
 .td-header-lives     { font-size: 14px; letter-spacing: 1px; }
-.td-header-wave      { font-size: 12px; color: #aaa; flex: 1; text-align: center; }
+.td-header-wave      { font-size: 12px; color: var(--color-gray-9); flex: 1; text-align: center; }
 .td-header-score     { font-size: 12px; color: var(--color-green-bright); }
 .td-header-mana      { font-size: 12px; color: #64b5f6; font-weight: bold; }
 .td-header-active    { font-size: 12px; color: #f90; }
@@ -312,13 +312,13 @@
   font-size: 11px;
   font-weight: bold;
   padding: 3px 7px;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   border-radius: 3px;
-  background: #111;
-  color: #888;
+  background: var(--game-bg-raised);
+  color: var(--color-gray-8);
   cursor: pointer;
 }
-.td-speed-btn:hover { border-color: #888; color: #ccc; }
+.td-speed-btn:hover { border-color: var(--color-gray-8); color: var(--color-gray-10); }
 .td-speed-btn--active { border-color: var(--color-green-bright); color: var(--color-green-bright); background: #162616; }
 
 /* Wave progress bar */
@@ -326,8 +326,8 @@
   position: relative;
   flex: 1;
   height: 18px;
-  background: #222;
-  border: 1px solid #444;
+  background: var(--color-gray-3);
+  border: 1px solid var(--color-gray-5);
   border-radius: 3px;
   overflow: hidden;
   min-width: 60px;
@@ -345,7 +345,7 @@
   align-items: center;
   justify-content: center;
   font-size: 10px;
-  color: #fff;
+  color: var(--text-inverse);
   text-shadow: 0 0 4px #000;
   z-index: 1;
 }
@@ -380,7 +380,7 @@
 .td-cell {
   position: absolute;
   box-sizing: border-box;
-  border: 1px solid #1a1a1a;
+  border: 1px solid var(--game-bg-card);
   cursor: pointer;
   display: flex;
   transition: background 0.1s;
@@ -395,7 +395,7 @@
 .td-cell--in-range       { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.45); background-color: rgba(100,181,246,0.08); }
 .td-cell--path.td-cell--in-range { box-shadow: inset 0 0 0 2px rgba(100,181,246,0.3); }
 .td-cell--tower-selected { box-shadow: inset 0 0 0 2px var(--color-gold) !important; background-color: rgba(255,215,0,0.12) !important; }
-.td-cell-label { font-size: 8px; color: #888; letter-spacing: 1px; pointer-events: none; }
+.td-cell-label { font-size: 8px; color: var(--color-gray-8); letter-spacing: 1px; pointer-events: none; }
 
 /* Tower inside cell */
 .td-tower-inner {
@@ -407,7 +407,7 @@
 .td-tower-hp-bar {
   width: 80%;
   height: 3px;
-  background: #333;
+  background: var(--game-border);
   border-radius: 2px;
   overflow: hidden;
   margin-top: 2px;
@@ -452,7 +452,7 @@
 .td-cell-label {
   position: absolute;
   font-size: 9px;
-  color: #fff;
+  color: var(--text-inverse);
   font-weight: bold;
   pointer-events: none;
   z-index: 2;
@@ -472,7 +472,7 @@
   white-space: nowrap;
 }
 .td-tooltip-hint { color: #f44; font-size: 9px; margin-top: 2px; }
-.td-tooltip-xp       { font-size: 9px; color: #888; margin-top: 1px; }
+.td-tooltip-xp       { font-size: 9px; color: var(--color-gray-8); margin-top: 1px; }
 .td-tooltip-xp-ready { font-size: 9px; color: var(--color-green-bright); font-weight: bold; margin-top: 1px; }
 
 /* Tower action buttons (inside tooltip) */
@@ -484,8 +484,8 @@
   font-size: 9px;
   padding: 2px 6px;
   border-radius: 3px;
-  border: 1px solid #555;
-  background: #1a1a1a;
+  border: 1px solid var(--color-gray-6);
+  background: var(--game-bg-card);
   color: #e0e0e0;
   cursor: pointer;
   line-height: 1.4;
@@ -512,7 +512,7 @@
 .td-enemy-hp-bar {
   width: 100%;
   height: 3px;
-  background: #333;
+  background: var(--game-border);
   border-radius: 2px;
   overflow: hidden;
   margin-top: 1px;
@@ -565,8 +565,8 @@
   align-items: center;
   gap: 3px;
   padding: 8px 6px;
-  background: #111;
-  border: 1px solid #444;
+  background: var(--game-bg-raised);
+  border: 1px solid var(--color-gray-5);
   border-radius: 6px;
   cursor: pointer;
   font-family: var(--font-mono);
@@ -592,17 +592,17 @@
   gap: 6px;
 }
 .td-selected-panel-info { font-size: 13px; color: #e0e0e0; }
-.td-selected-panel-stats { color: #aaa; font-size: 11px; }
-.td-selected-panel-hint { font-size: 10px; color: #666; }
+.td-selected-panel-stats { color: var(--color-gray-9); font-size: 11px; }
+.td-selected-panel-hint { font-size: 10px; color: var(--color-gray-7); }
 .td-selected-panel-maxed { font-size: 12px; color: var(--color-gold); align-self: center; }
 .td-selected-panel-xp { display: flex; align-items: center; gap: 6px; }
 .td-selected-panel-xp-bar {
   flex: 1;
   height: 5px;
-  background: #222;
+  background: var(--color-gray-3);
   border-radius: 3px;
   overflow: hidden;
-  border: 1px solid #333;
+  border: 1px solid var(--game-border);
 }
 .td-selected-panel-xp-fill {
   height: 100%;
@@ -610,7 +610,7 @@
   border-radius: 3px;
   transition: width 0.3s;
 }
-.td-selected-panel-xp-label       { font-size: 10px; color: #888; white-space: nowrap; }
+.td-selected-panel-xp-label       { font-size: 10px; color: var(--color-gray-8); white-space: nowrap; }
 .td-selected-panel-xp-label--ready { font-size: 10px; color: var(--color-green-bright); font-weight: bold; white-space: nowrap; animation: td-upgrade-pulse 0.8s ease-in-out infinite alternate; }
 .td-selected-panel-row {
   display: flex;
@@ -625,8 +625,8 @@
   font-weight: bold;
   padding: 6px 14px;
   border-radius: 4px;
-  border: 1px solid #555;
-  background: #1a1a1a;
+  border: 1px solid var(--color-gray-6);
+  background: var(--game-bg-card);
   color: #e0e0e0;
   cursor: pointer;
   letter-spacing: 0.5px;
@@ -636,11 +636,11 @@
 .td-selected-action-btn--sell:hover { background: rgba(244,67,54,0.12); }
 .td-selected-action-btn--sell-armed {
   background: #f44336;
-  color: #fff;
+  color: var(--text-inverse);
   animation: td-sell-armed-pulse 0.6s ease-in-out infinite alternate;
 }
 .td-selected-action-btn--sell-armed:hover { background: #d32f2f; }
-.td-selected-action-btn--cancel  { border-color: #444; color: #777; padding: 6px 10px; }
+.td-selected-action-btn--cancel  { border-color: var(--color-gray-5); color: #777; padding: 6px 10px; }
 
 @keyframes td-sell-armed-pulse {
   from { box-shadow: 0 0 0 rgba(244,67,54,0.6); }
@@ -657,7 +657,7 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  background: #1a1a1a;
+  background: var(--game-bg-card);
   border: 1px solid var(--color-green-bright);
   border-radius: 5px;
   padding: 5px 8px;
@@ -670,7 +670,7 @@
 .td-upgrade-option:hover:not(.td-upgrade-option--disabled):not(.td-upgrade-option--maxed) {
   background: #162616;
 }
-.td-upgrade-option--disabled { border-color: #333; opacity: 0.45; cursor: not-allowed; }
+.td-upgrade-option--disabled { border-color: var(--game-border); opacity: 0.45; cursor: not-allowed; }
 .td-upgrade-option--maxed    { border-color: var(--color-gold); color: var(--color-gold); cursor: default; opacity: 0.7; }
 .td-upgrade-option-icon  { font-size: 14px; flex-shrink: 0; }
 .td-upgrade-option-label { flex: 1; font-weight: bold; }
@@ -688,8 +688,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  background: #1a1a1a;
-  border: 1px solid #4caf50;
+  background: var(--game-bg-card);
+  border: 1px solid var(--color-green-bright);
   border-radius: 5px;
   padding: 5px 8px;
   cursor: pointer;
@@ -701,36 +701,36 @@
 .td-upgrade-option:hover:not(.td-upgrade-option--disabled):not(.td-upgrade-option--maxed) {
   background: #162616;
 }
-.td-upgrade-option--disabled { border-color: #333; opacity: 0.45; cursor: not-allowed; }
-.td-upgrade-option--maxed    { border-color: #ffd700; color: #ffd700; cursor: default; opacity: 0.7; }
+.td-upgrade-option--disabled { border-color: var(--game-border); opacity: 0.45; cursor: not-allowed; }
+.td-upgrade-option--maxed    { border-color: var(--color-gold); color: var(--color-gold); cursor: default; opacity: 0.7; }
 .td-upgrade-option-icon  { font-size: 14px; flex-shrink: 0; }
 .td-upgrade-option-label { flex: 1; font-weight: bold; }
-.td-upgrade-option-dots  { font-size: 10px; color: #4caf50; letter-spacing: 1px; flex-shrink: 0; }
-.td-upgrade-option--maxed .td-upgrade-option-dots { color: #ffd700; }
+.td-upgrade-option-dots  { font-size: 10px; color: var(--color-green-bright); letter-spacing: 1px; flex-shrink: 0; }
+.td-upgrade-option--maxed .td-upgrade-option-dots { color: var(--color-gold); }
 .td-upgrade-option-stat { font-size: 9px; color: #64b5f6; flex-shrink: 0; margin-left: auto; }
 
 /* ── Targeting mode row ── */
 .td-targeting-modes { display: flex; gap: 4px; }
 .td-targeting-btn {
   flex: 1;
-  background: #1a1a1a;
-  border: 1px solid #444;
+  background: var(--game-bg-card);
+  border: 1px solid var(--color-gray-5);
   border-radius: 4px;
-  color: #aaa;
+  color: var(--color-gray-9);
   font-size: 9px;
   font-family: var(--font-mono);
   cursor: pointer;
   padding: 3px 4px;
   transition: border-color 0.15s, background 0.15s;
 }
-.td-targeting-btn:hover { border-color: #888; color: #ccc; }
+.td-targeting-btn:hover { border-color: var(--color-gray-8); color: var(--color-gray-10); }
 .td-targeting-btn--active { border-color: var(--color-green-bright); color: var(--color-green-bright); background: #162616; }
 
 /* ── Bottom panel ── */
 .td-panel {
   flex-shrink: 0;
-  background: #111;
-  border-top: 1px solid #333;
+  background: var(--game-bg-raised);
+  border-top: 1px solid var(--game-border);
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -738,7 +738,7 @@
 }
 .td-panel-log {
   font-size: 10px;
-  color: #666;
+  color: var(--color-gray-7);
   padding: 0 10px;
   min-height: 14px;
   white-space: nowrap;
@@ -760,15 +760,15 @@
   overflow-x: auto;
   padding: 4px 8px 6px;
   scrollbar-width: thin;
-  scrollbar-color: #333 transparent;
+  scrollbar-color: var(--game-border) transparent;
 }
 .td-unit-chip {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  background: #1a1a1a;
-  border: 1px solid #333;
+  background: var(--game-bg-card);
+  border: 1px solid var(--game-border);
   border-radius: 6px;
   padding: 5px 6px;
   cursor: pointer;
@@ -778,7 +778,7 @@
   min-width: 52px;
   transition: border-color 0.1s, background 0.1s;
 }
-.td-unit-chip:hover:not(.td-unit-chip--disabled) { background: #222; border-color: var(--color-green-bright); }
+.td-unit-chip:hover:not(.td-unit-chip--disabled) { background: var(--color-gray-3); border-color: var(--color-green-bright); }
 .td-unit-chip--selected { border-color: var(--color-green-bright) !important; background: #162616 !important; }
 
 .td-unit-chip-sprite { width: 36px; height: 36px; position: relative; }
@@ -800,7 +800,7 @@
 .effect--gascloud { filter: drop-shadow(0 0 3px #80cbc4); }
 .td-unit-chip-name {
   font-size: 9px;
-  color: #aaa;
+  color: var(--color-gray-9);
   text-align: center;
   max-width: 52px;
   overflow: hidden;
@@ -808,7 +808,7 @@
   white-space: nowrap;
 }
 .td-unit-chip-count { font-size: 11px; font-weight: bold; color: var(--color-green-bright); }
-.td-unit-chip-count--zero { color: #555; }
+.td-unit-chip-count--zero { color: var(--color-gray-6); }
 .td-unit-chip-cost  { font-size: 9px; color: #64b5f6; }
 .td-unit-chip-cost--unaffordable { color: #f44336; }
 
@@ -818,7 +818,7 @@
   background: var(--game-bg);
   padding: 24px;
 }
-.td-end-stat   { font-size: 15px; color: #aaa; }
+.td-end-stat   { font-size: 15px; color: var(--color-gray-9); }
 .td-end-reward { font-size: 17px; color: var(--color-gold); font-weight: bold; }
 
 /* ── Farming Simulation ──────────────────────────────────────────────────────── */
@@ -1065,7 +1065,7 @@
 
 .casino-spinning-label {
   font-size: 14px;
-  color: #aaa;
+  color: var(--color-gray-9);
   font-family: var(--font-mono);
   animation: casino-pulse 1s ease-in-out infinite;
 }
@@ -1077,10 +1077,10 @@
 
 .casino-jackpot {
   font-size: 22px;
-  color: #ffd700;
+  color: var(--color-gold);
   font-family: var(--font-mono);
   font-weight: bold;
-  text-shadow: 0 0 12px #ffd700;
+  text-shadow: 0 0 12px var(--color-gold);
   animation: casino-jackpot-flash 0.5s ease-in-out 4;
 }
 
@@ -1093,7 +1093,7 @@
 
 .casino-result-headline {
   font-size: 18px;
-  color: #e8e8e8;
+  color: var(--text-primary);
   font-family: var(--font-mono);
 }
 

--- a/web/src/styles/modals.css
+++ b/web/src/styles/modals.css
@@ -99,8 +99,8 @@
 /* ─── Confirm Modal ─────────────────────────────────── */
 
 .confirm-modal {
-  background: var(--game-bg, #0a0a0a);
-  border: 1px solid var(--game-border, #333);
+  background: var(--game-bg, var(--game-bg));
+  border: 1px solid var(--game-border, var(--game-border));
   padding: 24px 20px;
   max-width: 320px;
   width: 100%;
@@ -127,8 +127,8 @@
 /* ─── Deck Selector Modal ────────────────────────────── */
 
 .deck-selector-modal {
-  background: var(--game-bg, #0a0a0a);
-  border: 1px solid var(--game-border, #333);
+  background: var(--game-bg, var(--game-bg));
+  border: 1px solid var(--game-border, var(--game-border));
   padding: 20px 18px 16px;
   width: min(680px, 96vw);
   font-family: var(--font-body);
@@ -146,7 +146,7 @@
 
 .deck-selector-panel {
   flex: 1;
-  border: 2px solid #333;
+  border: 2px solid var(--game-border);
   border-radius: 4px;
   padding: 10px 10px 8px;
   cursor: pointer;
@@ -157,7 +157,7 @@
   display: flex;
   flex-direction: column;
 }
-.deck-selector-panel:hover { border-color: #666; background: rgba(255,255,255,0.04); }
+.deck-selector-panel:hover { border-color: var(--color-gray-7); background: rgba(255,255,255,0.04); }
 .deck-selector-panel--active { border-color: #6ab07a; background: rgba(74,124,89,0.15); }
 
 .deck-selector-panel-header {
@@ -181,12 +181,12 @@
 .deck-selector-count {
   margin-left: auto;
   font-size: 0.7rem;
-  color: var(--game-text-color-dim, #888);
+  color: var(--game-text-color-dim, var(--color-gray-8));
 }
 
 .deck-selector-empty {
   font-size: 0.72rem;
-  color: #666;
+  color: var(--color-gray-7);
   text-align: center;
   padding: 16px 0;
 }
@@ -224,7 +224,7 @@
 
 .deck-selector-qty {
   flex-shrink: 0;
-  color: #888;
+  color: var(--color-gray-8);
   font-size: 0.65rem;
 }
 
@@ -345,7 +345,7 @@
 .cdm-spawn-lvl { white-space: nowrap; }
 .cdm-trait {
   font-size: var(--font-xxs);
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   color: var(--game-text-color-dim);
   padding: 1px 5px;
   border-radius: 2px;
@@ -397,7 +397,7 @@
   font-size: var(--font-xxs);
   color: var(--game-text-color-dim);
   background: rgba(0,0,0,0.3);
-  border-left: 2px solid #444;
+  border-left: 2px solid var(--color-gray-5);
   padding: 4px 8px;
   margin: 0 3px 2px 3px;
   line-height: 1.5;
@@ -408,7 +408,7 @@
 .cdm-sw-detail em { font-style: normal; color: #aad4ff; }
 
 .cdm-mastery-block {
-  border-top: 1px solid #1a1a1a;
+  border-top: 1px solid var(--game-bg-card);
   padding-top: 6px;
 }
 .cdm-mastery-header {
@@ -467,7 +467,7 @@
 .cdm-milestone      { font-size: var(--font-xxs); color: var(--game-text-color-muted); padding: 1px 0; }
 
 .cdm-battle-stats {
-  border-top: 1px solid #1a1a1a;
+  border-top: 1px solid var(--game-bg-card);
   padding-top: 6px;
 }
 
@@ -590,7 +590,7 @@
 }
 
 .inventory-cell:hover {
-  border-color: #444;
+  border-color: var(--color-gray-5);
 }
 
 .inventory-item-icon {
@@ -635,7 +635,7 @@
 
 .inventory-detail-modal {
   background: var(--game-bg-raised);
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   border-radius: 6px;
   padding: 24px 20px 20px;
   display: flex;
@@ -700,7 +700,7 @@
 
 .ach-tab {
   background: none;
-  border: 1px solid #444;
+  border: 1px solid var(--color-gray-5);
   color: var(--game-text-color-dim);
   font-family: inherit;
   font-size: var(--font-sm);
@@ -719,7 +719,7 @@
   top: -6px;
   right: -6px;
   background: var(--color-red);
-  color: #fff;
+  color: var(--text-inverse);
   font-size: var(--font-xxs);
   width: 14px;
   height: 14px;
@@ -730,7 +730,7 @@
 }
 
 .ach-claim-all-bar {
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid var(--color-gray-3);
 }
 
 .ach-category-label {

--- a/web/src/styles/rare-events.css
+++ b/web/src/styles/rare-events.css
@@ -6,7 +6,7 @@
   position: fixed;
   inset: 0;
   background: #0050d0;
-  color: #fff;
+  color: var(--text-inverse);
   font-family: 'Segoe UI', monospace;
   display: flex;
   align-items: center;
@@ -21,9 +21,9 @@
   gap: 16px;
 }
 
-.rc-reboot-logo   { font-size: var(--font-base); color: #555; letter-spacing: 2px; text-transform: uppercase; }
-.rc-reboot-spinner { font-size: 1.286rem; color: #333; letter-spacing: 2px; animation: crashBlink 0.8s step-end infinite; }
-.rc-reboot-text   { font-size: var(--font-md); color: #444; letter-spacing: 1px; }
+.rc-reboot-logo   { font-size: var(--font-base); color: var(--color-gray-6); letter-spacing: 2px; text-transform: uppercase; }
+.rc-reboot-spinner { font-size: 1.286rem; color: var(--game-border); letter-spacing: 2px; animation: crashBlink 0.8s step-end infinite; }
+.rc-reboot-text   { font-size: var(--font-md); color: var(--color-gray-5); letter-spacing: 1px; }
 
 @keyframes crashBlink {
   0%, 100% { opacity: 1; }
@@ -39,7 +39,7 @@
   font-size: 6.857rem;
   font-weight: 100;
   line-height: 1;
-  color: #fff;
+  color: var(--text-inverse);
 }
 
 .rc-headline {
@@ -94,8 +94,8 @@
 
 .wn-actions { display: flex; gap: 8px; }
 .wn-btn {
-  background: #333;
-  border: 1px solid #555;
+  background: var(--game-border);
+  border: 1px solid var(--color-gray-6);
   color: var(--game-text-color-muted);
   font-family: inherit;
   font-size: var(--font-sm);
@@ -104,7 +104,7 @@
   cursor: pointer;
   transition: all 0.15s;
 }
-.wn-btn:hover      { background: #444; color: var(--game-text-color-dim); }
+.wn-btn:hover      { background: var(--color-gray-5); color: var(--game-text-color-dim); }
 .wn-btn--muted     { border-color: var(--game-border); color: var(--game-text-color-muted); }
 .wn-btn--muted:hover { color: var(--game-text-color-muted); }
 
@@ -195,7 +195,7 @@
   font-size: 0.78rem;
   line-height: 1.6;
 }
-.dev-log-debug { color: #888; }
+.dev-log-debug { color: var(--color-gray-8); }
 .dev-log-warn  { color: var(--color-gold-alt); }
 .dev-log-error { color: var(--color-red); }
 .dev-log-info  { color: #44aaff; }
@@ -216,8 +216,8 @@
 .glitch-card-tile {
   width: 120px;
   min-height: 160px;
-  background: #111;
-  border: 2px solid #444;
+  background: var(--game-bg-raised);
+  border: 2px solid var(--color-gray-5);
   border-radius: 6px;
   display: flex;
   flex-direction: column;
@@ -228,11 +228,11 @@
   cursor: pointer;
   transition: border-color 0.2s, background 0.2s;
 }
-.glitch-card-tile:hover { border-color: #888; background: #1a1a1a; }
+.glitch-card-tile:hover { border-color: var(--color-gray-8); background: var(--game-bg-card); }
 .glitch-card-tile--revealed { border-color: #4a9a4a; background: #0a1a0a; }
-.glitch-card-name { font-size: 0.8rem; font-weight: bold; text-align: center; color: #ccc; }
+.glitch-card-name { font-size: 0.8rem; font-weight: bold; text-align: center; color: var(--color-gray-10); }
 .glitch-card-restored { font-size: 0.7rem; color: #7dbd7d; text-align: center; }
-.glitch-card-hint { font-size: 0.7rem; color: #666; }
+.glitch-card-hint { font-size: 0.7rem; color: var(--color-gray-7); }
 .glitch-text {
   animation: glitch-flicker 0.15s infinite;
   color: var(--color-red);
@@ -285,13 +285,13 @@
 }
 .tourist-speech {
   font-size: 0.8rem;
-  color: #ccc;
+  color: var(--color-gray-10);
   font-style: italic;
   line-height: 1.4;
 }
 .tourist-exit {
   font-size: 0.7rem;
-  color: #666;
+  color: var(--color-gray-7);
   margin-top: 0.5rem;
 }
 
@@ -306,7 +306,7 @@
   z-index: 9000;
 }
 .time-capsule-modal {
-  background: #111;
+  background: var(--game-bg-raised);
   border: 2px solid #8a6a2a;
   border-radius: 8px;
   padding: 2rem;
@@ -403,10 +403,10 @@
 .el-lb-ghost {
   opacity: 0.5;
   font-style: italic;
-  color: #888 !important;
+  color: var(--color-gray-8) !important;
 }
 .el-lb-ghost .el-lb-name { color: #999; }
-.el-lb-ghost .el-lb-rank { color: #666; }
+.el-lb-ghost .el-lb-rank { color: var(--color-gray-7); }
 
 /* ── Theatre / Curtain Call screen ─────────────────────────────────────── */
 .theatre-act-counter {
@@ -431,8 +431,8 @@
   top: 0;
   bottom: 0;
   background: rgba(255,215,0,0.28);
-  border-left: 1px solid #ffd700;
-  border-right: 1px solid #ffd700;
+  border-left: 1px solid var(--color-gold);
+  border-right: 1px solid var(--color-gold);
 }
 
 .theatre-marker {
@@ -459,7 +459,7 @@
 
 .theatre-flash--miss    { color: #ff6a6a; }
 .theatre-flash--good    { color: #88ddff; }
-.theatre-flash--perfect { color: #ffd700; text-shadow: 0 0 12px #ffd700; }
+.theatre-flash--perfect { color: var(--color-gold); text-shadow: 0 0 12px var(--color-gold); }
 
 @keyframes theatre-flash-pop {
   0%   { opacity: 0; transform: scale(0.7); }


### PR DESCRIPTION
Part of #2202 — a first, deliberately narrow slice, not the whole issue. See "What's still open" below; this does not close #2202.

## What this does

Built the token map straight from `tokens.css`'s own `:root` values (27 unique dark-theme colours) and mechanically replaced every byte-for-byte match of those exact hex strings across `web/src/styles/*.css` with the corresponding `var(--token)`. Case-insensitive, word-boundary matched so a 3-digit value never partial-matches inside a 6-digit one (`#333` doesn't touch `#333333`).

**280 literals converted across 16 files** (`minigames-4.css` alone: 82). 1,591 hex literals before this pass, 1,311 after.

## Why this scope, specifically

This is mechanical by construction — same colour value in, same rendered pixels out, only the *expression* changes. That's deliberately what makes it safe to do in one pass without the per-instance judgement the rest of #2202 needs (does a given literal deserve a *new* semantic token, or is it a genuine one-off that should stay literal — #2202 itself says one-offs should be left alone). Splitting that judgement call out lets this land now, cleanly verified, while the harder sorting work waits for a slower pass.

## Verification

- `npx tsc --noEmit -p .`, `npm run build` — clean
- **Full story catalog: 3651 tests across all 290 `.stories.tsx` files, 100% pass.** (This branch predates #2212's tag-filter fix, so nothing narrowed this run — for a value-preserving mechanical change like this one, that's more coverage, not less.)
- Visual spot-check on two of the heaviest-diffed files (the fishing minigame, the shop screen) — identical rendering.

## What's still open on #2202

The larger pieces need real per-instance design judgement or a product decision, not a sweep script — deliberately left for follow-up:

- **~1,311 hex literals remain**, plus **453 `rgba()`/`rgb()` literals** untouched entirely (an alpha channel means no exact-value match against an opaque token; would need a `color-mix()`-based approach). Most of the remaining hex volume sits in `minigames-1..4.css`, which is largely genuine per-minigame decorative palette — exactly the "one-off colours" #2202 says should stay literal, not get forced onto invented tokens. Separating the real remaining duplicates from the legitimate one-offs needs a slower, file-by-file pass.
- **City Builder, Farming Sim, the casino games, Tower Defence's HUD, and `MiniGamesMenu.tsx`** are still unmigrated onto Panel/Button/Modal/Toast — untouched here.
- **City Builder's `ResourceChip`/`ResourceStrip` genericization** — untouched.
- **The Blackjack casino-game scoping question** (fold `BlackjackEvent.tsx` in as the 6th casino game, build a new one, or drop it from the list) is a product decision, not something to guess at inside a sweep PR — left open for you to call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_