### PR TITLE
Responsive pass: widen Collection and deck builder past the 740px cap on tablet/desktop

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -101,6 +101,7 @@ import { auth } from './firebase'
 import { uploadSave } from './game/cloudSave'
 import { getHubWorldData, type HubWorldData } from './data/hub/hubWorldFactory'
 import type { Screen } from './app/screens'
+import { WIDE_SCREENS } from './app/screens'
 import { BROKEN_RELIC_ITEMS } from './app/merchantItems'
 
 // Apply saved display settings on load
@@ -1246,7 +1247,7 @@ export default function App() {
     <ToastProvider>
     <AppProvider value={appContextValue}>
     <BattleProvider value={battleContextValue}>
-    <div className="game-container">
+    <div className={`game-container${WIDE_SCREENS.has(screen) ? ' game-container--wide' : ''}`}>
       <IconSprite />
       <div className="game-title">JARV'S AMAZING WEB GAME</div>
 

--- a/web/src/app/screens.ts
+++ b/web/src/app/screens.ts
@@ -78,6 +78,13 @@ export type Screen =
   | 'location'
   | 'sceneryPreview'
 
+// Screens that opt into .game-container--wide (#2183) — ones with a grid
+// or split layout that genuinely benefits from tablet/desktop width. Title,
+// settings and other single-column screens are deliberately left out: for
+// those, wide is worse, not better. See base.css's ".game-container--wide"
+// comment for the breakpoint tiers this feeds into.
+export const WIDE_SCREENS = new Set<Screen>(['collection', 'collection-tabs', 'deckbuilder'])
+
 // Below this, a tab switch/app-switcher glance isn't worth a Rollbar breadcrumb —
 // only log genuine "away for a while" returns.
 export const VISIBILITY_BREADCRUMB_THRESHOLD_MS = 15_000

--- a/web/src/breakpoints.test.ts
+++ b/web/src/breakpoints.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { BREAKPOINT } from './breakpoints'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const stylesDir = join(here, 'styles')
+
+/**
+ * Every `@media (min-width: …)` rule is a desktop/tablet tier (#2183) — the
+ * only narrower breakpoints in this codebase are `max-width`. This test is
+ * what stands in for reading a shared CSS variable inside `@media`, which
+ * plain CSS can't do here (see breakpoints.ts): it fails the moment a new
+ * min-width rule uses a value that isn't one of BREAKPOINT's three tiers.
+ */
+describe('every min-width media query matches a canonical breakpoint', () => {
+  const canonical = new Set<number>(Object.values(BREAKPOINT))
+
+  const cssFiles = readdirSync(stylesDir).filter(f => f.endsWith('.css'))
+  const found: { file: string; px: number }[] = []
+  for (const file of cssFiles) {
+    const text = readFileSync(join(stylesDir, file), 'utf8')
+    for (const m of text.matchAll(/@media\s*\(min-width:\s*(\d+)px\)/g)) {
+      found.push({ file, px: Number(m[1]) })
+    }
+  }
+
+  it('found at least one min-width rule to check', () => {
+    expect(found.length).toBeGreaterThan(0)
+  })
+
+  it.each(found)('$file uses a canonical breakpoint ($pxpx)', ({ px }) => {
+    expect(canonical.has(px)).toBe(true)
+  })
+
+  it('tokens.css documents the same three values', () => {
+    const tokens = readFileSync(join(stylesDir, 'tokens.css'), 'utf8')
+    const rootBlock = tokens.split('html.light-mode')[0]
+    for (const [key, px] of Object.entries(BREAKPOINT)) {
+      const varName = `--breakpoint-${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`
+      const m = rootBlock.match(new RegExp(`${varName}:\\s*(\\d+)px;`))
+      expect(m, `tokens.css should define ${varName}`).toBeTruthy()
+      expect(Number(m![1])).toBe(px as number)
+    }
+  })
+})

--- a/web/src/breakpoints.ts
+++ b/web/src/breakpoints.ts
@@ -1,0 +1,17 @@
+/**
+ * Desktop/tablet breakpoints (#2183), mirrored in tokens.css as
+ * --breakpoint-tablet / --breakpoint-desktop / --breakpoint-desktop-lg.
+ *
+ * CSS custom properties can't be read inside an `@media` condition (that
+ * needs the still-unshipped-here Custom Media Queries spec / a PostCSS
+ * plugin this repo doesn't have), so every `@media (min-width: …)` rule
+ * for these tiers has to repeat the literal pixel value instead of
+ * `var(--breakpoint-*)`. This file — checked against every such rule by
+ * breakpoints.test.ts — is what keeps those literals from drifting apart
+ * the way the rarity colours did before #2206.
+ */
+export const BREAKPOINT = {
+  tablet: 768,
+  desktop: 1024,
+  desktopLg: 1440,
+} as const

--- a/web/src/components/screens/CollectionScreen.stories.tsx
+++ b/web/src/components/screens/CollectionScreen.stories.tsx
@@ -6,6 +6,14 @@ import { CollectionScreen } from './CollectionScreen';
 const meta = {
   component: CollectionScreen,
   parameters: { layout: 'fullscreen' },
+  // Real usage always sits inside .game-container(--wide) (#2183) — without
+  // it this story showed the grid at true unconstrained fullscreen width,
+  // which is wider than the app ever actually renders it.
+  decorators: [(Story) => (
+    <div className="game-container game-container--wide" style={{ height: '100vh' }}>
+      <Story />
+    </div>
+  )],
 } satisfies Meta<typeof CollectionScreen>;
 
 export default meta;

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -51,6 +51,25 @@ body {
   flex-shrink: 0;
 }
 
+/* ─── Desktop / tablet (#2183) ───────────────────────────
+   Opt-in per screen, not a change to .game-container itself: title,
+   settings and other simple screens are meant to stay narrow at any
+   viewport width (see #2183's scope), so App.tsx only adds this class
+   while a screen that actually benefits from more width — currently
+   Collection and the deck builder — is showing. The three tiers match
+   --breakpoint-tablet/-desktop/-desktop-lg in tokens.css; see
+   breakpoints.ts for why they're repeated as literals here rather than
+   read from the custom property. */
+@media (min-width: 768px) {
+  .game-container--wide { max-width: 900px; }
+}
+@media (min-width: 1024px) {
+  .game-container--wide { max-width: 1180px; }
+}
+@media (min-width: 1440px) {
+  .game-container--wide { max-width: 1400px; }
+}
+
 /* ─── Scrollbars ─────────────────────────────────────── */
 
 ::-webkit-scrollbar { width: 6px; height: 6px; }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -38,6 +38,16 @@
   --container-pad-x: 10px;
   --container-pad-y: 6px;
 
+  /* Tablet/desktop breakpoints (#2183), mirrored in breakpoints.ts. These
+     custom properties document the canonical values and are usable as
+     ordinary property values, but NOT inside an `@media` condition — this
+     repo has no Custom Media Queries plugin, so every `@media (min-width: …)`
+     rule at these tiers has to repeat the literal pixel value. That
+     repetition is checked against breakpoints.ts by breakpoints.test.ts. */
+  --breakpoint-tablet: 768px;
+  --breakpoint-desktop: 1024px;
+  --breakpoint-desktop-lg: 1440px;
+
   --game-text-color: #33ff33;
   --game-text-color-dim:   color-mix(in srgb, var(--game-text-color) 85%, transparent);
   --game-text-color-muted: color-mix(in srgb, var(--game-text-color) 70%, transparent);


### PR DESCRIPTION
Part of #2165. First slice of #2183.

## Problem

`.game-container` caps every screen at `max-width: 740px`, and the only media queries in the codebase are narrower than that (480/420/400/380px) — so on a tablet or desktop the game sits as a narrow centred strip with empty background on both sides. Collection browsing and the deck builder are the screens that would benefit most, and are the ones squeezed hardest.

Per the measurements already on this issue: the Collection grid (`flex-wrap`, fixed 90px cells) already scales correctly once unconstrained — 768px → 7 columns, 1024px → 10, 1440px → 14 — and the repo owner's call was **more columns, not bigger cards**. The blocker is purely `.game-container`'s cap.

## What this PR does

- **`.game-container--wide`**, opted into per-screen via a `WIDE_SCREENS` set in `app/screens.ts` (`collection`, `collection-tabs`, `deckbuilder`) rather than changing `.game-container` itself — so title, settings and every other single-column screen keep the narrow layout that's actually right for them.
- Three tiers raise the cap: `768px → 900px`, `1024px → 1180px`, `1440px → 1400px`. Bounded, not unconstrained — a 4K monitor doesn't get cards spread edge to edge.
- **`breakpoints.ts`** + matching `--breakpoint-tablet/-desktop/-desktop-lg` tokens in `tokens.css` document the three pixel values as a single source of truth. Plain CSS can't read a custom property inside an `@media` condition (no Custom Media Queries plugin here), so every `@media (min-width: …)` rule has to repeat the literal — `breakpoints.test.ts` checks every such rule in `styles/*.css` against `breakpoints.ts` so they can't drift apart, mirroring the pattern `theme.ts`/`theme.test.ts` already established for colour.
- `CollectionScreen.stories.tsx` now wraps in `.game-container.game-container--wide`, matching real usage — previously it rendered `fullscreen` and unwrapped, i.e. wider than the app ever actually shows it.

## Verification

Screenshotted via Storybook at all five widths the issue's acceptance criteria call for (380/480/768/1024/1440px) — Collection screen and, via a throwaway local story, the deck builder:

- 380/480px: unaffected (3–4 columns), as expected below the tablet tier.
- 768px: 7 columns, filter bar and progress bar both read cleanly.
- 1024px: 10 columns.
- 1440px: 14 columns, ~40px side margins.

An earlier design note on this issue worried a lifted cap would clip the shown/discovered counts and turn the progress bar into "a 1440px-wide hairline." That risk turned out to be specific to an *unconstrained* cap — with the bounded tiers here, the filter bar and progress bar look fine at every width; no chrome fixes were needed.

`npx tsc --noEmit`, `npm run build`, and the full `npx vitest run` (2911 tests, includes the chromium+webkit Storybook browser project) all pass.

## What's still open (follow-up, per #2183's own scope)

- Deck builder's top/bottom split staying stacked rather than becoming side-by-side on desktop. It does gain more columns per panel now (same `.collection-grid` mechanism as Collection), just not a layout change.
- Campaign map and hub world width.
- Battlefield's cap — it already letterboxes correctly via `useLetterboxSize` and wasn't touched.
- Landscape-phone handling.
- Coordination with #2086 (safe-area insets).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_