### PR TITLE
Motion and feel, first slice: haptics wrapper + press feedback on shared controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,22 @@ Key shared button classes:
 - `action-btn--danger` — red variant for destructive/abandon actions
 - `filter-btn` — compact filter/toggle button
 
+### Press feedback: every clickable element needs `:active`, not just `:hover`
+
+`:hover` never fires on touch. An element whose only feedback is `:hover`
+gives a phone/tablet player nothing when they tap it — no acknowledgement
+until whatever the tap *did* becomes visible, which for a slow action can
+feel like the tap didn't register. `.action-btn:active` already does this
+right (see `buttons.css`) — depress via `transform: translateY(1px)` (or
+`scale()` for small circular controls), reusing whatever `:hover` already
+darkens/lightens where that makes sense. When adding a new clickable
+element, or touching an existing one, add `:active` alongside its
+`:hover` rather than leaving it hover-only. (#2185 fixed the handful of
+most-reused shared primitives — `filter-btn`, `player-tab`, `hoa-tab`,
+`settings-toggle` — but plenty of screen-specific buttons across the
+minigames, hub and campaign stylesheets are still hover-only; fix the ones
+you touch.)
+
 ## Component Extraction and Storybook Stories
 
 **Break screen-level components into focused sub-components, each with its own story.**

--- a/web/src/components/screens/SettingsScreen.tsx
+++ b/web/src/components/screens/SettingsScreen.tsx
@@ -3,6 +3,7 @@ import {
   signOut as firebaseSignOut, type User,
 } from 'firebase/auth'
 import { isSoundEnabled, setSoundEnabled, getSoundVolume, setSoundVolume, getMusicVolume, setMusicVolume } from '../../game/sound'
+import { isHapticsSupported, isHapticsEnabled, setHapticsEnabled } from '../../game/haptics'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import { Section } from '../ui/Section'
 import { Button } from '../ui/Button'
@@ -175,6 +176,7 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
   const [eightbitOn,    setEightbitOn]    = useState(load8bitEnabled)
   const [eightbitUnlocked]               = useState(load8bitUnlocked)
   const [monochromeOn,   setMonochromeOn]   = useState(loadMonochromeEnabled)
+  const [hapticsOn,      setHapticsOn]      = useState(isHapticsEnabled)
   const [lightModeOn,   setLightModeOn]   = useState(loadLightMode)
   const [battlePopups,  setBattlePopups]  = useState(loadBattlePopups)
   const [hubDefault,    setHubDefault]    = useState(loadHubDefault)
@@ -282,6 +284,12 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
     setMonochromeOn(next)
     saveMonochromeEnabled(next)
     applyMonochromeMode(next)
+  }
+
+  function handleHapticsToggle() {
+    const next = !hapticsOn
+    setHapticsOn(next)
+    setHapticsEnabled(next)
   }
 
   function handleLightModeToggle() {
@@ -543,6 +551,33 @@ export function SettingsScreen({ onBack, onResetGame, user, authLoading, onDevCr
               </div>
             </div>
           </Section>
+
+        {/* Hidden entirely rather than shown-but-inert on iOS Safari (no
+            Vibration API) — a toggle that visibly does nothing is worse
+            than no toggle, same call as retiring light mode (#2184). */}
+        {isHapticsSupported() && (
+          <Section bordered title="HAPTICS">
+            <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">
+              <div>
+                <div className="settings-label">Vibration</div>
+                <div className="settings-sublabel">Short pulses for card plays, hits, and wins/losses</div>
+              </div>
+              <div
+                className="settings-toggle u-flex u-items-c u-gap-3 u-pointer u-no-select"
+                onClick={handleHapticsToggle}
+                onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleHapticsToggle() } }}
+                role="switch"
+                aria-checked={hapticsOn}
+                aria-label="Vibration"
+                tabIndex={0}
+              >
+                <div className={`settings-toggle-track${hapticsOn ? ' settings-toggle-track--on' : ''}`}>
+                  <div className="settings-toggle-thumb" />
+                </div>
+              </div>
+            </div>
+          </Section>
+        )}
 
         <Section bordered title="DISPLAY">
           <div className="settings-row u-flex u-items-c u-just-sb u-gap-7">

--- a/web/src/game/haptics.test.ts
+++ b/web/src/game/haptics.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// haptics.ts reads/writes localStorage — stub it the same way towerDefence's
+// save tests do, since this project's node test environment has no DOM globals.
+let store = new Map<string, string>()
+const localStorageStub = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => { store.set(k, v) },
+  removeItem: (k: string) => { store.delete(k) },
+}
+vi.stubGlobal('localStorage', localStorageStub)
+
+const { isHapticsSupported, isHapticsEnabled, setHapticsEnabled, hapticCardPlay, hapticWin } = await import('./haptics')
+
+describe('haptics', () => {
+  beforeEach(() => {
+    store.clear()
+    vi.stubGlobal('localStorage', localStorageStub)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.stubGlobal('localStorage', localStorageStub)
+  })
+
+  it('defaults to enabled when nothing is stored', () => {
+    expect(isHapticsEnabled()).toBe(true)
+  })
+
+  it('setHapticsEnabled persists the preference', () => {
+    setHapticsEnabled(false)
+    expect(isHapticsEnabled()).toBe(false)
+    setHapticsEnabled(true)
+    expect(isHapticsEnabled()).toBe(true)
+  })
+
+  it('calls navigator.vibrate when supported and enabled', () => {
+    const vibrate = vi.fn()
+    vi.stubGlobal('navigator', { vibrate })
+    setHapticsEnabled(true)
+    hapticCardPlay()
+    expect(vibrate).toHaveBeenCalledWith(10)
+  })
+
+  it('does not call navigator.vibrate when disabled', () => {
+    const vibrate = vi.fn()
+    vi.stubGlobal('navigator', { vibrate })
+    setHapticsEnabled(false)
+    hapticWin()
+    expect(vibrate).not.toHaveBeenCalled()
+  })
+
+  it('is unsupported when navigator.vibrate is missing (iOS Safari)', () => {
+    vi.stubGlobal('navigator', {})
+    expect(isHapticsSupported()).toBe(false)
+  })
+
+  it('does not throw when unsupported and enabled', () => {
+    vi.stubGlobal('navigator', {})
+    setHapticsEnabled(true)
+    expect(() => hapticCardPlay()).not.toThrow()
+  })
+})

--- a/web/src/game/haptics.ts
+++ b/web/src/game/haptics.ts
@@ -1,0 +1,36 @@
+// ─── Haptics ──────────────────────────────────────────────────────────────
+// Thin wrapper over navigator.vibrate, paired with the matching cue in
+// sound.ts rather than wired to its own separate set of call sites (#2185)
+// — every place the game already plays a card-play/hit/win/loss/reward sound
+// is exactly the set of moments a haptic pulse belongs to.
+
+const HAPTICS_KEY = 'jarv_haptics_enabled'
+
+/** iOS Safari has no Vibration API at all; this makes every call below a safe no-op there. */
+export function isHapticsSupported(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+}
+
+export function isHapticsEnabled(): boolean {
+  try { return localStorage.getItem(HAPTICS_KEY) !== 'false' }
+  catch { return true }
+}
+
+export function setHapticsEnabled(val: boolean): void {
+  try { localStorage.setItem(HAPTICS_KEY, val ? 'true' : 'false') } catch { /* ignore */ }
+}
+
+function vibrate(pattern: number | number[]): void {
+  if (!isHapticsEnabled() || !isHapticsSupported()) return
+  try { navigator.vibrate(pattern) } catch { /* ignore */ }
+}
+
+// Durations in ms. Short and light for frequent/minor events (a card play,
+// a single hit), longer patterned bursts reserved for moments that only
+// happen once per battle (win/loss) or are meant to feel like a reward.
+export function hapticCardPlay(): void { vibrate(10) }
+export function hapticHit(): void      { vibrate(15) }
+export function hapticImpact(): void   { vibrate(25) }
+export function hapticWin(): void      { vibrate([20, 40, 20, 40, 60]) }
+export function hapticLoss(): void     { vibrate([40, 30, 40]) }
+export function hapticReward(): void   { vibrate([15, 30, 25]) }

--- a/web/src/game/sound.ts
+++ b/web/src/game/sound.ts
@@ -1,6 +1,8 @@
 // ─── Web Audio API Sound Engine ──────────────────────────────────────────────
 // All sounds are procedurally generated — no external audio files needed.
 
+import { hapticCardPlay, hapticHit, hapticImpact, hapticWin, hapticLoss, hapticReward } from './haptics'
+
 let ctx: AudioContext | null = null
 let masterGain: GainNode | null = null
 
@@ -124,6 +126,7 @@ function now(): number {
 // ─── Individual sounds ────────────────────────────────────────────────────────
 
 export function playCardPlay() {
+  hapticCardPlay()
   const t = now()
   node(440, 'sine', t,       0.08, 0.25)
   node(660, 'sine', t + 0.06, 0.10, 0.20)
@@ -154,12 +157,14 @@ export function playBuildingDestroyed() {
 }
 
 export function playVictory() {
+  hapticWin()
   const t = now()
   const melody = [523, 659, 784, 1047]
   melody.forEach((f, i) => node(f, 'sine', t + i * 0.12, 0.18, 0.3))
 }
 
 export function playDefeat() {
+  hapticLoss()
   const t = now()
   const melody = [400, 350, 280, 220]
   melody.forEach((f, i) => node(f, 'sawtooth', t + i * 0.15, 0.22, 0.25))
@@ -201,12 +206,14 @@ export function playUnitAttack() {
   const now2 = Date.now()
   if (now2 - _lastAttackSoundMs < 80) return
   _lastAttackSoundMs = now2
+  hapticHit()
   const t = now()
   node(180, 'sawtooth', t,        0.04, 0.22)
   node(280, 'square',   t + 0.02, 0.03, 0.15)
 }
 
 export function playBaseHit() {
+  hapticImpact()
   const t = now()
   node(100, 'sawtooth', t,        0.10, 0.38)
   node(60,  'sine',     t,        0.15, 0.32)
@@ -223,6 +230,7 @@ export function playBattleStart() {
 }
 
 export function playUpgrade() {
+  hapticReward()
   const t = now()
   const notes = [523, 659, 784, 1047]
   notes.forEach((f, i) => node(f, 'sine', t + i * 0.07, 0.12, 0.22))

--- a/web/src/styles/battle-screens.css
+++ b/web/src/styles/battle-screens.css
@@ -298,7 +298,13 @@
   border: 1px solid #444;
   background: var(--game-bg-card);
   position: relative;
-  transition: background 0.2s, border-color 0.2s;
+  transition: background 0.2s, border-color 0.2s, transform 0.1s;
+}
+
+/* Press feedback (#2185) — the switch had no reaction at all to being
+   pressed until the toggle finished flipping. */
+.settings-toggle:active .settings-toggle-track {
+  transform: scale(0.92);
 }
 
 .settings-toggle-track--on {

--- a/web/src/styles/collection-meta.css
+++ b/web/src/styles/collection-meta.css
@@ -489,6 +489,11 @@
   border-radius: var(--radius-sm);
 }
 
+/* Had no hover OR active state at all (#2185) — a tab switch gave zero
+   feedback until the (already-selected) --active style appeared. */
+.player-tab:hover  { color: var(--game-text-color-dim); border-color: #777; }
+.player-tab:active { transform: translateY(1px); }
+
 /* Was a raw #0f0 — brighter than any green in the palette, and green is now
    semantic-only. Gold matches the active-tab treatment used elsewhere. */
 .player-tab--active {

--- a/web/src/styles/collection.css
+++ b/web/src/styles/collection.css
@@ -339,6 +339,15 @@
   border-color: #777;
 }
 
+/* Press feedback (#2185) — :hover never fires on touch, so without this a
+   tap on FILTERS/SORT/GROUP or any filter option gave no acknowledgement
+   at all. Matches .action-btn:active's depress, scaled down for a smaller
+   flat button. */
+.filter-btn:active {
+  transform: translateY(1px);
+  background: color-mix(in srgb, var(--game-text-color) 12%, transparent);
+}
+
 .filter-btn--active {
   border-color: var(--game-text-color);
   color: var(--game-text-color);
@@ -487,6 +496,7 @@
   opacity: 0.7;
 }
 .filter-pill button:hover { opacity: 1; }
+.filter-pill button:active { transform: scale(0.85); }
 
 /* ─── Deck builder search + filter ──────────────────── */
 
@@ -1163,6 +1173,7 @@
   border-radius: 2px 2px 0 0;
 }
 .hoa-tab:hover { color: #c8e8c8; border-color: #446644; }
+.hoa-tab:active { transform: translateY(1px); }
 .hoa-tab--active {
   color: #c8e8c8;
   border-color: #446644;


### PR DESCRIPTION
Part of #2165. First slice of #2185.

#2185 covers press feedback, screen transitions, reward choreography, combat feel and haptics — five sub-problems, each sizeable on its own. This PR takes the two pieces concrete and self-contained enough to land as one honest slice, and scopes the rest out explicitly below.

## Press feedback (the ":active" ask)

Audited every `:hover` rule in `styles/*.css` against a matching `:active` rule. 131 elements have `:hover`; only 6 had `:active` before this PR (all `.action-btn` variants + `.card-tile`).

`.action-btn` itself was already fine — it already had `:active` with a comment documenting exactly this rationale, contrary to the issue's premise that it's hover-only. Whatever added that landed before #2185 was filed.

That leaves ~125 hover-only elements, spread across every domain stylesheet (minigames, hub, campaign, battle...) with enough bespoke visual language each that fixing all of them responsibly in one pass isn't a single PR's worth of work. This one fixes the four most-reused **shared primitives** instead — each used across dozens of screens, so fixing them once cascades broadly:

- `.filter-btn` — filters/sort/group popups, deck builder search
- `.player-tab` — Player screen, Collection tabs (had *no* hover or active state at all)
- `.hoa-tab` — Hall of Achievements
- `.settings-toggle` — every toggle row in Settings

Documented the convention in `AGENTS.md` (new "Press feedback" section under CSS Styling Rules) so future screen-specific passes have a clear pattern instead of rediscovering it.

## Ambient animation audit — already done

#2185 also asks to audit the 90 ambient `@keyframes` for `prefers-reduced-motion` gating. Checked: #2182 (PR #2213) already added a global `@media (prefers-reduced-motion: reduce)` rule that force-kills every animation and transition on the page (`*, *::before, *::after { animation-duration: 0.01ms !important; ... }`), not a per-rule opt-out. That acceptance criterion was already satisfied before this PR — no changes needed.

## Haptics (`game/haptics.ts`, new)

Thin wrapper over `navigator.vibrate`: `isHapticsSupported`/`isHapticsEnabled`/`setHapticsEnabled`, and five named pulses (card play, hit, impact, win, loss, reward).

Rather than hunting down new call sites across the codebase, wired it into the `sound.ts` cue functions that already fire at exactly these moments — `playCardPlay`, `playUnitAttack`, `playBaseHit`, `playVictory`, `playDefeat`, `playUpgrade`. That's "pair haptics with existing audio cues," per the issue's own file list.

Settings toggle added under a new "HAPTICS" section — hidden entirely (not shown-but-inert) on iOS Safari, which has no Vibration API. Same call as retiring the light-mode toggle in #2184: a control that visibly does nothing is worse than no control.

## What's still open (follow-up, per #2185's own scope)

- The ~115 remaining hover-only, screen-specific buttons across the minigame/hub/campaign/battle stylesheets.
- Screen transitions — shared enter/exit treatment for navigation.
- Reward choreography — one anticipation → reveal → payoff vocabulary across post-battle rewards, card draft, relic select, achievements, level-ups, matching `PackOpening`'s existing quality.
- Combat feel — hit reactions, damage numbers, death moments in the DOM/HUD layer (canvas-side effects already exist in `battlefieldCanvas/effects.ts`).

## Verification

`npx tsc --noEmit`, `npm run build`, and the full `npx vitest run` (2912 tests, including a new `haptics.test.ts` covering the enable/disable/support-gating logic) all pass.

Visual check on the new Settings toggle was blocked in this sandbox — the `SettingsScreen` Storybook stories require Firebase auth, which errors here (`auth/invalid-api-key`) independent of this change; not something this PR introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_