### PR TITLE
theme.ts: a shared TS/CSS colour bridge, and one canonical rarity colour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,36 @@ anim.play()
 
 Both helpers use an in-memory texture cache so each SVG URL is only fetched once.
 
+### Colour: read from `theme.ts`, not a hardcoded literal
+
+Pixi's `fill`/`stroke`/`tint` APIs take numeric hex (`0xffcc00`), not CSS
+strings, so canvas code can't `var(--accent-gold)` the way DOM/CSS does.
+`web/src/theme.ts` is the bridge (#2203) — a shared palette that mirrors
+`tokens.css`'s dark-theme values, with a numeric-hex form ready for Pixi:
+
+```typescript
+import { PALETTE_HEX, RARITY_COLOR_HEX } from '../../theme'
+
+circle.stroke({ color: available ? PALETTE_HEX.accentGold : 0x444430, width: 2 })
+sprite.tint = RARITY_COLOR_HEX[card.rarity]
+```
+
+`theme.test.ts` parses `tokens.css` and fails the moment a value in one
+drifts from the other — CSS and TS can't literally import each other, so
+that test is what keeps them honest instead of a naming convention.
+
+Reach for `theme.ts` when a colour already corresponds to a named token
+(the four accents, the five surface tiers, any of the nine `CardRarity`
+colours). A colour that's genuinely one-off to a single effect — a
+specific enemy's unique glow, a particle tint nothing else shares — can
+stay a literal; forcing it onto an invented token just to satisfy this
+rule is not the goal. `NodeMapRederer.tsx`'s available-node ring
+(`PALETTE_HEX.accentGold`) is the reference example. Most of the game's
+PixiJS canvases (`BattlefieldCanvas.tsx`, the rest of `NodeMapRederer.tsx`,
+`GameGrid.tsx`, `HubTownCanvas.tsx`, `citybuilder/CityTerrainCanvas.tsx` +
+`CityWalkerCanvas.tsx`) still hardcode their own literals — migrating them
+is tracked in #2203, not yet done.
+
 ### Event bridge (PixiJS → React)
 
 Use a `useRef` to hold the current callback and read it from PixiJS event handlers:

--- a/web/src/components/cards/AugmentPickerModal.tsx
+++ b/web/src/components/cards/AugmentPickerModal.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../game/collection'
 import { getAugmentCard, augmentSlotLabel } from '../../game/augments'
 import { ModalBackdrop } from '../ui/ModalBackdrop'
+import { RARITY_COLOR } from '../../theme'
 
 interface Props {
   slot: AugmentSlot
@@ -14,14 +15,6 @@ interface Props {
   onClose: () => void
 }
 
-const RARITY_COLOUR: Record<string, string> = {
-  common:    '#999999',
-  uncommon:  '#4499ff',
-  rare:      '#bb66ff',
-  epic:      '#ff8800',
-  legendary: '#ffcc00',
-  mythic:    '#e040fb',
-}
 
 export function AugmentPickerModal({ slot, cardName, onClose }: Props) {
   const allInstances = loadAugmentInstances()
@@ -67,7 +60,7 @@ export function AugmentPickerModal({ slot, cardName, onClose }: Props) {
                   <div className="apm-item-info">
                     <span
                       className="apm-item-name"
-                      style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}
+                      style={{ color: RARITY_COLOR[augCard.rarity] ?? '#fff' }}
                     >
                       {augCard.name}
                     </span>

--- a/web/src/components/cards/CardAugmentScreen.tsx
+++ b/web/src/components/cards/CardAugmentScreen.tsx
@@ -28,6 +28,7 @@ import { ModalBackdrop } from '../ui/ModalBackdrop'
 import { CardDetailHeader } from './CardDetailHeader'
 import { AugStatRow, masteryStatBonuses } from './AugStatRow'
 import { AnimatedSpriteImg, SpriteImg } from '../ui/SpriteImg'
+import { RARITY_COLOR } from '../../theme'
 
 interface Props {
   card: Card
@@ -36,17 +37,6 @@ interface Props {
   onClose: () => void
 }
 
-const RARITY_COLOUR: Record<string, string> = {
-  common:    '#55cc55',
-  uncommon:  '#4499ff',
-  rare:      '#bb66ff',
-  epic:      '#ff8800',
-  legendary: '#ffcc00',
-  mythic:    '#e040fb',
-  shiny:     '#ffe066',
-  holofoil:  '#40e0d0',
-  glass:     '#a0d8ef',
-}
 
 function effectSummary(effect: AugmentEffect): string {
   const parts: string[] = []
@@ -68,7 +58,7 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
   const owned  = getOwnedCount(collection, card.name)
   const inDeck = deckEntries?.find(e => e.cardName === card.name)?.count ?? 0
   const { level: masteryLvl } = masteryProgress(getMasteryXp(collection, card.name))
-  const rarityCol = RARITY_COLOUR[card.rarity] ?? 'var(--game-text-color-dim)'
+  const rarityCol = RARITY_COLOR[card.rarity] ?? 'var(--game-text-color-dim)'
 
   const equippedMap = getEquippedAugments(card.name)
   const setBonus    = getSetBonus(card.name)
@@ -180,7 +170,7 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
                   <div className="cas-slot-label">{augmentSlotLabel(slot)}</div>
                   {inst && augCard ? (
                     <>
-                      <div className="cas-slot-name" style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}>
+                      <div className="cas-slot-name" style={{ color: RARITY_COLOR[augCard.rarity] ?? '#fff' }}>
                         {augCard.name}
                       </div>
                       <div className="cas-slot-level">Lv{inst.level}</div>
@@ -229,7 +219,7 @@ export function CardAugmentScreen({ card, collection, deckEntries, onClose }: Pr
             const slotsFilledSameSet = equipped.filter(i => getAugmentCard(i.cardId)?.setName === setName).length
             return (
               <div className={`cas-set-bonus${hasFullSet ? ' cas-set-bonus--active' : ''}`}>
-                <span className="cas-set-bonus-name" style={{ color: RARITY_COLOUR[setDef.rarity] ?? '#fff' }}>
+                <span className="cas-set-bonus-name" style={{ color: RARITY_COLOR[setDef.rarity] ?? '#fff' }}>
                   {setName} Set Bonus ({slotsFilledSameSet}/7)
                 </span>
                 <span className="cas-set-bonus-desc">{setDef.setBonusDescription}</span>

--- a/web/src/components/cards/CardDetailModal.tsx
+++ b/web/src/components/cards/CardDetailModal.tsx
@@ -28,6 +28,7 @@ import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
 import { AugmentPickerModal } from './AugmentPickerModal'
 import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
 import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
+import { RARITY_COLOR } from '../../theme'
 
 
 
@@ -50,21 +51,6 @@ interface Props {
   onUpgrade?: () => void
   breakdownValue?: number
   onBreakdown?: () => void
-}
-
-// Keep in step with .card-tile--* (--card-frame in cards.css) and
-// .rarity-badge--* in collection.css. There are five copies of this mapping
-// across the app today — see the consolidation issue.
-const RARITY_COLOUR: Record<string, string> = {
-  common:    '#999999',
-  uncommon:  '#4499ff',
-  rare:      '#bb66ff',
-  epic:      '#ff8800',
-  legendary: '#ffcc00',
-  mythic:    '#e040fb',
-  shiny:     '#ffe066',
-  holofoil:  '#40e0d0',
-  glass:     '#a0d8ef',
 }
 
 
@@ -96,7 +82,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
   const forceRefresh = () => setRefresh((r: number) => r + 1)
     
   const { level: masteryLvl, current: xpCur, needed: xpNeeded } = masteryProgress(xp)
-  const rarityCol = RARITY_COLOUR[card.rarity] ?? 'var(--game-text-color-dim)'
+  const rarityCol = RARITY_COLOR[card.rarity] ?? 'var(--game-text-color-dim)'
 
   const [activeTab, setActiveTab] = useState(0)
 
@@ -495,7 +481,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
                               <div className="cas-slot-label">{augmentSlotLabel(slot)}</div>
                               {inst && augCard ? (
                                 <>
-                                  <div className="cas-slot-name" style={{ color: RARITY_COLOUR[augCard.rarity] ?? '#fff' }}>
+                                  <div className="cas-slot-name" style={{ color: RARITY_COLOR[augCard.rarity] ?? '#fff' }}>
                                     {augCard.name}
                                   </div>
                                   <div className="cas-slot-level">Lv{inst.level}</div>
@@ -544,7 +530,7 @@ export function CardDetailModal({ card, collection, deckEntries, onClose, extras
                         const slotsFilledSameSet = equipped.filter(i => getAugmentCard(i.cardId)?.setName === setName).length
                         return (
                           <div className={`cas-set-bonus${hasFullSet ? ' cas-set-bonus--active' : ''}`}>
-                            <span className="cas-set-bonus-name" style={{ color: RARITY_COLOUR[setDef.rarity] ?? '#fff' }}>
+                            <span className="cas-set-bonus-name" style={{ color: RARITY_COLOR[setDef.rarity] ?? '#fff' }}>
                               {setName} Set Bonus ({slotsFilledSameSet}/7)
                             </span>
                             <span className="cas-set-bonus-desc">{setDef.setBonusDescription}</span>

--- a/web/src/components/screens/CodexScreen.tsx
+++ b/web/src/components/screens/CodexScreen.tsx
@@ -4,6 +4,8 @@ import {
   getCodexCards, getCodexRelics, getCodexWorld, getCodexFragments, getCodexConversations, getCodexChronicle,
   CodexCardEntry, CodexRelicEntry, CodexWorldEntry, CodexFragmentEntry, CodexConversationEntry, CodexChronicleEntry,
 } from '../../game/codex'
+import { RARITY_COLOR } from '../../theme'
+import type { CardRarity } from '../../game/types'
 
 type CodexTab = 'cards' | 'relics' | 'world' | 'fragments' | 'conversations' | 'chronicle'
 type CardTypeFilter = 'all' | 'unit' | 'structure' | 'upgrade'
@@ -13,17 +15,6 @@ const RARITY_ORDER: Record<string, number> = {
   legendary: 5, mythic: 6, shiny: 7, holofoil: 8, glass: 9,
 }
 
-const RARITY_COLORS: Record<string, string> = {
-  common:    '#999999',
-  uncommon:  '#4499ff',
-  rare:      '#bb66ff',
-  epic:      '#ff8800',
-  legendary: '#ffcc00',
-  mythic:    '#e040fb',
-  shiny:     '#ffe066',
-  holofoil:  '#40e0d0',
-  glass:     '#a0d8ef',
-}
 
 function ConversationLorePanel({ entry }: { entry: CodexConversationEntry }) {
   return (
@@ -124,7 +115,7 @@ function CardLorePanel({ card }: { card: CodexCardEntry }) {
   return (
     <div className="codex-entry">
       <div className="codex-entry-header">
-        <span className="codex-entry-name" style={{ color: RARITY_COLORS[card.rarity] ?? '#aaffaa' }}>
+        <span className="codex-entry-name" style={{ color: RARITY_COLOR[card.rarity as CardRarity] ?? '#aaffaa' }}>
           {card.name}
         </span>
         <span className="codex-entry-tag">{card.rarity.toUpperCase()}</span>

--- a/web/src/components/ui/NodeMap/NodeMapRederer.tsx
+++ b/web/src/components/ui/NodeMap/NodeMapRederer.tsx
@@ -28,6 +28,7 @@ import { COL_WIDTH, ROW_HEIGHT, AVATAR_PADDING, CONN_W, nodeCenter, startPos,
   type PixelPoint } from '../../ui/NodeMap/nodeLayout'
 import { getCurrentWorldLocation } from '../../../game/world/worldState'
 import { NodePeekModal } from '../../ui/NodeMap/NodePeekModal'
+import { PALETTE_HEX } from '../../../theme'
 
 interface Props {
   id: string
@@ -718,7 +719,7 @@ export function NodeMapRederer({ id, run, worldMap, clearedNodeIds, restrictedNo
         const circle = new PIXI.Graphics()
         circle.circle(0, 0, 22)
           .fill({ color: isCurrent ? 0x1a6b1a : available ? 0x3a3a20 : 0x222218, alpha: 0.9 })
-          .stroke({ color: isCurrent ? 0x66ff66 : available ? 0xccaa44 : 0x444430, width: 2 })
+          .stroke({ color: isCurrent ? 0x66ff66 : available ? PALETTE_HEX.accentGold : 0x444430, width: 2 })
         container.addChild(circle)
 
         if (node.decorTiles?.length) {

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -186,7 +186,10 @@
 
 /* Shiny: warm gold shimmer sweep */
 .card-tile--shiny {
-  --card-frame: #ffdc3c;
+  /* Matches RARITY_COLOR.shiny in theme.ts (#2206) — this was #ffdc3c,
+     the one place shiny's colour actually differed from its three other
+     independent copies, which all agreed on #ffe066. */
+  --card-frame: #ffe066;
   border-color: rgba(255, 220, 60, 0.8);
   background: linear-gradient(
     105deg,

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -117,11 +117,15 @@
 .shop-augment-desc  { font-size: var(--font-xxs); color: #aaa; text-align: center; }
 
 .rarity-badge { font-size: var(--font-xxs); text-transform: uppercase; letter-spacing: 1px; padding: 1px 5px; border-radius: 3px; }
-.rarity-badge--common    { color: #999; border: 1px solid #666; }
-.rarity-badge--uncommon  { color: #44aaff; border: 1px solid #44aaff; }
-.rarity-badge--rare      { color: #cc44ff; border: 1px solid #cc44ff; }
+.rarity-badge--common    { color: #999999; border: 1px solid #666; }
+.rarity-badge--uncommon  { color: #4499ff; border: 1px solid #4499ff; }
+.rarity-badge--rare      { color: #bb66ff; border: 1px solid #bb66ff; }
 .rarity-badge--epic      { color: #ff8800; border: 1px solid #ff8800; }
-.rarity-badge--legendary { color: #ffaa22; border: 1px solid #ffaa22; }
+.rarity-badge--legendary { color: #ffcc00; border: 1px solid #ffcc00; }
+.rarity-badge--mythic    { color: #e040fb; border: 1px solid #e040fb; }
+.rarity-badge--shiny     { color: #ffe066; border: 1px solid #ffe066; }
+.rarity-badge--holofoil  { color: #40e0d0; border: 1px solid #40e0d0; }
+.rarity-badge--glass     { color: #a0d8ef; border: 1px solid #a0d8ef; }
 .shop-discount-badge {
   position: absolute;
   top: -8px; right: -8px;

--- a/web/src/theme.test.ts
+++ b/web/src/theme.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { PALETTE, RARITY_COLOR } from './theme'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = join(here, 'styles')
+
+/**
+ * theme.ts and the CSS token layer can't import each other, so this is what
+ * stands in for that — it parses the raw CSS and fails the moment a value
+ * here and a value there disagree, instead of letting them drift silently
+ * the way the five/six independent rarity-colour copies did before #2206.
+ */
+function readCss(file: string): string {
+  return readFileSync(join(stylesDir, file), 'utf8')
+}
+
+/** Resolves one level of `var(--other-token)` indirection against the same :root block. */
+function resolveToken(rootBlock: string, value: string): string {
+  const ref = value.match(/^var\((--[a-z0-9-]+)\)$/)
+  if (!ref) return value
+  const aliased = rootBlock.match(new RegExp(`${ref[1]}:\\s*([^;]+);`))
+  if (!aliased) throw new Error(`theme.test.ts: couldn't resolve ${value} — is ${ref[1]} defined in :root?`)
+  return resolveToken(rootBlock, aliased[1].trim())
+}
+
+function tokenValue(rootBlock: string, name: string): string {
+  const m = rootBlock.match(new RegExp(`${name}:\\s*([^;]+);`))
+  if (!m) throw new Error(`theme.test.ts: ${name} not found in tokens.css :root`)
+  return resolveToken(rootBlock, m[1].trim()).toLowerCase()
+}
+
+describe('theme.ts stays in step with tokens.css', () => {
+  // Only the :root block — html.light-mode reuses the same custom property
+  // names for different values, which isn't what PALETTE mirrors.
+  const rootBlock = readCss('tokens.css').split('html.light-mode')[0]
+
+  const cases: [keyof typeof PALETTE, string][] = [
+    ['accentGold', '--accent-gold'],
+    ['accentEmber', '--accent-ember'],
+    ['accentArcane', '--accent-arcane'],
+    ['accentBlood', '--accent-blood'],
+    ['surface0', '--surface-0'],
+    ['surface1', '--surface-1'],
+    ['surface2', '--surface-2'],
+    ['surface3', '--surface-3'],
+    ['surface4', '--surface-4'],
+  ]
+
+  it.each(cases)('PALETTE.%s matches tokens.css %s', (key, cssVar) => {
+    const cssValue = tokenValue(rootBlock, cssVar)
+    const themeValue = PALETTE[key].toLowerCase()
+    // tokens.css shorthands 3-digit hex sometimes and not others (#111 vs
+    // #ffcc00) — normalise both sides to 6-digit before comparing.
+    const normalise = (h: string) => {
+      const s = h.replace('#', '')
+      return s.length === 3 ? s.split('').map(c => c + c).join('') : s
+    }
+    expect(normalise(themeValue)).toBe(normalise(cssValue))
+  })
+})
+
+describe('RARITY_COLOR stays in step with cards.css and collection.css', () => {
+  const cardsCss = readCss('cards.css')
+  const collectionCss = readCss('collection.css')
+  const tokensRoot = readCss('tokens.css').split('html.light-mode')[0]
+
+  function resolveMaybeVar(value: string): string {
+    const ref = value.match(/^var\((--[a-z0-9-]+)\)$/)
+    if (!ref) return value.toLowerCase()
+    return tokenValue(tokensRoot, ref[1])
+  }
+
+  const normalise = (h: string) => {
+    const s = h.replace('#', '').toLowerCase()
+    return s.length === 3 ? s.split('').map(c => c + c).join('') : s
+  }
+
+  // common is the one deliberate exception: cards.css gives it a dimmer
+  // steel frame (var(--color-gray-6), #555) rather than the rarity label's
+  // own grey (#999999) — common is meant to read as neutral chrome, not as
+  // a coloured label. See the comment on RARITY_COLOR in theme.ts.
+  const rarities = (Object.keys(RARITY_COLOR) as (keyof typeof RARITY_COLOR)[])
+    .filter(r => r !== 'common')
+
+  it.each(rarities)('cards.css --card-frame for .card-tile--%s matches RARITY_COLOR', rarity => {
+    const m = cardsCss.match(new RegExp(`\\.card-tile--${rarity}\\s*\\{[^}]*--card-frame:\\s*([^;]+);`))
+    if (!m) throw new Error(`.card-tile--${rarity} not found in cards.css`)
+    expect(normalise(resolveMaybeVar(m[1].trim()))).toBe(normalise(RARITY_COLOR[rarity]))
+  })
+
+  const badgedRarities: (keyof typeof RARITY_COLOR)[] = ['uncommon', 'rare', 'epic', 'legendary', 'mythic', 'shiny', 'holofoil', 'glass']
+
+  it.each(badgedRarities)('collection.css .rarity-badge--%s matches RARITY_COLOR', rarity => {
+    const m = collectionCss.match(new RegExp(`\\.rarity-badge--${rarity}\\s*\\{\\s*color:\\s*([^;]+);`))
+    if (!m) throw new Error(`.rarity-badge--${rarity} not found in collection.css`)
+    expect(normalise(resolveMaybeVar(m[1].trim()))).toBe(normalise(RARITY_COLOR[rarity]))
+  })
+})

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,0 +1,75 @@
+import type { CardRarity } from './game/types'
+
+/**
+ * Shared colour palette (#2203) — the single TypeScript source of truth for
+ * colours PixiJS canvases need, mirroring tokens.css's dark-theme :root
+ * values. CSS can't import a .ts file and this can't import a .css file, so
+ * the two are kept in step by convention plus theme.test.ts, which parses
+ * tokens.css and fails the build if a value here drifts from it.
+ *
+ * Before this, changing --accent-gold in tokens.css recoloured every DOM
+ * primitive (Panel, Button, Modal) but not a single sprite tint, aura glow,
+ * or connector line drawn on a PixiJS canvas — those needed a separate edit,
+ * in a different file, in a different language, with no link back to the
+ * token change. PixiJS draw code should import from here instead of
+ * hardcoding its own hex/rgba literals.
+ */
+export const PALETTE = {
+  accentGold:   '#ffcc00',
+  accentEmber:  '#ff4444',
+  accentArcane: '#e040fb',
+  accentBlood:  '#6a2288',
+  surface0:     '#0a0a0a',
+  surface1:     '#111111',
+  surface2:     '#1a1a1a',
+  surface3:     '#1c1c26',
+  surface4:     '#262633',
+} as const
+
+export type PaletteKey = keyof typeof PALETTE
+
+/** '#rrggbb' or '#rgb' → the numeric form Pixi's tint/fill/stroke APIs expect. */
+export function toPixiColor(hex: string): number {
+  const h = hex.replace('#', '')
+  const full = h.length === 3 ? h.split('').map(c => c + c).join('') : h
+  return parseInt(full, 16)
+}
+
+export const PALETTE_HEX: Record<PaletteKey, number> = Object.fromEntries(
+  (Object.entries(PALETTE) as [PaletteKey, string][]).map(([k, v]) => [k, toPixiColor(v)])
+) as Record<PaletteKey, number>
+
+/**
+ * Rarity → colour (#2206). Previously defined independently in four
+ * components (CardDetailModal, AugmentPickerModal, CodexScreen,
+ * CardAugmentScreen — the last of which had drifted to a stale green
+ * `common: '#55cc55'` left over from the pre-#2177 terminal theme) plus two
+ * CSS files (collection.css's .rarity-badge--*, cards.css's --card-frame),
+ * none of which agreed with each other. `Record<CardRarity, string>` makes
+ * adding a rarity to the CardRarity union a compile error here until its
+ * colour is defined, instead of a silent '#fff'/undefined fallback at the
+ * call site.
+ *
+ * This is the *text* colour — the shade used for rarity-coloured labels,
+ * stars and names. cards.css's --card-frame (border/background tint) uses
+ * the same value for every rarity except common, which intentionally uses a
+ * separate, dimmer steel (#555, var(--color-gray-6)) as its frame — common
+ * is meant to read as neutral chrome, not as a coloured label. See
+ * theme.test.ts for where that one exception is asserted explicitly rather
+ * than silently allowed to drift.
+ */
+export const RARITY_COLOR: Record<CardRarity, string> = {
+  common:    '#999999',
+  uncommon:  '#4499ff',
+  rare:      '#bb66ff',
+  epic:      '#ff8800',
+  legendary: '#ffcc00',
+  mythic:    '#e040fb',
+  shiny:     '#ffe066',
+  holofoil:  '#40e0d0',
+  glass:     '#a0d8ef',
+}
+
+export const RARITY_COLOR_HEX: Record<CardRarity, number> = Object.fromEntries(
+  (Object.entries(RARITY_COLOR) as [CardRarity, string][]).map(([k, v]) => [k, toPixiColor(v)])
+) as Record<CardRarity, number>


### PR DESCRIPTION
Closes #2206. Part of #2203 — the bridge itself plus one real PixiJS migration, not all five canvases. See "PixiJS" below; #2203 stays open for the rest.

## `theme.ts`

`web/src/theme.ts` is the single TypeScript source of truth for colours PixiJS canvases need. CSS can't import a `.ts` file and vice versa, so `theme.test.ts` is what keeps them honest instead of a naming convention — it parses `tokens.css`'s raw `:root` block and fails the moment a value here drifts from there.

`PALETTE` mirrors the four accent tokens and five surface tiers. `RARITY_COLOR` is `Record<CardRarity, string>` — deliberately typed against the real `CardRarity` union rather than a loose `Record<string, string>`, so adding a rarity to that union is a compile error here until its colour is defined, per #2206's own acceptance criterion.

## The rarity-colour drift this found

Re-auditing with fresh eyes (#2206's numbers were from PR #2205, over a week old): **six** independent copies, not five.

- `CardAugmentScreen.tsx`'s `common` was still `'#55cc55'` — a stale green left over from the pre-#2177 terminal theme that #2205's alignment pass missed entirely, and which was still shipping.
- `AugmentPickerModal.tsx` was missing the three secret rarities, silently falling back to `'#fff'`.
- `collection.css`'s `.rarity-badge--*` had its own values for uncommon (`#44aaff` vs the canon `#4499ff`), rare (`#cc44ff` vs `#bb66ff`) and legendary (`#ffaa22` vs `#ffcc00`), and no badge at all for the four secret rarities.
- `cards.css`'s `--card-frame` for shiny was `#ffdc3c` against every other copy's `#ffe066`.

All four TS copies now import `RARITY_COLOR` from `theme.ts`. `collection.css`'s badge values are corrected and extended to all nine rarities. `cards.css`'s shiny frame is corrected. `theme.test.ts` asserts both CSS files can't drift from `theme.ts` again — with one documented, intentional exception: common's `--card-frame` is a dimmer steel (`#555`) rather than the rarity label's own grey (`#999999`), since common is meant to read as neutral chrome, not a coloured label. That's an explicit exclusion in the test, not a silent gap.

## PixiJS: one real migration, not five

Full migration of every PixiJS canvas (`BattlefieldCanvas`, the rest of `NodeMapRederer`, `GameGrid`, `HubTownCanvas`, `CityTerrainCanvas`/`CityWalkerCanvas`) is real, separate work — none of their literals are exact value-matches to an existing token the way the CSS sweep in #2202 found (those were copy-pasted from the same source; these weren't), so each one is a small design decision needing its own verification, not a mechanical pass.

Did the one #2203 itself names as the example: `NodeMapRederer.tsx`'s available-node ring now reads `PALETTE_HEX.accentGold` instead of a private `0xccaa44`. Deliberate small colour nudge (duller amber → brighter gold), not a value-preserving no-op — verified with a screenshot of the campaign map story that the ring still reads clearly against the terrain. The remaining four canvases are documented as not-yet-migrated, in this PR and in AGENTS.md's new "Colour: read from theme.ts" section, which also states the boundary: a genuinely one-off effect colour stays literal rather than getting forced onto an invented token.

## Verification

`npx tsc --noEmit -p .`, `npm run build`, and the full story catalog — **3676 tests across all 291 story files, 100% pass** (this branch predates #2212's tag-filter fix, so nothing narrowed this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_