### PR TITLE
Fix clover label orientation, colour petals, speed becomes a clover

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1053,10 +1053,10 @@ export default function App() {
 
 
   const {
-    handlePlayCard, handlePlayAoeCard, handleSetStance, handleCycleSpeed,
+    handlePlayCard, handlePlayAoeCard, handleSetStance, handleSetSpeed,
     handleWaveRewardPick, handleWaveRewardSkip,
   } = useBattleControls({
-    gameStateRef, dispatch, speedMultiplier,
+    gameStateRef, dispatch,
     isTrainingModeRef, isCampaignRef, campaignPlayCountsRef,
     battleUsedStructure, battleUsedMobileUnit,
     setAchievementToasts, setQuestCompletes,
@@ -1231,13 +1231,13 @@ export default function App() {
     isCampaignRef, worldBattleNodeIdRef, isDailyChallengeRef, isWeeklyChallengeRef, isWandererBattleRef,
     gameStateRef, summaryDoneRef,
     handlePlayCard, handlePlayAoeCard, handleGiveUp, setIsUserPaused,
-    handleSetStance, handleCycleSpeed, handleWaveRewardPick, handleWaveRewardSkip,
+    handleSetStance, handleSetSpeed, handleWaveRewardPick, handleWaveRewardSkip,
     handleOpenPack, handleCampaignWin, handleCampaignRetry, handleDailyChallengeRetry,
     handlePlayAgain, handleWorldBattleRetry, handleMainMenu, handleAbandonRun,
   }), [
     battle, gameState, showBossSplash, actTheme, isCampaign, quickPlayRewardClaimed,
     activeRareEvent, handleRareEventDone,
-    handlePlayCard, handlePlayAoeCard, handleGiveUp, handleSetStance, handleCycleSpeed,
+    handlePlayCard, handlePlayAoeCard, handleGiveUp, handleSetStance, handleSetSpeed,
     handleWaveRewardPick, handleWaveRewardSkip, handleOpenPack, handleCampaignWin,
     handleCampaignRetry, handleDailyChallengeRetry, handlePlayAgain,
     handleWorldBattleRetry, handleMainMenu, handleAbandonRun,

--- a/web/src/app/BattleContext.tsx
+++ b/web/src/app/BattleContext.tsx
@@ -42,7 +42,7 @@ export interface BattleContextValue {
   handleGiveUp:      () => void
   setIsUserPaused:   Dispatch<SetStateAction<boolean>>
   handleSetStance:   (s: NonNullable<GameState['playerStance']>) => void
-  handleCycleSpeed:  () => void
+  handleSetSpeed:    (m: 1 | 2 | 4 | 8) => void
   handleWaveRewardPick: (cardName: string) => void
   handleWaveRewardSkip: () => void
 

--- a/web/src/app/routes/BattleRoutes.tsx
+++ b/web/src/app/routes/BattleRoutes.tsx
@@ -22,7 +22,7 @@ export function BattleRoutes() {
     isCampaignRef, worldBattleNodeIdRef, isDailyChallengeRef, isWeeklyChallengeRef, isWandererBattleRef,
     gameStateRef, summaryDoneRef,
     handlePlayCard, handlePlayAoeCard, handleGiveUp, setIsUserPaused,
-    handleSetStance, handleCycleSpeed, handleWaveRewardPick, handleWaveRewardSkip,
+    handleSetStance, handleSetSpeed, handleWaveRewardPick, handleWaveRewardSkip,
     handleOpenPack, handleCampaignWin, handleCampaignRetry, handleDailyChallengeRetry,
     handlePlayAgain, handleWorldBattleRetry, handleMainMenu, handleAbandonRun,
   } = useBattle()
@@ -53,7 +53,7 @@ export function BattleRoutes() {
         if (gameState.phase.type === 'celebration') {
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={false} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onSetSpeed={handleSetSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
               <VictoryPanel
                 playerScore={gameState.playerScore}
                 opponentScore={gameState.opponentScore}
@@ -69,7 +69,7 @@ export function BattleRoutes() {
         if (gameState.phase.type === 'fingerSmash') {
           return (
             <>
-              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
+              <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onSetSpeed={handleSetSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
               <FingerSmash
                 smashedNames={fingerSmashNames}
                 onDone={() => {
@@ -132,7 +132,7 @@ export function BattleRoutes() {
           />
         ) : (
           <>
-            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onCycleSpeed={handleCycleSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
+            <Battlefield state={gameState} onPlayCard={handlePlayCard} onPlayAoeCard={handlePlayAoeCard} onGiveUp={handleGiveUp} onPause={setIsUserPaused} actTheme={actTheme} activeRelic={run?.activeRelic} showBossSplash={showBossSplash} activeModifiers={run && actData ? getModifiersByCount(actData, run.activeModifierCount) : []} isCampaign={isCampaign} stance={gameState.playerStance ?? 'auto'} onSetStance={handleSetStance} speedMultiplier={speedMultiplier} onSetSpeed={handleSetSpeed} onCounterSpell={() => dispatch({ type: 'COUNTER_SPELL' })} isAdmin={isAdminUser(user)} />
             {showBossShockwave && <BossShockwave onDone={() => dispatch({ type: 'HIDE_BOSS_SHOCKWAVE' })} />}
             {activeRareEvent === 'fakeCrash'   && <FakeCrashEvent   onDone={handleRareEventDone} />}
             {activeRareEvent === 'blackjack'   && <BlackjackEvent   onDone={handleRareEventDone} />}

--- a/web/src/app/useBattleControls.ts
+++ b/web/src/app/useBattleControls.ts
@@ -12,7 +12,6 @@ import { playCardPlay } from '../game/sound'
 interface UseBattleControlsArgs {
   gameStateRef:    MutableRefObject<GameState | null>
   dispatch:        Dispatch<BattleAction>
-  speedMultiplier: number
   /** Per-battle flags App resets from every battle-start path, so they stay owned there. */
   isTrainingModeRef:      MutableRefObject<boolean>
   isCampaignRef:          MutableRefObject<boolean>
@@ -27,14 +26,14 @@ interface UseBattleControlsResult {
   handlePlayCard:       (cardId: string) => void
   handlePlayAoeCard:    (cardId: string, cx: number, cy: number) => void
   handleSetStance:      (s: NonNullable<GameState['playerStance']>) => void
-  handleCycleSpeed:     () => void
+  handleSetSpeed:       (m: 1 | 2 | 4 | 8) => void
   handleWaveRewardPick: (cardName: string) => void
   handleWaveRewardSkip: () => void
 }
 
 /** The player's in-battle inputs: playing cards, stance, speed, and wave rewards. */
 export function useBattleControls({
-  gameStateRef, dispatch, speedMultiplier,
+  gameStateRef, dispatch,
   isTrainingModeRef, isCampaignRef, campaignPlayCountsRef,
   battleUsedStructure, battleUsedMobileUnit,
   setAchievementToasts, setQuestCompletes,
@@ -109,15 +108,13 @@ export function useBattleControls({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleCycleSpeed = useCallback(() => {
-    const order = [1, 2, 4, 8] as const
-    const next = order[(order.indexOf(speedMultiplier as 1 | 2 | 4 | 8) + 1) % order.length]
-    dispatch({ type: 'SET_SPEED', multiplier: next })
+  const handleSetSpeed = useCallback((multiplier: 1 | 2 | 4 | 8) => {
+    dispatch({ type: 'SET_SPEED', multiplier })
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [speedMultiplier])
+  }, [])
 
   return {
-    handlePlayCard, handlePlayAoeCard, handleSetStance, handleCycleSpeed,
+    handlePlayCard, handlePlayAoeCard, handleSetStance, handleSetSpeed,
     handleWaveRewardPick, handleWaveRewardSkip,
   }
 }

--- a/web/src/components/battle/Battlefield.tsx
+++ b/web/src/components/battle/Battlefield.tsx
@@ -58,7 +58,7 @@ interface Props {
   stance?: NonNullable<GameState['playerStance']>
   onSetStance?: (s: NonNullable<GameState['playerStance']>) => void
   speedMultiplier?: 1 | 2 | 4 | 8
-  onCycleSpeed?: () => void
+  onSetSpeed?: (m: 1 | 2 | 4 | 8) => void
   onCounterSpell?: () => void
   /** True for the game admin. Together with `?dev` this reveals the dev-only
    *  passability overlay toggle in the pause menu. Passed as a boolean rather
@@ -96,7 +96,7 @@ function opponentPortraitSlug(bossAI: string | undefined, actTheme: string | und
   return 'bandit'
 }
 
-export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign, stance = 'auto', onSetStance, speedMultiplier = 1, onCycleSpeed, onCounterSpell, isAdmin = false }: Props) {
+export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPause, actTheme, activeRelic, showBossSplash, activeModifiers, isCampaign, stance = 'auto', onSetStance, speedMultiplier = 1, onSetSpeed, onCounterSpell, isAdmin = false }: Props) {
   const { openDetail, cardDetailNode } = useCardDetail()
   const [heroLightning, setHeroLightning] = useState<{ owner: 'player' | 'opponent'; key: number } | null>(null)
   const [paused, setPaused] = useState(false)
@@ -441,7 +441,7 @@ export function Battlefield({ state, onPlayCard, onPlayAoeCard, onGiveUp, onPaus
                 durationSecsLeft={durationSecsLeft}
                 speedMultiplier={speedMultiplier}
                 onSetStance={onSetStance}
-                onCycleSpeed={onCycleSpeed}
+                onSetSpeed={onSetSpeed}
               />
             </>}
           />

--- a/web/src/components/battle/battlefield/SpeedClover.stories.tsx
+++ b/web/src/components/battle/battlefield/SpeedClover.stories.tsx
@@ -1,0 +1,44 @@
+import { fn, within, userEvent, expect } from 'storybook/test';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { SpeedClover } from './SpeedClover';
+
+const meta = {
+  component: SpeedClover,
+  tags: ['ci'],
+  parameters: { layout: 'centered' },
+  title: 'Battle/SpeedClover',
+  decorators: [(Story) => <div style={{ background: '#0a0a0a', padding: 12 }}><Story /></div>],
+} satisfies Meta<typeof SpeedClover>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const OneX: Story = {
+  args: { speedMultiplier: 1, onSetSpeed: fn() },
+};
+
+export const TwoX: Story = {
+  args: { speedMultiplier: 2, onSetSpeed: fn() },
+};
+
+export const FourX: Story = {
+  args: { speedMultiplier: 4, onSetSpeed: fn() },
+};
+
+export const EightX: Story = {
+  args: { speedMultiplier: 8, onSetSpeed: fn() },
+};
+
+// Same pattern as StanceBar.stories.tsx's expanded stories: clicking the tiny meter
+// open should always yield 4 real petal buttons, one per speed option.
+export const Expanded: Story = {
+  args: { speedMultiplier: 2, onSetSpeed: fn() },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /tap to change/i }))
+    const group = await canvas.findByRole('group', { name: 'Speed' })
+    expect(group.querySelectorAll('.stance-petal').length).toBe(4)
+  },
+};

--- a/web/src/components/battle/battlefield/SpeedClover.tsx
+++ b/web/src/components/battle/battlefield/SpeedClover.tsx
@@ -1,0 +1,85 @@
+import React, { useId, useRef, useState } from 'react'
+import { useClickOutsideToClose } from '../../../hooks/useClickOutsideToClose'
+import { CORNER_CLASS_4, CLOVER_VIEWBOX, ARC_RANGE_4, arcPath } from './cloverGeometry'
+
+const SPEED_ORDER = [1, 2, 4, 8] as const
+type Speed = typeof SPEED_ORDER[number]
+
+interface Props {
+  speedMultiplier: Speed
+  onSetSpeed?: (m: Speed) => void
+}
+
+/**
+ * Battle-speed control, shaped like the stance clover beside it. Collapsed, it's a
+ * level meter rather than a selector — one quadrant filled at 1x, two at 2x, three at
+ * 4x, all four at 8x — since speed is a single quantity growing, not four distinct
+ * choices. Tapping it expands into the same kind of picker StanceBar uses: one real
+ * button per speed value, tap to select and collapse.
+ */
+export function SpeedClover({ speedMultiplier, onSetSpeed }: Props) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLSpanElement>(null)
+  const idPrefix = useId()
+
+  const filledCount = SPEED_ORDER.indexOf(speedMultiplier) + 1
+
+  useClickOutsideToClose(open, () => setOpen(false), wrapRef)
+
+  return (
+    <span className="stance-clover-wrap" ref={wrapRef}>
+      {!open ? (
+        <button
+          type="button"
+          className="stance-clover stance-clover--tiny"
+          onClick={() => setOpen(true)}
+          aria-label={`Speed: ${speedMultiplier}x — tap to change`}
+        >
+          <span className="stance-clover-grid" data-count={4}>
+            {SPEED_ORDER.map((s, i) => (
+              <span
+                key={s}
+                className={`stance-petal ${CORNER_CLASS_4[i]}${i < filledCount ? ' stance-petal--filled' : ''}`}
+              />
+            ))}
+          </span>
+        </button>
+      ) : (
+        <div className="stance-clover stance-clover--expanded" role="group" aria-label="Speed">
+          <span className="stance-clover-grid" data-count={4}>
+            {SPEED_ORDER.map((s, i) => (
+              <button
+                key={s}
+                type="button"
+                className={`stance-petal ${CORNER_CLASS_4[i]}${s === speedMultiplier ? ' stance-petal--active' : ''}`}
+                onClick={() => { onSetSpeed?.(s); setOpen(false) }}
+                // The visible label is the curved SVG text drawn on top (see below) —
+                // plain button text can't follow the petal's own curve, so this stays
+                // as the accessible name only.
+                aria-label={`${s}x`}
+              />
+            ))}
+          </span>
+          {/* Decorative labels, curved along each petal's own rim — see arcPath in
+              cloverGeometry.ts for why. pointer-events:none (in CSS) so taps still
+              land on the real petal buttons beneath. */}
+          <svg className="stance-clover-labels" viewBox={`0 0 ${CLOVER_VIEWBOX} ${CLOVER_VIEWBOX}`} aria-hidden="true">
+            <defs>
+              {SPEED_ORDER.map((s, i) => {
+                const [from, to] = ARC_RANGE_4[i]
+                return <path key={s} id={`speed-arc-${idPrefix}-${s}`} d={arcPath(from, to)} />
+              })}
+            </defs>
+            {SPEED_ORDER.map(s => (
+              <text key={s} className={`stance-petal-label${s === speedMultiplier ? ' stance-petal-label--active' : ''}`}>
+                <textPath href={`#speed-arc-${idPrefix}-${s}`} startOffset="50%" textAnchor="middle">
+                  {s}x
+                </textPath>
+              </text>
+            ))}
+          </svg>
+        </div>
+      )}
+    </span>
+  )
+}

--- a/web/src/components/battle/battlefield/StanceBar.stories.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const callbacks = { onSetStance: fn(), onCycleSpeed: fn() };
+const callbacks = { onSetStance: fn(), onSetSpeed: fn() };
 
 export const Default: Story = {
   args: {
@@ -94,7 +94,9 @@ export const ExpandedFourPetals: Story = {
   args: Default.args,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await userEvent.click(canvas.getByRole('button', { name: /tap to change/i }))
+    // StanceBar now renders SpeedClover beside it, which has its own "tap to
+    // change" trigger — match on the Stance-specific label to avoid grabbing both.
+    await userEvent.click(canvas.getByRole('button', { name: /^Stance:.*tap to change/i }))
     const group = await canvas.findByRole('group', { name: 'Stance' })
     expect(group.querySelectorAll('.stance-petal').length).toBe(4)
   },
@@ -104,7 +106,7 @@ export const ExpandedTwoPetals: Story = {
   args: TwoStances.args,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    await userEvent.click(canvas.getByRole('button', { name: /tap to change/i }))
+    await userEvent.click(canvas.getByRole('button', { name: /^Stance:.*tap to change/i }))
     const group = await canvas.findByRole('group', { name: 'Stance' })
     expect(group.querySelectorAll('.stance-petal').length).toBe(2)
   },

--- a/web/src/components/battle/battlefield/StanceBar.tsx
+++ b/web/src/components/battle/battlefield/StanceBar.tsx
@@ -1,5 +1,9 @@
-import React, { useEffect, useId, useRef, useState } from 'react'
-import { Button } from '../../ui/Button'
+import React, { useId, useRef, useState } from 'react'
+import { useClickOutsideToClose } from '../../../hooks/useClickOutsideToClose'
+import { SpeedClover } from './SpeedClover'
+import {
+  CORNER_CLASS_4, CORNER_CLASS_2, CLOVER_VIEWBOX, ARC_RANGE_4, ARC_RANGE_2, arcPath,
+} from './cloverGeometry'
 
 type Stance = 'attack' | 'hold' | 'defend' | 'auto'
 
@@ -12,69 +16,15 @@ const STANCE_LABEL: Record<Stance, string> = {
 
 const STANCE_ORDER = ['attack', 'hold', 'defend', 'auto'] as const
 
-// Which outer corner each grid cell rounds, by its index in `allowed` — this is
-// what turns 4 plain grid squares into 4 petals meeting at a shared center.
-// Index 0/1/2/3 = reading order (top-left, top-right, bottom-left, bottom-right).
-const CORNER_CLASS_4 = [
-  'stance-petal--tl',
-  'stance-petal--tr',
-  'stance-petal--bl',
-  'stance-petal--br',
-]
-// Two allowed stances render as left/right halves instead of quadrants.
-const CORNER_CLASS_2 = ['stance-petal--l', 'stance-petal--r']
-
-// Label curve geometry for the expanded clover. Plain horizontal text ignores
-// the petal's own curve entirely — cramped at the sharp center point, wasted
-// space out at the rounded rim. Curving each label along an arc concentric
-// with that rim uses the petal's actual shape instead of fighting it.
-//
-// The clover's petals are true quarter/half discs (each cell's outer corner
-// rounds at radius = the cell's own size, per .stance-petal's CSS), all
-// sharing the SAME center — so one shared arc radius, centered on the
-// expanded clover's own center, traces every petal's rim.
-const CLOVER_VIEWBOX = 108     // must match .stance-clover--expanded's size
-const CLOVER_CENTER  = CLOVER_VIEWBOX / 2
-const CLOVER_LABEL_R = 38      // inside the true ~52px petal rim, clear of the border
-
-/**
- * One SVG arc `d` string from `fromDeg` to `toDeg`, both measured clockwise
- * from 3 o'clock (0deg = right, 90deg = bottom, 180deg = left, 270deg = top —
- * standard screen/SVG convention, y grows downward). `sweep` is the raw SVG
- * sweep-flag (0 or 1) — see the comment on ARC_RANGE_4 for why the two
- * bottom petals need it flipped relative to the top two.
- */
-function arcPath(fromDeg: number, toDeg: number, sweep: 0 | 1): string {
-  const rad = (d: number) => (d * Math.PI) / 180
-  const x1 = CLOVER_CENTER + CLOVER_LABEL_R * Math.cos(rad(fromDeg))
-  const y1 = CLOVER_CENTER + CLOVER_LABEL_R * Math.sin(rad(fromDeg))
-  const x2 = CLOVER_CENTER + CLOVER_LABEL_R * Math.cos(rad(toDeg))
-  const y2 = CLOVER_CENTER + CLOVER_LABEL_R * Math.sin(rad(toDeg))
-  return `M ${x1} ${y1} A ${CLOVER_LABEL_R} ${CLOVER_LABEL_R} 0 0 ${sweep} ${x2} ${y2}`
+// Each stance gets its own petal colour (see battle.css's --petal-color modifiers) —
+// keyed by stance value rather than grid position, so a stance's colour stays fixed
+// even when only 2 are allowed and petals render as l/r halves instead of quadrants.
+const STANCE_COLOR_CLASS: Record<Stance, string> = {
+  attack: 'stance-petal--attack',
+  hold:   'stance-petal--hold',
+  defend: 'stance-petal--defend',
+  auto:   'stance-petal--auto',
 }
-
-// One arc range per petal, same index order as CORNER_CLASS_4/2. Two points
-// 90deg apart admit two different circles of the shared radius — one centered
-// on the clover's own center (the one we want, bulging out to the petal's
-// rim) and one mirrored across the chord (bulging in toward the center
-// instead). With a fixed sweep-flag, which one gets drawn depends on point
-// order — so the top two petals (sweep=1, "start at the shared edge, sweep
-// out to the corner") and the bottom two (same points, sweep=0, which keeps
-// the same rim-hugging circle but reverses the traversal direction so their
-// text reads upright instead of upside-down) need opposite flags. Both the
-// bulge and the reading direction were confirmed empirically via Storybook
-// screenshots — getting either flag wrong is visually obvious (text bows
-// toward the center, or reads upside-down) rather than subtly off.
-const ARC_RANGE_4: [number, number, 0 | 1][] = [
-  [180, 270, 1], // tl
-  [270, 360, 1], // tr
-  [180, 90, 0],  // bl (same rim-hugging arc as the un-flipped order, reversed)
-  [360, 90, 0],  // br
-]
-const ARC_RANGE_2: [number, number, 0 | 1][] = [
-  [90, 270, 1],  // l (bottom -> top, the long way round through left)
-  [270, 90, 1],  // r
-]
 
 interface Props {
   stance: Stance
@@ -85,7 +35,7 @@ interface Props {
   durationSecsLeft: number
   speedMultiplier: 1 | 2 | 4 | 8
   onSetStance?: (s: Stance) => void
-  onCycleSpeed?: () => void
+  onSetSpeed?: (m: 1 | 2 | 4 | 8) => void
 }
 
 /**
@@ -101,11 +51,11 @@ interface Props {
  * in the expanded overlay, a real role="group" of full-size petal buttons.
  * Selecting one calls onSetStance and collapses back to the dot.
  *
- * Replaces #2222's dropdown-list version — same allowed/cooldown/duration/
- * sudden-death rules, same STANCE_LABEL/STANCE_ORDER, same Props, so
- * Battlefield.tsx needed no changes to embed this.
+ * The speed control beside it (SpeedClover) is a sibling using the same shape
+ * language, not a StanceBar concern — see Battlefield.tsx for how the two are
+ * laid out together.
  */
-export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, cooldownSecsLeft, durationSecsLeft, speedMultiplier, onSetStance, onCycleSpeed }: Props) {
+export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, cooldownSecsLeft, durationSecsLeft, speedMultiplier, onSetStance, onSetSpeed }: Props) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLSpanElement>(null)
   // Namespaces the SVG arc ids so two StanceBars on one page (e.g. a
@@ -124,27 +74,13 @@ export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, coo
     : onCooldown && cooldownSecsLeft > 0     ? `${cooldownSecsLeft}s`
     : null
 
-  useEffect(() => {
-    if (!open) return
-    function handlePointer(e: MouseEvent) {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
-    }
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', handlePointer)
-    document.addEventListener('keydown', handleKey)
-    return () => {
-      document.removeEventListener('mousedown', handlePointer)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [open])
+  useClickOutsideToClose(open, () => setOpen(false), wrapRef)
 
   return (
     <span className="stance-control u-flex u-items-c u-gap-2">
-      {/* Own positioning context, separate from the speed button beside it —
+      {/* Own positioning context, separate from the speed control beside it —
           the expanded clover anchors to THIS box, not the whole control, so
-          growing it never covers the speed button next to it. */}
+          growing it never covers anything else in the row. */}
       <span className="stance-clover-wrap" ref={wrapRef}>
         {!open ? (
           <button
@@ -157,7 +93,7 @@ export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, coo
               {allowed.map((s, i) => (
                 <span
                   key={s}
-                  className={`stance-petal ${cornerClasses[i]}${stance === s ? ' stance-petal--active' : ''}`}
+                  className={`stance-petal ${cornerClasses[i]} ${STANCE_COLOR_CLASS[s]}${stance === s ? ' stance-petal--active' : ''}`}
                 />
               ))}
             </span>
@@ -173,7 +109,7 @@ export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, coo
                   <button
                     key={s}
                     type="button"
-                    className={`stance-petal ${cornerClasses[i]}${isActive ? ' stance-petal--active' : ''}`}
+                    className={`stance-petal ${cornerClasses[i]} ${STANCE_COLOR_CLASS[s]}${isActive ? ' stance-petal--active' : ''}`}
                     disabled={blockedBySuddenDeath || isCoolingDown}
                     title={isCoolingDown ? `Available in ${cooldownSecsLeft}s` : undefined}
                     onClick={() => { onSetStance?.(s); setOpen(false) }}
@@ -186,13 +122,14 @@ export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, coo
               })}
             </span>
             {/* Decorative labels, curved along each petal's own rim — see
-                arcPath/ARC_RANGE_4/ARC_RANGE_2 above for why. pointer-events:none
-                (in CSS) so taps still land on the real petal buttons beneath. */}
+                arcPath/ARC_RANGE_4/ARC_RANGE_2 in cloverGeometry.ts for why.
+                pointer-events:none (in CSS) so taps still land on the real
+                petal buttons beneath. */}
             <svg className="stance-clover-labels" viewBox={`0 0 ${CLOVER_VIEWBOX} ${CLOVER_VIEWBOX}`} aria-hidden="true">
               <defs>
                 {allowed.map((s, i) => {
-                  const [from, to, sweep] = (allowed.length === 2 ? ARC_RANGE_2 : ARC_RANGE_4)[i]
-                  return <path key={s} id={`stance-arc-${idPrefix}-${s}`} d={arcPath(from, to, sweep)} />
+                  const [from, to] = (allowed.length === 2 ? ARC_RANGE_2 : ARC_RANGE_4)[i]
+                  return <path key={s} id={`stance-arc-${idPrefix}-${s}`} d={arcPath(from, to)} />
                 })}
               </defs>
               {allowed.map(s => (
@@ -208,9 +145,7 @@ export function StanceBar({ stance, allowedStances, suddenDeath, onCooldown, coo
         )}
       </span>
 
-      <Button className="stance-bar__speed" onClick={onCycleSpeed} aria-label={`Speed ${speedMultiplier}x — tap to cycle`}>
-        ×{speedMultiplier}
-      </Button>
+      <SpeedClover speedMultiplier={speedMultiplier} onSetSpeed={onSetSpeed} />
     </span>
   )
 }

--- a/web/src/components/battle/battlefield/cloverGeometry.ts
+++ b/web/src/components/battle/battlefield/cloverGeometry.ts
@@ -1,0 +1,57 @@
+// Shared geometry for the clover-shaped radial pickers (StanceBar, SpeedClover): a
+// 2x2 (or 1x2) grid of cells, each rounded ONLY on its true outer corner, renders as
+// petals meeting at a shared center point. Curved labels trace an arc concentric with
+// that same center, at a radius inside the petals' own rounded rim.
+
+// Which outer corner each grid cell rounds, by its index in a 4-option list — this is
+// what turns 4 plain grid squares into 4 petals meeting at a shared center. Index
+// 0/1/2/3 = reading order (top-left, top-right, bottom-left, bottom-right).
+export const CORNER_CLASS_4 = [
+  'stance-petal--tl',
+  'stance-petal--tr',
+  'stance-petal--bl',
+  'stance-petal--br',
+]
+// Two options render as left/right halves instead of quadrants.
+export const CORNER_CLASS_2 = ['stance-petal--l', 'stance-petal--r']
+
+// Label curve geometry for the expanded clover. Plain horizontal text ignores the
+// petal's own curve entirely — cramped at the sharp center point, wasted space out at
+// the rounded rim. Curving each label along an arc concentric with that rim uses the
+// petal's actual shape instead of fighting it.
+export const CLOVER_VIEWBOX = 108     // must match .stance-clover--expanded's size
+export const CLOVER_CENTER  = CLOVER_VIEWBOX / 2
+export const CLOVER_LABEL_R = 38      // inside the true ~52px petal rim, clear of the border
+
+/**
+ * One SVG arc `d` string from `fromDeg` to `toDeg`, both measured clockwise from
+ * 3 o'clock (0deg = right, 90deg = bottom, 180deg = left, 270deg = top — standard
+ * screen/SVG convention, y grows downward).
+ */
+export function arcPath(fromDeg: number, toDeg: number): string {
+  const rad = (d: number) => (d * Math.PI) / 180
+  const x1 = CLOVER_CENTER + CLOVER_LABEL_R * Math.cos(rad(fromDeg))
+  const y1 = CLOVER_CENTER + CLOVER_LABEL_R * Math.sin(rad(fromDeg))
+  const x2 = CLOVER_CENTER + CLOVER_LABEL_R * Math.cos(rad(toDeg))
+  const y2 = CLOVER_CENTER + CLOVER_LABEL_R * Math.sin(rad(toDeg))
+  return `M ${x1} ${y1} A ${CLOVER_LABEL_R} ${CLOVER_LABEL_R} 0 0 1 ${x2} ${y2}`
+}
+
+// One arc range per petal, same index order as CORNER_CLASS_4/2. textPath orients
+// glyphs to the path's direction of travel; all four labels read upright when every
+// petal's arc sweeps the SAME direction (increasing angle / clockwise) as one
+// continuous 360deg cycle around the circle: tl(180->270), tr(270->360), br(360->90),
+// bl(90->180) — each entry picks straight back up where the previous one ended.
+// (An earlier version alternated direction per top/bottom hemisphere on the theory
+// that upright text needs opposite winding above and below center; that was wrong —
+// confirmed by screenshot, not just re-derived.)
+export const ARC_RANGE_4: [number, number][] = [
+  [180, 270], // tl
+  [270, 360], // tr
+  [90, 180],  // bl
+  [360, 90],  // br
+]
+export const ARC_RANGE_2: [number, number][] = [
+  [90, 270],  // l (bottom -> top, the long way round through left)
+  [270, 90],  // r reversed: (top -> bottom, through right) so text reads upright
+]

--- a/web/src/hooks/useClickOutsideToClose.ts
+++ b/web/src/hooks/useClickOutsideToClose.ts
@@ -1,0 +1,20 @@
+import { useEffect, type RefObject } from 'react'
+
+/** Collapses an expanded control (e.g. a popup or radial picker) on outside click or Escape. */
+export function useClickOutsideToClose(open: boolean, onClose: () => void, ref: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    if (!open) return
+    function handlePointer(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', handlePointer)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handlePointer)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open, onClose, ref])
+}

--- a/web/src/styles/battle.css
+++ b/web/src/styles/battle.css
@@ -568,6 +568,8 @@
    is what reads as separate petals meeting at a center point, rather than one
    rounded square. `border-radius: 999px` renders as a true quarter/half circle
    at any box size, so the same rules serve both the tiny and expanded sizes.
+   These rules are shared with SpeedClover.tsx, the speed control beside it —
+   same shape language, different fill semantics (see .stance-petal--filled).
 
    Two states, not one small live control: four real buttons packed into a
    ~22px circle would each be a ~10px hit target. Collapsed
@@ -618,12 +620,30 @@
 .stance-petal--l  { border-top-left-radius: 999px; border-bottom-left-radius: 999px; }
 .stance-petal--r  { border-top-right-radius: 999px; border-bottom-right-radius: 999px; }
 
+/* One colour per stance (keyed by stance value in StanceBar.tsx, not grid position,
+   so a stance keeps its colour even when only 2 are allowed and it renders as an l/r
+   half instead of a quadrant). Everything that needs the colour — border, active glow —
+   reads it back off this custom property instead of repeating four near-identical
+   blocks. */
+.stance-petal--attack { --petal-color: var(--accent-ember); }
+.stance-petal--hold   { --petal-color: var(--accent-arcane); }
+.stance-petal--defend { --petal-color: var(--color-green-bright); }
+.stance-petal--auto   { --petal-color: var(--accent-gold); }
+
 /* The current stance's petal — glows even at tiny size, which is the whole
    point of the small state: legible without expanding anything. */
 .stance-petal--active {
   background: color-mix(in srgb, var(--game-text-color) 30%, var(--surface-2));
   border-color: var(--game-text-color);
   box-shadow: 0 0 5px color-mix(in srgb, var(--game-text-color) 60%, transparent);
+}
+
+/* SpeedClover's collapsed level meter — quadrants fill solid gold up to the current
+   speed, rather than each getting a distinct colour (this is one quantity growing,
+   not four separate choices). */
+.stance-petal--filled {
+  background: color-mix(in srgb, var(--accent-gold) 55%, var(--surface-2));
+  border-color: var(--accent-gold);
 }
 
 /* Expanded: a real button per petal, large enough to tap confidently.
@@ -651,9 +671,19 @@
 .stance-clover--expanded .stance-petal {
   cursor: pointer;
   box-shadow: var(--elevation-raised);
+  /* Matches .action-btn's 2px border weight (the speed control uses the same base) —
+     the collapsed 22px dot keeps its thinner 1px border, set below, since a 2px
+     border on a ~10px petal reads as chunky rather than crisp. */
+  border-width: 2px;
+  border-color: var(--petal-color, var(--game-border));
+}
+.stance-clover--expanded .stance-petal--active {
+  background: color-mix(in srgb, var(--petal-color, var(--game-text-color)) 30%, var(--surface-2));
+  border-color: var(--petal-color, var(--game-text-color));
+  box-shadow: 0 0 6px color-mix(in srgb, var(--petal-color, var(--game-text-color)) 70%, transparent);
 }
 .stance-clover--expanded .stance-petal:hover:not(:disabled) {
-  border-color: #777;
+  border-color: color-mix(in srgb, var(--petal-color, #777) 70%, #777);
 }
 .stance-clover--expanded .stance-petal:active:not(:disabled) {
   transform: translateY(1px);
@@ -666,8 +696,8 @@
 /* The visible label — plain text ignored the petal's own curve entirely
    (cramped at the sharp center point, empty space at the rounded rim); this
    follows an arc concentric with that rim instead. See arcPath in
-   StanceBar.tsx for the geometry. Sits on top of the (now unlabelled) petal
-   buttons; pointer-events:none so taps still reach them. */
+   cloverGeometry.ts for the geometry. Sits on top of the (now unlabelled)
+   petal buttons; pointer-events:none so taps still reach them. */
 .stance-clover-labels {
   position: absolute;
   inset: 0;
@@ -719,29 +749,6 @@
   min-height: 32px;
 }
 
-
-/* A round gold badge, matching the clover's own roundness rather than sitting
-   next to it as a leftover rectangle — was a raw-hex-and-!important override
-   of .filter-btn's rectangular shape; this owns its shape and colour outright
-   instead of fighting a rectangle base class for both. */
-.stance-bar__speed {
-  flex: 0 0 auto;
-  width: 32px;
-  height: 32px;
-  min-height: 32px;
-  padding: 0;
-  border-radius: 50%;
-  border-color: var(--color-gold-dim);
-  color: var(--color-gold-light);
-  font-size: var(--font-xs);
-  font-weight: bold;
-}
-
-.stance-bar__speed:hover {
-  border-color: var(--accent-gold);
-  color: var(--accent-gold);
-  box-shadow: 0 0 5px color-mix(in srgb, var(--accent-gold) 50%, transparent);
-}
 
 .hand-panel {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Follow-up feedback on the merged clover stance picker (#2223):

- **Fixed curved-label orientation** on the two bottom petals. The bug: the original implementation alternated arc winding direction between the top and bottom hemispheres on the theory that upright text needs opposite winding above/below center. That was wrong — all four petals actually need the *same* clockwise winding, continuing as one 360° cycle around the circle (tl → tr → br → bl). Confirmed empirically via Storybook screenshots, including one wrong turn along the way (an attempt to fix a label-overlap issue with SVG `textLength`/`lengthAdjust` accidentally broke the orientation again — reverted).
- **Distinct colour per stance petal** — ember/arcane/green/gold, keyed by stance value (not grid position) so a stance keeps its colour even in the 2-petal case (`l`/`r` halves). Reuses existing `--accent-*`/`--color-*` tokens, no new ones added.
- **Thicker expanded-petal border** (2px, scoped to the expanded state only) to match the speed control's border weight.
- **Speed control is now a clover**, matching the stance control's shape language:
  - Collapsed: a level meter — 1 quadrant filled at 1x, 2 at 2x, 3 at 4x, all 4 at 8x.
  - Tapping it expands into a picker with one petal per speed option (1x/2x/4x/8x), replacing the old cycle-on-tap round badge.
- Extracted the geometry (`cloverGeometry.ts`) and outside-click/Escape collapse behaviour (`useClickOutsideToClose.ts`) shared by `StanceBar` and the new `SpeedClover`, instead of duplicating both.
- Threaded `onSetSpeed(multiplier)` end to end (`useBattleControls` → `BattleContext` → `App` → `BattleRoutes` → `Battlefield` → `StanceBar`/`SpeedClover`), replacing the old cycle-only `onCycleSpeed`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npx vitest run` — full suite passes (one `Battlefield.stories.tsx` perf-timing assertion flaked under load in the full run; passes cleanly re-run in isolation, unrelated to this change)
- [x] Storybook screenshots of `StanceBar`'s expanded 4-petal and 2-petal stories, and `SpeedClover`'s collapsed levels + expanded picker — verified label orientation, petal colours, and border thickness visually
- [x] Fixed a story query collision (`ExpandedFourPetals`/`ExpandedTwoPetals` in `StanceBar.stories.tsx`) caused by `StanceBar` now rendering `SpeedClover` beside it — both had a "tap to change" trigger button, so the play function's `getByRole` match needed narrowing

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQncSGUpwVPCPoWbEvyic)_