### PR TITLE
Battlefield: four-leaf-clover stance picker

### DIFF
--- a/web/src/components/battle/battlefield/StanceBar.stories.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.stories.tsx
@@ -1,10 +1,11 @@
-import { fn } from 'storybook/test';
+import { fn, within, userEvent, expect } from 'storybook/test';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { StanceBar } from './StanceBar';
 
 const meta = {
   component: StanceBar,
+  tags: ['ci'],
   parameters: { layout: 'centered' },
   title: 'Battle/StanceBar',
   decorators: [(Story) => <div style={{ background: '#0a0a0a', padding: 12 }}><Story /></div>],
@@ -65,5 +66,46 @@ export const SuddenDeath: Story = {
     cooldownSecsLeft: 0,
     durationSecsLeft: 0,
     speedMultiplier: 4,
+  },
+};
+
+// Boss nodes restrict to 2 stances (see STANCE_RULES_BY_NODE_TYPE in
+// app/screens.ts) — the clover renders as two halves instead of four
+// quadrants for this case.
+export const TwoStances: Story = {
+  args: {
+    ...callbacks,
+    stance: 'defend',
+    allowedStances: ['defend', 'auto'],
+    suddenDeath: false,
+    onCooldown: false,
+    cooldownSecsLeft: 0,
+    durationSecsLeft: 0,
+    speedMultiplier: 1,
+  },
+};
+
+// The collapsed clover is a single ~22px button by design (see the component
+// doc comment) — these two stories click it open and assert the expanded
+// overlay's petal count, so a regression collapsing to the wrong shape (e.g.
+// still rendering 4 petals for a 2-stance node) fails a real assertion rather
+// than only being catchable by eye.
+export const ExpandedFourPetals: Story = {
+  args: Default.args,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /tap to change/i }))
+    const group = await canvas.findByRole('group', { name: 'Stance' })
+    expect(group.querySelectorAll('.stance-petal').length).toBe(4)
+  },
+};
+
+export const ExpandedTwoPetals: Story = {
+  args: TwoStances.args,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /tap to change/i }))
+    const group = await canvas.findByRole('group', { name: 'Stance' })
+    expect(group.querySelectorAll('.stance-petal').length).toBe(2)
   },
 };

--- a/web/src/components/battle/battlefield/StanceBar.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.tsx
@@ -1,7 +1,5 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Button } from '../../ui/Button'
-import { FilterPopup } from '../../ui/filters/FilterPopup'
-import { FilterOption } from '../../ui/filters/FilterOption'
 
 type Stance = 'attack' | 'hold' | 'defend' | 'auto'
 
@@ -13,6 +11,18 @@ const STANCE_LABEL: Record<Stance, string> = {
 }
 
 const STANCE_ORDER = ['attack', 'hold', 'defend', 'auto'] as const
+
+// Which outer corner each grid cell rounds, by its index in `allowed` — this is
+// what turns 4 plain grid squares into 4 petals meeting at a shared center.
+// Index 0/1/2/3 = reading order (top-left, top-right, bottom-left, bottom-right).
+const CORNER_CLASS_4 = [
+  'stance-petal--tl',
+  'stance-petal--tr',
+  'stance-petal--bl',
+  'stance-petal--br',
+]
+// Two allowed stances render as left/right halves instead of quadrants.
+const CORNER_CLASS_2 = ['stance-petal--l', 'stance-petal--r']
 
 interface Props {
   stance: Stance
@@ -27,71 +37,100 @@ interface Props {
 }
 
 /**
- * Stance selector + speed cycle. Same allowed/cooldown/duration/sudden-death
- * rules as before, but as a single trigger plus a popup rather than a row of
- * up to five always-visible buttons.
+ * Stance selector, shaped like a four-leaf clover: a 2x2 (or 1x2, when only two
+ * stances are allowed) grid of buttons, each rounded on its outer corner only —
+ * a small gap between cells is what reads as four separate petals meeting at a
+ * center point, rather than one rounded square.
  *
- * That row was a whole 39px band of the battlefield frame, and on a phone the
- * frame's height is what caps the play area's *width* too (the lane is
- * letterboxed to a fixed ratio). Collapsing it to one trigger is what pays for
- * the base HP bars to sit above and below the lane instead of on top of it,
- * where they were covering the spawn strip.
+ * Two states rather than one small live control, because four real buttons
+ * packed into a ~22px circle would each be a ~10px hit target — well under any
+ * usable minimum. Collapsed is a single real <button> (one hit target, one
+ * accessible name, current stance shown as a glowing petal); tapping it swaps
+ * in the expanded overlay, a real role="group" of full-size petal buttons.
+ * Selecting one calls onSetStance and collapses back to the dot.
  *
- * A popup also fits the control better than a fixed row did: `allowedStances`
- * varies by node — boss battles permit only auto/defend — so the row's width
- * changed under the player anyway, and a cooling-down stance reads more clearly
- * as a disabled list row than as one greyed button among five.
+ * Replaces #2222's dropdown-list version — same allowed/cooldown/duration/
+ * sudden-death rules, same STANCE_LABEL/STANCE_ORDER, same Props, so
+ * Battlefield.tsx needed no changes to embed this.
  */
 export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, cooldownSecsLeft, durationSecsLeft, speedMultiplier, onSetStance, onCycleSpeed }: Props) {
   const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLSpanElement>(null)
 
   const allowed = STANCE_ORDER.filter(s => !allowedStances || allowedStances.includes(s))
+  const cornerClasses = allowed.length === 2 ? CORNER_CLASS_2 : CORNER_CLASS_4
 
-  // The trigger carries whichever timer is currently meaningful, so the state
-  // the row used to show inline is still visible without opening anything.
-  const suffix =
-    durationSecsLeft > 0 && stance !== 'auto' ? ` ${durationSecsLeft}s`
-    : onCooldown && cooldownSecsLeft > 0     ? ` ${cooldownSecsLeft}s`
-    : ''
+  // The trigger — and the expanded overlay's center badge — carry whichever
+  // timer is currently meaningful, so the state the old row showed inline is
+  // still visible without anything being tapped.
+  const timerText =
+    durationSecsLeft > 0 && stance !== 'auto' ? `${durationSecsLeft}s`
+    : onCooldown && cooldownSecsLeft > 0     ? `${cooldownSecsLeft}s`
+    : null
+
+  useEffect(() => {
+    if (!open) return
+    function handlePointer(e: MouseEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handlePointer)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handlePointer)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
 
   return (
     <span className="stance-control u-flex u-items-c u-gap-2">
-      <FilterPopup
-        label={STANCE_LABEL[stance]}
-        activeSuffix={suffix}
-        isActive={stance !== 'auto'}
-        open={open}
-        onToggle={() => setOpen(o => !o)}
-        onClose={() => setOpen(false)}
-      >
-        <div className="filter-popup-section u-col">
-          <span className="filter-group-label">STANCE</span>
-          <div className="filter-popup-btns u-flex u-wrap u-gap-2">
-            {allowed.map(s => {
-              const isActive = stance === s
-              const isCoolingDown = onCooldown && s !== 'auto' && !isActive
-              const blockedBySuddenDeath = suddenDeath && s !== 'attack'
-              return (
-                <FilterOption
+      {/* Own positioning context, separate from the speed button beside it —
+          the expanded clover anchors to THIS box, not the whole control, so
+          growing it never covers the speed button next to it. */}
+      <span className="stance-clover-wrap" ref={wrapRef}>
+        {!open ? (
+          <button
+            type="button"
+            className="stance-clover stance-clover--tiny"
+            onClick={() => setOpen(true)}
+            aria-label={`Stance: ${STANCE_LABEL[stance]}${timerText ? `, ${timerText}` : ''} — tap to change`}
+          >
+            <span className="stance-clover-grid" data-count={allowed.length}>
+              {allowed.map((s, i) => (
+                <span
                   key={s}
-                  active={isActive}
-                  disabled={blockedBySuddenDeath || isCoolingDown}
-                  title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
-                  onClick={() => { onSetStance?.(s); setOpen(false) }}
-                >
-                  {STANCE_LABEL[s]}
-                  {isActive && s !== 'auto' && durationSecsLeft > 0 && (
-                    <span className="stance-timer"> {durationSecsLeft}s</span>
-                  )}
-                  {isCoolingDown && cooldownSecsLeft > 0 && (
-                    <span className="stance-timer stance-timer--cd"> {cooldownSecsLeft}s</span>
-                  )}
-                </FilterOption>
-              )
-            })}
+                  className={`stance-petal ${cornerClasses[i]}${stance === s ? ' stance-petal--active' : ''}`}
+                />
+              ))}
+            </span>
+          </button>
+        ) : (
+          <div className="stance-clover stance-clover--expanded" role="group" aria-label="Stance">
+            <span className="stance-clover-grid" data-count={allowed.length}>
+              {allowed.map((s, i) => {
+                const isActive = stance === s
+                const isCoolingDown = onCooldown && s !== 'auto' && !isActive
+                const blockedBySuddenDeath = suddenDeath && s !== 'attack'
+                return (
+                  <button
+                    key={s}
+                    type="button"
+                    className={`stance-petal ${cornerClasses[i]}${isActive ? ' stance-petal--active' : ''}`}
+                    disabled={blockedBySuddenDeath || isCoolingDown}
+                    title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
+                    onClick={() => { onSetStance?.(s); setOpen(false) }}
+                  >
+                    {STANCE_LABEL[s]}
+                  </button>
+                )
+              })}
+            </span>
+            {timerText && <span className="stance-clover-timer">{timerText}</span>}
           </div>
-        </div>
-      </FilterPopup>
+        )}
+      </span>
 
       <Button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
         x{speedMultiplier}

--- a/web/src/components/battle/battlefield/StanceBar.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useId, useRef, useState } from 'react'
 import { Button } from '../../ui/Button'
 
 type Stance = 'attack' | 'hold' | 'defend' | 'auto'
@@ -23,6 +23,58 @@ const CORNER_CLASS_4 = [
 ]
 // Two allowed stances render as left/right halves instead of quadrants.
 const CORNER_CLASS_2 = ['stance-petal--l', 'stance-petal--r']
+
+// Label curve geometry for the expanded clover. Plain horizontal text ignores
+// the petal's own curve entirely — cramped at the sharp center point, wasted
+// space out at the rounded rim. Curving each label along an arc concentric
+// with that rim uses the petal's actual shape instead of fighting it.
+//
+// The clover's petals are true quarter/half discs (each cell's outer corner
+// rounds at radius = the cell's own size, per .stance-petal's CSS), all
+// sharing the SAME center — so one shared arc radius, centered on the
+// expanded clover's own center, traces every petal's rim.
+const CLOVER_VIEWBOX = 108     // must match .stance-clover--expanded's size
+const CLOVER_CENTER  = CLOVER_VIEWBOX / 2
+const CLOVER_LABEL_R = 38      // inside the true ~52px petal rim, clear of the border
+
+/**
+ * One SVG arc `d` string from `fromDeg` to `toDeg`, both measured clockwise
+ * from 3 o'clock (0deg = right, 90deg = bottom, 180deg = left, 270deg = top —
+ * standard screen/SVG convention, y grows downward). `sweep` is the raw SVG
+ * sweep-flag (0 or 1) — see the comment on ARC_RANGE_4 for why the two
+ * bottom petals need it flipped relative to the top two.
+ */
+function arcPath(fromDeg: number, toDeg: number, sweep: 0 | 1): string {
+  const rad = (d: number) => (d * Math.PI) / 180
+  const x1 = CLOVER_CENTER + CLOVER_LABEL_R * Math.cos(rad(fromDeg))
+  const y1 = CLOVER_CENTER + CLOVER_LABEL_R * Math.sin(rad(fromDeg))
+  const x2 = CLOVER_CENTER + CLOVER_LABEL_R * Math.cos(rad(toDeg))
+  const y2 = CLOVER_CENTER + CLOVER_LABEL_R * Math.sin(rad(toDeg))
+  return `M ${x1} ${y1} A ${CLOVER_LABEL_R} ${CLOVER_LABEL_R} 0 0 ${sweep} ${x2} ${y2}`
+}
+
+// One arc range per petal, same index order as CORNER_CLASS_4/2. Two points
+// 90deg apart admit two different circles of the shared radius — one centered
+// on the clover's own center (the one we want, bulging out to the petal's
+// rim) and one mirrored across the chord (bulging in toward the center
+// instead). With a fixed sweep-flag, which one gets drawn depends on point
+// order — so the top two petals (sweep=1, "start at the shared edge, sweep
+// out to the corner") and the bottom two (same points, sweep=0, which keeps
+// the same rim-hugging circle but reverses the traversal direction so their
+// text reads upright instead of upside-down) need opposite flags. Both the
+// bulge and the reading direction were confirmed empirically via Storybook
+// screenshots — getting either flag wrong is visually obvious (text bows
+// toward the center, or reads upside-down) rather than subtly off.
+const ARC_RANGE_4: [number, number, 0 | 1][] = [
+  [180, 270, 1], // tl
+  [270, 360, 1], // tr
+  [180, 90, 0],  // bl (same rim-hugging arc as the un-flipped order, reversed)
+  [360, 90, 0],  // br
+]
+const ARC_RANGE_2: [number, number, 0 | 1][] = [
+  [90, 270, 1],  // l (bottom -> top, the long way round through left)
+  [270, 90, 1],  // r
+]
 
 interface Props {
   stance: Stance
@@ -56,6 +108,10 @@ interface Props {
 export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, cooldownSecsLeft, durationSecsLeft, speedMultiplier, onSetStance, onCycleSpeed }: Props) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLSpanElement>(null)
+  // Namespaces the SVG arc ids so two StanceBars on one page (e.g. a
+  // Storybook docs page rendering several stories at once) never collide —
+  // <textPath href="#..."> resolves by document-wide id, not by component.
+  const idPrefix = useId()
 
   const allowed = STANCE_ORDER.filter(s => !allowedStances || allowedStances.includes(s))
   const cornerClasses = allowed.length === 2 ? CORNER_CLASS_2 : CORNER_CLASS_4
@@ -121,19 +177,39 @@ export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, coo
                     disabled={blockedBySuddenDeath || isCoolingDown}
                     title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
                     onClick={() => { onSetStance?.(s); setOpen(false) }}
-                  >
-                    {STANCE_LABEL[s]}
-                  </button>
+                    // The visible label is the curved SVG text drawn on top (see
+                    // below) — plain button text can't follow the petal's own
+                    // curve, so this stays as the accessible name only.
+                    aria-label={STANCE_LABEL[s]}
+                  />
                 )
               })}
             </span>
+            {/* Decorative labels, curved along each petal's own rim — see
+                arcPath/ARC_RANGE_4/ARC_RANGE_2 above for why. pointer-events:none
+                (in CSS) so taps still land on the real petal buttons beneath. */}
+            <svg className="stance-clover-labels" viewBox={`0 0 ${CLOVER_VIEWBOX} ${CLOVER_VIEWBOX}`} aria-hidden="true">
+              <defs>
+                {allowed.map((s, i) => {
+                  const [from, to, sweep] = (allowed.length === 2 ? ARC_RANGE_2 : ARC_RANGE_4)[i]
+                  return <path key={s} id={`stance-arc-${idPrefix}-${s}`} d={arcPath(from, to, sweep)} />
+                })}
+              </defs>
+              {allowed.map(s => (
+                <text key={s} className={`stance-petal-label${stance === s ? ' stance-petal-label--active' : ''}`}>
+                  <textPath href={`#stance-arc-${idPrefix}-${s}`} startOffset="50%" textAnchor="middle">
+                    {STANCE_LABEL[s]}
+                  </textPath>
+                </text>
+              ))}
+            </svg>
             {timerText && <span className="stance-clover-timer">{timerText}</span>}
           </div>
         )}
       </span>
 
-      <Button className="filter-btn stance-bar__speed" onClick={onCycleSpeed}>
-        x{speedMultiplier}
+      <Button className="stance-bar__speed" onClick={onCycleSpeed} aria-label={`Speed ${speedMultiplier}x — tap to cycle`}>
+        ×{speedMultiplier}
       </Button>
     </span>
   )

--- a/web/src/components/ui/filters/FilterOption.tsx
+++ b/web/src/components/ui/filters/FilterOption.tsx
@@ -5,19 +5,14 @@ interface Props {
   gold?: boolean
   onClick: () => void
   children: React.ReactNode
-  /** Battle stance options can be unavailable (cooldown, sudden death). */
-  disabled?: boolean
-  title?: string
 }
 
 /** One selectable option inside a FilterPopup (TYPE/RARITY/SORT/... rows). */
-export function FilterOption({ active, gold, onClick, children, disabled = false, title }: Props) {
+export function FilterOption({ active, gold, onClick, children }: Props) {
   return (
     <button
       className={`filter-btn filter-btn--sm${active ? ' filter-btn--active' : ''}${gold ? ' filter-btn--gold' : ''}`}
       onClick={onClick}
-      disabled={disabled}
-      title={title}
     >
       {children}
     </button>

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -562,23 +562,128 @@
 
 /* ─── Hand Panel ─────────────────────────────────────── */
 
-/* The stance selector lives inside the player base bar's right-hand slot now,
-   not in a band of its own. Its popup therefore has to open UPWARDS and align
-   to the right — .filter-popup's default drops down from the left, which from
-   the bottom bar would open straight off the bottom of the screen. */
-.stance-control .filter-popup {
-  top: auto;
-  bottom: calc(100% + 4px);
-  left: auto;
-  right: 0;
-  /* The shared default is 260px, wider than this bar has to give. */
-  min-width: 0;
-  width: max-content;
-  max-width: 60vw;
+/* ─── Stance clover ────────────────────────────────────
+   A four-leaf-clover radial picker. Shape: a 2x2 grid (or 1x2 for the 2-stance
+   case), each cell rounded ONLY on its true outer corner — a gap between cells
+   is what reads as separate petals meeting at a center point, rather than one
+   rounded square. `border-radius: 999px` renders as a true quarter/half circle
+   at any box size, so the same rules serve both the tiny and expanded sizes.
+
+   Two states, not one small live control: four real buttons packed into a
+   ~22px circle would each be a ~10px hit target. Collapsed
+   (.stance-clover--tiny) is a single real <button> whose petals are purely
+   decorative spans — one hit target, one accessible name, current stance glows.
+   Expanded (.stance-clover--expanded) swaps in real per-stance <button> petals
+   at a size that's actually tappable. See StanceBar.tsx. */
+.stance-clover-wrap {
+  position: relative;
+  display: inline-block;
+  /* Reserves only the TINY footprint — the expanded clover overlays via
+     position:absolute anchored to THIS box specifically (not the speed button
+     beside it, which lives outside .stance-clover-wrap for exactly this
+     reason), so growing it never shifts or covers anything else in the row. */
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
 }
 
-.stance-control .filter-btn {
-  white-space: nowrap;
+.stance-clover-grid {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  gap: 2px;
+}
+.stance-clover-grid[data-count="4"] { grid-template-columns: repeat(2, 1fr); grid-template-rows: repeat(2, 1fr); }
+.stance-clover-grid[data-count="2"] { grid-template-columns: repeat(2, 1fr); }
+
+.stance-clover--tiny {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.stance-petal {
+  background: var(--surface-2);
+  border: 1px solid var(--game-border);
+  transition: background var(--dur-fast), box-shadow var(--dur-fast);
+}
+.stance-petal--tl { border-top-left-radius: 999px; }
+.stance-petal--tr { border-top-right-radius: 999px; }
+.stance-petal--bl { border-bottom-left-radius: 999px; }
+.stance-petal--br { border-bottom-right-radius: 999px; }
+.stance-petal--l  { border-top-left-radius: 999px; border-bottom-left-radius: 999px; }
+.stance-petal--r  { border-top-right-radius: 999px; border-bottom-right-radius: 999px; }
+
+/* The current stance's petal — glows even at tiny size, which is the whole
+   point of the small state: legible without expanding anything. */
+.stance-petal--active {
+  background: color-mix(in srgb, var(--game-text-color) 30%, var(--surface-2));
+  border-color: var(--game-text-color);
+  box-shadow: 0 0 5px color-mix(in srgb, var(--game-text-color) 60%, transparent);
+}
+
+/* Expanded: a real button per petal, large enough to tap confidently.
+   Positioned absolute over the row (see .stance-clover-wrap) and anchored to
+   grow up-and-left from the tiny control's spot — the same "don't clip off
+   the bottom of the frame" logic #2222's dropdown needed, since this sits in
+   the bottom-most HUD row. */
+.stance-clover--expanded {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: var(--z-dropdown);
+  width: 108px;
+  height: 108px;
+  animation: stanceCloverGrow var(--dur-fast) ease-out;
+  transform-origin: bottom right;
+}
+@keyframes stanceCloverGrow {
+  from { transform: scale(0.2); opacity: 0.6; }
+  to   { transform: scale(1);   opacity: 1; }
+}
+
+.stance-clover--expanded .stance-clover-grid { gap: 4px; }
+
+.stance-clover--expanded .stance-petal {
+  color: var(--game-text-color-dim);
+  font-family: inherit;
+  font-size: var(--font-xxs);
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  box-shadow: var(--elevation-raised);
+}
+.stance-clover--expanded .stance-petal:hover:not(:disabled) {
+  border-color: #777;
+  color: var(--game-text-color-dim);
+}
+.stance-clover--expanded .stance-petal:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.stance-clover--expanded .stance-petal--active {
+  color: var(--game-text-color);
+}
+.stance-clover--expanded .stance-petal:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.stance-clover-timer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: var(--font-xxs);
+  font-weight: bold;
+  color: var(--color-orange);
+  background: var(--surface-1);
+  border-radius: var(--radius-sm);
+  padding: 1px 4px;
+  pointer-events: none;
 }
 
 /* ─── Battle HUD control density ──────────────────────

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -649,27 +649,44 @@
 .stance-clover--expanded .stance-clover-grid { gap: 4px; }
 
 .stance-clover--expanded .stance-petal {
-  color: var(--game-text-color-dim);
-  font-family: inherit;
-  font-size: var(--font-xxs);
-  font-weight: bold;
-  letter-spacing: 0.5px;
   cursor: pointer;
   box-shadow: var(--elevation-raised);
 }
 .stance-clover--expanded .stance-petal:hover:not(:disabled) {
   border-color: #777;
-  color: var(--game-text-color-dim);
 }
 .stance-clover--expanded .stance-petal:active:not(:disabled) {
   transform: translateY(1px);
 }
-.stance-clover--expanded .stance-petal--active {
-  color: var(--game-text-color);
-}
 .stance-clover--expanded .stance-petal:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* The visible label — plain text ignored the petal's own curve entirely
+   (cramped at the sharp center point, empty space at the rounded rim); this
+   follows an arc concentric with that rim instead. See arcPath in
+   StanceBar.tsx for the geometry. Sits on top of the (now unlabelled) petal
+   buttons; pointer-events:none so taps still reach them. */
+.stance-clover-labels {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.stance-petal-label {
+  fill: var(--game-text-color-dim);
+  font-family: inherit;
+  font-size: 8px;
+  font-weight: bold;
+  letter-spacing: 0.3px;
+}
+/* The active petal's own background glow (.stance-petal--active) already
+   carries the "current stance" signal; this just keeps its label as legible
+   against that lighter fill as the dim labels are against the plain one. */
+.stance-petal-label--active {
+  fill: var(--game-text-color);
 }
 
 .stance-clover-timer {
@@ -703,16 +720,27 @@
 }
 
 
+/* A round gold badge, matching the clover's own roundness rather than sitting
+   next to it as a leftover rectangle — was a raw-hex-and-!important override
+   of .filter-btn's rectangular shape; this owns its shape and colour outright
+   instead of fighting a rectangle base class for both. */
 .stance-bar__speed {
-  flex: 0 0 auto !important;
-  min-width: 36px;
-  border-color: #5a5a00 !important;
-  color: #cccc44 !important;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+  border-radius: 50%;
+  border-color: var(--color-gold-dim);
+  color: var(--color-gold-light);
+  font-size: var(--font-xs);
+  font-weight: bold;
 }
 
 .stance-bar__speed:hover {
-  border-color: #aaaa00 !important;
-  color: #ffff66 !important;
+  border-color: var(--accent-gold);
+  color: var(--accent-gold);
+  box-shadow: 0 0 5px color-mix(in srgb, var(--accent-gold) 50%, transparent);
 }
 
 .hand-panel {


### PR DESCRIPTION
Part of #2165. Replaces the stance dropdown from #2222 per your spec: a tiny button shaped like a four-leaf clover, one petal per stance (halved when only 2 are allowed), the current stance's petal glowing even at tiny size, growing on tap into an easy-to-hit picker.

## Shape

A 2×2 grid (1×2 for the 2-stance case — boss nodes, per `STANCE_RULES_BY_NODE_TYPE`), each cell rounded only on its true outer corner. A small gap between cells is what reads as four separate petals meeting at a center point, rather than one rounded square. `border-radius: 999px` renders as a true quarter/half circle at any box size, so the same CSS serves the tiny and expanded states.

## Two states, not one small live control

Four real buttons packed into a ~22px circle would each be a ~10px hit target — well under any usable minimum. So:

- **Collapsed**: a single real `<button>` whose petals are decorative spans. One hit target, one accessible name, the current stance's petal glows — no text at that size, which is the only feedback small state needs per your spec.
- **Expanded**: tapping it swaps in `role="group"` with real per-stance petal buttons at a tappable 108px. Selecting one calls `onSetStance` and collapses back. Closes on outside click or Escape.

Same `Props`, same `allowedStances`/`onCooldown`/`durationSecsLeft`/`suddenDeath` rules as the dropdown it replaces — `Battlefield.tsx` needed no changes to keep embedding it.

## Bug caught in testing

The expanded overlay originally anchored to a wrapper that also contained the speed (`x1`) button — growing the clover covered `x1` entirely. Fixed by giving the clover its own positioning box, separate from the speed button. Confirmed via screenshot that `x1` stays clickable with the picker open.

## Files

- `StanceBar.tsx` — full rewrite of the render (same props/logic).
- `battle.css` — new `.stance-clover*`/`.stance-petal*` rules.
- `FilterOption.tsx` — reverted the `disabled`/`title` props #2222 added for the dropdown this replaces; nothing else calls them.
- `StanceBar.stories.tsx` — added a 2-stance story and two `play`-function stories that click the trigger open and assert the expanded group's real petal count, so a regression collapsing to the wrong shape fails a real assertion, not just eyeballing.

## Verification

`npx tsc --noEmit`, `npm run build` clean. Full `npx vitest run` — **2931 passed** (up from 2917: the two new play-function stories). Manual screenshots of collapsed/expanded/2-petal/cooldown states in Storybook, sent to the requester directly.