### PR TITLE
Battlefield: unhide the spawn strip, retire the stance row

### DIFF
--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -308,6 +308,23 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
         </div>
       )}
 
+      {/* Opponent base. Lives in the band above the lane, not over it: #2221
+          briefly rode these bars on the lane's own edges to reclaim their
+          height, but a bar covers ~9% of the lane at each end, and on the
+          engine's 0-500 forward axis that is the strip holding PLAYER_SPAWN_X
+          (30), COMMANDER_HOME_X (15) and OPPONENT_SPAWN_X (470) — everything
+          entering play was hidden underneath. See game/engine/constants.ts. */}
+      <BaseBar
+        owner="opponent"
+        portraitSrc={`${BASE_SPRITE_PATH}${opponentCommanderSlug}.svg`}
+        portraitAlt="opponent"
+        hp={state.opponentBase.hp}
+        maxHp={state.opponentBase.maxHp}
+        color="#ff4444"
+        rightSlot={STRATEGY_LABELS[state.opponentStrategy] && (
+          <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
+        )}
+      />
       </div>
 
       <CombatLogPanel entries={state.log} open={logOpen} onClose={() => setLogOpen(false)} />
@@ -335,39 +352,6 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           debugOverlay={debugOverlay}
           selectedUnitId={inspectedUnit?.id ?? null}
         />
-
-        {/* Base HP bars ride the lane's own top and bottom edges rather than
-            sitting in the HUD bands above and below it. Each bar belongs to the
-            base at that end of the lane, so this is where they read most
-            naturally — and it hands ~100px of the frame's vertical budget back
-            to the play area. That matters more than it sounds: the lane is
-            letterboxed to a fixed ratio, so height it cannot use it also cannot
-            spend on width, and the reclaimed space is what takes the lane from
-            an 18%-pillarboxed column to very nearly the full frame width. */}
-        <div className="lane-base-bar lane-base-bar--opponent">
-          <BaseBar
-            owner="opponent"
-            portraitSrc={`${BASE_SPRITE_PATH}${opponentCommanderSlug}.svg`}
-            portraitAlt="opponent"
-            hp={state.opponentBase.hp}
-            maxHp={state.opponentBase.maxHp}
-            color="#ff4444"
-            rightSlot={STRATEGY_LABELS[state.opponentStrategy] && (
-              <span className="strategy-label">{STRATEGY_LABELS[state.opponentStrategy]}</span>
-            )}
-          />
-        </div>
-        <div className="lane-base-bar lane-base-bar--player">
-          <BaseBar
-            owner="player"
-            portraitSrc={`${BASE_SPRITE_PATH}${playerAvatar}.svg`}
-            portraitAlt={playerName}
-            hp={state.playerBase.hp}
-            maxHp={state.playerBase.maxHp}
-            color="#33ff33"
-            rightSlot={<>MANA {state.mana}/{state.maxMana} <ManaBar mana={state.mana} maxMana={state.maxMana} manaAccum={state.manaAccum} /></>}
-          />
-        </div>
 
         {/* AoE targeting overlay */}
         {pendingAoeCard && (
@@ -417,7 +401,11 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
 
       {/* Bottom cluster: floats below the lane in the reserved bottom band */}
       <div className="bf-bottom-cluster" ref={bottomClusterRef}>
-      {/* Stance + speed controls */}
+      {/* Player base. Its right-hand slot is the player's whole control strip:
+          mana, stance and speed. The stance selector used to be a 39px row of
+          its own directly below this one — folding it in here is what frees the
+          height for the base bars to sit outside the lane rather than over the
+          spawn strip. */}
       {(() => {
         const rules = state.stanceRules
         const onCooldown = rules?.cooldownMs !== undefined &&
@@ -431,16 +419,31 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
           : 0
 
         return (
-          <StanceBar
-            stance={stance}
-            allowedStances={rules?.allowed ?? null}
-            suddenDeath={state.suddenDeath}
-            onCooldown={onCooldown}
-            cooldownSecsLeft={cooldownSecsLeft}
-            durationSecsLeft={durationSecsLeft}
-            speedMultiplier={speedMultiplier}
-            onSetStance={onSetStance}
-            onCycleSpeed={onCycleSpeed}
+          <BaseBar
+            owner="player"
+            portraitSrc={`${BASE_SPRITE_PATH}${playerAvatar}.svg`}
+            portraitAlt={playerName}
+            hp={state.playerBase.hp}
+            maxHp={state.playerBase.maxHp}
+            color="#33ff33"
+            rightSlot={<>
+              {/* "MANA" spelled out cost ~35px in a row that now also carries
+                  the stance control; the pips beside the number are already
+                  unmistakably the mana meter. */}
+              {state.mana}/{state.maxMana}
+              <ManaBar mana={state.mana} maxMana={state.maxMana} manaAccum={state.manaAccum} />
+              <StanceBar
+                stance={stance}
+                allowedStances={rules?.allowed ?? null}
+                suddenDeath={state.suddenDeath}
+                onCooldown={onCooldown}
+                cooldownSecsLeft={cooldownSecsLeft}
+                durationSecsLeft={durationSecsLeft}
+                speedMultiplier={speedMultiplier}
+                onSetStance={onSetStance}
+                onCycleSpeed={onCycleSpeed}
+              />
+            </>}
           />
         )
       })()}

--- a/web/src/components/battle/battlefield/StanceBar.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.tsx
@@ -1,5 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Button } from '../../ui/Button'
+import { FilterPopup } from '../../ui/filters/FilterPopup'
+import { FilterOption } from '../../ui/filters/FilterOption'
 
 type Stance = 'attack' | 'hold' | 'defend' | 'auto'
 
@@ -9,6 +11,8 @@ const STANCE_LABEL: Record<Stance, string> = {
   defend: 'DEFEND',
   auto:   'ATTACK',
 }
+
+const STANCE_ORDER = ['attack', 'hold', 'defend', 'auto'] as const
 
 interface Props {
   stance: Stance
@@ -22,36 +26,76 @@ interface Props {
   onCycleSpeed?: () => void
 }
 
-/** Stance selector + speed-cycle control, unchanged behavior from the inline
- *  version — same allowed/cooldown/duration rules, now on ui/Button so it
- *  gets real :disabled/focus handling instead of a raw <button>. */
+/**
+ * Stance selector + speed cycle. Same allowed/cooldown/duration/sudden-death
+ * rules as before, but as a single trigger plus a popup rather than a row of
+ * up to five always-visible buttons.
+ *
+ * That row was a whole 39px band of the battlefield frame, and on a phone the
+ * frame's height is what caps the play area's *width* too (the lane is
+ * letterboxed to a fixed ratio). Collapsing it to one trigger is what pays for
+ * the base HP bars to sit above and below the lane instead of on top of it,
+ * where they were covering the spawn strip.
+ *
+ * A popup also fits the control better than a fixed row did: `allowedStances`
+ * varies by node — boss battles permit only auto/defend — so the row's width
+ * changed under the player anyway, and a cooling-down stance reads more clearly
+ * as a disabled list row than as one greyed button among five.
+ */
 export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, cooldownSecsLeft, durationSecsLeft, speedMultiplier, onSetStance, onCycleSpeed }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const allowed = STANCE_ORDER.filter(s => !allowedStances || allowedStances.includes(s))
+
+  // The trigger carries whichever timer is currently meaningful, so the state
+  // the row used to show inline is still visible without opening anything.
+  const suffix =
+    durationSecsLeft > 0 && stance !== 'auto' ? ` ${durationSecsLeft}s`
+    : onCooldown && cooldownSecsLeft > 0     ? ` ${cooldownSecsLeft}s`
+    : ''
+
   return (
-    <div className="stance-bar">
-      {(['attack', 'hold', 'defend', 'auto'] as const).map(s => {
-        const isAllowed = !allowedStances || allowedStances.includes(s)
-        if (!isAllowed) return null
-        const isActive = stance === s
-        const isCoolingDown = onCooldown && s !== 'auto' && !isActive
-        const showCountdown = isActive && s !== 'auto' && durationSecsLeft > 0
-        const showCooldown = isCoolingDown && cooldownSecsLeft > 0
-        return (
-          <Button
-            key={s}
-            className={`filter-btn${isActive ? ' filter-btn--active' : ''}${isCoolingDown ? ' filter-btn--cooldown' : ''}`}
-            onClick={() => onSetStance?.(s)}
-            disabled={(suddenDeath && s !== 'attack') || isCoolingDown}
-            title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
-          >
-            {STANCE_LABEL[s]}
-            {showCountdown && <span className="stance-timer"> {durationSecsLeft}s</span>}
-            {showCooldown && <span className="stance-timer stance-timer--cd"> {cooldownSecsLeft}s</span>}
-          </Button>
-        )
-      })}
+    <span className="stance-control u-flex u-items-c u-gap-2">
+      <FilterPopup
+        label={STANCE_LABEL[stance]}
+        activeSuffix={suffix}
+        isActive={stance !== 'auto'}
+        open={open}
+        onToggle={() => setOpen(o => !o)}
+        onClose={() => setOpen(false)}
+      >
+        <div className="filter-popup-section u-col">
+          <span className="filter-group-label">STANCE</span>
+          <div className="filter-popup-btns u-flex u-wrap u-gap-2">
+            {allowed.map(s => {
+              const isActive = stance === s
+              const isCoolingDown = onCooldown && s !== 'auto' && !isActive
+              const blockedBySuddenDeath = suddenDeath && s !== 'attack'
+              return (
+                <FilterOption
+                  key={s}
+                  active={isActive}
+                  disabled={blockedBySuddenDeath || isCoolingDown}
+                  title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
+                  onClick={() => { onSetStance?.(s); setOpen(false) }}
+                >
+                  {STANCE_LABEL[s]}
+                  {isActive && s !== 'auto' && durationSecsLeft > 0 && (
+                    <span className="stance-timer"> {durationSecsLeft}s</span>
+                  )}
+                  {isCoolingDown && cooldownSecsLeft > 0 && (
+                    <span className="stance-timer stance-timer--cd"> {cooldownSecsLeft}s</span>
+                  )}
+                </FilterOption>
+              )
+            })}
+          </div>
+        </div>
+      </FilterPopup>
+
       <Button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
         x{speedMultiplier}
       </Button>
-    </div>
+    </span>
   )
 }

--- a/web/src/components/ui/filters/FilterOption.tsx
+++ b/web/src/components/ui/filters/FilterOption.tsx
@@ -5,14 +5,19 @@ interface Props {
   gold?: boolean
   onClick: () => void
   children: React.ReactNode
+  /** Battle stance options can be unavailable (cooldown, sudden death). */
+  disabled?: boolean
+  title?: string
 }
 
 /** One selectable option inside a FilterPopup (TYPE/RARITY/SORT/... rows). */
-export function FilterOption({ active, gold, onClick, children }: Props) {
+export function FilterOption({ active, gold, onClick, children, disabled = false, title }: Props) {
   return (
     <button
       className={`filter-btn filter-btn--sm${active ? ' filter-btn--active' : ''}${gold ? ' filter-btn--gold' : ''}`}
       onClick={onClick}
+      disabled={disabled}
+      title={title}
     >
       {children}
     </button>

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -167,40 +167,6 @@
   box-shadow: var(--elevation-raised);
 }
 
-/* Base bars as lane-edge overlays (see Battlefield.tsx). Pinned to the lane
-   itself rather than the slot, so they track the play area's exact width even
-   while it is still letterboxed narrower than the frame.
-
-   Only the bar itself takes pointer events — the wrapper spans the full lane
-   width, and swallowing taps across it would kill unit inspection along the
-   top and bottom rows. */
-.lane-base-bar {
-  position: absolute;
-  left: 0;
-  right: 0;
-  z-index: 4;
-  display: flex;
-  padding: 3px;
-  pointer-events: none;
-}
-
-.lane-base-bar > * {
-  flex: 1;
-  pointer-events: auto;
-}
-
-.lane-base-bar--opponent { top: 0; }
-.lane-base-bar--player { bottom: 0; }
-
-/* Units spawn at their base — i.e. directly under these bars now that the bars
-   sit inside the lane. #2176 gave .base-bar a solid fill so its text stayed
-   legible over bright terrain; keep most of that, but not so much that a freshly
-   spawned unit is invisible until it walks out. Units read through as shapes,
-   while the HP fill and label still have ~80% of a solid backing behind them. */
-.lane-base-bar .base-bar {
-  background: color-mix(in srgb, var(--surface-1) 80%, transparent);
-}
-
 .base-bar--opponent {
   border-color: var(--color-red);
   color: var(--color-red);
@@ -316,7 +282,7 @@
      the cap the track is exactly as wide as its pips need; above it, the pips
      share 96px instead. flex: 0 0 auto because the HP track next to it is
      flex: 1 and would otherwise shrink this to its min-width. */
-  width: min(96px, calc(var(--mana-pips, 10) * 14px));
+  width: min(84px, calc(var(--mana-pips, 10) * 14px));
   flex: 0 0 auto;
 }
 
@@ -596,18 +562,23 @@
 
 /* ─── Hand Panel ─────────────────────────────────────── */
 
-.stance-bar {
-  display: flex;
-  gap: 4px;
-  padding: 3px 6px;
-  border-top: 1px solid var(--game-border);
-  flex-shrink: 0;
-  background: var(--surface-1);
+/* The stance selector lives inside the player base bar's right-hand slot now,
+   not in a band of its own. Its popup therefore has to open UPWARDS and align
+   to the right — .filter-popup's default drops down from the left, which from
+   the bottom bar would open straight off the bottom of the screen. */
+.stance-control .filter-popup {
+  top: auto;
+  bottom: calc(100% + 4px);
+  left: auto;
+  right: 0;
+  /* The shared default is 260px, wider than this bar has to give. */
+  min-width: 0;
+  width: max-content;
+  max-width: 60vw;
 }
 
-.stance-bar .filter-btn {
-  flex: 1;
-  text-align: center;
+.stance-control .filter-btn {
+  white-space: nowrap;
 }
 
 /* ─── Battle HUD control density ──────────────────────
@@ -620,7 +591,8 @@
    These targets stay 32px tall and are 60-90px WIDE, well clear of WCAG 2.2
    AA's 24x24 minimum (2.5.8). It relaxes only the AAA 44x44 target (2.5.5), and
    only here — every other button in the game keeps the full 44px. */
-.stance-bar .action-btn,
+.stance-control .action-btn,
+.base-bar .action-btn,
 .top-bar .action-btn {
   min-height: 32px;
 }


### PR DESCRIPTION
Part of #2165. Follows #2221, and fixes the risk that PR flagged.

## The problem

#2221 reclaimed the base HP bars' ~100px by riding them on the lane's own top and bottom edges. That covered exactly the wrong strip:

- Each bar spans **~9% of the lane** at its end.
- On the engine's 0–500 forward axis that hides roughly **x = 0…44**.
- `PLAYER_SPAWN_X` is **30**, `COMMANDER_HOME_X` is **15**, `OPPONENT_SPAWN_X` is **470** (`game/engine/constants.ts`).

So spawners, freshly spawned units, and the commander at its home position all sat underneath a bar. The 80% translucency wasn't enough — that strip is where everything enters play.

## The fix

**Bars go back into the bands** above and below the lane. The height is paid for by **retiring the stance row** instead, per your call to move those buttons elsewhere.

`StanceBar` becomes a single trigger + popup rather than up to five always-visible buttons, and moves into the player base bar's right-hand slot beside mana and speed:

- Reuses **`FilterPopup`** — already the shared trigger + dropdown + outside-click shell behind Collection's and the deck builder's filter menus, and its trigger is the same `.filter-btn` `StanceBar` was already rendering.
- `FilterOption` gains optional `disabled`/`title` so the cooldown and sudden-death rules survive unchanged.
- The trigger carries whichever timer is live (duration or cooldown), so the state the row showed inline is still visible without opening anything.
- The popup opens **upward and right-aligned** — the shared default drops down from the left, which from the bottom bar would open off the bottom of the screen.

A popup suits this control better than the fixed row did anyway: `allowedStances` varies by node (boss battles permit only auto/defend), so the row's width already changed under the player, and a cooling-down stance reads more clearly as a disabled list row than as one greyed button among five.

Also trimmed the mana track cap **96px → 84px**, since that row now carries the stance control too — at 360px wide it buys the HP track back 12px.

## Result — measured at 360 / 390 / 430

| | 360×800 | 390×844 | 430×932 |
|---|---|---|---|
| lane | 320×498 | **355×552** | 411×639 |
| pillarboxing | 9% | **6%** | 2% |
| `.base-bar` inside `.lane` | **0** | **0** | **0** |
| band reserved == actual | ✓ | ✓ | ✓ |

For reference, before any of this work the battlefield was **310×481 at 18% pillarboxing, plus the 20px overlap bug**. So this still lands **~+31% play area** over where it started — with the spawn strip completely clear.

Giving up the last 6% to reach full width would need the HUD under 232px, and that would have to come out of the hand or the base bars. Not worth it; 6% is the resting point.

## Verification

- Geometry probe at all three widths asserting **zero `.base-bar` descendants of `.lane`** and no stale `.stance-bar` node.
- Programmatic check that the popup's bottom edge sits above the trigger's top (opens upward) and stays in the viewport.
- Screenshots with the popup both closed and open.
- `npx tsc --noEmit`, `npm run build`, full `npx vitest run` — **2917 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_