### PR TITLE
Merge the hub header/toolbar, kill the duplicate clock, and keep bubbles clear of the minimap

### DIFF
--- a/web/src/components/hub/HubMinimap.tsx
+++ b/web/src/components/hub/HubMinimap.tsx
@@ -21,6 +21,15 @@ interface Props {
   objectives:   MinimapObjective[]
   playerRef:    React.RefObject<{ x: number; y: number }>
   viewportRef:  React.RefObject<HTMLDivElement | null>
+  /** Exposes this component's own on-screen box, so canvas-drawn speech
+   *  bubbles can steer clear of it instead of spawning underneath it — see
+   *  HubTownCanvas's createSpeechBubble. Reading getBoundingClientRect() off
+   *  this ref on demand (rather than duplicating hub.css's pixel offsets as a
+   *  second, hardcoded copy) means the exclusion zone can't silently drift
+   *  out of sync with wherever the minimap actually renders, and it
+   *  automatically shrinks to just the toggle button when the map itself is
+   *  hidden. */
+  wrapRef?:     React.RefObject<HTMLDivElement>
 }
 
 function loadVisible(): boolean {
@@ -37,7 +46,7 @@ function saveVisible(on: boolean): void {
   } catch { /* ignore */ }
 }
 
-export function HubMinimap({ locationData, objectives, playerRef, viewportRef }: Props) {
+export function HubMinimap({ locationData, objectives, playerRef, viewportRef, wrapRef }: Props) {
   const { MAP_W, MAP_H, HUB_BUILDINGS } = locationData
 
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -209,7 +218,7 @@ export function HubMinimap({ locationData, objectives, playerRef, viewportRef }:
       )}
 
       {/* Corner minimap */}
-      <div className="hub-minimap-wrap">
+      <div className="hub-minimap-wrap" ref={wrapRef}>
         {visible && (
           <canvas
             ref={canvasRef}

--- a/web/src/components/hub/HubStatusBar.stories.tsx
+++ b/web/src/components/hub/HubStatusBar.stories.tsx
@@ -1,0 +1,75 @@
+import { fn, within, userEvent, expect } from 'storybook/test'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { HubStatusBar } from './HubStatusBar'
+
+const meta = {
+  component: HubStatusBar,
+  parameters: { layout: 'fullscreen' },
+  decorators: [(Story) => (<div className="game-container"><Story /></div>)],
+  args: {
+    townName: 'Ravenwatch',
+    festivalLabel: null,
+    crystals: 8924,
+    timeLabel: '07:14',
+    isNight: false,
+    wrongSaveCrystals: null,
+    onOpenMenu: fn(),
+    worldMapLocked: false,
+    onWorldMap: fn(),
+    onWorldMapLocked: fn(),
+    user: null,
+    playerName: 'Commander',
+    onSignIn: fn(),
+    onSignOut: fn(),
+    onPlayerTap: fn(),
+    onFeedback: fn(),
+    onSettings: fn(),
+  },
+} satisfies Meta<typeof HubStatusBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Night: Story = {
+  args: { isNight: true, timeLabel: '22:40' },
+}
+
+/** The world map button stays visible and tappable while locked — it
+ *  explains why via onWorldMapLocked instead of just sitting dim and inert.
+ *  The old button used HTML `disabled`, which blocks onClick outright; a tap
+ *  did nothing, with no way to find out why on a touchscreen. */
+export const WorldMapLocked: Story = {
+  args: { worldMapLocked: true },
+}
+
+/** Regression guard for that fix: tapping the locked button must route to
+ *  onWorldMapLocked, never onWorldMap — and the reverse once it's unlocked. */
+export const WorldMapClickRouting: Story = {
+  tags: ['ci'],
+  args: { worldMapLocked: true },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const mapButton = canvas.getByTitle('World Map — locked')
+
+    await userEvent.click(mapButton)
+    expect(args.onWorldMapLocked).toHaveBeenCalledTimes(1)
+    expect(args.onWorldMap).not.toHaveBeenCalled()
+  },
+}
+
+export const DuringAFestival: Story = {
+  args: { festivalLabel: '🎪 Harvest Fair' },
+}
+
+/** Secret #9 (Wrong Save File) — a momentary glitch on the crystal count. */
+export const WrongSaveGlitch: Story = {
+  args: { wrongSaveCrystals: 41 },
+}
+
+/** Below the toolbar's container-query breakpoint, sign-in/feedback/settings
+ *  collapse into the account dropdown instead of sitting inline. */
+export const NarrowViewport: Story = {
+  globals: { viewport: { value: 'mobile1' } },
+}

--- a/web/src/components/hub/HubStatusBar.tsx
+++ b/web/src/components/hub/HubStatusBar.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import type { User } from 'firebase/auth'
+import { Toolbar } from '../ui/Toolbar/Toolbar'
+import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
+import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
+import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
+import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
+import { Icon } from '../ui/icons/Icon'
+import { LoginButton } from '../ui/LoginButton'
+
+interface Props {
+  townName: string
+  /** Real-date-driven festival badge, e.g. "🎪 Harvest Fair", or null. */
+  festivalLabel: string | null
+  crystals: number
+  timeLabel: string
+  isNight: boolean
+  /** Secret #9 (Wrong Save File) glitch — crystals only; the card-count
+   *  version of this glitch went with the card count itself. */
+  wrongSaveCrystals: number | null
+  onOpenMenu: () => void
+  worldMapLocked: boolean
+  onWorldMap: () => void
+  /** Fires instead of onWorldMap while locked, so a tap always does
+   *  something rather than silently nothing on a touchscreen. */
+  onWorldMapLocked: () => void
+  user: User | null
+  playerName: string
+  onSignIn?: () => void
+  onSignOut?: () => void
+  onPlayerTap?: () => void
+  onFeedback: () => void
+  onSettings: () => void
+}
+
+/**
+ * The hub's entire header, in one row: town name, economy stats, the clock,
+ * and every button — replacing what used to be two separate chrome bands
+ * (a PageHeader title row, then a full Toolbar row underneath it).
+ *
+ * Hub-specific rather than a shared primitive: nothing else in the game wants
+ * this exact "town name + stats + nav" combination. If another hub screen
+ * needs the same merged-row layout later, that's the point to generalise it.
+ */
+export function HubStatusBar({
+  townName, festivalLabel, crystals, timeLabel, isNight, wrongSaveCrystals,
+  onOpenMenu, worldMapLocked, onWorldMap, onWorldMapLocked,
+  user, playerName, onSignIn, onSignOut, onPlayerTap, onFeedback, onSettings,
+}: Props) {
+  const glitching = wrongSaveCrystals != null
+  const statClass = `title-deck-info${glitching ? ' title-deck-info--glitch' : ''}`
+
+  const accountMenu = (
+    <>
+      <LoginButton onSignIn={() => onSignIn?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
+      <ToolbarButton className="title-auth-btn" onClick={onFeedback} title="Send feedback or report a bug" icon="🗣️" />
+      <ToolbarButton className="action-btn hub-hud__btn" onClick={onSettings} icon="⚙" title="Settings" />
+    </>
+  )
+
+  return (
+    <Toolbar>
+      <span className="hub-status-bar__town">
+        🏠 {townName}
+        {festivalLabel && <span className="hub-status-bar__festival">{festivalLabel}</span>}
+      </span>
+
+      <ToolbarLabel className={statClass}>💎 {(glitching ? wrongSaveCrystals! : crystals).toLocaleString()}</ToolbarLabel>
+      <ToolbarLabel className="title-deck-info">{isNight ? '🌙' : '☀️'} {timeLabel}</ToolbarLabel>
+
+      <ToolbarButton icon="📋" title="Menu" onClick={onOpenMenu} />
+      <ToolbarButton
+        icon={worldMapLocked ? '🔒🗺' : '🗺'}
+        title={worldMapLocked ? 'World Map — locked' : 'World Map'}
+        className={worldMapLocked ? 'hub-status-bar__map-btn--locked' : undefined}
+        onClick={worldMapLocked ? onWorldMapLocked : onWorldMap}
+      />
+
+      <ToolbarSpacer />
+      <div className="toolbar-overflow-inline">
+        {accountMenu}
+      </div>
+      <div className="toolbar-overflow-dropdown">
+        <ToolbarDropdown label={<Icon name="player" size={16} aria-label="Account" />} align="right">
+          {accountMenu}
+        </ToolbarDropdown>
+      </div>
+    </Toolbar>
+  )
+}

--- a/web/src/components/hub/HubStatusCluster.stories.tsx
+++ b/web/src/components/hub/HubStatusCluster.stories.tsx
@@ -15,26 +15,22 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const ClearDay: Story = {
-  args: { areaName: 'The Courtyard', isNight: false, timeLabel: '2:30 PM', weather: 'clear' },
-}
-
-export const ClearNight: Story = {
-  args: { areaName: 'The Courtyard', isNight: true, timeLabel: '10:45 PM', weather: 'clear' },
+export const Clear: Story = {
+  args: { areaName: 'The Courtyard', weather: 'clear' },
 }
 
 export const Rain: Story = {
-  args: { areaName: "The Fisherman's Dock", isNight: false, timeLabel: '4:10 PM', weather: 'rain' },
+  args: { areaName: "The Fisherman's Dock", weather: 'rain' },
 }
 
-export const SnowAtNight: Story = {
-  args: { areaName: 'Frostgate Market', isNight: true, timeLabel: '9:00 PM', weather: 'snow' },
+export const Snow: Story = {
+  args: { areaName: 'Frostgate Market', weather: 'snow' },
 }
 
 export const Fog: Story = {
-  args: { areaName: 'The Old Quarry', isNight: false, timeLabel: '6:20 AM', weather: 'fog' },
+  args: { areaName: 'The Old Quarry', weather: 'fog' },
 }
 
 export const Hidden: Story = {
-  args: { areaName: null, isNight: false, timeLabel: '12:00 PM', weather: 'clear' },
+  args: { areaName: null, weather: 'clear' },
 }

--- a/web/src/components/hub/HubStatusCluster.tsx
+++ b/web/src/components/hub/HubStatusCluster.tsx
@@ -3,8 +3,6 @@ import type { WeatherType } from '../../game/hub/weather'
 
 interface Props {
   areaName: string | null
-  isNight:  boolean
-  timeLabel: string
   weather:  WeatherType
 }
 
@@ -14,19 +12,24 @@ const WEATHER_GLYPH: Partial<Record<WeatherType, string>> = {
   fog:  '🌫️',
 }
 
-/** Consolidated ambient overlay — day/night, weather, and the current area
- *  name — so the canvas carries one coherent status readout in its corner
- *  instead of three unrelated floating pieces of chrome. */
-export function HubStatusCluster({ areaName, isNight, timeLabel, weather }: Props) {
+/** Ambient overlay in the canvas's corner: a weather glyph (when there's
+ *  weather worth naming) and the current area name.
+ *
+ *  Used to also carry the clock, duplicating the one HubStatusBar already
+ *  shows in the header — 07:14 rendered twice, simultaneously, on the same
+ *  screen. The clock is load-bearing for hub decisions (it gates shop hours,
+ *  NPC schedules, festivals) so it stays in the header where it's actionable
+ *  context; this corner keeps only what's genuinely local — day/night has no
+ *  second home, but weather is also shown as real rain/snow particles on the
+ *  canvas, so the glyph here is a legible label for that, not a duplicate. */
+export function HubStatusCluster({ areaName, weather }: Props) {
   const weatherGlyph = WEATHER_GLYPH[weather]
 
   return (
     <div className="hub-status-cluster">
-      <div className="hub-status-cluster__time">
-        <span aria-hidden="true">{isNight ? '🌙' : '☀️'}</span>
-        {weatherGlyph && <span aria-hidden="true">{weatherGlyph}</span>}
-        <span>{timeLabel}</span>
-      </div>
+      {weatherGlyph && (
+        <div className="hub-status-cluster__weather" aria-hidden="true">{weatherGlyph}</div>
+      )}
       <div className={`hub-status-cluster__area${areaName ? ' hub-status-cluster__area--visible' : ''}`}>
         {areaName ?? ''}
       </div>

--- a/web/src/components/hub/HubTownCanvas.tsx
+++ b/web/src/components/hub/HubTownCanvas.tsx
@@ -8,6 +8,7 @@ import { resolveNpcSprite, spriteSlug } from '../../game/sprites'
 import { getTodaysShopItems } from '../../game/hub/shopStock'
 import { loadDailyShopState, isShopItemSold } from '../../game/shopSchedule'
 import { PATH_TILE } from '../../data/tiles/tileIndex'
+import { leftShiftToClear, type Rect } from './bubblePlacement'
 import { findPath, nearestWalkable } from '../../utils/hubPathfinder'
 import { isBuildingOpen, getNpcLocation, getNpcActivity, getNpcDialoguePool, resolveNpcInteriorPresence } from '../../game/hub/hubNpcSchedule'
 import { recordDeparture, claimArrival } from '../../game/hub/townTravelers'
@@ -204,6 +205,11 @@ interface Props {
   /** Scroll container whose scroll position drives the camera. When set, the
    *  canvas is viewport-sized; without it (e.g. Storybook) it spans the map. */
   viewportRef?:          React.RefObject<HTMLDivElement | null>
+  /** The corner minimap's own DOM node — createSpeechBubble reads its live
+   *  on-screen rect so a bubble doesn't spawn underneath it. Optional, same
+   *  as viewportRef: without it (Storybook, or the minimap unmounted while
+   *  indoors) bubbles just skip the avoidance check. */
+  minimapRef?:           React.RefObject<HTMLDivElement>
 }
 
 export function HubTownCanvas({
@@ -220,7 +226,8 @@ export function HubTownCanvas({
   buildingUpgradeLevelsRef,
   locationData,
   questData,
-  viewportRef
+  viewportRef,
+  minimapRef,
 }: Props) {
   const {
     MAP_W, MAP_H, AVATAR_START,
@@ -3108,6 +3115,34 @@ export function HubTownCanvas({
     let nextSpawnTimer = 0
     let lastBubbleIdx  = -1
 
+    // The DOM minimap has no idea a canvas bubble is about to render behind
+    // it — different layering systems, screen space vs. world space — so a
+    // bubble spawning near the top-right of the visible map can land right
+    // under it. Nudges left to clear it, using live getBoundingClientRect()s
+    // rather than duplicating hub.css's pixel offsets as a second, hardcoded
+    // copy that could silently drift out of sync.
+    function minimapAvoidanceShiftX(px: number, py: number, bw: number, bh: number): number {
+      const vp = viewportRef?.current
+      const mm = minimapRef?.current
+      if (!vp || !mm) return 0
+
+      const vpRect = vp.getBoundingClientRect()
+      const mmRect = mm.getBoundingClientRect()
+      // World → screen: this canvas is exactly viewport-sized (resizeTo:
+      // viewportRef below) and unzoomed, so it's a straight scroll-offset
+      // subtraction, no scale factor.
+      const bubbleScreen: Rect = {
+        left:   vpRect.left + (px - bw / 2 - vp.scrollLeft),
+        right:  vpRect.left + (px + bw / 2 - vp.scrollLeft),
+        top:    vpRect.top  + (py - bh      - vp.scrollTop),
+        bottom: vpRect.top  + (py           - vp.scrollTop),
+      }
+      const exclude: Rect = { left: mmRect.left, top: mmRect.top, right: mmRect.right, bottom: mmRect.bottom }
+      // Room to the bubble's left before it would run off the viewport.
+      const maxShift = Math.max(0, bubbleScreen.left - vpRect.left - 8)
+      return leftShiftToClear(bubbleScreen, exclude, 6, maxShift)
+    }
+
     function createSpeechBubble(text: string, cx: number, cy: number): PIXI.Container {
       const c   = new PIXI.Container()
       const lbl = new PIXI.Text({
@@ -3125,7 +3160,9 @@ export function HubTownCanvas({
       bg.moveTo(-6, 0).lineTo(6, 0).lineTo(0, 8).closePath().fill({ color: 0xffffff })
       bg.moveTo(-6, 0).lineTo(6, 0).lineTo(0, 8).closePath().stroke({ color: 0x000000, width: 1.5 })
       c.addChild(bg, lbl)
-      c.position.set(cx, cy - SPRITE_SIZE - 4)
+      const py = cy - SPRITE_SIZE - 4
+      const shift = minimapAvoidanceShiftX(cx, py, bw, bh)
+      c.position.set(cx - shift, py)
       return c
     }
 

--- a/web/src/components/hub/HubWorld.tsx
+++ b/web/src/components/hub/HubWorld.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
-import { OverlayScreen } from '../ui/OverlayScreen'
 import { HubTownCanvas } from './HubTownCanvas'
+import { HubStatusBar } from './HubStatusBar'
 import { HubStatusCluster } from './HubStatusCluster'
 import { HubMinimap } from './HubMinimap'
 import type { MinimapObjective } from './HubMinimap'
@@ -23,14 +23,8 @@ import { getCardCatalog } from '../../game/cards'
 import { CommanderState } from '../../game/commander'
 import { loadSkipIntro } from '../screens/SettingsScreen'
 import { getSavedHubTile } from './HubTownCanvas'
-import { Toolbar } from '../ui/Toolbar/Toolbar'
-import { ToolbarLabel } from '../ui/Toolbar/ToolbarLabel'
-import { ToolbarButton } from '../ui/Toolbar/ToolbarButton'
-import { ToolbarSpacer } from '../ui/Toolbar/ToolbarSpacer'
-import { ToolbarDropdown } from '../ui/Toolbar/ToolbarDropdown'
 import { User } from 'firebase/auth'
 import { loadPlayerName, addToConsumableStash, isCampaignComplete } from '../../game/questline'
-import { LoginButton } from '../ui/LoginButton'
 import { addCollectible, addConsumable, getCollectibles, addHubItem, removeHubItem, getHubItemCount, hasHubItem, getHubItemCatalogEntry, getHubItems, spendTickets, getTickets } from '../../game/itemStore'
 import { questItemId } from '../../game/hub/questItems'
 import { SatchelMenu, type SatchelSectionId, type TownView } from './SatchelMenu'
@@ -504,6 +498,9 @@ export function HubWorld({ onBack, onNavigate, onCampaign, onCampaign2, onEndles
   }
 
   const scrollRef        = useRef<HTMLDivElement>(null)
+  // The minimap's own DOM node — read via getBoundingClientRect() so a
+  // canvas-drawn speech bubble can steer clear of it. See bubblePlacement.ts.
+  const minimapRef       = useRef<HTMLDivElement>(null)
   const returnRef        = useRef(null) as React.MutableRefObject<(() => void) | null>
   const interiorEnterRef = useRef<((buildingId: string) => void) | null>(null)
   const interiorExitRef  = useRef<(() => void) | null>(null)
@@ -2398,16 +2395,35 @@ function hasOfferableQuest(giverId: string): boolean {
     if (def) runReactions(def, 0)
   }
 
+  const worldMapLocked = getQuestState('thorin-the-last-watch').status !== 'completed'
+
   return (
-    <OverlayScreen
-      title={`🏠 ${locationData.HUB_TOWN_NAME}`}
-      right={activeFestival && `${activeFestival.icon} ${activeFestival.name}`}
-      // --bleed lets the town canvas reach the screen edge instead of sitting
-      // inside .game-container's gutter, which read as a black outline that the
-      // phone's corner radius cropped unevenly.
-      className="overlay-screen overlay-screen--bleed u-col u-grow"
-    >
-      {HubWorldToolbar(wrongSave, crystals, collectionCount, catalogTotal, isGameNight,  setTabbedModalOpen, onWorldMap, onLoginToggle, onSignOut, onPlayerTap, user, playerName, onFeedback, onBack)}
+    // --bleed lets the town canvas reach the screen edge instead of sitting
+    // inside .game-container's gutter, which read as a black outline that the
+    // phone's corner radius cropped unevenly.
+    <div className="overlay-screen overlay-screen--bleed u-col u-grow">
+      <HubStatusBar
+        townName={locationData.HUB_TOWN_NAME}
+        festivalLabel={activeFestival ? `${activeFestival.icon} ${activeFestival.name}` : null}
+        crystals={crystals}
+        timeLabel={formatGameTime()}
+        isNight={isGameNight}
+        wrongSaveCrystals={wrongSave?.crystals ?? null}
+        onOpenMenu={() => setTabbedModalOpen(true)}
+        worldMapLocked={worldMapLocked}
+        onWorldMap={() => onWorldMap?.()}
+        onWorldMapLocked={() => setDialogueEvent({
+          speakerName: '',
+          text: "Complete ‘The Last Watch’ to unlock the World Map.",
+        })}
+        user={user}
+        playerName={playerName}
+        onSignIn={onLoginToggle}
+        onSignOut={onSignOut}
+        onPlayerTap={onPlayerTap}
+        onFeedback={onFeedback}
+        onSettings={onBack}
+      />
 
       <div
         className="nm-map nm-map--camp"
@@ -2463,12 +2479,11 @@ function hasOfferableQuest(giverId: string): boolean {
             locationData={locationData}
             questData={locationQuests}
             viewportRef={scrollRef}
+            minimapRef={minimapRef}
           />
         </div>
         <HubStatusCluster
           areaName={currentArea}
-          isNight={isGameNight}
-          timeLabel={formatGameTime()}
           weather={resolveWeather(locationData.WEATHER, locationData.ENVIRONMENT)}
         />
 
@@ -2478,6 +2493,7 @@ function hasOfferableQuest(giverId: string): boolean {
             objectives={minimapObjectives}
             playerRef={playerPixelRef}
             viewportRef={scrollRef}
+            wrapRef={minimapRef}
           />
         )}
 
@@ -2549,40 +2565,6 @@ function hasOfferableQuest(giverId: string): boolean {
           </div>
         )}
       </div>
-    </OverlayScreen>
+    </div>
   )
-}
-
-
-function HubWorldToolbar(wrongSave: { cards: number; crystals: number; deck: number } | null, crystals: number, collectionCount: number, catalogTotal: number, isGameNight: boolean,  setTabbedModalOpen: React.Dispatch<React.SetStateAction<boolean>>, onWorldMap: (() => void) | undefined, onLoginToggle: (() => void) | undefined, onSignOut: (() => void) | undefined, onPlayerTap: (() => void) | undefined, user: User | null, playerName: string, onFeedback: () => void, onBack: () => void) {
-  return <Toolbar>
-    <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>💎 {wrongSave ? wrongSave.crystals.toLocaleString() : crystals.toLocaleString()}</ToolbarLabel>
-    <ToolbarLabel className={`title-deck-info${wrongSave ? ' title-deck-info--glitch' : ''}`}>🃏 {wrongSave ? wrongSave.cards : collectionCount}/{catalogTotal}</ToolbarLabel>
-    <ToolbarLabel className="title-deck-info">{isGameNight ? '🌙' : '☀️'} {formatGameTime()}</ToolbarLabel>
-    <ToolbarButton icon="📋" title="Menu" onClick={() => setTabbedModalOpen(true)} />
-    <ToolbarButton icon="🗺" title="World Map" onClick={() => onWorldMap?.()} disabled={getQuestState('thorin-the-last-watch').status !== 'completed'} />
-
-    <ToolbarSpacer />
-    <div className="toolbar-overflow-inline">
-      <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
-      <ToolbarButton
-        className="title-auth-btn"
-        onClick={onFeedback}
-        title="Send feedback or report a bug"
-        icon={'🗣️'} />
-      <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'} />
-    </div>
-    <div className="toolbar-overflow-dropdown">
-      <ToolbarDropdown label="📊" align="right">
-        <LoginButton onSignIn={() => onLoginToggle?.()} onSignOut={() => onSignOut?.()} onPlayerTap={onPlayerTap} user={user} playerName={playerName} />
-        <ToolbarButton
-          className="title-auth-btn"
-          onClick={onFeedback}
-          title="Send feedback or report a bug"
-          icon={'🗣️'} />
-        <ToolbarButton className="action-btn hub-hud__btn" onClick={onBack} icon={'⚙'} />          </ToolbarDropdown>
-    </div>
-
-
-  </Toolbar>
 }

--- a/web/src/components/hub/bubblePlacement.test.ts
+++ b/web/src/components/hub/bubblePlacement.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { leftShiftToClear, type Rect } from './bubblePlacement'
+
+// A minimap-shaped exclusion box pinned to a phone viewport's top-right
+// corner, matching how HubMinimap actually sits on screen.
+const minimap: Rect = { left: 290, top: 16, right: 390, bottom: 116 }
+
+describe('leftShiftToClear', () => {
+  it('does nothing when the bubble sits nowhere near the box', () => {
+    expect(leftShiftToClear({ left: 20, top: 400, right: 120, bottom: 440 }, minimap, 6, 999)).toBe(0)
+  })
+
+  it('does nothing when the bubble is beside the box but not overlapping', () => {
+    // Directly below the minimap — horizontal overlap, no vertical overlap.
+    expect(leftShiftToClear({ left: 300, top: 130, right: 380, bottom: 160 }, minimap, 6, 999)).toBe(0)
+    // Level with the minimap but well clear to its left — vertical overlap, no horizontal.
+    expect(leftShiftToClear({ left: 20, top: 30, right: 100, bottom: 70 }, minimap, 6, 999)).toBe(0)
+  })
+
+  it('shifts left exactly enough to clear the box, plus the margin', () => {
+    // Bubble's right edge (360) pokes 70px past the minimap's left edge (290).
+    const bubble: Rect = { left: 280, top: 40, right: 360, bottom: 80 }
+    expect(leftShiftToClear(bubble, minimap, 6, 999)).toBe(76)
+
+    const shifted: Rect = { left: bubble.left - 76, top: bubble.top, right: bubble.right - 76, bottom: bubble.bottom }
+    expect(shifted.right).toBeLessThanOrEqual(minimap.left - 6)
+  })
+
+  it('is already clear once margin is satisfied, at the boundary', () => {
+    const bubble: Rect = { left: 200, top: 40, right: 284, bottom: 80 } // right edge = 290 - 6
+    expect(leftShiftToClear(bubble, minimap, 6, 999)).toBe(0)
+  })
+
+  it('never returns more than maxShift, even for a deep overlap', () => {
+    const bubble: Rect = { left: 300, top: 40, right: 400, bottom: 80 } // fully inside the box
+    expect(leftShiftToClear(bubble, minimap, 6, 40)).toBe(40)
+  })
+
+  it('returns 0 rather than a negative shift when maxShift is 0', () => {
+    const bubble: Rect = { left: 300, top: 40, right: 400, bottom: 80 }
+    expect(leftShiftToClear(bubble, minimap, 6, 0)).toBe(0)
+  })
+})

--- a/web/src/components/hub/bubblePlacement.ts
+++ b/web/src/components/hub/bubblePlacement.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure screen-space geometry for keeping a canvas-drawn speech bubble clear of
+ * a fixed DOM overlay (the corner minimap). Kept out of HubTownCanvas so it's
+ * testable without a canvas, a DOM, or PixiJS.
+ */
+
+export interface Rect {
+  left:   number
+  top:    number
+  right:  number
+  bottom: number
+}
+
+/**
+ * How far left `bubble` needs to shift to clear `exclude` horizontally, with
+ * `margin` px of breathing room — 0 if they don't overlap at all. Never
+ * returns more than `maxShift`, so a caller can cap the nudge at "still on
+ * screen" and a bubble can't be pushed off the left edge to dodge the box.
+ */
+export function leftShiftToClear(bubble: Rect, exclude: Rect, margin: number, maxShift: number): number {
+  const overlapsVertically   = bubble.top   < exclude.bottom && bubble.bottom > exclude.top
+  const overlapsHorizontally = bubble.right > exclude.left   && bubble.left   < exclude.right
+  if (!overlapsVertically || !overlapsHorizontally) return 0
+
+  const penetration = bubble.right - exclude.left + margin
+  return Math.max(0, Math.min(penetration, maxShift))
+}

--- a/web/src/styles/hub.css
+++ b/web/src/styles/hub.css
@@ -694,6 +694,40 @@
   min-width: 0;
 }
 
+/* ── Hub Status Bar ───────────────────────────────────────────────────────
+   One merged header row — town name, economy stats, clock and every nav
+   button — replacing what used to be a separate page-title band on top of a
+   full toolbar row. */
+
+.hub-status-bar__town {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  font-family: var(--font-display);
+  font-size: var(--font-sm);
+  font-weight: bold;
+  letter-spacing: 0.06em;
+  color: var(--color-gold-alt);
+  white-space: nowrap;
+  padding: 0 var(--gap-3);
+}
+
+.hub-status-bar__festival {
+  font-family: var(--font-mono);
+  font-size: var(--font-xxs);
+  font-weight: normal;
+  letter-spacing: 0.02em;
+  color: var(--accent-arcane);
+  white-space: nowrap;
+}
+
+/* Still tappable — the lock explains why on tap rather than doing nothing —
+   so this is a lighter dim than .filter-btn--disabled, which is inert. */
+.hub-status-bar__map-btn--locked {
+  opacity: 0.75;
+}
+
 /* ── Hub World Splash Intro ────────────────────────────────────────────── */
 .hub-splash {
   position: absolute;
@@ -1171,16 +1205,13 @@
   gap: 2px;
 }
 
-.hub-status-cluster__time {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: var(--font-xs);
-  letter-spacing: 0.08em;
-  color: rgba(200, 220, 200, 0.75);
+.hub-status-cluster__weather {
+  align-self: flex-end;
+  font-size: var(--font-sm);
   background: rgba(0, 0, 0, 0.35);
   border-radius: var(--radius-sm);
   padding: 2px 6px;
+  line-height: 1;
 }
 
 .hub-status-cluster__area {


### PR DESCRIPTION
Companion PR to the hub-town HUD review. Fixes the four remaining findings — the fifth (H6, ambient dialogue living inside PixiJS rather than the DOM) was a scoping note, not something to fix.

Design proposal, with mockups: https://claude.ai/code/artifact/b4997a64-fd5f-40fb-b1bf-a0632d224c5a

## What changed

**Kill the duplicate clock (H2).** `HubStatusCluster` no longer shows the day/night+time readout — the reported screenshot has `07:14` rendered twice, simultaneously, in the toolbar and in the canvas's corner. It keeps the weather glyph (not duplicated anywhere as text — real rain/snow particles already render on their own canvas layer, so the glyph is a legible label for that, not a second source of truth) and the area-name pop-up.

**Merge the header row and the toolbar (H1), drop the card count (H7).** New `HubStatusBar` replaces `OverlayScreen`'s `PageHeader` plus the private `HubWorldToolbar` function with one row: town name, crystals, clock, every button. `🃏 641/960` doesn't ride along into it — it was a plain, non-interactive `<span>`, permanent chrome for a stat that governs nothing in the hub, unlike crystals (spent on upgrades/tribute from this exact screen) or the clock (gates shop hours, NPC schedules, festivals). It already has a real home on the Collection screen.

**Fix the two silent controls (H4, H5).** The account dropdown was labelled `📊` — a bar-chart emoji with no relation to sign-in/feedback/settings; it's the existing `player` icon now. The locked 🗺 World Map button used HTML `disabled`, which blocks `onClick` outright — a tap did nothing, and the only explanation lived in a `title` attribute that never fires on a touchscreen. It's a normal button now: tapping it while locked surfaces what unlocks it ("Complete 'The Last Watch' to unlock the World Map") through the existing narration dialogue instead of doing nothing.

**Keep speech bubbles clear of the minimap (H3), in PixiJS.** The minimap is a fixed DOM overlay; ambient/proximity chat bubbles are `PIXI.Text` painted into the world layer — different layering systems with no idea about each other, which is why the reported screenshot shows "Woof!" wedged against the minimap's corner. `createSpeechBubble` — the single function every chat bubble routes through (idle ambient, tap-flavour, and named-NPC proximity dialogue all call it) — now nudges left to clear the minimap when they'd overlap on screen.

## How the bubble fix works

The geometry is a pure, unit-tested function (`bubblePlacement.ts`, `leftShiftToClear`, 6 cases) fed by two `getBoundingClientRect()` reads rather than a third hardcoded copy of `hub.css`'s pixel offsets. `HubMinimap` exposes its own DOM node via a new `wrapRef` prop, so the exclusion zone can't silently drift out of sync with wherever the minimap actually renders — and it naturally shrinks to just the toggle button when the map is hidden, no extra logic needed.

I verified the world-space→screen-space math against the actual camera model (`worldRoot.position = -scrollLeft/-scrollTop`, resynced every tick) rather than assuming it, since this file is called out in the repo's own docs as expensive to verify visually — getting the coordinate transform right by inspection mattered more here than usual.

## Verification

`npm run build` and `npm run test` pass — 2945 unit tests, 6 new for the geometry.

Every touched/new story file — including `HubWorld`'s and `HubTownCanvas`'s, which mount a real PixiJS app — was smoke-rendered in chromium (34 stories, all passing) via the same local Playwright-binary workaround used for the earlier Satchel work; nothing from that workaround is committed.

The locked-map-button behavior is covered by a `ci`-tagged regression test, confirmed to actually fail without the fix (reverted it, watched the test fail, restored it, watched it pass again).

**No screenshot verification was possible in this environment.** Worth a look on a real device before merge, particularly the merged row's wrapping at narrow widths and the bubble nudge with the minimap toggled off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvYFAdLbyKeoc1UMnxGEJA)_