### PR TITLE
Battlefield: give the play area its space back (+49%, zero pillarboxing)

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -18,6 +18,7 @@ import { loadBattlePopups } from '../screens/SettingsScreen'
 import { TutorialOverlay } from '../modals/TutorialOverlay'
 import { hasSeen, markSeen } from '../../game/tutorial'
 import { useLetterboxSize } from '../../hooks/useLetterboxSize'
+import { useMeasuredHeight } from '../../hooks/useMeasuredHeight'
 import { loadDevConfig, patchDevConfig } from '../../game/devStore'
 import { isDevMode } from '../../game/debug'
 import { BaseBar } from './battlefield/BaseBar'
@@ -122,6 +123,14 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   // grid on every screen (see LANE_ASPECT_RATIO in game/types.ts).
   const laneSlotRef = useRef<HTMLDivElement>(null)
   const laneSize = useLetterboxSize(laneSlotRef, LANE_ASPECT_RATIO)
+  // The HUD bands reserve exactly as much room as the clusters actually occupy,
+  // measured rather than hardcoded. The previous fixed-pixel constants had drifted
+  // ~20px too small at both ends, so the opponent base bar and the player mana bar
+  // sat on top of the play area. See useMeasuredHeight.
+  const topClusterRef = useRef<HTMLDivElement>(null)
+  const bottomClusterRef = useRef<HTMLDivElement>(null)
+  const topBufferPx = useMeasuredHeight(topClusterRef)
+  const bottomBufferPx = useMeasuredHeight(bottomClusterRef)
   const playerName   = loadPlayerName()
   const playerAvatar = loadPlayerAvatar()
 
@@ -213,18 +222,24 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
   // The battlefield always renders at a fixed aspect ratio (BATTLEFIELD_ASPECT_RATIO),
   // letterboxed within the stage rather than stretched — see useLetterboxSize. Falls
   // back to filling the stage until the first ResizeObserver measurement lands.
-  const frameStyle: React.CSSProperties = frameSize
-    ? { width: frameSize.width, height: frameSize.height }
-    : { width: '100%', height: '100%' }
+  const frameStyle: React.CSSProperties = {
+    ...(frameSize
+      ? { width: frameSize.width, height: frameSize.height }
+      : { width: '100%', height: '100%' }),
+    // Until the first measurement lands these stay unset and battle.css's
+    // defaults apply, so the first paint is never a 0-height band.
+    ...(topBufferPx    != null ? { '--bf-top-buffer':    `${topBufferPx}px` } : {}),
+    ...(bottomBufferPx != null ? { '--bf-bottom-buffer': `${bottomBufferPx}px` } : {}),
+  } as React.CSSProperties
   // Rounded to whole pixels: BattlefieldCanvas measures its own box with
   // Math.ceil, so a fractional size would land the canvas a pixel off the ratio
   // and reintroduce a small collision/art drift across the lane's 17 columns.
   const laneStyle: React.CSSProperties = laneSize
     ? { width: Math.round(laneSize.width), height: Math.round(laneSize.height) }
     : { width: '100%', height: '100%' }
-  const isCompactFrame = !!frameSize && frameSize.width <= 480
-  const isTinyFrame = !!frameSize && frameSize.width <= 380
-  const frameClassName = `battlefield-frame${isCompactFrame ? ' battlefield-frame--compact' : ''}${isTinyFrame ? ' battlefield-frame--tiny' : ''}`
+  // The --compact/--tiny frame tiers are gone: they existed only to nudge the
+  // hardcoded band constants per frame width, and the bands now measure themselves.
+  const frameClassName = 'battlefield-frame'
 
   return (
     <div
@@ -266,7 +281,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       )}
 
       {/* Top cluster: floats above the lane in the reserved top band */}
-      <div className="bf-top-cluster">
+      <div className="bf-top-cluster" ref={topClusterRef}>
       <TopBar
         timeStr={timeStr}
         suddenDeath={state.suddenDeath}
@@ -293,18 +308,6 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         </div>
       )}
 
-      {/* Opponent base */}
-      <BaseBar
-        owner="opponent"
-        portraitSrc={`${BASE_SPRITE_PATH}${opponentCommanderSlug}.svg`}
-        portraitAlt="opponent"
-        hp={state.opponentBase.hp}
-        maxHp={state.opponentBase.maxHp}
-        color="#ff4444"
-        rightSlot={STRATEGY_LABELS[state.opponentStrategy] && (
-          <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
-        )}
-      />
       </div>
 
       <CombatLogPanel entries={state.log} open={logOpen} onClose={() => setLogOpen(false)} />
@@ -332,6 +335,39 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           debugOverlay={debugOverlay}
           selectedUnitId={inspectedUnit?.id ?? null}
         />
+
+        {/* Base HP bars ride the lane's own top and bottom edges rather than
+            sitting in the HUD bands above and below it. Each bar belongs to the
+            base at that end of the lane, so this is where they read most
+            naturally — and it hands ~100px of the frame's vertical budget back
+            to the play area. That matters more than it sounds: the lane is
+            letterboxed to a fixed ratio, so height it cannot use it also cannot
+            spend on width, and the reclaimed space is what takes the lane from
+            an 18%-pillarboxed column to very nearly the full frame width. */}
+        <div className="lane-base-bar lane-base-bar--opponent">
+          <BaseBar
+            owner="opponent"
+            portraitSrc={`${BASE_SPRITE_PATH}${opponentCommanderSlug}.svg`}
+            portraitAlt="opponent"
+            hp={state.opponentBase.hp}
+            maxHp={state.opponentBase.maxHp}
+            color="#ff4444"
+            rightSlot={STRATEGY_LABELS[state.opponentStrategy] && (
+              <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
+            )}
+          />
+        </div>
+        <div className="lane-base-bar lane-base-bar--player">
+          <BaseBar
+            owner="player"
+            portraitSrc={`${BASE_SPRITE_PATH}${playerAvatar}.svg`}
+            portraitAlt={playerName}
+            hp={state.playerBase.hp}
+            maxHp={state.playerBase.maxHp}
+            color="#33ff33"
+            rightSlot={<>MANA {state.mana}/{state.maxMana} <ManaBar mana={state.mana} maxMana={state.maxMana} manaAccum={state.manaAccum} /></>}
+          />
+        </div>
 
         {/* AoE targeting overlay */}
         {pendingAoeCard && (
@@ -380,18 +416,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
       })()}
 
       {/* Bottom cluster: floats below the lane in the reserved bottom band */}
-      <div className="bf-bottom-cluster">
-      {/* Player base */}
-      <BaseBar
-        owner="player"
-        portraitSrc={`${BASE_SPRITE_PATH}${playerAvatar}.svg`}
-        portraitAlt={playerName}
-        hp={state.playerBase.hp}
-        maxHp={state.playerBase.maxHp}
-        color="#33ff33"
-        rightSlot={<>MANA {state.mana}/{state.maxMana} <ManaBar mana={state.mana} maxMana={state.maxMana} manaAccum={state.manaAccum} /></>}
-      />
-
+      <div className="bf-bottom-cluster" ref={bottomClusterRef}>
       {/* Stance + speed controls */}
       {(() => {
         const rules = state.stanceRules
@@ -444,6 +469,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
               <div key={card.id} className="hand-card-wrap u-relative u-col" title={isMaxUpgrade ? 'Already at max level' : undefined}>
                 <CardTile
                   card={card}
+                  compact
                   canAfford={!isMaxUpgrade && state.mana >= getEffectiveCardCost(card, state)}
                   displayCost={getEffectiveCardCost(card, state)}
                   onClick={() => {

--- a/web/src/components/battle/battlefield/ManaBar.tsx
+++ b/web/src/components/battle/battlefield/ManaBar.tsx
@@ -15,7 +15,12 @@ export function ManaBar({ mana, maxMana, manaAccum }: Props) {
     return 'empty'
   })
   return (
-    <div className="mana-bar u-flex u-items-c">
+    // The track's width is driven by the pip count but capped in CSS, so the
+    // meter stays compact at a 3-mana start and stops growing once maxMana is
+    // high enough that pips have to share the space instead. Without the count
+    // here CSS can only either fix the width (wasting space at low maxMana) or
+    // let it shrink to nothing against the HP bar's flex: 1.
+    <div className="mana-bar u-flex u-items-c" style={{ '--mana-pips': maxMana } as React.CSSProperties}>
       {pips.map((pipState, i) => (
         <span key={i} className={`mana-pip mana-pip--${pipState}`}>
           {pipState === 'partial'

--- a/web/src/components/cards/CardTile.tsx
+++ b/web/src/components/cards/CardTile.tsx
@@ -135,9 +135,18 @@ interface Props {
   deckMatches?: number   // deck builder: how many deck cards this one pairs with
   selected?: boolean     // deck builder / picker screens: this tile is the active selection
   isNew?: boolean        // collection: unseen since last acquired
+  /**
+   * Battle hand: show only what a play decision needs — name, icon, cost, type.
+   * Drops the stat line and rarity stars, and tightens the art/padding. The hand
+   * is the single biggest consumer of the battlefield's vertical budget, and every
+   * pixel it gives back widens the play area too (the lane is aspect-locked, so
+   * height loss costs width — see .battlefield-frame in battle.css). Full stats
+   * stay one tap away via the hand's ⓘ button.
+   */
+  compact?: boolean
 }
 
-export function CardTile({ card, canAfford = true, disabled = false, onClick, lockedSecs = 0, upgradeable = false , showDetails = false, displayCost, deckMatches = 0, selected = false, isNew = false }: Props) {
+export function CardTile({ card, canAfford = true, disabled = false, onClick, lockedSecs = 0, upgradeable = false , showDetails = false, displayCost, deckMatches = 0, selected = false, isNew = false, compact = false }: Props) {
   const heroLocked = card.isHero && lockedSecs > 0
   const clickable = canAfford && !disabled && !heroLocked
   const { openDetail, cardDetailNode } = useCardDetail()
@@ -186,6 +195,7 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
         `card-tile--${card.rarity}`,
         clickable ? '' : 'card-tile--disabled',
         selected ? 'card-tile--selected' : '',
+        compact ? 'card-tile--compact' : '',
       ].filter(Boolean).join(' ')}
       title={heroLocked ? `Hero cards unlock after 30 seconds (${lockedSecs}s remaining)` : card.description}
     >
@@ -237,9 +247,9 @@ export function CardTile({ card, canAfford = true, disabled = false, onClick, lo
           }
         </div>
 
-        <div className="card-stats">{stats}</div>
+        {!compact && <div className="card-stats">{stats}</div>}
         <div className={`card-bottom-row${showDetails ? ' card-bottom-row--with-info' : ''}`}>
-          <div className="card-rarity">{rarityStars(card.rarity)}</div>
+          {!compact && <div className="card-rarity">{rarityStars(card.rarity)}</div>}
           <div className={`card-type-badge card-type-badge--${getCardCategory(card)}`}>
             {CATEGORY_ICON[getCardCategory(card)]}
             {/* The label carries its own ellipsis: text-overflow can't act on the

--- a/web/src/hooks/useMeasuredHeight.ts
+++ b/web/src/hooks/useMeasuredHeight.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+/**
+ * Tracks an element's rendered height via ResizeObserver, rAF-debounced — the
+ * same measure-and-store shape as useLetterboxSize, narrowed to one axis.
+ *
+ * Exists so a layout can reserve space for a box by *measuring* it rather than
+ * hardcoding what someone once measured by hand. The battlefield reserved its
+ * HUD bands as fixed pixel constants in three breakpoint tiers; the HUD then
+ * grew past them and the bars silently began overlapping the play area. Numbers
+ * like that are only ever correct on the day they are written.
+ *
+ * Returns null until the first measurement so callers can fall back to a CSS
+ * default for the first paint instead of collapsing to 0.
+ */
+export function useMeasuredHeight(ref: RefObject<HTMLElement | null>): number | null {
+  const [height, setHeight] = useState<number | null>(null)
+  const rafRef = useRef(0)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => {
+      // Round up: a fractional height that rounds down leaves a sub-pixel of the
+      // cluster outside its own reserved band — the exact bug this hook prevents.
+      const next = Math.ceil(el.getBoundingClientRect().height)
+      if (next > 0) setHeight(prev => (prev === next ? prev : next))
+    }
+
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = requestAnimationFrame(measure)
+    })
+    ro.observe(el)
+    measure()
+    return () => { cancelAnimationFrame(rafRef.current); ro.disconnect() }
+  }, [ref])
+
+  return height
+}

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -19,28 +19,23 @@
 .battlefield-frame {
   position: relative;
   overflow: hidden;
-  /* Fixed bands reserved for the floating bar clusters. The lane fills the space
+  /* Bands reserved for the floating bar clusters. The lane fills the space
      between them, so the play area's size depends only on the frame — never on
      bar content (long scores, wave status, event tags, card-bar height changes).
-     Retuned for #2176's HUD pass by measuring actual cluster height in a real
-     battle (see PR description) — the previous values already under-reserved
-     space before this pass (a pre-existing gap this issue called out), and the
-     larger card hand/base-bar surfaces need a little more. BATTLEFIELD_ASPECT_RATIO
-     is tall/narrow (9:19.5), so in practice almost every real viewport letterboxes
-     down to the --compact or --tiny tier — this default tier is a rarely-hit
-     ceiling for unusually tall windows, kept in proportion with the other two. */
-  --bf-top-buffer: 92px;
-  --bf-bottom-buffer: 255px;
-}
 
-/* Narrower-frame tuning — keyed off the letterboxed frame's own computed width
-   (set as classes from Battlefield.tsx), not the device viewport: a wide desktop
-   window letterboxed down to a phone-width frame needs the same phone tuning a
-   real phone gets, which a viewport @media query alone could never detect.
-   The lane has no min-height override here: it is letterboxed to a fixed ratio
-   (see .lane below), and a minimum on one axis would silently break that ratio. */
-.battlefield-frame--compact { --bf-top-buffer: 88px; --bf-bottom-buffer: 250px; }
-.battlefield-frame--tiny { --bf-top-buffer: 86px; --bf-bottom-buffer: 244px; }
+     Battlefield.tsx overwrites both of these with the clusters' MEASURED heights
+     (useMeasuredHeight) as soon as the first ResizeObserver callback lands. The
+     values here are only a first-paint fallback.
+
+     They used to be the real thing: three hand-tuned tiers of fixed pixels. They
+     were correct on the day they were measured and then the HUD grew — by the
+     time this was investigated the bands under-reserved by 17px at the top and
+     23px at the bottom, so the opponent base bar and the player mana bar were
+     both sitting on top of the play area on every phone. A constant describing
+     the size of something that can change is a bug with a delay on it. */
+  --bf-top-buffer: 105px;
+  --bf-bottom-buffer: 275px;
+}
 
 /* Floating bar clusters: absolutely positioned in the reserved bands above/below
    the lane. Their content can grow/wrap without ever resizing or reflowing the lane. */
@@ -68,7 +63,7 @@
   flex-wrap: nowrap;
   white-space: nowrap;
   overflow: hidden;
-  padding: 4px 8px;
+  padding: 3px 8px;
   border: 1px solid var(--border-edge-dark);
   border-radius: var(--radius-md);
   background: var(--surface-1);
@@ -170,6 +165,40 @@
      at all before #2176). */
   background: var(--surface-1);
   box-shadow: var(--elevation-raised);
+}
+
+/* Base bars as lane-edge overlays (see Battlefield.tsx). Pinned to the lane
+   itself rather than the slot, so they track the play area's exact width even
+   while it is still letterboxed narrower than the frame.
+
+   Only the bar itself takes pointer events — the wrapper spans the full lane
+   width, and swallowing taps across it would kill unit inspection along the
+   top and bottom rows. */
+.lane-base-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 4;
+  display: flex;
+  padding: 3px;
+  pointer-events: none;
+}
+
+.lane-base-bar > * {
+  flex: 1;
+  pointer-events: auto;
+}
+
+.lane-base-bar--opponent { top: 0; }
+.lane-base-bar--player { bottom: 0; }
+
+/* Units spawn at their base — i.e. directly under these bars now that the bars
+   sit inside the lane. #2176 gave .base-bar a solid fill so its text stayed
+   legible over bright terrain; keep most of that, but not so much that a freshly
+   spawned unit is invisible until it walks out. Units read through as shapes,
+   while the HP fill and label still have ~80% of a solid backing behind them. */
+.lane-base-bar .base-bar {
+  background: color-mix(in srgb, var(--surface-1) 80%, transparent);
 }
 
 .base-bar--opponent {
@@ -548,7 +577,7 @@
 .stance-bar {
   display: flex;
   gap: 4px;
-  padding: 4px 6px;
+  padding: 3px 6px;
   border-top: 1px solid var(--game-border);
   flex-shrink: 0;
   background: var(--surface-1);
@@ -558,6 +587,22 @@
   flex: 1;
   text-align: center;
 }
+
+/* ─── Battle HUD control density ──────────────────────
+   #2182's touch-target pass gives every .action-btn a 44px min-height under
+   `@media (pointer: coarse)`. That is the right default, but the battle HUD is
+   the one screen where vertical space is the scarcest thing in the game: these
+   buttons hold ~16px of content, so 44px was leaving 28px of forced blank space
+   in each of the two densest rows, twice over, directly against the play area.
+
+   These targets stay 32px tall and are 60-90px WIDE, well clear of WCAG 2.2
+   AA's 24x24 minimum (2.5.8). It relaxes only the AAA 44x44 target (2.5.5), and
+   only here — every other button in the game keeps the full 44px. */
+.stance-bar .action-btn,
+.top-bar .action-btn {
+  min-height: 32px;
+}
+
 
 .stance-bar__speed {
   flex: 0 0 auto !important;
@@ -912,7 +957,9 @@
   background: none;
   border: 1px solid var(--game-text-color-muted);
   color: var(--game-text-color-dim);
-  font-size: 1rem;
+  /* Was 1rem — the largest text in a bar of ~10px labels, which made the button
+     bigger than anything it sits beside for no hierarchy reason. */
+  font-size: var(--font-sm);
   padding: 0 6px;
   border-radius: 3px;
   cursor: pointer;

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -300,15 +300,37 @@
 
 /* ─── Mana Pips ──────────────────────────────────────── */
 
+/* The pips share a bounded track instead of each taking a fixed 12px + 4px gap.
+   That old sizing made the meter's width a function of maxMana: at 10 it was
+   156px — 42% of the player base bar, and more than twice the HP track beside
+   it, which is the more important number of the two. Relics raise maxMana with
+   no ceiling, so it also kept growing; at 20 it would have been wider than the
+   lane.
+
+   Now it costs at most 96px however high maxMana goes, and the HP track (flex:
+   1) absorbs what it gives back. At small maxMana the per-pip max-width keeps
+   pips their original chunky size, so a 3- or 5-mana start looks unchanged. */
 .mana-bar {
-  gap: 4px;
+  gap: 2px;
+  /* --mana-pips comes from ManaBar.tsx. 14px is one pip plus its gap, so below
+     the cap the track is exactly as wide as its pips need; above it, the pips
+     share 96px instead. flex: 0 0 auto because the HP track next to it is
+     flex: 1 and would otherwise shrink this to its min-width. */
+  width: min(96px, calc(var(--mana-pips, 10) * 14px));
+  flex: 0 0 auto;
 }
 
 /* Arcane-accent tone rather than the CRT green — mana is magic, not the
    "friendly" semantic colour, per the epic's palette direction (#2166). */
 .mana-pip {
   display: inline-block;
-  width: 12px;
+  /* Shrink to share the track when there are many, but never grow past the
+     original 12px when there are few. min-width keeps a very high maxMana
+     legible as segments rather than hairlines. */
+  flex: 1 1 12px;
+  width: auto;
+  max-width: 12px;
+  min-width: 3px;
   height: 12px;
   border: 1px solid var(--accent-arcane);
   border-radius: var(--radius-sm);

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -39,6 +39,31 @@
   transition-duration: 0.05s;
 }
 
+/* ─── Compact tile (battle hand) ──────────────────────
+   The hand only needs what a play decision turns on: name, icon, mana cost,
+   type. CardTile's `compact` prop drops the stat line and rarity stars; this
+   trims the remaining chrome. Scoped to the modifier so Collection and the
+   deck builder keep the full-size tile untouched.
+
+   This is a battlefield layout fix as much as a visual one: the hand is the
+   largest single consumer of the frame's vertical budget, and the lane is
+   letterboxed to a fixed ratio — so height the hand gives back widens the play
+   area too. See .battlefield-frame in battle.css. */
+.card-tile--compact {
+  padding: 6px 8px;
+  gap: 2px;
+}
+
+.card-tile--compact .card-art {
+  height: 38px;
+}
+
+/* The stat line is gone, so the type badge is the bottom row's only child —
+   space-between would leave it hugging the left edge under a centred title. */
+.card-tile--compact .card-bottom-row {
+  justify-content: center;
+}
+
 .card-tile--disabled,
 .fm-hold-btn--blocked,
 .td-selected-action-btn--disabled,


### PR DESCRIPTION
Part of #2165. Reported directly: the battlefield had become a narrow column with thick black pillars either side and terrain clipped top and bottom.

Measured the `Battlefield` story at phone viewports rather than guessing. At **390×844** the frame is 378×819, and there were two separate causes.

## 1. The HUD was overlapping the play area (a bug)

| band | reserved | actual | |
|---|---|---|---|
| top | 88px | **105px** (top-bar 54 + opponent bar 46 + gap 5) | **17px overlap** |
| bottom | 250px | **273px** (player bar 46 + stance 53 + hand 164 + gaps 10) | **23px overlap** |

The bands were hardcoded pixel constants in three frame-width tiers. They were accurate when measured by hand for #2176 — then the HUD grew. The opponent base bar and player mana bar were both sitting on top of the lane on every phone.

Replaced all three tiers with **`useMeasuredHeight`**, a `ResizeObserver` that reports each cluster's real height, which `Battlefield.tsx` feeds back as the buffer values. A constant describing the size of something that can change is a bug with a delay on it.

## 2. The HUD was eating 46% of the frame (378px of 819)

That costs the play area *twice*, because the lane is letterboxed to a fixed ratio — height it can't use it also can't spend on width. Three changes give it back:

- **Base bars ride the lane's own edges** instead of occupying exclusive bands above and below it. Each belongs to the base at that end of the lane, so it reads naturally there — and that's where the space was (~100px). Held at **80% opacity** rather than the solid fill #2176 gave them, because units spawn at their base, i.e. directly under these now.
- **Compact battle hand card — name, icon, mana cost, type**, per your spec. Dropped the stat line and rarity stars, trimmed art (48→38px) and padding. Full stats stay one tap away on the card's existing ⓘ button. Implemented as a `compact` prop on `CardTile`, so **Collection and the deck builder keep the full-size #2177 tile** — verified still exactly 90×151 with both rows present. **151px → 112px.**
- **HUD buttons were all exactly 44px for ~16px of content** — #2182's touch-target minimum. Right as a default, but it left 28px of forced blank space in each of the two densest rows, twice over, right against the play area. Scoped to **32px in the battle HUD only**; also brought the pause button down from `1rem` (it was the largest text in a row of 10px labels). See the a11y note below.

## Result

| viewport | lane before | lane after | pillarbox |
|---|---|---|---|
| 360×800 | 279×433 | **352×547** | 21% → **0%** |
| 390×844 | 310×481 | **378×587** | 18% → **0%** |
| 430×932 | 365×567 | **418×649** | 13% → **0%** |

**+49% play area at 390×844**, full frame width at every size, and each band now reserves exactly what its cluster occupies (probe asserts reserved == actual).

Total HUD 378px → 209px.

## Accessibility note — please sanity-check this one

The 32px button height relaxes **WCAG 2.5.5 Target Size (AAA, 44×44)**, which #2182 had adopted globally. These targets are 60–90px wide and stay well clear of **2.5.8 Target Size Minimum (AA, 24×24)**, and the override is scoped to the battle HUD alone — every other button in the game keeps the full 44px. Flagging it explicitly because it partly walks back a deliberate accessibility decision; happy to go to 36px or revert it if you'd rather keep AAA everywhere.

## Verification

- Geometry probe at 360/390/430 — asserts no overlap and lane ≈ frame width.
- Before/after screenshots at 390×844.
- Collection tile confirmed unchanged (90×151, stats + rarity present, art 48px).
- `npx tsc --noEmit`, `npm run build`, full `npx vitest run` — **2911 passed**.

One thing worth knowing for future browser checks: Storybook needs `web/.env.test` copied to `web/.env.local` or every auth-touching story renders a Firebase error card. It's in AGENTS.md; it's also why the SettingsScreen screenshot in #2220 couldn't be taken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_