### PR TITLE
Use vitest/browser instead of the deprecated @vitest/browser/context

### DIFF
--- a/web/src/components/hub/satchel/SatchelSheet.stories.tsx
+++ b/web/src/components/hub/satchel/SatchelSheet.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { fn, within, expect } from 'storybook/test'
-import { page } from '@vitest/browser/context'
+import { page } from 'vitest/browser'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { SatchelSheet, SatchelEmpty } from './SatchelSheet'
 import { GroupHeading } from './GroupHeading'


### PR DESCRIPTION
One-line follow-up to #2227. The viewport-setting import I added there uses a path vitest deprecates, and logs on every CI run:

```
SatchelSheet.stories.tsx tries to load a deprecated "@vitest/browser/context"
module. This import will stop working in the next major version.
Please, use "vitest/browser" instead.
```

Same `page` export from the new path, so it's a straight swap. Clears the warning and stops the next vitest major from breaking the phone-viewport regression tests added in #2227.

`npm run build` and `npm run test` pass (2933 tests); the six `SatchelSheet` story tests still pass in chromium locally, with no deprecation line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvYFAdLbyKeoc1UMnxGEJA)_