### PR TITLE
Chronicle S2: ChronicleScreen decision UI + alignment meter

### DIFF
--- a/web/src/components/screens/ChronicleScreen.tsx
+++ b/web/src/components/screens/ChronicleScreen.tsx
@@ -2,8 +2,13 @@ import React, { useState } from 'react'
 import { OverlayScreen } from '../ui/OverlayScreen'
 import {
   getChronicleStatus, markChapterRead, describeChallenge, describeReward,
-  ChronicleChapterStatus,
+  recordChronicleDecision, getChronicleAlignment,
+  ChronicleChapterStatus, ChronicleAlignmentTrack,
 } from '../../game/chronicle'
+
+const ALIGNMENT_LABELS: Record<ChronicleAlignmentTrack, string> = {
+  vigil: 'Vigil', accord: 'Accord', unbinding: 'Unbinding',
+}
 
 interface Props {
   onBack: () => void
@@ -28,9 +33,22 @@ export function ChronicleScreen({ onBack }: Props) {
     setOpenId(chapter.def.id)
   }
 
+  function handleDecision(chapterId: string, optionId: string) {
+    recordChronicleDecision(chapterId, optionId)
+    setChapters(getChronicleStatus())
+  }
+
   // ── Reading view ────────────────────────────────────────────────────────────
   if (open) {
     const c = open.def.challenge
+    const decision = open.def.decision ?? null
+    const chosenOption = decision && open.decisionOptionId
+      ? decision.options.find(o => o.id === open.decisionOptionId) ?? null
+      : null
+    // Reading is part of completing a chapter; once it also has a decision,
+    // making that decision is too — the challenge only appears once resolved.
+    const challengeUnlocked = !decision || chosenOption !== null
+
     return (
       <OverlayScreen
         title="FRACTURE CHRONICLE"
@@ -42,37 +60,91 @@ export function ChronicleScreen({ onBack }: Props) {
             <p key={i} className="chr-lore-para">{para}</p>
           ))}
 
-          <div className="chr-challenge u-col u-gap-3">
-            <div className="chr-section-label">CHAPTER CHALLENGE</div>
-            <div className="chr-challenge-desc">{describeChallenge(c)}</div>
-            <div className="chr-progress-bar">
-              <div
-                className="chr-progress-fill"
-                style={{ width: `${Math.round((open.progress / c.count) * 100)}%` }}
-              />
+          {decision && (
+            <div className="chr-decision u-col u-gap-3">
+              <div className="chr-section-label">A CHOICE</div>
+              <div className="chr-decision-prompt">{decision.prompt}</div>
+              <div className="chr-decision-options u-col u-gap-2">
+                {decision.options.map((option, i) => {
+                  const isChosen   = chosenOption?.id === option.id
+                  const isDisabled = chosenOption !== null && !isChosen
+                  return (
+                    <button
+                      key={option.id}
+                      className={[
+                        'chr-decision-option',
+                        isChosen ? 'chr-decision-option--chosen' : '',
+                      ].join(' ')}
+                      onClick={() => handleDecision(open.def.id, option.id)}
+                      disabled={isDisabled}
+                    >
+                      <span className="chr-decision-letter">{String.fromCharCode(65 + i)}.</span>
+                      <span className="chr-decision-label u-grow">{option.label}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              {chosenOption && (
+                <div className="chr-decision-consequence">{chosenOption.consequence}</div>
+              )}
             </div>
-            <div className="chr-progress-label">
-              {open.completed
-                ? '✓ Challenge complete'
-                : `${open.progress} / ${c.count}`}
+          )}
+
+          {challengeUnlocked && (
+            <div className="chr-challenge u-col u-gap-3">
+              <div className="chr-section-label">CHAPTER CHALLENGE</div>
+              <div className="chr-challenge-desc">{describeChallenge(c)}</div>
+              <div className="chr-progress-bar">
+                <div
+                  className="chr-progress-fill"
+                  style={{ width: `${Math.round((open.progress / c.count) * 100)}%` }}
+                />
+              </div>
+              <div className="chr-progress-label">
+                {open.completed
+                  ? '✓ Challenge complete'
+                  : `${open.progress} / ${c.count}`}
+              </div>
+              <div className="chr-reward">
+                Reward: {describeReward(open.def.reward)}
+                {open.completed && <span className="chr-reward-claimed"> — claimed</span>}
+              </div>
             </div>
-            <div className="chr-reward">
-              Reward: {describeReward(open.def.reward)}
-              {open.completed && <span className="chr-reward-claimed"> — claimed</span>}
-            </div>
-          </div>
+          )}
         </div>
       </OverlayScreen>
     )
   }
 
   // ── Chapter list ────────────────────────────────────────────────────────────
+  const alignment = getChronicleAlignment()
+  const alignmentTracks = Object.keys(alignment) as ChronicleAlignmentTrack[]
+  const alignmentMax = Math.max(1, ...alignmentTracks.map(t => alignment[t]))
+  const hasAlignment = alignmentTracks.some(t => alignment[t] > 0)
+
   return (
     <OverlayScreen
       title="FRACTURE CHRONICLE"
       subtitle="What caused the Fracture? The story unfolds, chapter by chapter."
       onBack={onBack}
     >
+      {hasAlignment && (
+        <div className="chr-alignment-meter u-col u-gap-2">
+          <div className="chr-section-label">YOUR PATH</div>
+          {alignmentTracks.map(track => (
+            <div key={track} className="chr-alignment-row u-flex u-items-c u-gap-3">
+              <span className="chr-alignment-label">{ALIGNMENT_LABELS[track]}</span>
+              <div className="chr-alignment-bar">
+                <div
+                  className="chr-alignment-fill"
+                  style={{ width: `${(alignment[track] / alignmentMax) * 100}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="chr-list u-col u-gap-4">
         {chapters.map(chapter => (
           <button

--- a/web/src/styles/campaign-events.css
+++ b/web/src/styles/campaign-events.css
@@ -815,6 +815,73 @@
 .chr-reward { font-size: var(--font-md); color: #ffd54f; }
 .chr-reward-claimed { color: #8bc34a; }
 
+.chr-decision {
+  border: 1px solid #ddaa55;
+  border-radius: 4px;
+  padding: 12px 14px;
+}
+.chr-decision-prompt {
+  font-size: var(--font-base);
+  font-weight: bold;
+  color: #ddaa55;
+}
+.chr-decision-option {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  background: none;
+  border: 1px solid var(--game-border);
+  color: var(--game-text-color-dim);
+  font-family: inherit;
+  font-size: var(--font-md);
+  padding: 10px 14px;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  transition: border-color 0.15s, background 0.15s;
+}
+.chr-decision-option:hover:not(:disabled) {
+  border-color: #ddaa55;
+  background: rgba(221, 170, 85, 0.05);
+  color: #ddaa55;
+}
+.chr-decision-option--chosen {
+  border-color: #ddaa55;
+  background: rgba(221, 170, 85, 0.08);
+  color: #ddaa55;
+}
+.chr-decision-option:disabled { cursor: default; }
+.chr-decision-letter { font-weight: bold; color: #886633; min-width: 16px; }
+.chr-decision-option--chosen .chr-decision-letter { color: #ddaa55; }
+.chr-decision-consequence {
+  font-size: var(--font-sm);
+  color: var(--game-text-color-muted);
+  font-style: italic;
+  border-top: 1px solid var(--game-border);
+  padding-top: 10px;
+}
+
+.chr-alignment-meter {
+  max-width: 520px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 16px 12px;
+}
+.chr-alignment-row { font-size: var(--font-sm); }
+.chr-alignment-label { min-width: 80px; color: var(--game-text-color-muted); }
+.chr-alignment-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.chr-alignment-fill {
+  height: 100%;
+  background: #ddaa55;
+  transition: width 0.3s ease;
+}
+
 .dc-actions {
   width: 100%;
   max-width: 260px;


### PR DESCRIPTION
## Summary
Closes #2232.

- `ChronicleScreen` now renders a chapter's `decision` (if present) as lettered options after the lore text, matching the visual language of the existing campaign event-choice UI (`EventScreen.tsx`).
- Picking an option calls `recordChronicleDecision` immediately (first pick is final, same spirit as `markChapterRead`), shows the chosen option's consequence text, and disables the other options.
- The chapter challenge section is now gated behind the decision being made (when the chapter has one) — reading + deciding both gate progress, matching the existing "reading is part of completing" rule.
- The chapter list header shows a compact Vigil/Accord/Unbinding alignment meter (three thin bars), only once the player has made at least one decision.
- Season 1 chapters (`ch1`–`ch6`) carry no `decision` field, so they render exactly as before — this PR is a no-op for existing players until #2234 lands real Season 2 content.

Depends on #2231 (already merged in #2236).

## Test plan
- [x] `npm run build` passes (typecheck clean).
- [x] `npm run test` — all tests pass (2924/2924), no regressions.
- [x] No visual verification via browser — the feature is inert with today's data (no chapter has a `decision` yet), so there's nothing to screenshot; it'll get real exercise once #2234 authors Chapter 7.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGJacwxMD1wksx57FjwChX)_